### PR TITLE
Add dashboard landing page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Arcanos Backend Dashboard</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 20px; background: #f5f5f7; color: #333; }
+    h1 { margin-top: 0; }
+    .status { margin-bottom: 20px; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 20px; }
+    .card { text-decoration: none; background: #fff; padding: 20px; border-radius: 10px; box-shadow: 0 2px 5px rgba(0,0,0,0.1); color: #333; transition: transform 0.1s; }
+    .card:hover { transform: translateY(-2px); }
+    pre { background: #272822; color: #f8f8f2; padding: 10px; border-radius: 5px; overflow-x: auto; }
+  </style>
+</head>
+<body>
+  <h1>Arcanos Backend Dashboard</h1>
+  <div class="status" id="health">Checking server status...</div>
+
+  <div class="grid">
+    <a class="card" href="worker-status.html">📦 Worker Status Dashboard</a>
+    <a class="card" href="test.html">🤖 AI Chat Interface</a>
+    <a class="card" href="test-sleep-config.html">🛌 Sleep Schedule Config</a>
+    <a class="card" href="test-active-sleep-schedule.html">⏰ Active Sleep Schedule</a>
+    <a class="card" href="booker-test.html">🎭 Backstage Booker Test</a>
+  </div>
+
+  <h2>Model Info</h2>
+  <pre id="model-info">Loading...</pre>
+
+  <script>
+    fetch('/health').then(r => r.text()).then(t => {
+      document.getElementById('health').textContent = 'Server Status: ' + t;
+    }).catch(() => {
+      document.getElementById('health').textContent = 'Server Status: unavailable';
+    });
+
+    fetch('/api/model/info')
+      .then(r => r.json())
+      .then(data => {
+        document.getElementById('model-info').textContent = JSON.stringify(data, null, 2);
+      })
+      .catch(() => {
+        document.getElementById('model-info').textContent = 'Error fetching model info';
+      });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `public/index.html` as a dashboard
- show health and model info
- link to existing test pages

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f0f320fdc8325962fb4a48d582033