### PR TITLE
Expose dashboard

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
 const express = require('express');
+const path = require('path');
 const app = express();
 const statusRoute = require('./routes/status');
 const memoryRoute = require('./routes/memory');
 
 // Initialize database connection and memory table
 require('./services/database-connection');
+
+// Serve static dashboard assets
+app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/status', statusRoute);
 app.use('/memory', memoryRoute);
@@ -30,6 +34,11 @@ const { logError } = require('./utils/logger');
 app.use((err, req, res, next) => {
   logError(err);
   res.status(500).json({ error: 'Internal server error' });
+});
+
+// Root dashboard route
+app.get('/', (_req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
 const PORT = process.env.PORT || 3000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import * as dotenv from 'dotenv';
 import axios from 'axios';
 import * as os from 'os';
 import * as fs from 'fs';
+import path from 'path';
 import { exec } from 'child_process';
 import bodyParser from 'body-parser';
 import cors from 'cors';
@@ -50,7 +51,8 @@ app.use(bodyParser.json());
 app.use(express.urlencoded({ extended: true }));
 
 // Serve static files for frontend testing
-app.use(express.static('public'));
+const publicDir = path.join(__dirname, '../public');
+app.use(express.static(publicDir));
 
 // Basic Healthcheck
 app.get('/health', (_, res) => res.send('✅ OK'));
@@ -251,9 +253,9 @@ app.post('/ask', (req, res) => {
   res.json(response);
 });
 
-// Root route - matches problem statement specification
-app.get('/', (req, res) => {
-  res.send('ARCANOS API is live.');
+// Root route - serve dashboard index
+app.get('/', (_req, res) => {
+  res.sendFile(path.join(publicDir, 'index.html'));
 });
 
 // Mount core logic or routes here


### PR DESCRIPTION
## Summary
- serve files from `public` in production
- return dashboard index page when hitting `/`

## Testing
- `npm run dev` and checked `http://localhost:8080/`

------
https://chatgpt.com/codex/tasks/task_e_687f115c8cf08325aa63e268049fe1b3