### PR TITLE
Add API endpoint tests CI

### DIFF
--- a/.github/workflows/api-endpoint-tests.yml
+++ b/.github/workflows/api-endpoint-tests.yml
@@ -1,0 +1,25 @@
+name: API Endpoint Tests
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v3
+
+      - name: 🧰 Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: 🚀 Install, start server, and run tests
+        run: |
+          npm install
+          npm start &
+          sleep 7  # wait for server to be ready
+          ./test-api-endpoints.sh
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `test-api-endpoints.sh`

## Testing
- `npm install`
- `PORT=8080 npm run dev &`
- `./test-api-endpoints.sh`

------
https://chatgpt.com/codex/tasks/task_e_687f27fe3b2c8325bb4161989037ad33