### PR TITLE
Add memory bootstrap endpoint

### DIFF
--- a/memory/actions/bootstrapMemory.js
+++ b/memory/actions/bootstrapMemory.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+const { Pool } = require('pg');
+const pool = new Pool(); // assumes DATABASE_URL env is set
+
+module.exports = async function bootstrapMemory() {
+  const sqlPath = path.join(__dirname, '../state/memory_state.sql');
+
+  if (!fs.existsSync(sqlPath)) {
+    return { error: 'memory_state.sql not found.' };
+  }
+
+  const sql = fs.readFileSync(sqlPath, 'utf8');
+  try {
+    await pool.query(sql);
+    return { success: true, message: 'Memory schema initialized.' };
+  } catch (err) {
+    return { error: err.message };
+  }
+};

--- a/memory/kernel.js
+++ b/memory/kernel.js
@@ -9,6 +9,7 @@ const actions = {
   clearCache: require('./actions/clearCache'),
   updateGoal: require('./actions/updateGoal'),
   hydrateState: require('./actions/hydrateState'),
+  bootstrap: require('./actions/bootstrapMemory'),
 };
 
 function dispatch(command, payload) {

--- a/routes/memory.js
+++ b/routes/memory.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const pool = require('../services/database-connection');
+const memory = require('../memory/kernel');
 
 // Middleware to parse JSON
 router.use(express.json());
@@ -153,6 +154,15 @@ router.get('/health', async (req, res) => {
       error: error.message
     });
   }
+});
+
+// POST /memory/bootstrap - Initialize memory schema if missing
+router.post('/bootstrap', async (req, res) => {
+  const result = await memory.dispatch('bootstrap');
+  if (result.error) {
+    return res.status(500).json({ error: result.error });
+  }
+  res.json(result);
 });
 
 module.exports = router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -209,6 +209,20 @@ router.get('/memory', async (req, res) => {
   res.json({ success: true, memories: list });
 });
 
+// Bootstrap memory schema from SQL file if available
+router.post('/memory/bootstrap', async (_req, res) => {
+  const sqlPath = path.join(__dirname, '../../sql/memory_state.sql');
+  if (!fs.existsSync(sqlPath)) {
+    return res.status(404).json({ error: 'memory_state.sql not found' });
+  }
+  try {
+    await databaseService.initialize();
+    res.json({ success: true, message: 'Memory schema initialized.' });
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
 // ARCANOS V1 Safe Interface endpoint
 router.post('/ask-v1-safe', async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- implement memory schema bootstrapping action
- expose bootstrap action via memory kernel
- add `/memory/bootstrap` route in JS router
- add `/api/memory/bootstrap` endpoint in TS router

## Testing
- `node test-memory-endpoints.js` *(fails: connection refused)*
- `node test-database-connection.js` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687f48c816b08325905cfdb9e2974787