### PR TITLE
Add memory bootstrap endpoint

### DIFF
--- a/memory/actions/bootstrapMemory.js
+++ b/memory/actions/bootstrapMemory.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+const { Pool } = require('pg');
+const pool = new Pool(); // assumes DATABASE_URL env is set
+
+module.exports = async function bootstrapMemory() {
+  const sqlPath = path.join(__dirname, '../state/memory_state.sql');
+
+  if (!fs.existsSync(sqlPath)) {
+    return { error: 'memory_state.sql not found.' };
+  }
+
+  const sql = fs.readFileSync(sqlPath, 'utf8');
+  try {
+    await pool.query(sql);
+    return { success: true, message: 'Memory schema initialized.' };
+  } catch (err) {
+    return { error: err.message };
+  }
+};

--- a/memory/kernel.js
+++ b/memory/kernel.js
@@ -9,6 +9,7 @@ const actions = {
   clearCache: require('./actions/clearCache'),
   updateGoal: require('./actions/updateGoal'),
   hydrateState: require('./actions/hydrateState'),
+  bootstrap: require('./actions/bootstrapMemory'),
 };
 
 function dispatch(command, payload) {

--- a/memory/state/memory_state.sql
+++ b/memory/state/memory_state.sql
@@ -6,3 +6,8 @@ CREATE TABLE IF NOT EXISTS goals (
   objective TEXT,
   completed BOOLEAN DEFAULT FALSE
 );
+
+CREATE TABLE IF NOT EXISTS identity (
+  key TEXT PRIMARY KEY,
+  value TEXT
+);

--- a/routes/memory.js
+++ b/routes/memory.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const pool = require('../services/database-connection');
+const memory = require('../memory/kernel');
 
 // Middleware to parse JSON
 router.use(express.json());
@@ -153,6 +154,15 @@ router.get('/health', async (req, res) => {
       error: error.message
     });
   }
+});
+
+// POST /memory/bootstrap - Initialize memory schema if missing
+router.post('/bootstrap', async (req, res) => {
+  const result = await memory.dispatch('bootstrap');
+  if (result.error) {
+    return res.status(500).json({ error: result.error });
+  }
+  res.json(result);
 });
 
 module.exports = router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,8 @@
 import { Router } from 'express';
 import { OpenAIService, ChatMessage } from '../services/openai';
+import fs from 'fs';
+import path from 'path';
+import { databaseService } from '../services/database';
 import askRoute from './ask';
 import canonRoute from './canon';
 import containersRoute from './containers';
@@ -207,6 +210,20 @@ router.post('/memory', async (req, res) => {
 router.get('/memory', async (req, res) => {
   const list = await memoryStorage.getMemoriesByUser('user');
   res.json({ success: true, memories: list });
+});
+
+// Bootstrap memory schema from SQL file if available
+router.post('/memory/bootstrap', async (_req, res) => {
+  const sqlPath = path.join(process.cwd(), 'sql', 'memory_state.sql');
+  if (!fs.existsSync(sqlPath)) {
+    return res.status(404).json({ error: 'memory_state.sql not found' });
+  }
+  try {
+    await databaseService.initialize();
+    res.json({ success: true, message: 'Memory schema initialized.' });
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
 });
 
 // ARCANOS V1 Safe Interface endpoint

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -104,7 +104,7 @@ export class DatabaseService {
 
   private loadInitSQL(): string | null {
     try {
-      const schemaPath = path.join(__dirname, '../../sql/memory_state.sql');
+      const schemaPath = path.join(process.cwd(), 'sql', 'memory_state.sql');
       const schema = fs.readFileSync(schemaPath, 'utf8');
       console.log('✅ Loaded memory_state.sql');
       return schema;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "moduleResolution": "node"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- implement memory schema bootstrapping action
- expose bootstrap action via memory kernel
- add `/memory/bootstrap` route in JS router
- add `/api/memory/bootstrap` endpoint in TS router
- fix path resolution for memory schema SQL
- update memory_state.sql schema with identity table

## Testing
- `npm run build`
- `node test-memory-endpoints.js` *(fails: expected connection refused)*
- `node test-database-connection.js` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687f48c816b08325905cfdb9e2974787