### PR TITLE
Fix memory_state.sql init path

### DIFF
--- a/memory/actions/bootstrapMemory.js
+++ b/memory/actions/bootstrapMemory.js
@@ -4,7 +4,7 @@ const { Pool } = require('pg');
 const pool = new Pool(); // assumes DATABASE_URL env is set
 
 module.exports = async function bootstrapMemory() {
-  const sqlPath = path.join(__dirname, '../state/memory_state.sql');
+  const sqlPath = path.resolve(__dirname, '../state/memory_state.sql');
 
   if (!fs.existsSync(sqlPath)) {
     return { error: 'memory_state.sql not found.' };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -214,7 +214,7 @@ router.get('/memory', async (req, res) => {
 
 // Bootstrap memory schema from SQL file if available
 router.post('/memory/bootstrap', async (_req, res) => {
-  const sqlPath = path.join(process.cwd(), 'sql', 'memory_state.sql');
+  const sqlPath = path.resolve(__dirname, '..', '..', 'sql', 'memory_state.sql');
   if (!fs.existsSync(sqlPath)) {
     return res.status(404).json({ error: 'memory_state.sql not found' });
   }

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -104,7 +104,7 @@ export class DatabaseService {
 
   private loadInitSQL(): string | null {
     try {
-      const schemaPath = path.join(process.cwd(), 'sql', 'memory_state.sql');
+      const schemaPath = path.resolve(__dirname, '..', '..', 'sql', 'memory_state.sql');
       const schema = fs.readFileSync(schemaPath, 'utf8');
       console.log('✅ Loaded memory_state.sql');
       return schema;


### PR DESCRIPTION
## Summary
- resolve `memory_state.sql` path using `__dirname`
- fix memory bootstrap route path
- adjust path in helper script

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f4da09a608325a8f17e51441a171c