### PR TITLE
Add modular memory state schema

### DIFF
--- a/app/memory/state/memory_state.sql
+++ b/app/memory/state/memory_state.sql
@@ -1,0 +1,21 @@
+-- Initial schema for modular memory logging
+-- This file defines basic tables for goals, identity, and event logs.
+-- Compatible with SQLite or PostgreSQL for bootstrapping a local state DB.
+
+CREATE TABLE IF NOT EXISTS goals (
+  id TEXT PRIMARY KEY,
+  objective TEXT,
+  completed BOOLEAN DEFAULT FALSE
+);
+
+CREATE TABLE IF NOT EXISTS identity (
+  key TEXT PRIMARY KEY,
+  value TEXT
+);
+
+-- Log events for each memory module
+CREATE TABLE IF NOT EXISTS memory_events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  module TEXT NOT NULL,
+  timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- add new `memory_state.sql` under `/app/memory/state` for portable modular memory logging

## Testing
- `node test-memory-endpoints.js` *(fails: Save memory failed, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687f56fb32d4832594bfe4d2d7e2e989