### PR TITLE
Add plugin system with memory bridging

### DIFF
--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,0 +1,10 @@
+import reversePlugin from './reverse-plugin';
+import { pluginManager } from '../services/plugin-manager';
+
+let loaded = false;
+
+export function loadPlugins() {
+  if (loaded) return;
+  pluginManager.register(reversePlugin);
+  loaded = true;
+}

--- a/src/plugins/reverse-plugin.ts
+++ b/src/plugins/reverse-plugin.ts
@@ -1,0 +1,11 @@
+import { ArcanosPlugin, PluginRequest, PluginResponse } from '../services/plugin-manager';
+
+const reversePlugin: ArcanosPlugin = {
+  name: 'reverse',
+  async execute(request: PluginRequest): Promise<PluginResponse> {
+    const reversed = (request.message || '').split('').reverse().join('');
+    return { success: true, data: { reversed } };
+  }
+};
+
+export default reversePlugin;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -7,6 +7,7 @@ import askRoute from './ask';
 import canonRoute from './canon';
 import containersRoute from './containers';
 import queryRouter from './query-router';
+import pluginRoute from './plugins';
 import { HRCCore } from '../modules/hrc';
 import { MemoryStorage } from '../storage/memory-storage';
 import { processArcanosRequest } from '../services/arcanos-router';
@@ -483,6 +484,7 @@ router.get('/v1/sleep_schedule/active_sleep_schedule', (req, res) => {
 });
 
 router.use('/api', askRoute);
+router.use('/arcanos/plugins', pluginRoute);
 
 // Canon API routes - Clean Canon Access API for Backstage Booker
 router.use('/canon', canonRoute);

--- a/src/routes/plugins.ts
+++ b/src/routes/plugins.ts
@@ -1,0 +1,45 @@
+import { Router } from 'express';
+import { loadPlugins } from '../plugins';
+import { pluginManager } from '../services/plugin-manager';
+import { MemoryStorage } from '../storage/memory-storage';
+
+const router = Router();
+let pluginsLoaded = false;
+const memoryStorage = new MemoryStorage();
+
+function ensurePluginsLoaded() {
+  if (!pluginsLoaded) {
+    loadPlugins();
+    pluginsLoaded = true;
+  }
+}
+
+router.post('/:name', async (req, res) => {
+  ensurePluginsLoaded();
+  const pluginName = req.params.name;
+  const { message = '', args } = req.body;
+
+  const plugin = pluginManager.getPlugin(pluginName);
+  if (!plugin) {
+    return res.status(404).json({ error: 'Plugin not found', plugin: pluginName });
+  }
+
+  try {
+    const result = await plugin.execute({ message, args });
+    // Store plugin interaction in memory for bridging
+    await memoryStorage.storeMemory(
+      'user',
+      'plugin-session',
+      'interaction',
+      `${pluginName}_${Date.now()}`,
+      { request: { message, args }, response: result.data },
+      [pluginName, 'plugin']
+    );
+
+    res.json(result);
+  } catch (error: any) {
+    res.status(500).json({ success: false, error: error.message || 'Plugin execution failed' });
+  }
+});
+
+export default router;

--- a/src/services/plugin-manager.ts
+++ b/src/services/plugin-manager.ts
@@ -1,0 +1,29 @@
+export interface PluginRequest {
+  message: string;
+  args?: any;
+}
+
+export interface PluginResponse {
+  success: boolean;
+  data: any;
+  error?: string;
+}
+
+export interface ArcanosPlugin {
+  name: string;
+  execute(request: PluginRequest): Promise<PluginResponse>;
+}
+
+class PluginManager {
+  private plugins: Map<string, ArcanosPlugin> = new Map();
+
+  register(plugin: ArcanosPlugin): void {
+    this.plugins.set(plugin.name, plugin);
+  }
+
+  getPlugin(name: string): ArcanosPlugin | undefined {
+    return this.plugins.get(name);
+  }
+}
+
+export const pluginManager = new PluginManager();


### PR DESCRIPTION
## Summary
- add basic plugin manager service
- register plugins through a new `src/plugins` directory
- implement example `reverse` plugin
- expose plugins via `/api/arcanos/plugins/:name` route

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f5bdd8fe4832588d41de95d65ee30