### PR TITLE
Add background workers with conditional startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,11 @@ import './worker-init';
 // Load environment variables
 dotenv.config();
 
+// Boot additional background workers if enabled
+if (process.env.RUN_WORKERS === 'true') {
+  require('../workers/index');
+}
+
 // 1. VERIFY: Environment variable loading
 console.log("Model (FINE_TUNED_MODEL):", process.env.FINE_TUNED_MODEL);
 console.log("Model (OPENAI_FINE_TUNED_MODEL):", process.env.OPENAI_FINE_TUNED_MODEL);

--- a/workers/clearTemp.js
+++ b/workers/clearTemp.js
@@ -1,0 +1,6 @@
+const clearCache = require('../memory/actions/clearCache');
+
+module.exports = async function clearTemp() {
+  clearCache();
+  console.log('[CACHE CLEANER] Shortterm memory flushed');
+};

--- a/workers/goalWatcher.js
+++ b/workers/goalWatcher.js
@@ -1,0 +1,7 @@
+const goals = require('../memory/modules/goals');
+
+module.exports = async function goalWatcher() {
+  const list = goals.read();
+  const pending = list.filter(g => !g.completed);
+  console.log(`[GOAL WATCHER] ${pending.length} goals active`);
+};

--- a/workers/index.js
+++ b/workers/index.js
@@ -1,0 +1,17 @@
+const jobs = [
+  require('./memorySync'),
+  require('./goalWatcher'),
+  require('./clearTemp'),
+];
+
+console.log('[WORKERS] Booting background task loop');
+
+setInterval(() => {
+  jobs.forEach(async job => {
+    try {
+      await job();
+    } catch (err) {
+      console.error(`[WORKER ERROR] ${job.name}:`, err.message);
+    }
+  });
+}, 1000 * 60 * 5); // every 5 minutes

--- a/workers/memorySync.js
+++ b/workers/memorySync.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const path = require('path');
+const shortterm = require('../memory/modules/shortterm');
+
+module.exports = async function memorySync() {
+  const state = shortterm.read();
+  const snapshotPath = path.join(__dirname, '../memory/state/cache.snapshot.json');
+  fs.writeFileSync(snapshotPath, JSON.stringify(state, null, 2));
+  console.log('[MEMORY SYNC] Saved snapshot at', new Date().toISOString());
+};


### PR DESCRIPTION
## Summary
- add new worker modules for memory sync, goal watcher, and temp clearing
- add worker orchestrator that runs tasks every 5 minutes
- start these workers from the server when `RUN_WORKERS=true`

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687f63cff6c48325bb9d4e6063b4d3bb