### PR TITLE
Add memory test route

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const path = require('path');
 const app = express();
 const statusRoute = require('./routes/status');
 const memoryRoute = require('./routes/memory');
+const testMemoryRoute = require('./routes/testMemory');
 
 // Initialize database connection and memory table
 require('./services/database-connection');
@@ -12,6 +13,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/status', statusRoute);
 app.use('/memory', memoryRoute);
+app.use('/api', testMemoryRoute);
 
 // Prisma example connection (as specified in problem statement)
 const { PrismaClient } = require('@prisma/client');

--- a/routes/testMemory.js
+++ b/routes/testMemory.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const router = express.Router();
+const memory = require('../services/memory');
+
+router.get('/test-memory', async (req, res) => {
+  try {
+    await memory.set('test_key', '✅ Memory is working!');
+    const result = await memory.get('test_key');
+    res.json({ status: 'success', test_key: result });
+  } catch (error) {
+    res.status(500).json({
+      status: 'error',
+      message: 'Memory test failed',
+      error: error.message
+    });
+  }
+});
+
+module.exports = router;

--- a/services/memory.js
+++ b/services/memory.js
@@ -1,0 +1,15 @@
+const shortterm = require('../memory/modules/shortterm');
+
+module.exports = {
+  async set(key, value) {
+    const data = await shortterm.read();
+    data[key] = value;
+    await shortterm.write(data);
+    return { key, value };
+  },
+
+  async get(key) {
+    const data = await shortterm.read();
+    return data[key];
+  }
+};


### PR DESCRIPTION
## Summary
- add simple memory service wrapper
- add testMemory route to test setting and getting memory
- mount new route in legacy index.js
- run build and test scripts

## Testing
- `npm run build`
- `npx ts-node src/index.ts &`
- `./test-api-endpoints.sh`

------
https://chatgpt.com/codex/tasks/task_e_687fd8c4075883259218cdefe2a21055