### PR TITLE
Add task runner script for scheduled assistant calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@prisma/client": "^6.12.0",
+        "ajv": "^8.12.0",
         "axios": "^1.10.0",
         "body-parser": "^1.20.3",
         "cors": "^2.8.5",
@@ -819,6 +820,22 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -1317,6 +1334,28 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1654,6 +1693,12 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -2155,6 +2200,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "node-cron": "^4.2.1",
     "openai": "^5.10.1",
     "pg": "^8.16.3",
-    "prisma": "^6.12.0"
+    "prisma": "^6.12.0",
+    "ajv": "^8.12.0"
   },
   "devDependencies": {
     "@types/axios": "^0.9.36",

--- a/railway.json
+++ b/railway.json
@@ -21,5 +21,11 @@
         "PORT": "3000"
       }
     }
-  }
+  },
+  "crons": [
+    {
+      "schedule": "*/10 * * * *",
+      "command": "node task-runner.js"
+    }
+  ]
 }

--- a/schemas/gpt_shell_manager.json
+++ b/schemas/gpt_shell_manager.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GPT Shell Manager Command",
+  "type": "object",
+  "properties": {
+    "command": {
+      "type": "string",
+      "enum": ["push_update", "query_state", "fetch_fragment"]
+    },
+    "shell_id": { "type": "string" },
+    "target_pattern": { "type": "string" },
+    "constraints": { "type": "object" }
+  },
+  "required": ["command"],
+  "additionalProperties": false
+}

--- a/schemas/scoped_task_agent.json
+++ b/schemas/scoped_task_agent.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Scoped Task Agent Payload",
+  "type": "object",
+  "properties": {
+    "shell_id": { "type": "string" },
+    "target_pattern": { "type": "string" },
+    "constraints": { "type": "object" }
+  },
+  "required": ["shell_id"],
+  "additionalProperties": false
+}

--- a/task-runner.js
+++ b/task-runner.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const axios = require('axios');
+const OpenAI = require('openai');
+const Ajv = require('ajv');
+
+const ajv = new Ajv({ strict: true });
+
+function loadSchema(filename) {
+  const file = path.join(__dirname, 'schemas', filename);
+  return JSON.parse(fs.readFileSync(file, 'utf-8'));
+}
+
+const shellSchema = loadSchema('gpt_shell_manager.json');
+const agentSchema = loadSchema('scoped_task_agent.json');
+const validateShell = ajv.compile(shellSchema);
+const validateAgent = ajv.compile(agentSchema);
+
+if (!process.env.OPENAI_API_KEY) {
+  console.error('OPENAI_API_KEY environment variable is missing');
+  process.exit(1);
+}
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const OVERSEER_ID = process.env.OVERSEER_ID;
+const RUNTIME_COMPANION_ID = process.env.RUNTIME_COMPANION_ID;
+const LOG_WEBHOOK = process.env.LOG_WEBHOOK_URL;
+
+async function logSystem(data) {
+  if (LOG_WEBHOOK) {
+    try {
+      await axios.post(LOG_WEBHOOK, data);
+    } catch (err) {
+      console.error('Failed to send log webhook:', err.message);
+    }
+  } else {
+    console.log('[LOG]', JSON.stringify(data, null, 2));
+  }
+}
+
+async function triggerAssistant(id, command, payload, retries = 1) {
+  const thread = await openai.beta.threads.create();
+  await openai.beta.threads.messages.create(thread.id, {
+    role: 'user',
+    content: JSON.stringify({ command, payload }),
+  });
+  const run = await openai.beta.threads.runs.create(thread.id, {
+    assistant_id: id,
+  });
+  let status = 'queued';
+  while (status !== 'completed' && status !== 'failed') {
+    await new Promise((r) => setTimeout(r, 1000));
+    const rInfo = await openai.beta.threads.runs.retrieve(thread.id, run.id);
+    status = rInfo.status;
+  }
+  if (status === 'failed') {
+    if (retries > 0) {
+      await logSystem({ level: 'warn', message: 'Retrying assistant after failure' });
+      return triggerAssistant(id, command, payload, retries - 1);
+    }
+    throw new Error('Assistant run failed');
+  }
+  const messages = await openai.beta.threads.messages.list(thread.id);
+  const last = messages.data[messages.data.length - 1];
+  const result = last?.content?.[0]?.text?.value || '';
+  return result;
+}
+
+async function execute(command, payload) {
+  const assistant = command === 'runtime' ? RUNTIME_COMPANION_ID : OVERSEER_ID;
+  if (!assistant) throw new Error('Assistant ID not configured');
+  const response = await triggerAssistant(assistant, command, payload).catch(async (err) => {
+    await logSystem({ level: 'error', error: err.message });
+    if (assistant !== OVERSEER_ID && OVERSEER_ID) {
+      return triggerAssistant(OVERSEER_ID, command, payload);
+    }
+    throw err;
+  });
+  await logSystem({ level: 'info', response });
+  return response;
+}
+
+async function main() {
+  const [command = 'runtime', payloadArg] = process.argv.slice(2);
+  const payload = payloadArg ? JSON.parse(payloadArg) : {};
+  if (!validateShell({ command, ...payload }) || !validateAgent(payload)) {
+    console.error('Input failed validation');
+    process.exit(1);
+  }
+  try {
+    await execute(command, payload);
+  } catch (err) {
+    await logSystem({ level: 'error', error: err.message });
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { execute };


### PR DESCRIPTION
## Summary
- add GPT shell manager and scoped task agent schemas
- implement `task-runner.js` to run assistant commands
- install Ajv for JSON schema validation
- configure Railway cron to run the script every 10 minutes

## Testing
- `npm install`
- `npm run build`
- `node task-runner.js push_update '{"shell_id":"demo"}'` *(fails without `OPENAI_API_KEY`)*

------
https://chatgpt.com/codex/tasks/task_e_688054ac08fc8325925fd050d3fd2f97