### PR TITLE
Add system diagnostics endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import bodyParser from 'body-parser';
 import cors from 'cors';
 import router from './routes/index';
 import memoryRouter from './routes/memory';
+import systemRouter from './routes/system';
 import { databaseService } from './services/database';
 import { serverService } from './services/server';
 
@@ -268,6 +269,8 @@ app.use('/api', router);
 
 // Mount memory routes - Universal Memory Archetype
 app.use('/memory', memoryRouter);
+// Mount system diagnostics routes
+app.use('/system', systemRouter);
 
 // POST endpoint for natural language inputs with improved error handling
 app.post('/', async (req, res) => {

--- a/src/routes/system.ts
+++ b/src/routes/system.ts
@@ -1,0 +1,25 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/diagnostics', async (_req, res) => {
+  try {
+    const result = {
+      last_run: new Date().toISOString(),
+      status: 'healthy',
+      active_agents: ['ARCANOS Overseer', 'Runtime Companion'],
+      pending_tasks: 2,
+      errors: [] as string[],
+    };
+
+    res.json(result);
+  } catch (error: any) {
+    res.status(500).json({
+      status: 'error',
+      message: 'Diagnostics failed',
+      details: error.message,
+    });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add new `/system/diagnostics` route
- mount diagnostics router in server

## Testing
- `npm run build`
- `node dist/index.js &`
- `curl -s http://localhost:8080/system/diagnostics`


------
https://chatgpt.com/codex/tasks/task_e_68805c0a77bc8325a788dc7d30e568ea