### PR TITLE
Enable workers by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ DATABASE_URL=postgresql://arcanos:arcanos@localhost:5432/arcanos
 # For in-memory fallback: Comment out DATABASE_URL above
 
 # Worker Configuration
-RUN_WORKERS=false
+RUN_WORKERS=true
 SERVER_URL=http://localhost:8080
 
 # GPT API Access Token (for diagnostics endpoint)

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ The backend implements intelligent intent detection that routes requests to spec
 - `PORT` - Server port (default: 8080)
 - `OPENAI_API_KEY` - Your OpenAI API key
 - `FINE_TUNED_MODEL` - Your fine-tuned model name
-- `RUN_WORKERS` - Enable background workers (true/false)
+- `RUN_WORKERS` - Set to `true` to enable background workers and audit tasks
 - `SERVER_URL` - Server URL for health checks
 - `GPT_TOKEN` - Authorization token for GPT diagnostic access
 
@@ -280,7 +280,7 @@ npm start
 
 ### Diagnostic & Management
 - `POST /api/diagnostics` - Natural language system commands
-- `GET /api/workers/status` - Background process monitoring
+- `GET /api/workers/status` - Background process monitoring (verify workers after setting `RUN_WORKERS=true`)
 - `GET /api/containers/status` - Docker container management
 - `GET /api/canon/files` - Storyline file management
 


### PR DESCRIPTION
## Summary
- default `RUN_WORKERS=true` in `.env.example`
- clarify usage in README and point to `/api/workers/status`

## Testing
- `./test-api-endpoints.sh`

------
https://chatgpt.com/codex/tasks/task_e_68807a9921908325b6056de81a2709c5