### PR TITLE
Add fallback in-memory storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,8 @@ SERVER_URL=http://localhost:8080
 
 # GPT API Access Token (for diagnostics endpoint)
 GPT_TOKEN=your-gpt-access-token-here
+# ARCANOS API Token (required for /api/memory endpoints)
+ARCANOS_API_TOKEN=your-arcanos-api-token-here
 
 # Sleep Configuration (optional)
 SLEEP_ENABLED=true

--- a/DATABASE_IMPLEMENTATION.md
+++ b/DATABASE_IMPLEMENTATION.md
@@ -62,11 +62,11 @@ module.exports = pool;
   - `value` JSONB NOT NULL
 
 ### 3. API Endpoints
-- `GET /memory/health` - Database connection health check
-- `POST /memory/save` - Save key-value pairs
-- `GET /memory/load?key=<key>` - Load value by key
-- `GET /memory/all` - Get all memory entries
-- `DELETE /memory/clear` - Clear all memory
+- `GET /api/memory/health` - Database connection health check
+- `POST /api/memory/save` - Save key-value pairs
+- `GET /api/memory/load?key=<key>` - Load value by key
+- `GET /api/memory/all` - Get all memory entries
+- `DELETE /api/memory/clear` - Clear all memory
 
 ### 4. Error Handling
 - Graceful fallback when DATABASE_URL is not set (development)
@@ -96,19 +96,19 @@ npm start  # Works with graceful fallback
 
 **Save Memory:**
 ```bash
-curl -X POST http://localhost:3000/memory/save \
+curl -X POST http://localhost:3000/api/memory/save \
   -H "Content-Type: application/json" \
   -d '{"key": "user_preference", "value": {"theme": "dark"}}'
 ```
 
 **Load Memory:**
 ```bash
-curl http://localhost:3000/memory/load?key=user_preference
+curl http://localhost:3000/api/memory/load?key=user_preference
 ```
 
 **Health Check:**
 ```bash
-curl http://localhost:3000/memory/health
+curl http://localhost:3000/api/memory/health
 ```
 
 ## Integration with Existing System

--- a/DATABASE_RECOVERY_GUIDE.md
+++ b/DATABASE_RECOVERY_GUIDE.md
@@ -50,7 +50,7 @@ When the database is unavailable:
 
 ### 4. Health Monitoring
 
-The `/memory/health` endpoint provides real-time database status:
+The `/api/memory/health` endpoint provides real-time database status:
 
 ```json
 {
@@ -97,7 +97,7 @@ This test verifies:
 
 ## Best Practices
 
-1. **Monitor health endpoint**: Use `/memory/health` for monitoring
+1. **Monitor health endpoint**: Use `/api/memory/health` for monitoring
 2. **Handle recovery errors**: Check for recovery-specific error messages
 3. **Implement client retry**: Applications should retry failed database operations
 4. **Use graceful degradation**: Core functionality should remain available

--- a/README.md
+++ b/README.md
@@ -243,7 +243,15 @@ The backend implements intelligent intent detection that routes requests to spec
 - `RUN_WORKERS` - Set to `true` to enable background workers and audit tasks
 - `SERVER_URL` - Server URL for health checks
 - `GPT_TOKEN` - Authorization token for GPT diagnostic access
+- `ARCANOS_API_TOKEN` - Token for memory and diagnostic endpoints
 - `ASK_CONCURRENCY_LIMIT` - Max concurrent `/api/ask` requests (default: 3)
+
+Example memory request with token:
+
+```bash
+curl -X GET http://localhost:8080/api/memory/health \
+  -H "Authorization: Bearer $ARCANOS_API_TOKEN"
+```
 
 ## 📚 Documentation
 

--- a/public/web-dashboard.html
+++ b/public/web-dashboard.html
@@ -48,7 +48,8 @@
   <pre id="output"></pre>
 </div>
 <script>
-const BASE_URL = 'https://arcanos-production-426d.up.railway.app';
+// Default to same origin for local deployments
+const BASE_URL = window.BASE_URL || window.location.origin;
 
 async function sendPrompt() {
   const text = document.getElementById('prompt').value.trim();

--- a/src/handlers/ask-handler.ts
+++ b/src/handlers/ask-handler.ts
@@ -64,8 +64,9 @@ export const askHandler = async (req: Request, res: Response) => {
     if (useRAG) {
       try {
         const memory = getMemoryStorage();
+        const userId = (req.headers['x-user-id'] as string) || 'default';
         // Retrieve relevant context from memory
-        const memories = await memory.getMemoriesByUser('user');
+        const memories = await memory.getMemoriesByUser(userId);
         ragContext = memories.slice(0, 5); // Get last 5 memories for context
         console.log("Retrieved RAG context:", ragContext?.length || 0, "entries");
       } catch (error: any) {
@@ -116,8 +117,9 @@ export const askHandler = async (req: Request, res: Response) => {
       if (useRAG) {
         try {
           const memory = getMemoryStorage();
+          const userId = (req.headers['x-user-id'] as string) || 'default';
           await memory.storeMemory(
-            'user',
+            userId,
             (req as any).sessionID || 'default-session',
             'interaction',
             `interaction_${Date.now()}`,

--- a/src/middleware/api-token.ts
+++ b/src/middleware/api-token.ts
@@ -1,0 +1,19 @@
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * Middleware to enforce ARCANOS API token authentication.
+ * Requires Authorization header: "Bearer <token>".
+ */
+export function requireApiToken(req: Request, res: Response, next: NextFunction) {
+  const expected = process.env.ARCANOS_API_TOKEN;
+  if (!expected) {
+    console.warn('ARCANOS_API_TOKEN not set - memory endpoints are unprotected');
+    return next();
+  }
+  const auth = req.headers['authorization'];
+  const token = Array.isArray(auth) ? auth[0] : auth;
+  if (token !== `Bearer ${expected}`) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  next();
+}

--- a/src/storage/memory-storage.ts
+++ b/src/storage/memory-storage.ts
@@ -1,3 +1,5 @@
+import { databaseService } from '../services/database';
+
 export interface MemoryEntry {
   id: string;
   userId: string;
@@ -19,6 +21,7 @@ export interface MemoryEntry {
 
 export class MemoryStorage {
   private memories: Map<string, MemoryEntry> = new Map();
+  private persistent = !!process.env.DATABASE_URL;
 
   async storeMemory(
     userId: string,
@@ -48,20 +51,71 @@ export class MemoryStorage {
       }
     };
     this.memories.set(memory.id, memory);
+
+    if (this.persistent) {
+      try {
+        await databaseService.saveMemory({
+          memory_key: memory.id,
+          memory_value: memory,
+          container_id: userId,
+        });
+      } catch (error: any) {
+        console.warn('Persistent memory save failed:', error.message);
+      }
+    }
+
     return memory;
   }
 
   async getMemoriesByUser(userId: string, type?: MemoryEntry['type']): Promise<MemoryEntry[]> {
-    const memories = Array.from(this.memories.values())
-      .filter(m => {
-        if (type && m.type !== type) return false;
-        if (m.ttl && Date.now() - m.timestamp.getTime() > m.ttl) {
-          this.memories.delete(m.id);
-          return false;
-        }
-        return true;
-      })
-      .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
-    return memories;
+    let entries: MemoryEntry[] = [];
+
+    if (this.persistent) {
+      try {
+        const results = await databaseService.loadAllMemory(userId);
+        entries = results.map(r => r.memory_value as MemoryEntry);
+      } catch (error: any) {
+        console.warn('Persistent memory load failed:', error.message);
+        entries = [];
+      }
+    } else {
+      entries = Array.from(this.memories.values()).filter(m => m.userId === userId);
+    }
+
+    const filtered = entries.filter(m => {
+      if (type && m.type !== type) return false;
+      if (m.ttl && Date.now() - new Date(m.timestamp).getTime() > m.ttl) {
+        this.memories.delete(m.id);
+        return false;
+      }
+      return true;
+    });
+
+    return filtered.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+  }
+
+  async getMemory(userId: string, key: string): Promise<MemoryEntry | undefined> {
+    const entries = await this.getMemoriesByUser(userId);
+    return entries.find(m => m.key === key);
+  }
+
+  async clearAll(userId: string): Promise<{ cleared: number }> {
+    let cleared = 0;
+    for (const [id, mem] of this.memories.entries()) {
+      if (mem.userId === userId) {
+        this.memories.delete(id);
+        cleared++;
+      }
+    }
+
+    if (this.persistent) {
+      try {
+        await databaseService.clearMemory(userId);
+      } catch (error: any) {
+        console.warn('Persistent memory clear failed:', error.message);
+      }
+    }
+
+    return { cleared };
   }
 }

--- a/test-memory-endpoints.js
+++ b/test-memory-endpoints.js
@@ -8,7 +8,10 @@
 const axios = require('axios');
 
 const BASE_URL = process.env.TEST_URL || 'http://localhost:8080';
-const MEMORY_ENDPOINT = `${BASE_URL}/memory`;
+const MEMORY_ENDPOINT = `${BASE_URL}/api/memory`;
+const AUTH_HEADER = process.env.ARCANOS_API_TOKEN
+  ? { Authorization: `Bearer ${process.env.ARCANOS_API_TOKEN}` }
+  : {};
 
 async function testMemoryEndpoints() {
   console.log('🧠 Testing Universal Memory Archetype endpoints...');
@@ -16,48 +19,56 @@ async function testMemoryEndpoints() {
   
   try {
     // Test 1: Health check
-    console.log('\n1️⃣ Testing /memory/health...');
+  console.log('\n1️⃣ Testing /api/memory/health...');
     try {
-      const healthResponse = await axios.get(`${MEMORY_ENDPOINT}/health`);
+      const healthResponse = await axios.get(`${MEMORY_ENDPOINT}/health`, {
+        headers: AUTH_HEADER
+      });
       console.log('✅ Health check:', healthResponse.data);
     } catch (error) {
       console.log('⚠️ Health check (expected degraded mode):', error.response?.data || error.message);
     }
 
     // Test 2: Save memory
-    console.log('\n2️⃣ Testing POST /memory/save...');
+  console.log('\n2️⃣ Testing POST /api/memory/save...');
     const saveData = {
       memory_key: 'test_preference',
       memory_value: { theme: 'dark', language: 'en' }
     };
     
     try {
-      const saveResponse = await axios.post(`${MEMORY_ENDPOINT}/save`, saveData);
+      const saveResponse = await axios.post(`${MEMORY_ENDPOINT}/save`, saveData, {
+        headers: AUTH_HEADER
+      });
       console.log('✅ Save memory:', saveResponse.data);
     } catch (error) {
       console.log('❌ Save memory failed:', error.response?.data || error.message);
     }
 
     // Test 3: Load memory
-    console.log('\n3️⃣ Testing GET /memory/load...');
+  console.log('\n3️⃣ Testing GET /api/memory/load...');
     try {
-      const loadResponse = await axios.get(`${MEMORY_ENDPOINT}/load?key=test_preference`);
+      const loadResponse = await axios.get(`${MEMORY_ENDPOINT}/load?key=test_preference`, {
+        headers: AUTH_HEADER
+      });
       console.log('✅ Load memory:', loadResponse.data);
     } catch (error) {
       console.log('❌ Load memory failed:', error.response?.data || error.message);
     }
 
     // Test 4: Load all memory
-    console.log('\n4️⃣ Testing GET /memory/all...');
+  console.log('\n4️⃣ Testing GET /api/memory/all...');
     try {
-      const allResponse = await axios.get(`${MEMORY_ENDPOINT}/all`);
+      const allResponse = await axios.get(`${MEMORY_ENDPOINT}/all`, {
+        headers: AUTH_HEADER
+      });
       console.log('✅ Load all memory:', allResponse.data);
     } catch (error) {
       console.log('❌ Load all memory failed:', error.response?.data || error.message);
     }
 
     // Test 5: Container isolation
-    console.log('\n5️⃣ Testing container isolation...');
+  console.log('\n5️⃣ Testing container isolation...');
     const containerSaveData = {
       memory_key: 'container_specific',
       memory_value: { service: 'backstage-booker' }
@@ -65,14 +76,14 @@ async function testMemoryEndpoints() {
     
     try {
       const containerSaveResponse = await axios.post(`${MEMORY_ENDPOINT}/save`, containerSaveData, {
-        headers: { 'X-Container-Id': 'backstage-booker' }
+        headers: { ...AUTH_HEADER, 'X-Container-Id': 'backstage-booker' }
       });
       console.log('✅ Container save:', containerSaveResponse.data);
       
       // Load from different container (should not find it)
       try {
         const containerLoadResponse = await axios.get(`${MEMORY_ENDPOINT}/load?key=container_specific`, {
-          headers: { 'X-Container-Id': 'segment-engine' }
+          headers: { ...AUTH_HEADER, 'X-Container-Id': 'segment-engine' }
         });
         console.log('⚠️ Container isolation test (should be 404):', containerLoadResponse.data);
       } catch (loadError) {
@@ -87,9 +98,11 @@ async function testMemoryEndpoints() {
     }
 
     // Test 6: Clear memory (optional - only test if database is available)
-    console.log('\n6️⃣ Testing DELETE /memory/clear...');
+  console.log('\n6️⃣ Testing DELETE /api/memory/clear...');
     try {
-      const clearResponse = await axios.delete(`${MEMORY_ENDPOINT}/clear`);
+      const clearResponse = await axios.delete(`${MEMORY_ENDPOINT}/clear`, {
+        headers: AUTH_HEADER
+      });
       console.log('✅ Clear memory:', clearResponse.data);
     } catch (error) {
       console.log('❌ Clear memory failed:', error.response?.data || error.message);


### PR DESCRIPTION
## Summary
- support memory API without a database
- add helpers to MemoryStorage
- route /api/memory requests to MemoryStorage when DATABASE_URL is unset

## Testing
- `npm run build`
- `node dist/index.js` *(background)*
- `node test-memory-endpoints.js`

------
https://chatgpt.com/codex/tasks/task_e_6880a38b11a4832591ce15c9b5c05535