### PR TITLE
Implement thread retrieval endpoint

### DIFF
--- a/src/routes/memory.ts
+++ b/src/routes/memory.ts
@@ -134,6 +134,35 @@ router.get('/all', async (req: Request, res: Response) => {
   }
 });
 
+// GET /memory/thread/:id - Retrieve a memory thread by id
+router.get('/thread/:id', async (req: Request, res: Response) => {
+  try {
+    const id = req.params.id;
+    const container_id = getContainerId(req);
+
+    if (!id) {
+      return res.status(400).json({ error: 'id parameter is required' });
+    }
+
+    const result = useDatabase
+      ? await databaseService.loadMemory({ memory_key: id, container_id })
+      : await fallbackMemory.getMemoryById(id);
+
+    if (!result) {
+      return res.status(404).json({ error: 'Thread not found', id });
+    }
+
+    const thread = useDatabase
+      ? (result as any).memory_value
+      : result;
+
+    res.status(200).json(thread);
+  } catch (error: any) {
+    console.error('❌ Error loading thread:', error);
+    res.status(500).json({ error: 'Failed to load thread', details: error.message });
+  }
+});
+
 // DELETE /memory/clear - Clear/reset all memory for container
 router.delete('/clear', async (req: Request, res: Response) => {
   try {

--- a/src/storage/memory-storage.ts
+++ b/src/storage/memory-storage.ts
@@ -99,6 +99,19 @@ export class MemoryStorage {
     return entries.find(m => m.key === key);
   }
 
+  async getMemoryById(id: string): Promise<MemoryEntry | undefined> {
+    if (this.persistent) {
+      try {
+        const result = await databaseService.loadMemory({ memory_key: id });
+        return result ? (result.memory_value as MemoryEntry) : undefined;
+      } catch (error: any) {
+        console.warn('Persistent memory load by id failed:', error.message);
+        return undefined;
+      }
+    }
+    return this.memories.get(id);
+  }
+
   async clearAll(userId: string): Promise<{ cleared: number }> {
     let cleared = 0;
     for (const [id, mem] of this.memories.entries()) {


### PR DESCRIPTION
## Summary
- support retrieving a memory thread by id
- expose new `/api/memory/thread/:id` route
- add helper to `MemoryStorage` for id lookup

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6881348a98048325821c03e4c24c6586