### PR TITLE
Fix thread retrieval response

### DIFF
--- a/src/routes/memory.ts
+++ b/src/routes/memory.ts
@@ -156,7 +156,11 @@ router.get('/thread/:id', async (req: Request, res: Response) => {
       ? (result as any).memory_value
       : result;
 
-    res.status(200).json(thread);
+    if (!thread || (typeof thread === 'object' && Object.keys(thread).length === 0)) {
+      return res.status(404).json({ error: 'Thread not found', id });
+    }
+
+    return res.status(200).json(thread);
   } catch (error: any) {
     console.error('❌ Error loading thread:', error);
     res.status(500).json({ error: 'Failed to load thread', details: error.message });


### PR DESCRIPTION
## Summary
- ensure `/memory/thread/:id` returns 404 when result or thread is missing
- return 200 with thread payload otherwise

## Testing
- `npm run build`
- `node validate-requirements.js`
- `node testStatus.js` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68813dc4ef708325bb973190eb339989