### PR TITLE
Handle RUN_WORKERS boolean values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,9 @@ DATABASE_URL=postgresql://arcanos:arcanos@localhost:5432/arcanos
 # For in-memory fallback: Comment out DATABASE_URL above
 
 # Worker Configuration
-RUN_WORKERS=true
+# Set to 'true' or '1' to enable background workers.
+# Use 'false' to run only the API server (recommended for simple memory backends)
+RUN_WORKERS=false
 SERVER_URL=http://localhost:8080
 
 # GPT API Access Token (for diagnostics endpoint)

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ The backend implements intelligent intent detection that routes requests to spec
 - `DATABASE_URL` - PostgreSQL connection string (optional, uses in-memory fallback if not set)
 
 ### Worker Configuration
-- `RUN_WORKERS` - Set to `true` to enable background workers and audit tasks (default: false)
+- `RUN_WORKERS` - Set to `true` (or `1`) to enable background workers. Use `false` (default) if you only need the memory API and want the server to keep running without background jobs.
 - `SERVER_URL` - Server URL for health checks (default: http://localhost:8080)
 
 ### Optional Configuration
@@ -319,6 +319,18 @@ npm start
 - `./continue_finetune.sh [file-id] [model]` - Start fine-tuning jobs
 - `./track_job.sh [--follow]` - Monitor training progress
 - `./test-finetune-pipeline.sh` - Test pipeline components
+
+### Railway Deployment (Memory Only)
+If you just need the memory API, set `RUN_WORKERS=false` in your `.env` file. The server
+will start an Express app on `process.env.PORT || 8080` and keep itself alive with a
+minimal interval so Railway doesn't terminate the container. Run:
+
+```bash
+npm run build
+npm start
+# test the health endpoint
+curl $PORT/api/memory/health
+```
 
 ## Project Structure
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,12 +28,13 @@ import './services/database-connection';
 
 // Import worker initialization module (will run conditionally)
 import './worker-init';
+import { isTrue } from './utils/env';
 
 // Load environment variables
 dotenv.config();
 
 // Boot additional background workers if enabled
-if (process.env.RUN_WORKERS === 'true') {
+if (isTrue(process.env.RUN_WORKERS)) {
   require('../workers/index');
 }
 
@@ -532,6 +533,11 @@ serverService.start(app, PORT).then(async () => {
   bootstrapWorkers().catch(err => {
     console.error('[BOOT] Bootstrap sequence failed:', err.message);
   });
+
+  if (!isTrue(process.env.RUN_WORKERS)) {
+    console.log('[SERVER] RUN_WORKERS not enabled - keeping process alive');
+    setInterval(() => {}, 1 << 30); // Prevent Node from exiting
+  }
 });
 
 // --- RAILWAY SERVICE CONFIG VALIDATION ✅ ---

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,4 @@
+export function isTrue(value: string | undefined): boolean {
+  if (!value) return false;
+  return value === '1' || value.toLowerCase() === 'true';
+}

--- a/src/worker-init.ts
+++ b/src/worker-init.ts
@@ -1,5 +1,6 @@
 // Worker initialization module - conditionally starts workers based on RUN_WORKERS environment variable
 import { workerStatusService } from './services/worker-status';
+import { isTrue } from './utils/env';
 
 function startWorkers() {
   // Import and start the cron worker service
@@ -13,7 +14,7 @@ workerStatusService.initializeSystemWorkers();
 console.log('[WORKER-INIT] System workers initialized for status tracking');
 
 // Conditional worker startup based on environment variable
-if (process.env.RUN_WORKERS === 'true') {
+if (isTrue(process.env.RUN_WORKERS)) {
   startWorkers(); // Your worker orchestration entry
 } else {
   console.log('[WORKER-INIT] Workers disabled (RUN_WORKERS not set to true)');


### PR DESCRIPTION
## Summary
- allow `RUN_WORKERS=1` or `RUN_WORKERS=TRUE` to enable workers
- keep signal handling and keep-alive logic but use helper `isTrue`
- document new env behavior
- add Railway deployment notes and default `RUN_WORKERS=false`

## Testing
- `npm run build`
- `node dist/index.js` *(terminated after start)*

------
https://chatgpt.com/codex/tasks/task_e_688143c261b48325933ed94d2f10cf59