### PR TITLE
Simplify entrypoint

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+PORT=8080
+RUN_WORKERS=true
+

--- a/index.js
+++ b/index.js
@@ -1,51 +1,12 @@
 const express = require('express');
-const path = require('path');
 const app = express();
-const statusRoute = require('./routes/status');
-const memoryRoute = require('./routes/memory');
-const testMemoryRoute = require('./routes/testMemory');
-const snapshotRoute = require('./routes/memorySnapshots');
-const systemRoute = require('./routes/system');
+const PORT = process.env.PORT || 8080;
 
-// Initialize database connection and memory table
-require('./services/database-connection');
+// Your routes and memory handlers go here
+app.get('/', (req, res) => res.send('ARCANOS backend running'));
+app.use('/api/memory', require('./routes/memory')); // Example
 
-// Serve static dashboard assets
-app.use(express.static(path.join(__dirname, 'public')));
-
-app.use('/status', statusRoute);
-app.use('/memory', memoryRoute);
-app.use('/api', testMemoryRoute);
-app.use('/api/memory/snapshots', snapshotRoute);
-app.use('/system', systemRoute);
-
-// Prisma example connection (as specified in problem statement)
-const { PrismaClient } = require('@prisma/client');
-const prisma = new PrismaClient();
-
-async function examplePrismaUsage() {
-  try {
-    const users = await prisma.user.findMany();
-    console.log('Users from Prisma:', users);
-  } catch (error) {
-    console.log('Prisma connection info: Database connection will be established when DATABASE_URL points to active PostgreSQL instance');
-  }
-}
-
-// Run Prisma example on startup
-examplePrismaUsage();
-
-// Global error catcher
-const { logError } = require('./utils/logger');
-app.use((err, req, res, next) => {
-  logError(err);
-  res.status(500).json({ error: 'Internal server error' });
+// Prevent shutdown: Start persistent listener
+app.listen(PORT, () => {
+  console.log(`✅ Server listening on port ${PORT}`);
 });
-
-// Root dashboard route
-app.get('/', (_req, res) => {
-  res.sendFile(path.join(__dirname, 'public', 'index.html'));
-});
-
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => console.log(`✅ Server live on port ${PORT}`));


### PR DESCRIPTION
## Summary
- simplify `index.js` to use a minimal express server
- add `.env` with default port and worker settings

## Testing
- `node validate-requirements.js`

------
https://chatgpt.com/codex/tasks/task_e_688151b929008325923fd90fa0fe54c3