### PR TITLE
Fix worker path in build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN npm ci --only=production && npm cache clean --force
 
 # Copy source code
 COPY src/ ./src/
+COPY workers/ ./workers/
 COPY sql/ ./sql/
 COPY tsconfig.json ./
 
@@ -20,7 +21,7 @@ COPY tsconfig.json ./
 RUN npm ci
 
 # Build the application
-RUN npm run build
+RUN npm run build && cp -R workers dist/
 
 # Production stage
 FROM node:18-alpine AS production

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ dotenv.config();
 
 // Boot additional background workers if enabled
 if (isTrue(process.env.RUN_WORKERS)) {
-  require('../workers/index');
+  require('./workers/index');
 }
 
 // 1. VERIFY: Environment variable loading


### PR DESCRIPTION
## Summary
- ensure workers are copied in Docker build
- adjust worker import path to match build output

## Testing
- `node verify-railway.js`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68815e6d63c08325bb7cc82056bf72b1