### PR TITLE
Fix dist worker imports and build setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN npm ci --only=production && npm cache clean --force
 # Copy source code
 COPY src/ ./src/
 COPY workers/ ./workers/
+COPY memory/ ./memory/
 COPY sql/ ./sql/
 COPY tsconfig.json ./
 
@@ -21,7 +22,7 @@ COPY tsconfig.json ./
 RUN npm ci
 
 # Build the application
-RUN npm run build && cp -R workers dist/
+RUN npm run build
 
 # Production stage
 FROM node:18-alpine AS production
@@ -45,6 +46,8 @@ RUN npm ci --only=production && npm cache clean --force
 # Copy built application from builder stage
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/sql ./sql
+COPY workers ./dist/workers
+COPY memory ./dist/memory
 
 # Change ownership to non-root user
 RUN chown -R arcanos:nodejs /app

--- a/dist/workers/clearTemp.js
+++ b/dist/workers/clearTemp.js
@@ -1,0 +1,6 @@
+const clearCache = require('./memory/actions/clearCache');
+
+module.exports = async function clearTemp() {
+  clearCache();
+  console.log('[CACHE CLEANER] Shortterm memory flushed');
+};

--- a/dist/workers/goalWatcher.js
+++ b/dist/workers/goalWatcher.js
@@ -1,0 +1,7 @@
+const goals = require('./memory/modules/goals');
+
+module.exports = async function goalWatcher() {
+  const list = goals.read();
+  const pending = list.filter(g => !g.completed);
+  console.log(`[GOAL WATCHER] ${pending.length} goals active`);
+};

--- a/dist/workers/memorySync.js
+++ b/dist/workers/memorySync.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const path = require('path');
+const shortterm = require('./memory/modules/shortterm');
+
+module.exports = async function memorySync() {
+  const state = shortterm.read();
+  const snapshotPath = path.join(__dirname, './memory/state/cache.snapshot.json');
+  fs.writeFileSync(snapshotPath, JSON.stringify(state, null, 2));
+  console.log('[MEMORY SYNC] Saved snapshot at', new Date().toISOString());
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "npm": ">=8.0.0"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp -r workers dist/workers && cp -r memory dist/memory",
     "start": "node --max-old-space-size=7168 dist/index.js",
     "start:railway": "node --max-old-space-size=7168 dist/index.js",
     "dev": "node --max-old-space-size=7168 -r ts-node/register src/index.ts",


### PR DESCRIPTION
## Summary
- copy workers and memory folders during build
- ensure Docker build uses new folders
- adjust compiled worker paths in `dist` for memory imports

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688168a9ba448325a44e8aa078951bf9