### PR TITLE
Fix goalWatcher array handling

### DIFF
--- a/dist/workers/goalWatcher.js
+++ b/dist/workers/goalWatcher.js
@@ -2,7 +2,21 @@ const path = require('path');
 const goals = require(path.resolve(__dirname, '../memory/modules/goals'));
 
 module.exports = async function goalWatcher() {
-  const list = goals.read();
-  const pending = list.filter(g => !g.completed);
+  let list;
+  try {
+    list = await goals.read();
+    console.log('[GOAL WATCHER] list value:', list);
+  } catch (err) {
+    console.error('[GOAL WATCHER] Failed to read goals:', err);
+    list = [];
+  }
+
+  let pending = [];
+  if (Array.isArray(list)) {
+    pending = list.filter(g => g && !g.completed);
+  } else {
+    console.warn('[GOAL WATCHER] goal list is not an array; skipping filter');
+  }
+
   console.log(`[GOAL WATCHER] ${pending.length} goals active`);
 };

--- a/workers/goalWatcher.js
+++ b/workers/goalWatcher.js
@@ -2,7 +2,21 @@ const path = require('path');
 const goals = require(path.resolve(__dirname, '../memory/modules/goals'));
 
 module.exports = async function goalWatcher() {
-  const list = goals.read();
-  const pending = list.filter(g => !g.completed);
+  let list;
+  try {
+    list = await goals.read();
+    console.log('[GOAL WATCHER] list value:', list);
+  } catch (err) {
+    console.error('[GOAL WATCHER] Failed to read goals:', err);
+    list = [];
+  }
+
+  let pending = [];
+  if (Array.isArray(list)) {
+    pending = list.filter(g => g && !g.completed);
+  } else {
+    console.warn('[GOAL WATCHER] goal list is not an array; skipping filter');
+  }
+
   console.log(`[GOAL WATCHER] ${pending.length} goals active`);
 };


### PR DESCRIPTION
## Summary
- fix goalWatcher to await goals.read()
- guard against invalid return values
- log what happens when list isn't an array

## Testing
- `node -e "require('./workers/goalWatcher')()"`
- `npm run build` *(fails: Cannot find module 'axios' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6881738dd7c48325961c12a5e5e86490