### PR TITLE
Add thread storage and saveThread action

### DIFF
--- a/examples/save-thread.js
+++ b/examples/save-thread.js
@@ -1,0 +1,16 @@
+const memory = require('../memory/kernel');
+
+async function main() {
+  const result = await memory.dispatch('saveThread', {
+    id: 'thread-test-save',
+    tags: ['test', 'save'],
+    state: {
+      goals: ['Test memory write'],
+      context: 'This is a test save operation from the goalWatcher console.',
+      log: [{ role: 'user', content: 'Did this save?' }]
+    }
+  });
+  console.log(result);
+}
+
+main();

--- a/memory/actions/saveThread.js
+++ b/memory/actions/saveThread.js
@@ -1,0 +1,9 @@
+const threads = require('../modules/threads');
+
+module.exports = async function saveThread({ id, tags = [], state = {} }) {
+  if (!id) {
+    return { error: 'id is required' };
+  }
+  const thread = { id, tags, state, timestamp: new Date().toISOString() };
+  return threads.save(id, thread);
+};

--- a/memory/kernel.js
+++ b/memory/kernel.js
@@ -4,6 +4,7 @@ const modules = {
   identity: require('./modules/identity'),
   goals: require('./modules/goals'),
   emotions: require('./modules/emotions'),
+  threads: require('./modules/threads'),
 };
 
 const actions = {
@@ -12,6 +13,7 @@ const actions = {
   hydrateState: require('./actions/hydrateState'),
   bootstrap: require('./actions/bootstrapMemory'),
   sync: require('./actions/syncToPostgres'),
+  saveThread: require('./actions/saveThread'),
 };
 
 async function dispatch(command, payload = {}) {

--- a/memory/modules/threads.js
+++ b/memory/modules/threads.js
@@ -1,0 +1,21 @@
+const shortterm = require('./shortterm');
+const { logEvent } = require('../logEvent');
+
+module.exports = {
+  async read() {
+    const data = await shortterm.read();
+    return data.threads || {};
+  },
+  async write(threads) {
+    const data = await shortterm.read();
+    data.threads = threads;
+    await shortterm.write(data);
+    await logEvent('threads');
+  },
+  async save(id, thread) {
+    const threads = await this.read();
+    threads[id] = thread;
+    await this.write(threads);
+    return { saved: true, id };
+  },
+};


### PR DESCRIPTION
## Summary
- support storing memory threads
- add saveThread action for memory kernel
- document usage with a save-thread example

## Testing
- `npm run build`
- `node examples/save-thread.js`

------
https://chatgpt.com/codex/tasks/task_e_688185a5142083259c6c64dd684512d5