### PR TITLE
Add memory audit worker

### DIFF
--- a/dist/workers/index.js
+++ b/dist/workers/index.js
@@ -3,6 +3,7 @@ const jobs = [
   require(path.resolve(__dirname, './memorySync')),
   require(path.resolve(__dirname, './goalWatcher')),
   require(path.resolve(__dirname, './clearTemp')),
+  require(path.resolve(__dirname, './memoryAudit')),
 ];
 
 console.log('[WORKERS] Booting background task loop');

--- a/dist/workers/memoryAudit.js
+++ b/dist/workers/memoryAudit.js
@@ -1,0 +1,24 @@
+const path = require('path');
+const memory = require(path.resolve(__dirname, '../../services/memory'));
+
+module.exports = async function memoryAudit() {
+  const threadId = 'thread-test-save-audit';
+  const entry = {
+    context: 'Memory audit context check',
+    log: [
+      {
+        role: 'user',
+        content: 'Sample message for audit verification'
+      }
+    ],
+    timestamp: new Date().toISOString()
+  };
+
+  try {
+    await memory.set(threadId, entry);
+    const result = await memory.get(threadId);
+    console.log('[MEMORY AUDIT] Recalled:', result);
+  } catch (err) {
+    console.error('[MEMORY AUDIT] Error:', err.message);
+  }
+};

--- a/workers/index.js
+++ b/workers/index.js
@@ -3,6 +3,7 @@ const jobs = [
   require(path.resolve(__dirname, './memorySync')),
   require(path.resolve(__dirname, './goalWatcher')),
   require(path.resolve(__dirname, './clearTemp')),
+  require(path.resolve(__dirname, './memoryAudit')),
 ];
 
 console.log('[WORKERS] Booting background task loop');

--- a/workers/memoryAudit.js
+++ b/workers/memoryAudit.js
@@ -1,0 +1,24 @@
+const path = require('path');
+const memory = require(path.resolve(__dirname, '../../services/memory'));
+
+module.exports = async function memoryAudit() {
+  const threadId = 'thread-test-save-audit';
+  const entry = {
+    context: 'Memory audit context check',
+    log: [
+      {
+        role: 'user',
+        content: 'Sample message for audit verification'
+      }
+    ],
+    timestamp: new Date().toISOString()
+  };
+
+  try {
+    await memory.set(threadId, entry);
+    const result = await memory.get(threadId);
+    console.log('[MEMORY AUDIT] Recalled:', result);
+  } catch (err) {
+    console.error('[MEMORY AUDIT] Error:', err.message);
+  }
+};


### PR DESCRIPTION
## Summary
- implement `memoryAudit` worker to verify shortterm memory
- wire worker into background job list
- include built artifacts for deployment

## Testing
- `node validate-requirements.js`
- `node -e "const w=require('./dist/workers/memoryAudit');w();"`

------
https://chatgpt.com/codex/tasks/task_e_68818736493883259fff31e790527ada