### PR TITLE
Implement worker dispatch flow

### DIFF
--- a/api/worker/dispatch.js
+++ b/api/worker/dispatch.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const cors = require('cors');
+
+const router = express.Router();
+router.use(cors());
+router.use(express.json());
+
+router.post('/', async (req, res) => {
+  const { type, payload } = req.body || {};
+  if (!type) return res.status(400).json({ ok: false, error: 'type required' });
+  try {
+    const worker = require(`../../workers/${type}.js`);
+    const result = await worker(payload);
+    res.json({ ok: true, result });
+  } catch (err) {
+    console.error('Worker dispatch error:', err);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,8 @@ import './services/database-connection';
 // Import worker initialization module (will run conditionally)
 import './worker-init';
 import { isTrue } from './utils/env';
+// Frontend-triggered worker dispatch route
+const workerDispatch = require('../api/worker/dispatch');
 
 // Load environment variables
 dotenv.config();
@@ -271,6 +273,9 @@ app.get('/', (_req, res) => {
 
 // Mount core logic or routes here
 app.use('/api', router);
+
+// Dispatch tasks to dynamic workers
+app.use('/api/worker/dispatch', workerDispatch);
 
 // Mount memory routes - protected by ARCANOS_API_TOKEN
 // Expose memory routes under /api/memory to match documentation

--- a/test-api-endpoints.sh
+++ b/test-api-endpoints.sh
@@ -10,6 +10,18 @@ echo ""
 
 BASE_URL="http://localhost:8080"
 
+# Build and start the API server in the background
+npm run build > /tmp/build.log 2>&1
+node dist/index.js > /tmp/server.log 2>&1 &
+SERVER_PID=$!
+# Wait for server to be ready
+for i in {1..30}; do
+  if curl -s "$BASE_URL/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -89,6 +101,11 @@ test_endpoint "Ask with Fallback (Error Test)" "POST" "/api/ask-with-fallback" '
 
 # Test 12: Sleep Configuration
 test_endpoint "Sleep Configuration" "GET" "/api/config/sleep" ""
+
+# Test 13: Worker Dispatch
+test_endpoint "Worker Dispatch" "POST" "/api/worker/dispatch" '{"type":"fineTuneProcessor","payload":{"type":"audit","payload":"const x = y + 1;"}}'
+
+kill $SERVER_PID
 
 echo "=================================================="
 echo "                 Test Summary"

--- a/workers/fineTuneProcessor.js
+++ b/workers/fineTuneProcessor.js
@@ -1,0 +1,36 @@
+const OpenAI = require('openai');
+
+module.exports = async function fineTuneProcessor(task) {
+  if (!task || typeof task !== 'object') throw new Error('Task object required');
+  const { type, payload, taskId } = task;
+  if (!type || typeof payload === 'undefined') {
+    throw new Error('Invalid task format');
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  const model = process.env.FINE_TUNED_MODEL;
+  if (!apiKey || !model) {
+    throw new Error('Missing OpenAI configuration');
+  }
+
+  const promptMap = {
+    audit: (p) => `Audit the following code and describe any issues:\n\n${p}`,
+    score: (p) => `Provide a score from 1-10 for the following content:\n\n${p}`,
+    summarize: (p) => `Summarize the following text:\n\n${p}`,
+  };
+
+  const builder = promptMap[type];
+  if (!builder) throw new Error(`Unsupported task type: ${type}`);
+  const prompt = builder(payload);
+
+  const client = new OpenAI({ apiKey });
+  const completion = await client.chat.completions.create({
+    model,
+    messages: [{ role: 'user', content: prompt }],
+    max_tokens: 1000,
+    temperature: 0.3,
+  });
+
+  const output = completion.choices?.[0]?.message?.content?.trim() || '';
+  return { taskId: taskId || null, output };
+};


### PR DESCRIPTION
## Summary
- add `fineTuneProcessor` worker for on-demand task execution
- provide `/api/worker/dispatch` router to run workers
- expose the dispatch route from server
- update API test script to start the server and hit the new endpoint

## Testing
- `npm run build`
- `./test-api-endpoints.sh` *(fails for endpoints requiring API keys)*

------
https://chatgpt.com/codex/tasks/task_e_6881a81ee7788325b5f058c56beeaa6e