### PR TITLE
Fix worker dispatch build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "npm": ">=8.0.0"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc && mkdir -p dist && cp -r workers dist && cp -r memory dist",
+    "build": "rm -rf dist && tsc && mkdir -p dist && cp -r workers dist && cp -r memory dist && cp -r api dist",
     "start": "node --max-old-space-size=7168 dist/index.js",
     "start:railway": "node --max-old-space-size=7168 dist/index.js",
     "dev": "node --max-old-space-size=7168 -r ts-node/register src/index.ts",


### PR DESCRIPTION
## Summary
- copy `api` folder into `dist` on build so `src/index.ts` can require the worker dispatcher

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6881ad3ea014832598ad106ccccb4b33