### PR TITLE
Fix worker dispatch path

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "npm": ">=8.0.0"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc && mkdir -p dist && cp -r workers dist && cp -r memory dist",
+    "build": "rm -rf dist && tsc && mkdir -p dist && cp -r workers dist && cp -r memory dist && cp -r api dist",
     "start": "node --max-old-space-size=7168 dist/index.js",
     "start:railway": "node --max-old-space-size=7168 dist/index.js",
     "dev": "node --max-old-space-size=7168 -r ts-node/register src/index.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,9 @@ import './services/database-connection';
 import './worker-init';
 import { isTrue } from './utils/env';
 // Frontend-triggered worker dispatch route
-const workerDispatch = require('../api/worker/dispatch');
+// Use a path relative to the compiled "dist" directory so the API folder can be
+// packaged with the build output.
+const workerDispatch = require('./api/worker/dispatch');
 
 // Load environment variables
 dotenv.config();


### PR DESCRIPTION
## Summary
- require worker dispatch using a path that survives packaging
- ensure `npm run build` succeeds

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6881ad3ea014832598ad106ccccb4b33