### PR TITLE
Fix worker dispatch load path for Railway

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "npm": ">=8.0.0"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc && mkdir -p dist && cp -r workers dist && cp -r memory dist",
+    "build": "rm -rf dist && tsc && mkdir -p dist && cp -r workers dist && cp -r memory dist && cp -r api dist",
     "start": "node --max-old-space-size=7168 dist/index.js",
     "start:railway": "node --max-old-space-size=7168 dist/index.js",
     "dev": "node --max-old-space-size=7168 -r ts-node/register src/index.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,8 +29,14 @@ import './services/database-connection';
 // Import worker initialization module (will run conditionally)
 import './worker-init';
 import { isTrue } from './utils/env';
-// Frontend-triggered worker dispatch route
-const workerDispatch = require('../api/worker/dispatch');
+
+// Frontend-triggered worker dispatch route. We check both possible locations so
+// the import works when running the TypeScript sources directly and after
+// compilation in the dist folder.
+const builtPath = path.join(__dirname, 'api', 'worker', 'dispatch.js');
+const sourcePath = path.join(__dirname, '..', 'api', 'worker', 'dispatch.js');
+const dispatchModule = fs.existsSync(builtPath) ? builtPath : sourcePath;
+const workerDispatch = require(dispatchModule);
 
 // Load environment variables
 dotenv.config();


### PR DESCRIPTION
## Summary
- adjust backend entrypoint to locate `api/worker/dispatch` from either the build output or source tree

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6881ad3ea014832598ad106ccccb4b33