### PR TITLE
Fix worker dispatch load path for Railway

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "npm": ">=8.0.0"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc && mkdir -p dist && cp -r workers dist && cp -r memory dist",
+    "build": "rm -rf dist && tsc && mkdir -p dist && cp -r workers dist && cp -r memory dist && cp -r api dist",
     "start": "node --max-old-space-size=7168 dist/index.js",
     "start:railway": "node --max-old-space-size=7168 dist/index.js",
     "dev": "node --max-old-space-size=7168 -r ts-node/register src/index.ts",

--- a/services/workerOps.js
+++ b/services/workerOps.js
@@ -1,0 +1,19 @@
+async function auditBackend(data) {
+  console.log('[AUDIT BACKEND]', data);
+  return { status: 'ok', action: 'audit', data };
+}
+
+async function processTask(data) {
+  console.log('[PROCESS TASK]', data);
+  return { status: 'ok', action: 'process', data };
+}
+
+async function logHealth() {
+  return { status: 'ok', timestamp: new Date().toISOString() };
+}
+
+module.exports = {
+  auditBackend,
+  processTask,
+  logHealth,
+};


### PR DESCRIPTION
## Summary
- adjust backend entrypoint to locate `api/worker/dispatch` from either the build output or source tree
- add new `workerOps` service and dispatch logic for handling audit/process/health tasks
- support using the dispatch module as either a router or function

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6881ad3ea014832598ad106ccccb4b33