### PR TITLE
Fix worker dispatch load path for Railway

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "npm": ">=8.0.0"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc && mkdir -p dist && cp -r workers dist && cp -r memory dist",
+    "build": "rm -rf dist && tsc && mkdir -p dist && cp -r workers dist && cp -r memory dist && cp -r api dist",
     "start": "node --max-old-space-size=7168 dist/index.js",
     "start:railway": "node --max-old-space-size=7168 dist/index.js",
     "dev": "node --max-old-space-size=7168 -r ts-node/register src/index.ts",

--- a/src/services/workerOps.ts
+++ b/src/services/workerOps.ts
@@ -1,0 +1,13 @@
+export async function auditBackend(data: any) {
+  console.log('[AUDIT BACKEND]', data);
+  return { status: 'ok', action: 'audit', data };
+}
+
+export async function processTask(data: any) {
+  console.log('[PROCESS TASK]', data);
+  return { status: 'ok', action: 'process', data };
+}
+
+export async function logHealth() {
+  return { status: 'ok', timestamp: new Date().toISOString() };
+}


### PR DESCRIPTION
## Summary
- move workerOps module into src so it gets built
- ensure worker dispatch path detection remains

## Testing
- `npm run build`
- `node dist/index.js` (server starts without missing module error)

------
https://chatgpt.com/codex/tasks/task_e_6881ad3ea014832598ad106ccccb4b33