### PR TITLE
Fix sleep scheduler to use ET

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@prisma/client": "^6.12.0",
+        "@types/luxon": "^3.6.2",
         "ajv": "^8.12.0",
         "axios": "^1.10.0",
         "body-parser": "^1.20.3",
@@ -16,6 +17,7 @@
         "dotenv": "^16.0.0",
         "express": "^4.21.2",
         "iconv-lite": "^0.6.3",
+        "luxon": "^3.7.1",
         "node-cron": "^4.2.1",
         "nodemailer": "^7.0.5",
         "openai": "^5.10.1",
@@ -689,6 +691,12 @@
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
       "license": "MIT"
     },
     "node_modules/@types/mime": {
@@ -1692,6 +1700,15 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.12.0",
+    "@types/luxon": "^3.6.2",
     "ajv": "^8.12.0",
     "axios": "^1.10.0",
     "body-parser": "^1.20.3",
@@ -24,6 +25,7 @@
     "dotenv": "^16.0.0",
     "express": "^4.21.2",
     "iconv-lite": "^0.6.3",
+    "luxon": "^3.7.1",
     "node-cron": "^4.2.1",
     "nodemailer": "^7.0.5",
     "openai": "^5.10.1",

--- a/src/services/sleep-manager.ts
+++ b/src/services/sleep-manager.ts
@@ -118,13 +118,17 @@ export class SleepManager {
     });
 
     // Daily code improvement suggestions - once at 9 AM ET (during sleep window)
-    cron.schedule('0 14 * * *', async () => { // 9 AM ET = 14:00 UTC (approximate)
-      if (shouldReduceServerActivity()) {
-        await this.executeMaintenanceTask('code-improvement-suggestions', async () => {
-          await this.runCodeImprovementSuggestions();
-        });
-      }
-    });
+    cron.schedule(
+      '0 9 * * *',
+      async () => {
+        if (shouldReduceServerActivity()) {
+          await this.executeMaintenanceTask('code-improvement-suggestions', async () => {
+            await this.runCodeImprovementSuggestions();
+          });
+        }
+      },
+      { timezone: 'America/New_York' }
+    );
 
     this.maintenanceTasksScheduled = true;
     console.log('[SLEEP-MANAGER] 📅 Maintenance tasks scheduled for sleep window');


### PR DESCRIPTION
## Summary
- use `luxon` for accurate Eastern Time calculations
- adjust sleep window calculation logic
- schedule code improvement cron job with timezone
- add `luxon` and types

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68831d26b2f48325b856e4d703c660f1