### PR TITLE
Add pinned memory helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ npm start
 - `DELETE /memory/clear` - Clear memory entries
 - `GET /memory/health` - Memory system health check
 
+Pinned resources can be uploaded using the helper script:
+```bash
+node utils/pin_memory_resource.js --label MY_LABEL --type task --file ./workflow.md
+```
+
 ### Canon Management
 - `GET /api/canon/files` - List all canon storyline files
 - `GET /api/canon/files/:filename` - Read specific canon file

--- a/docs/pinned-memory-guide.md
+++ b/docs/pinned-memory-guide.md
@@ -1,0 +1,42 @@
+# Pinned Memory & Task Library
+
+This guide explains how to store important resources in the ARCANOS memory system using the new helper script.
+
+## Script Usage
+
+```bash
+node utils/pin_memory_resource.js --label PROJECT_X --type task --file ./workflow.md
+```
+
+Options:
+- `--label` (or `-l`): context label / container ID
+- `--type` (or `-t`): `task`, `reference`, or `logic`
+- `--file` (or `-f`): path to a file containing the content to store
+- `--key` (or `-k`): optional custom memory key
+- `--base` (or `-b`): base API URL (defaults to `http://localhost:8080` or `$ARCANOS_URL`)
+
+The script sends the content to `/api/memory/save` with the `X-Container-Id` header and marks the entry as pinned. The data is stored as:
+
+```json
+{
+  "pinned": true,
+  "type": "task",
+  "content": "...file contents..."
+}
+```
+
+Retrieve stored entries with:
+
+```bash
+curl -H "X-Container-Id: PROJECT_X" http://localhost:8080/api/memory/all
+```
+
+## Example Workflow
+1. Prepare a workflow file, e.g. `deploy.md`.
+2. Pin it to memory:
+   ```bash
+   node utils/pin_memory_resource.js -l PROJECT_X -t task -f deploy.md
+   ```
+3. Verify storage with the retrieval command above.
+
+This mechanism supports uploading task libraries, reference documents, and logic definitions for later use by ARCANOS.

--- a/utils/pin_memory_resource.js
+++ b/utils/pin_memory_resource.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const axios = require('axios');
+const yargs = require('yargs');
+
+const argv = yargs
+  .option('label', { alias: 'l', type: 'string', demandOption: true, describe: 'Context label / container id' })
+  .option('type', { alias: 't', type: 'string', choices: ['task', 'reference', 'logic'], demandOption: true, describe: 'Resource type' })
+  .option('file', { alias: 'f', type: 'string', describe: 'Path to file with content to upload' })
+  .option('key', { alias: 'k', type: 'string', describe: 'Optional memory key' })
+  .option('base', { alias: 'b', type: 'string', describe: 'Base API URL' })
+  .help()
+  .argv;
+
+const BASE_URL = argv.base || process.env.ARCANOS_URL || process.env.SERVER_URL || 'http://localhost:8080';
+const memoryKey = argv.key || `${argv.type}_${Date.now()}`;
+
+async function readContent() {
+  if (argv.file) {
+    return fs.readFileSync(path.resolve(argv.file), 'utf8');
+  }
+  return new Promise((resolve, reject) => {
+    if (process.stdin.isTTY) {
+      return reject(new Error('No input provided. Use --file or pipe data via stdin.'));
+    }
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => (data += chunk));
+    process.stdin.on('end', () => resolve(data.trim()));
+  });
+}
+
+async function main() {
+  try {
+    const content = await readContent();
+    const payload = {
+      memory_key: memoryKey,
+      memory_value: {
+        pinned: true,
+        type: argv.type,
+        content
+      }
+    };
+
+    const res = await axios.post(`${BASE_URL}/api/memory/save`, payload, {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Container-Id': argv.label
+      }
+    });
+
+    console.log('✅ Pinned memory saved:', res.data);
+  } catch (err) {
+    const message = err.response?.data || err.message;
+    console.error('❌ Failed to save pinned memory:', message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add pinned-memory helper script for uploading tasks/docs/logic
- document pinned memory workflow
- mention script in README

## Testing
- `node test-memory-endpoints.js` *(fails: Unexpected end of input)*
- `node test-concurrency-limit.js` *(fails: cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_68832768bbe083258495d6740a20133f