### PR TITLE
Enable Codex access to ARCANOS runtime

### DIFF
--- a/scripts/codex-internal.js
+++ b/scripts/codex-internal.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const path = require('path');
+const Module = require('module');
+
+/**
+ * Mount ARCANOS runtime modules into Node's resolution paths for Codex.
+ * Missing paths will generate warnings but will not throw errors.
+ */
+function mountArcanosInternal() {
+  const root = path.resolve(__dirname, '..');
+  const internalPaths = [
+    path.join(root, 'dist'),
+    path.join(root, 'src'),
+    path.join(root, 'workers')
+  ];
+
+  internalPaths.forEach(p => {
+    if (fs.existsSync(p)) {
+      if (!Module.globalPaths.includes(p)) {
+        Module.globalPaths.push(p);
+      }
+    } else {
+      console.warn(`[CODEX-INTERNAL] Missing internal module path: ${p}`);
+    }
+  });
+}
+
+/**
+ * Safe require helper with fallback logging if module is missing.
+ */
+function safeRequire(modulePath) {
+  try {
+    const resolved = path.isAbsolute(modulePath)
+      ? modulePath
+      : path.join(process.cwd(), modulePath);
+    return require(resolved);
+  } catch (err) {
+    console.error(`[CODEX-INTERNAL] Failed to load module ${modulePath}: ${err.message}`);
+    return {};
+  }
+}
+
+mountArcanosInternal();
+
+module.exports = { mountArcanosInternal, safeRequire };

--- a/test-comprehensive.js
+++ b/test-comprehensive.js
@@ -3,7 +3,8 @@ console.log('🌙 ARCANOS Sleep and Maintenance Scheduler - Comprehensive Test')
 console.log('==============================================================');
 
 // Load the sleep configuration and manager
-const { getCurrentSleepWindowStatus, shouldReduceServerActivity, logSleepWindowStatus } = require('./dist/services/sleep-config');
+const { safeRequire } = require('./scripts/codex-internal');
+const { getCurrentSleepWindowStatus, shouldReduceServerActivity, logSleepWindowStatus } = safeRequire('./dist/services/sleep-config');
 
 async function runComprehensiveTest() {
   try {

--- a/test-database-mock.js
+++ b/test-database-mock.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 // Test script to demonstrate database connection with mocked PostgreSQL
+const { safeRequire } = require('./scripts/codex-internal');
 const originalEnv = process.env.DATABASE_URL;
 
 // Set a mock DATABASE_URL to test connection logic
@@ -76,7 +77,8 @@ Module.prototype.require = function(id) {
 console.log('🧪 Testing Database Connection with Mock PostgreSQL...\n');
 
 // Load the database connection module (will use our mock)
-const dbConnection = require('./dist/services/database-connection');
+const dbConnectionModule = safeRequire('./dist/services/database-connection');
+const dbConnection = dbConnectionModule.default || dbConnectionModule;
 
 // Give it a moment to initialize
 setTimeout(async () => {

--- a/test-sleep-window.js
+++ b/test-sleep-window.js
@@ -1,5 +1,6 @@
 // Test Sleep Window Functionality
-const { getCurrentSleepWindowStatus, shouldReduceServerActivity, logSleepWindowStatus } = require('./dist/services/sleep-config');
+const { safeRequire } = require('./scripts/codex-internal');
+const { getCurrentSleepWindowStatus, shouldReduceServerActivity, logSleepWindowStatus } = safeRequire('./dist/services/sleep-config');
 
 console.log('🌙 Testing ARCANOS Sleep Window System');
 console.log('=====================================');

--- a/test-workers.js
+++ b/test-workers.js
@@ -1,6 +1,7 @@
 // Test Enhanced Workers Functionality
 console.log('🔧 Testing ARCANOS Enhanced Workers');
 console.log('===================================');
+require('./scripts/codex-internal');
 
 // Mock the model control hooks for testing
 const mockModelControlHooks = {

--- a/validate-ai-refactor-test.js
+++ b/validate-ai-refactor-test.js
@@ -2,6 +2,7 @@
 
 // Comprehensive ARCANOS AI-Control Validation Test
 const axios = require('axios');
+require('./scripts/codex-internal');
 
 const BASE_URL = 'http://localhost:8080';
 

--- a/validate-ai-refactor.js
+++ b/validate-ai-refactor.js
@@ -2,6 +2,7 @@
 // Validates that all requirements from the problem statement are met
 
 const axios = require('axios');
+require('./scripts/codex-internal');
 
 const BASE_URL = 'http://localhost:8080';
 

--- a/validate-requirements.js
+++ b/validate-requirements.js
@@ -5,6 +5,8 @@
 
 const fs = require('fs');
 const path = require('path');
+// Mount ARCANOS runtime modules for Codex execution
+require('./scripts/codex-internal');
 
 console.log('==================================================');
 console.log('  ARCANOS Railway + GitHub Copilot Validation');
@@ -36,6 +38,18 @@ function validateFileContent(filePath, searchText, description) {
     }
   } else {
     console.log(`❌ ${description}: File not found`);
+    allPassed = false;
+    return false;
+  }
+}
+
+function validateInternalModule(modulePath, description) {
+  try {
+    require.resolve(modulePath);
+    console.log(`✅ ${description}: Found`);
+    return true;
+  } catch (err) {
+    console.log(`⚠️ ${description}: Missing - ${err.message}`);
     allPassed = false;
     return false;
   }
@@ -92,6 +106,11 @@ console.log('\n8. Testing Infrastructure:');
 validateFile('test-railway-copilot.js', 'Railway + Copilot test script');
 validateFile('test-cors-compliance.js', 'CORS compliance test');
 
+// 9. Internal Runtime Modules
+console.log('\n9. Internal Runtime Modules:');
+validateInternalModule('./dist/services/model-control-hooks', 'Model control hooks');
+validateInternalModule('./workers/index.js', 'Worker system');
+
 console.log('\n==================================================');
 if (allPassed) {
   console.log('           🎉 ALL REQUIREMENTS PASSED! 🎉');
@@ -110,4 +129,4 @@ if (allPassed) {
   console.log('==================================================');
   console.log('Please review the failed items above.');
 }
-console.log('==================================================');
+console.log('==================================================')

--- a/workers/clearTemp.js
+++ b/workers/clearTemp.js
@@ -4,7 +4,7 @@
 
 const { modelControlHooks } = require('../dist/services/model-control-hooks');
 const { diagnosticsService } = require('../dist/services/diagnostics');
-const { createServiceLogger } = require('../src/utils/logger');
+const { createServiceLogger } = require('../dist/utils/logger');
 const fs = require('fs').promises;
 const path = require('path');
 const logger = createServiceLogger('TempCleanerWorker');

--- a/workers/codeImprovement.js
+++ b/workers/codeImprovement.js
@@ -3,7 +3,7 @@
 
 const { modelControlHooks } = require('../dist/services/model-control-hooks');
 const { diagnosticsService } = require('../dist/services/diagnostics');
-const { createServiceLogger } = require('../src/utils/logger');
+const { createServiceLogger } = require('../dist/utils/logger');
 const logger = createServiceLogger('CodeImprovementWorker');
 
 async function reportFailure(error) {

--- a/workers/goalWatcher.js
+++ b/workers/goalWatcher.js
@@ -4,7 +4,7 @@
 
 const { modelControlHooks } = require('../dist/services/model-control-hooks');
 const { diagnosticsService } = require('../dist/services/diagnostics');
-const { createServiceLogger } = require('../src/utils/logger');
+const { createServiceLogger } = require('../dist/utils/logger');
 const logger = createServiceLogger('GoalWatcherWorker');
 
 async function reportFailure(error) {

--- a/workers/index.js
+++ b/workers/index.js
@@ -1,8 +1,8 @@
 // AI-Controlled Worker System - Workers only execute when AI model instructs them to
 const path = require('path');
-const { modelControlHooks } = require('../src/services/model-control-hooks');
+const { modelControlHooks } = require('../dist/services/model-control-hooks');
 const { diagnosticsService } = require('../dist/services/diagnostics');
-const { createServiceLogger } = require('../src/utils/logger');
+const { createServiceLogger } = require('../dist/utils/logger');
 const logger = createServiceLogger('Workers');
 
 // Determine worker logic mode

--- a/workers/memorySync.js
+++ b/workers/memorySync.js
@@ -4,7 +4,7 @@
 
 const { modelControlHooks } = require('../dist/services/model-control-hooks');
 const { diagnosticsService } = require('../dist/services/diagnostics');
-const { createServiceLogger } = require('../src/utils/logger');
+const { createServiceLogger } = require('../dist/utils/logger');
 const logger = createServiceLogger('MemorySyncWorker');
 
 async function reportFailure(error) {


### PR DESCRIPTION
## Summary
- add `scripts/codex-internal.js` helper to mount internal runtime modules for Codex
- update validation script to use mounted modules
- update tests to load runtime modules via helper
- switch worker scripts to compiled logger path
- make database mock test load default export

## Testing
- `npm run build`
- `node validate-requirements.js`
- `node test-sleep-window.js`
- `node test-comprehensive.js`
- `node test-workers.js`
- `node test-database-mock.js`


------
https://chatgpt.com/codex/tasks/task_e_6883404476c08325a91653950db8dfc3