### PR TITLE
Add code interpreter tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ LOGIC_ROUTE=/ask
 # OpenAI Configuration
 OPENAI_API_KEY=your-openai-api-key-here
 FINE_TUNED_MODEL=your-fine-tuned-model-id-here
+CODE_INTERPRETER_MODEL=gpt-4o
 
 # Fine-tuning Pipeline Configuration
 # MODEL_ID is used as base model for continuing fine-tuning

--- a/PROMPT_API_EXAMPLES.md
+++ b/PROMPT_API_EXAMPLES.md
@@ -497,4 +497,13 @@ result = client.ask_safe("Explain Python decorators", "programming")
 print(result["response"])
 ```
 
+### Code Interpreter Example
+```python
+response = requests.post(
+    f"{client.base_url}/api/code-interpreter",
+    json={"prompt": "Calculate the mean of [1,2,3,4]"}
+)
+print(response.json()["data"]["content"])
+```
+
 These examples provide a comprehensive set of ready-to-use implementations for testing and integrating with the Arcanos API.

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -31,6 +31,7 @@ dist/              # Compiled output (generated)
 - `POST /api/ask-with-fallback` - AI query with fallback permission granted
 - `POST /api/ask-v1-safe` - Safe interface with RAG/HRC features
 - `POST /api/arcanos` - Intent-based routing (WRITE/AUDIT)
+- `POST /api/code-interpreter` - Python tool execution via code interpreter
 - `GET /api/model-status` - Current model configuration
 - `GET /api/model/info` - Detailed model information
 
@@ -71,6 +72,7 @@ NODE_ENV=development
 RUN_WORKERS=true
 SERVER_URL=https://your-app.railway.app
 GPT_TOKEN=your-gpt-diagnostic-token
+CODE_INTERPRETER_MODEL=gpt-4o
 ```
 
 ## Model Hierarchy

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ The backend implements intelligent intent detection that routes requests to spec
 - **Runtime Lookup**: Assistants available via `config/assistants.json`
 - **Name Normalization**: `UPPERCASE_WITH_UNDERSCORES` format for consistent access
 - **Full Integration**: Assistant tools and instructions preserved and accessible
+- **Python Code Interpreter**: Execute Python for data transformation via secure tool calling
 
 ### Memory & Context Management
 - **PostgreSQL Backend**: Persistent storage with automatic schema management
@@ -266,6 +267,7 @@ The backend implements intelligent intent detection that routes requests to spec
 ### Required Variables
 - `OPENAI_API_KEY` - Your OpenAI API key
 - `FINE_TUNED_MODEL` - Your fine-tuned model name
+- `CODE_INTERPRETER_MODEL` - Model for Python tool execution (default: gpt-4o)
 
 ### Server Configuration
 - `NODE_ENV` - Environment (development/production) (default: development)
@@ -354,6 +356,7 @@ npm start
 - `POST /api/ask-with-fallback` - AI chat with GPT-4 fallback
 - `POST /api/ask-v1-safe` - Safe interface with RAG/HRC features
 - `POST /api/arcanos` - Intent-based routing (WRITE/AUDIT)
+- `POST /api/code-interpreter` - Python tool execution via code interpreter
 - `POST /memory/save` - Save memory entries for context
 
 ### Diagnostic & Management

--- a/src/routes/ai.ts
+++ b/src/routes/ai.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import path from 'path';
 import { modelControlHooks } from '../services/model-control-hooks';
 import { sendErrorResponse, sendSuccessResponse, handleServiceResult, handleCatchError } from '../utils/response';
+import { codeInterpreterService } from '../services/code-interpreter';
 
 const router = Router();
 
@@ -98,6 +99,20 @@ router.get('/sync/diagnostics', async (req, res) => {
     }
   } catch (error: any) {
     handleCatchError(res, error, 'Diagnostics');
+  }
+});
+
+// POST /code-interpreter - Run Python code using OpenAI's tool calling
+router.post('/code-interpreter', async (req, res) => {
+  const { prompt } = req.body;
+  if (!prompt) {
+    return sendErrorResponse(res, 400, 'Prompt is required');
+  }
+  try {
+    const result = await codeInterpreterService.run(prompt);
+    sendSuccessResponse(res, 'Code interpreter executed', result);
+  } catch (error: any) {
+    handleCatchError(res, error, 'Code interpreter');
   }
 });
 

--- a/src/services/code-interpreter.ts
+++ b/src/services/code-interpreter.ts
@@ -1,0 +1,36 @@
+import OpenAI from 'openai';
+
+export interface CodeInterpreterResult {
+  content: string;
+  files?: any[];
+}
+
+export class CodeInterpreterService {
+  private client: OpenAI;
+  private model: string;
+
+  constructor() {
+    if (!process.env.OPENAI_API_KEY) {
+      throw new Error('OPENAI_API_KEY is required');
+    }
+
+    this.client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    this.model = process.env.CODE_INTERPRETER_MODEL || 'gpt-4o';
+  }
+
+  async run(prompt: string): Promise<CodeInterpreterResult> {
+    const completion = await this.client.chat.completions.create({
+      model: this.model,
+      messages: [{ role: 'user', content: prompt }],
+      tools: [{ type: 'code_interpreter' }] as any,
+    });
+
+    const message: any = completion.choices[0].message;
+    return {
+      content: message.content || '',
+      files: (message.files as any[]) || [],
+    };
+  }
+}
+
+export const codeInterpreterService = new CodeInterpreterService();


### PR DESCRIPTION
## Summary
- support Python code execution via OpenAI code interpreter
- expose `/api/code-interpreter` endpoint
- document new tool and env variable
- show usage example in docs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688351e83eb083259112be069169cf13