### PR TITLE
Use fine-tuned model ID everywhere

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 OPENAI_API_KEY=test_key_for_development
+AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106:BpYtP0ox
 DATABASE_URL=postgresql://test:test@localhost:5432/test_db
 ARCANOS_API_TOKEN=test_token_123
 NODE_ENV=development

--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ LOGIC_ROUTE=/ask
 
 # OpenAI Configuration
 OPENAI_API_KEY=your-openai-api-key-here
-FINE_TUNED_MODEL=your-fine-tuned-model-id-here
+AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106:BpYtP0ox
 CODE_INTERPRETER_MODEL=gpt-4o
 
 # Fine-tuning Pipeline Configuration

--- a/.env.test
+++ b/.env.test
@@ -1,4 +1,5 @@
 OPENAI_API_KEY=test_key_for_development
+AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106:BpYtP0ox
 DATABASE_URL=postgresql://test:test@localhost:5432/test_db
 ARCANOS_API_TOKEN=test_token_123
 NODE_ENV=development

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -47,7 +47,7 @@ export const config: Config = {
   },
   ai: {
     openaiApiKey: process.env.OPENAI_API_KEY,
-    fineTunedModel: process.env.FINE_TUNED_MODEL || process.env.OPENAI_FINE_TUNED_MODEL,
+    fineTunedModel: process.env.AI_MODEL || process.env.FINE_TUNED_MODEL || process.env.OPENAI_FINE_TUNED_MODEL,
     gptToken: process.env.GPT_TOKEN,
   },
   database: {
@@ -92,6 +92,13 @@ export function validateConfig(): { valid: boolean; errors: string[] } {
   // Validate port number
   if (isNaN(config.server.port) || config.server.port < 1 || config.server.port > 65535) {
     errors.push('PORT must be a valid port number (1-65535)');
+  }
+
+  const expectedModel = 'ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106:BpYtP0ox';
+  if (!config.ai.fineTunedModel) {
+    errors.push(`AI_MODEL is required and must be set to ${expectedModel}`);
+  } else if (config.ai.fineTunedModel !== expectedModel) {
+    errors.push(`AI_MODEL mismatch. Expected ${expectedModel}`);
   }
 
   return {

--- a/src/handlers/ask-handler.ts
+++ b/src/handlers/ask-handler.ts
@@ -80,7 +80,7 @@ export const askHandler = async (req: Request, res: Response) => {
       const openai = getOpenAIService();
       
       // Log the fine-tuned model being used
-      console.log('🔍 Using fine-tuned model:', process.env.FINE_TUNED_MODEL || process.env.OPENAI_FINE_TUNED_MODEL || 'default');
+      console.log('🔍 Using fine-tuned model:', process.env.AI_MODEL || process.env.FINE_TUNED_MODEL || process.env.OPENAI_FINE_TUNED_MODEL || 'default');
       console.log('🎯 Processing message:', message.substring(0, 100) + (message.length > 100 ? '...' : ''));
       
       // Build chat messages with context

--- a/src/services/ai-dispatcher.ts
+++ b/src/services/ai-dispatcher.ts
@@ -38,7 +38,7 @@ export class AIDispatcher {
   private model: string;
 
   constructor() {
-    this.model = process.env.FINE_TUNED_MODEL || process.env.OPENAI_FINE_TUNED_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106';
+    this.model = process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106:BpYtP0ox';
     
     try {
       this.openaiService = new OpenAIService();

--- a/src/services/ai/core-ai-service.ts
+++ b/src/services/ai/core-ai-service.ts
@@ -56,8 +56,8 @@ export class CoreAIService {
       maxRetries: 2,
     });
 
-    // Use arcanos-v1 as standardized model (as requested in refactor)
-    this.defaultModel = 'arcanos-v1';
+    // Use configured fine-tuned model or fallback ID
+    this.defaultModel = process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106:BpYtP0ox';
     this.maxRetries = 3;
     this.retryDelayMs = 1000;
 

--- a/src/services/arcanos-v1-interface.ts
+++ b/src/services/arcanos-v1-interface.ts
@@ -142,7 +142,7 @@ export async function getActiveModel(): Promise<ArcanosModel | null> {
     }
 
     // Check if a fine-tuned model is configured
-    const fineTunedModel = process.env.FINE_TUNED_MODEL || process.env.OPENAI_FINE_TUNED_MODEL;
+    const fineTunedModel = process.env.AI_MODEL || process.env.FINE_TUNED_MODEL || process.env.OPENAI_FINE_TUNED_MODEL;
     if (!fineTunedModel) {
       console.warn("No fine-tuned model configured");
       return null;
@@ -173,7 +173,7 @@ export async function askArcanosV1_Safe({
   useHRC?: boolean;
 }): Promise<{ response: string; model?: string }> {
   // Get the actual model name from environment (if available)
-  const modelName = process.env.FINE_TUNED_MODEL || process.env.OPENAI_FINE_TUNED_MODEL;
+  const modelName = process.env.AI_MODEL || process.env.FINE_TUNED_MODEL || process.env.OPENAI_FINE_TUNED_MODEL;
   
   const model = await getActiveModel(); // ← Your current backend model hook
 

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -30,8 +30,8 @@ export class OpenAIService {
       maxRetries: 3,  // Increased from 2 for better reliability
     });
 
-    // Standardize on arcanos-v1 model (as requested in refactor)
-    this.model = 'arcanos-v1';
+    // Use configured fine-tuned model or fallback to predefined ID
+    this.model = process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106:BpYtP0ox';
     
     // Log model configuration for audit purposes
     logger.info('OpenAI Service initialized', { 
@@ -53,7 +53,7 @@ export class OpenAIService {
     });
     
     try {
-      // Use the standardized arcanos-v1 model
+      // Use the configured AI model
       const completion = await this.client.chat.completions.create({
         model: this.model,
         messages,


### PR DESCRIPTION
## Summary
- configure `AI_MODEL` in env files
- enforce model validation during config load
- use `process.env.AI_MODEL` in OpenAI service and core AI services
- update AI dispatcher and wrappers to use the new model
- log chosen model with `AI_MODEL`

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68835cb333f88325b4c27d33c6be1911