### PR TITLE
Add intent for email+model response

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,8 @@ npm start
 - `POST /api/arcanos` - Intent-based routing (WRITE/AUDIT)
 - `POST /api/code-interpreter` - Python tool execution via code interpreter
 - `POST /memory/save` - Save memory entries for context
+- `POST /intent/send_email` - Send an email via intent
+- `POST /intent/send_email_and_respond` - Email user and return model reply
 
 ### Diagnostic & Management
 - `POST /api/diagnostics` - Natural language system commands

--- a/src/intents/send_email_and_respond.ts
+++ b/src/intents/send_email_and_respond.ts
@@ -1,0 +1,41 @@
+import { Request, Response } from 'express';
+import { sendEmail } from '../utils/sendEmail';
+import { OpenAIService, ChatMessage } from '../services/openai';
+
+let openaiService: OpenAIService | null = null;
+
+function getOpenAIService(): OpenAIService {
+  if (!openaiService) {
+    openaiService = new OpenAIService();
+  }
+  return openaiService;
+}
+
+export async function sendEmailAndRespond(req: Request, res: Response) {
+  try {
+    const { to, subject, body } = req.body;
+
+    if (!to || !subject || !body) {
+      return res.status(400).json({ error: 'Missing required fields: to, subject, body.' });
+    }
+
+    const emailResult = await sendEmail(to, subject, body);
+
+    const messages: ChatMessage[] = [
+      { role: 'system', content: 'You are ARCANOS, a modular AI operations interface.' },
+      { role: 'user', content: 'Confirm diagnostics and report readiness.' }
+    ];
+    const aiService = getOpenAIService();
+    const aiResponse = await aiService.chat(messages);
+
+    return res.status(200).json({
+      success: true,
+      email: emailResult,
+      modelResponse: aiResponse.message,
+      model: aiResponse.model,
+    });
+  } catch (error: any) {
+    console.error('sendEmailAndRespond error:', error.message);
+    return res.status(500).json({ success: false, error: error.message });
+  }
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,7 @@ import { diagnosticsService } from '../services/diagnostics';
 import { workerStatusService } from '../services/worker-status';
 import { sendEmail, verifyEmailConnection, getEmailSender, getEmailTransportType } from '../services/email';
 import { sendEmailIntent } from '../intents/send_email';
+import { sendEmailAndRespond } from '../intents/send_email_and_respond';
 import assistantsRouter from './assistants';
 
 const router = Router();
@@ -217,6 +218,7 @@ router.post('/email/send', async (req, res) => {
 
 // Intent endpoints
 router.post('/intent/send_email', sendEmailIntent);
+router.post('/intent/send_email_and_respond', sendEmailAndRespond);
 
 // Mount assistant routes
 router.use('/', assistantsRouter);


### PR DESCRIPTION
## Summary
- expose intent to send an email and return AI confirmation
- document new endpoint

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883de7cc8588325a6e342a0bdf2589f