### PR TITLE
Add overlay diagnostics

### DIFF
--- a/src/utils/overlay-diagnostics.ts
+++ b/src/utils/overlay-diagnostics.ts
@@ -1,0 +1,44 @@
+import fs from 'fs';
+import path from 'path';
+import { createServiceLogger } from './logger';
+import { fallbackHandler } from '../handlers/fallback-handler';
+
+const logger = createServiceLogger('OverlayDiagnostics');
+
+/**
+ * Check for the existence of model-control-hooks.js in the compiled services
+ * directory. If missing, trigger a fallback audit and log an overlay reroute
+ * event so the AI can diagnose missing hooks.
+ */
+export async function checkModelControlHooks(): Promise<boolean> {
+  const hooksPath = path.join(__dirname, '../services/model-control-hooks.js');
+  const exists = fs.existsSync(hooksPath);
+
+  if (!exists) {
+    logger.warning('model-control-hooks.js missing', {
+      event: 'ARCANOS::overlay_reroute',
+      severity: 'MID',
+    });
+
+    try {
+      const logEventPath = path.join(__dirname, '../memory/logEvent.js');
+      const { logEvent } = require(logEventPath);
+      await logEvent('overlay_reroute');
+    } catch (err) {
+      logger.error('Failed to record overlay_reroute event', err);
+    }
+
+    try {
+      await fallbackHandler.handleUndefinedWorker({
+        type: 'audit',
+        message: 'goalWatcher overlay reroute - missing model-control-hooks.js',
+      });
+    } catch (err) {
+      logger.error('Dynamic audit reroute failed', err);
+    }
+
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- add overlay diagnostics utility to check for compiled hooks
- log ARCANOS::overlay_reroute events and trigger audit fallback
- update `goalWatcher` worker to invoke diagnostics and skip when hooks missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884ef4d938c8325aafc771606d3db94