### PR TITLE
Add Arcanos overview docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A comprehensive TypeScript + Express backend for the Arcanos AI project, featuring fine-tuned OpenAI model integration, intent-based routing, and persistent memory storage.
 
+Arcanos is designed as an **AI-managed backend**. A fine-tuned GPT model controls background workers, decides when to run maintenance tasks, and processes incoming requests through an intent router. Persistent memory is stored in PostgreSQL with an in-memory fallback so the system can maintain context even if the database is unavailable. In short, Arcanos provides a conventional HTTP API that is orchestrated by an AI model.
+
 ## ⚠️ Current Build Status
 
 **Note**: The current codebase has TypeScript compilation dependencies that may need to be installed. If you encounter build errors, ensure all dependencies are properly installed:
@@ -321,8 +323,10 @@ curl -X GET http://localhost:8080/api/memory/health \
 
 ## 📚 Documentation
 
-### Core Documentation  
+### Core Documentation
+
 - **[🚀 Setup Guide](./SETUP_GUIDE.md)** - Quick start and initial configuration
+- **[🌟 Arcanos Overview](./docs/arcanos-overview.md)** - Explanation of the project goals
 - **[🔧 Quick Reference](./QUICK_REFERENCE.md)** - Essential commands and endpoints
 - **[🧠 Backend Documentation](./docs/backend.md)** - Comprehensive backend system overview
 - **[📋 Changelog](./docs/changelog.md)** - Version history and recent updates

--- a/docs/arcanos-overview.md
+++ b/docs/arcanos-overview.md
@@ -1,0 +1,13 @@
+# 🌟 What is Arcanos?
+
+Arcanos is an AI-focused backend system that pairs a fine-tuned GPT model with traditional web services. It is built with TypeScript and Express and relies on a PostgreSQL database for memory persistence. The design goal is to give the model operational control over common tasks while still providing standard HTTP endpoints for interaction.
+
+Key capabilities include:
+
+- **Fine-Tuned Model Integration** – Core logic routes through a fine-tuned GPT model. The model approves fallback to standard GPT models when necessary.
+- **Intent-Based Routing** – Incoming requests are analyzed to detect intents such as `WRITE` or `AUDIT` and routed to specialized handlers.
+- **Persistent Memory** – Conversation context and arbitrary key/value data are stored in PostgreSQL with an in-memory fallback for development.
+- **OpenAI Assistants** – The backend can synchronize organization assistants so they are available at runtime.
+- **AI-Controlled Workers** – Background tasks such as health checks and memory sync run only with AI approval.
+
+In short, Arcanos acts as a comprehensive AI backend where the model plays an active role in system management while exposing a conventional API for clients.


### PR DESCRIPTION
## Summary
- add an overview document describing what Arcanos is
- mention the AI-managed backend design in README
- link to the new overview file from the documentation section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68850bddc9d08325bfa74c355dba3b1d