### PR TITLE
Add periodic memory monitor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { databaseService } from './services/database';
 import { serverService } from './services/server';
 import { chatGPTUserWhitelist } from './services/chatgpt-user-whitelist';
 import { diagnosticsService } from './services/diagnostics';
+import { memoryMonitor } from './services/memory-monitor';
 
 // Handlers (for initialization)
 import { memoryHandler } from './handlers/memory-handler';
@@ -201,6 +202,7 @@ serverService.start(app, PORT).then(async () => {
   // Memory usage monitoring
   const memStats = process.memoryUsage();
   console.log('🧠 [MEMORY] Initial RSS:', (memStats.rss / 1024 / 1024).toFixed(2), 'MB');
+  memoryMonitor.start();
   
   // Railway-specific logging
   if (config.railway.environment) {

--- a/src/services/memory-monitor.ts
+++ b/src/services/memory-monitor.ts
@@ -1,0 +1,38 @@
+import { performanceMonitor } from '../utils/performance';
+import { getHeapStatistics } from 'v8';
+
+class MemoryMonitor {
+  private intervalId?: NodeJS.Timeout;
+
+  start(intervalMs = 5 * 60 * 1000) {
+    if (this.intervalId) return;
+    this.logUsage();
+    this.intervalId = setInterval(() => this.logUsage(), intervalMs);
+    process.on('exit', () => this.stop());
+  }
+
+  stop() {
+    if (this.intervalId) clearInterval(this.intervalId);
+    this.intervalId = undefined;
+  }
+
+  private logUsage() {
+    const mem = process.memoryUsage();
+    const heapStats = getHeapStatistics();
+    const rssMB = (mem.rss / 1024 / 1024).toFixed(2);
+    const heapUsedMB = (mem.heapUsed / 1024 / 1024).toFixed(2);
+    const heapTotalMB = (mem.heapTotal / 1024 / 1024).toFixed(2);
+    const externalMB = (mem.external / 1024 / 1024).toFixed(2);
+    const bufferMB = (mem.arrayBuffers / 1024 / 1024).toFixed(2);
+    const diffMB = ((mem.rss - mem.heapTotal) / 1024 / 1024).toFixed(2);
+    const heapLimitGB = (heapStats.heap_size_limit / 1024 / 1024 / 1024).toFixed(2);
+
+    console.log(
+      `🧠 [MEMORY_MONITOR] RSS: ${rssMB}MB, Heap: ${heapUsedMB}/${heapTotalMB}MB, External: ${externalMB}MB, Buffers: ${bufferMB}MB, RSS-HeapDiff: ${diffMB}MB, HeapLimit: ${heapLimitGB}GB`
+    );
+
+    performanceMonitor.updateMemorySnapshot();
+  }
+}
+
+export const memoryMonitor = new MemoryMonitor();


### PR DESCRIPTION
## Summary
- add service to periodically log memory usage
- start memory monitor during app initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885703da18883258aeb588280afc4a0