### PR TITLE
Add email fallback with diagnostics tracking

### DIFF
--- a/src/middleware/diagnostics.ts
+++ b/src/middleware/diagnostics.ts
@@ -1,0 +1,24 @@
+import fs from 'fs'
+import path from 'path'
+import { createServiceLogger } from '../utils/logger'
+
+const logger = createServiceLogger('DiagnosticsMiddleware')
+
+export interface DiagnosticPayload {
+  error: any
+  fallbackResult: any
+}
+
+export function trackDiagnostics(payload: DiagnosticPayload): void {
+  const logDir = path.join(process.cwd(), 'storage', 'diagnostics')
+  if (!fs.existsSync(logDir)) {
+    fs.mkdirSync(logDir, { recursive: true })
+  }
+  const logPath = path.join(logDir, `diagnostic_${new Date().toISOString().slice(0,10)}.log`)
+  const entry = {
+    ...payload,
+    timestamp: new Date().toISOString()
+  }
+  fs.appendFileSync(logPath, JSON.stringify(entry) + '\n')
+  logger.info('Diagnostics event tracked', { logPath })
+}

--- a/src/plugins/email.ts
+++ b/src/plugins/email.ts
@@ -1,0 +1,28 @@
+import fs from 'fs'
+import path from 'path'
+import { sendEmail } from '../services/email'
+
+export interface EmailPayload {
+  to: string
+  subject: string
+  html: string
+  from?: string
+}
+
+export async function sendEmailPrimary(payload: EmailPayload) {
+  return await sendEmail(payload.to, payload.subject, payload.html, payload.from)
+}
+
+export async function sendEmailFallback(payload: EmailPayload) {
+  try {
+    const dir = path.join(process.cwd(), 'storage', 'fallback-emails')
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true })
+    }
+    const file = path.join(dir, `email_${Date.now()}.json`)
+    fs.writeFileSync(file, JSON.stringify(payload, null, 2))
+  } catch (err) {
+    // ignore file system errors
+  }
+  return { success: false, error: 'Fallback email stored locally' }
+}

--- a/src/services/email-dispatch.ts
+++ b/src/services/email-dispatch.ts
@@ -1,0 +1,20 @@
+import { createServiceLogger } from '../utils/logger'
+import { sendEmailPrimary, sendEmailFallback, EmailPayload } from '../plugins/email'
+import { trackDiagnostics } from '../middleware/diagnostics'
+
+const logger = createServiceLogger('EmailDispatch')
+
+export async function dispatchEmail(payload: EmailPayload) {
+  try {
+    logger.info('Initiating primary email dispatch...')
+    const result = await sendEmailPrimary(payload)
+    logger.info('Primary dispatch successful', result)
+    return result
+  } catch (error: any) {
+    logger.warning('Primary dispatch failed. Initiating fallback...', { error: error.message })
+    const fallbackResult = await sendEmailFallback(payload)
+    trackDiagnostics({ error, fallbackResult })
+    logger.info('Fallback dispatch completed', fallbackResult)
+    return fallbackResult
+  }
+}


### PR DESCRIPTION
## Summary
- implement diagnostics tracker middleware
- create email plugin with fallback to store messages locally
- add email dispatch helper that logs and uses fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688581ece3088325beae71fa36af32e6