### PR TITLE
Add goal input validator with example

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ curl $PORT/api/memory/health
 ./src/modules/hrc/          # HRCCore validation module
 ./src/storage/              # Memory and file storage systems
 ./src/handlers/             # Request handlers
+./src/utils/goal-validator.ts # Goal input validation utility
 ./index.js                  # Legacy entry point (JavaScript)
 ./package.json              # Dependencies and scripts
 ./tsconfig.json             # TypeScript configuration

--- a/examples/goal-validator-usage.ts
+++ b/examples/goal-validator-usage.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { validateGoalInput } from '../src/utils/goal-validator';
+import { HRCCore } from '../src/modules/hrc';
+
+(async () => {
+  const hrc = new HRCCore();
+  await hrc.initialize();
+
+  const sampleGoal = {
+    userId: 'user-123',
+    title: 'Finish project documentation',
+    description: 'Complete the remaining sections of the project docs',
+    priority: 'high',
+    progress: 40
+  };
+
+  try {
+    const validated = await validateGoalInput(sampleGoal, hrc);
+    console.log('Validated goal:', validated);
+  } catch (error) {
+    console.error('Validation failed:', error);
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/dotenv": "^6.1.1",
     "@types/express": "^4.17.0",
     "@types/node": "^20.19.9",
+    "@types/axios": "^0.14.4",
     "@types/node-cron": "^3.0.11",
     "@types/nodemailer": "^6.4.17",
     "@types/pg": "^8.15.4",

--- a/src/utils/goal-validator.ts
+++ b/src/utils/goal-validator.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import { HRCCore } from '../modules/hrc';
+
+export const goalSchema = z.object({
+  id: z.string().uuid().optional(),
+  userId: z.string().min(1),
+  title: z.string().min(3).max(200),
+  description: z.string().min(1).max(4000),
+  targetDate: z.preprocess(val => (val ? new Date(val as string) : undefined), z.date().optional()),
+  status: z.enum(['active', 'completed', 'paused', 'cancelled']).default('active'),
+  priority: z.enum(['low', 'medium', 'high']).default('medium'),
+  progress: z.number().int().min(0).max(100).default(0),
+  createdAt: z.preprocess(val => (val ? new Date(val as string) : new Date()), z.date().optional()),
+  updatedAt: z.preprocess(val => (val ? new Date(val as string) : new Date()), z.date().optional())
+}).strict();
+
+export type GoalInput = z.infer<typeof goalSchema>;
+
+export async function validateGoalInput(input: unknown, hrc?: HRCCore): Promise<GoalInput> {
+  const parsed = goalSchema.parse(input);
+
+  if (hrc) {
+    const titleCheck = await hrc.validate(parsed.title, {});
+    const descriptionCheck = await hrc.validate(parsed.description, {});
+    if (!titleCheck.success || !descriptionCheck.success) {
+      throw new Error('Unsafe goal content detected');
+    }
+  }
+
+  return parsed;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,12 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "*": ["node_modules/*", "src/types/*"]
+    }
   },
-  "include": ["src", "memory"],
+  "include": ["src", "memory", "src/types"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- implement a `goal-validator` utility using zod
- add example script demonstrating validator usage
- document new utility in the project structure section of README
- install missing type defs and update tsconfig paths to fix builds

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68859d2c83f88325bbc8672e1179dbf0