### PR TITLE
Add CI build script and refine goal validator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,12 @@ WORKDIR /app
 # Copy package files for dependency installation
 COPY package*.json ./
 
-# Install dependencies with npm ci for reproducible builds
-RUN npm ci --omit=dev && npm cache clean --force
+# Install dependencies with better memory handling
+RUN npm ci --omit=dev --prefer-offline --no-audit --no-fund
+# Clean npm cache separately
+RUN npm cache clean --force
+# Reduce build parallelism to prevent memory overrun
+ENV NODE_OPTIONS="--max_old_space_size=256"
 
 # Copy source code
 COPY src/ ./src/
@@ -41,8 +45,9 @@ WORKDIR /app
 # Copy package files
 COPY package*.json ./
 
-# Install only production dependencies
-RUN npm ci --omit=dev && npm cache clean --force
+# Install only production dependencies with improved memory handling
+RUN npm ci --omit=dev --prefer-offline --no-audit --no-fund
+RUN npm cache clean --force
 
 # Copy built application from builder stage
 COPY --from=builder /app/dist ./dist

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ This starts the server with hot reloading and 7GB memory allocation for optimal 
 npm run build
 npm start
 ```
+For CI environments like Railway, use the optimized build script:
+```bash
+npm run ci:build
+```
 
 ## API Endpoints
 
@@ -443,6 +447,8 @@ curl $PORT/api/memory/health
 ./src/modules/hrc/          # HRCCore validation module
 ./src/storage/              # Memory and file storage systems
 ./src/handlers/             # Request handlers
+./src/utils/goal-validator.ts # Goal input validation utility
+./examples/goal-validator-usage.ts # Example usage of the goal validator
 ./index.js                  # Legacy entry point (JavaScript)
 ./package.json              # Dependencies and scripts
 ./tsconfig.json             # TypeScript configuration

--- a/examples/goal-validator-usage.ts
+++ b/examples/goal-validator-usage.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { validateGoalInput } from '../src/utils/goal-validator';
+import { HRCCore } from '../src/modules/hrc';
+
+(async () => {
+  const hrc = new HRCCore();
+  await hrc.initialize();
+
+  const sampleGoal = {
+    userId: 'user-123',
+    title: 'Finish project documentation',
+    description: 'Complete the remaining sections of the project docs',
+    priority: 'high',
+    progress: 40
+  };
+
+  try {
+    const validated = await validateGoalInput(sampleGoal, hrc);
+    console.log('Validated goal:', validated);
+  } catch (error) {
+    console.error('Validation failed:', error);
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "prisma:push": "prisma db push",
     "prisma:studio": "prisma studio",
     "test": "echo \"No tests defined\" && exit 0",
-    "email:diagnostic": "node bin/email-diagnostic.js"
+    "email:diagnostic": "node bin/email-diagnostic.js",
+    "ci:build": "NODE_OPTIONS='--max_old_space_size=256' npm ci --omit=dev && npm run build"
   },
   "dependencies": {
     "@prisma/client": "^6.12.0",
@@ -42,6 +43,7 @@
     "@types/dotenv": "^6.1.1",
     "@types/express": "^4.17.0",
     "@types/node": "^20.19.9",
+    "@types/axios": "^0.14.4",
     "@types/node-cron": "^3.0.11",
     "@types/nodemailer": "^6.4.17",
     "@types/pg": "^8.15.4",

--- a/src/utils/goal-validator.ts
+++ b/src/utils/goal-validator.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import { HRCCore } from '../modules/hrc';
+
+export const goalSchema = z.object({
+  id: z.string().uuid().optional(),
+  userId: z.string().min(1),
+  title: z.string().min(3).max(200),
+  description: z.string().min(1).max(4000),
+  targetDate: z.preprocess((val: unknown) => (val ? new Date(val as string) : undefined), z.date().optional()),
+  status: z.enum(['active', 'completed', 'paused', 'cancelled']).default('active'),
+  priority: z.enum(['low', 'medium', 'high']).default('medium'),
+  progress: z.number().int().min(0).max(100).default(0),
+  createdAt: z.preprocess((val: unknown) => (val ? new Date(val as string) : new Date()), z.date().optional()),
+  updatedAt: z.preprocess((val: unknown) => (val ? new Date(val as string) : new Date()), z.date().optional())
+}).strict();
+
+export type GoalInput = z.infer<typeof goalSchema>;
+
+export async function validateGoalInput(input: unknown, hrc?: HRCCore): Promise<GoalInput> {
+  const parsed = goalSchema.parse(input);
+
+  if (hrc) {
+    const titleCheck = await hrc.validate(parsed.title, {});
+    const descriptionCheck = await hrc.validate(parsed.description, {});
+    if (!titleCheck.success || !descriptionCheck.success) {
+      throw new Error('Unsafe goal content detected');
+    }
+  }
+
+  return parsed;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,12 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "*": ["node_modules/*", "src/types/*"]
+    }
   },
-  "include": ["src", "memory"],
+  "include": ["src", "memory", "src/types"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- fix `goal-validator` preprocess type errors
- optimize Dockerfile install steps for Railway
- expose new `ci:build` script in package.json
- mention validator example and CI build script in README

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68859d2c83f88325bbc8672e1179dbf0