### PR TITLE
Add Codex integrator helper

### DIFF
--- a/codex-integrator.js
+++ b/codex-integrator.js
@@ -1,0 +1,7 @@
+// Convenience wrapper for the compiled Codex integrator
+try {
+  module.exports = require('./dist/codex-integrator');
+} catch (err) {
+  // Fallback to TypeScript source for development environments
+  module.exports = require('./src/codex-integrator');
+}

--- a/src/codex-integrator.ts
+++ b/src/codex-integrator.ts
@@ -1,0 +1,19 @@
+const { mountArcanosInternal } = require('../scripts/codex-internal');
+
+let enabled = false;
+
+/**
+ * Enable Codex interface by mounting internal modules.
+ * This ensures Codex can resolve compiled files when executing
+ * within the repository.
+ */
+export function enableCodexInterface(): void {
+  if (enabled) return;
+  try {
+    mountArcanosInternal();
+    enabled = true;
+    console.log('[CODEX-INTEGRATOR] Codex interface enabled');
+  } catch (err) {
+    console.error('[CODEX-INTEGRATOR] Failed to enable Codex interface:', (err as Error).message);
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple Codex integrator module with `enableCodexInterface`
- provide root JS wrapper that loads the compiled version

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885ac343be8832591067705929a32b7