### PR TITLE
Add Codex dispatch endpoint and memory-managed storage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import mainRoutes from './routes/main';
 import aiRoutes from './routes/ai';
 import memoryRouter from './routes/memory';
 import systemRouter from './routes/system';
+import codexRouter from './routes/codex';
 
 // Middleware
 import { requireApiToken } from './middleware/api-token';
@@ -130,6 +131,7 @@ app.use('/', aiRoutes);    // AI-controlled endpoints (/ask, /query-finetune, et
 app.use('/api', router);
 app.use('/api/memory', requireApiToken, memoryRouter);
 app.use('/system', systemRouter);
+app.use('/codex', codexRouter);
 
 // Error handling middleware (must be last)
 app.use(errorHandler.handleError);

--- a/src/routes/codex.ts
+++ b/src/routes/codex.ts
@@ -1,0 +1,56 @@
+import { Router } from 'express';
+import { modelControlHooks, memoryControl } from '../services/model-control-hooks';
+import { sendErrorResponse, sendSuccessResponse, handleCatchError } from '../utils/response';
+
+const router = Router();
+
+// POST /codex/dispatch - route requests through AI dispatcher
+router.post('/dispatch', async (req, res) => {
+  const { prompt, context } = req.body || {};
+
+  if (!prompt) {
+    return sendErrorResponse(res, 400, 'prompt is required');
+  }
+
+  const userId = (req.headers['x-user-id'] as string) || 'codex';
+  const sessionId = (req.headers['x-session-id'] as string) || 'dispatch';
+
+  try {
+    // Store dispatch request via memory interface
+    const memKey = `dispatch_${Date.now()}`;
+    await memoryControl('store', { key: memKey, value: { prompt, context }, userId, sessionId }, {
+      userId,
+      sessionId,
+      source: 'api',
+      metadata: { headers: req.headers }
+    });
+
+    // Route request through ARCANOS model
+    const result = await modelControlHooks.handleApiRequest(
+      '/codex/dispatch',
+      'POST',
+      { prompt, context, memKey },
+      {
+        userId,
+        sessionId,
+        source: 'api',
+        metadata: { headers: req.headers }
+      }
+    );
+
+    if (result.success) {
+      sendSuccessResponse(res, 'Dispatch processed', {
+        response: result.response,
+        results: result.results,
+        memory_key: memKey,
+        timestamp: new Date().toISOString()
+      });
+    } else {
+      sendErrorResponse(res, 500, result.error || 'Dispatch failed');
+    }
+  } catch (error: any) {
+    handleCatchError(res, error, 'Codex dispatch');
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- introduce `/codex/dispatch` route using ARCANOS model to validate requests
- refactor memory handler to dispatch memory operations through `modelControlHooks`
- mount new Codex router in main server

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885c09d3e4c8325a8c71572e42bc2db