### PR TITLE
Add admin control support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import aiRoutes from './routes/ai';
 import memoryRouter from './routes/memory';
 import systemRouter from './routes/system';
 import codexRouter from './routes/codex';
+import { enableAdminControl, getAdminRouter } from './system/auth';
 
 // Middleware
 import { requireApiToken } from './middleware/api-token';
@@ -64,6 +65,15 @@ applyCLEAROverlay({
 
 const app = express();
 const PORT = config.server.port;
+
+if (process.env.ADMIN_KEY) {
+  enableAdminControl(process.env.ADMIN_KEY);
+  const adminRouter = getAdminRouter();
+  if (adminRouter) {
+    app.use('/admin', adminRouter);
+  }
+  console.log('🛡 Admin access enabled');
+}
 
 // Middleware stack
 app.use(cors());

--- a/src/system/auth.ts
+++ b/src/system/auth.ts
@@ -1,0 +1,38 @@
+import { Router, Request, Response, NextFunction } from 'express';
+
+let adminRouter: Router | null = null;
+let adminKey: string | null = null;
+let enabled = false;
+
+/**
+ * Enable admin control routes protected by a shared ADMIN_KEY.
+ * When enabled, requests must include `Authorization: Bearer <ADMIN_KEY>`.
+ */
+export function enableAdminControl(key: string): void {
+  if (enabled) return;
+  adminKey = key;
+  adminRouter = Router();
+
+  adminRouter.use((req: Request, res: Response, next: NextFunction) => {
+    const auth = req.headers['authorization'];
+    const token = Array.isArray(auth) ? auth[0] : auth;
+    if (token === `Bearer ${adminKey}`) {
+      return next();
+    }
+    res.status(403).json({ error: 'Forbidden' });
+  });
+
+  adminRouter.get('/status', (_req: Request, res: Response) => {
+    res.json({ status: 'ok', timestamp: new Date().toISOString() });
+  });
+
+  enabled = true;
+  console.log('[ADMIN] Admin control routes enabled');
+}
+
+/**
+ * Retrieve the admin router if admin control is enabled.
+ */
+export function getAdminRouter(): Router | null {
+  return adminRouter;
+}


### PR DESCRIPTION
## Summary
- implement admin control setup under `src/system/auth.ts`
- enable optional admin router in `src/index.ts`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885df9601e48325ac455e3ec39e5c44