### PR TITLE
Implement Codex worker router and OpenAI webhook

### DIFF
--- a/src/handlers/backendEdit.ts
+++ b/src/handlers/backendEdit.ts
@@ -1,0 +1,4 @@
+export async function editBackendCode(_payload: any, _meta?: any): Promise<any> {
+  console.log('[BACKEND-EDIT] Editing backend with payload', _payload, _meta);
+  return { success: true, message: 'Edit request received' };
+}

--- a/src/handlers/branchDraft.ts
+++ b/src/handlers/branchDraft.ts
@@ -1,0 +1,4 @@
+export async function createDraftBranch(_payload: any): Promise<any> {
+  console.log('[BRANCH-DRAFT] Creating draft branch', _payload);
+  return { success: true, branch: 'draft/placeholder' };
+}

--- a/src/handlers/diagnostics.ts
+++ b/src/handlers/diagnostics.ts
@@ -1,0 +1,6 @@
+import { diagnosticsService } from '../services/diagnostics';
+
+export async function runDiagnostics(payload: any): Promise<any> {
+  const command = typeof payload === 'string' ? payload : payload?.command;
+  return diagnosticsService.executeDiagnosticCommand(command || 'system health');
+}

--- a/src/handlers/refactor.ts
+++ b/src/handlers/refactor.ts
@@ -1,0 +1,4 @@
+export async function runRefactor(_payload: any): Promise<any> {
+  console.log('[REFACTOR] Request received', _payload);
+  return { success: true, message: 'Refactor task queued' };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import aiRoutes from './routes/ai';
 import memoryRouter from './routes/memory';
 import systemRouter from './routes/system';
 import codexRouter from './routes/codex';
+import openaiWebhookRouter from './webhooks/openai';
 import { enableAdminControl, getAdminRouter } from './system/auth';
 
 // Middleware
@@ -142,6 +143,7 @@ app.use('/api', router);
 app.use('/api/memory', requireApiToken, memoryRouter);
 app.use('/system', systemRouter);
 app.use('/codex', codexRouter);
+app.use('/webhooks', openaiWebhookRouter);
 
 // Error handling middleware (must be last)
 app.use(errorHandler.handleError);

--- a/src/routes/codex-worker-router.ts
+++ b/src/routes/codex-worker-router.ts
@@ -1,0 +1,50 @@
+import { Router, Request, Response } from 'express';
+import { runDiagnostics } from '../handlers/diagnostics';
+import { runRefactor } from '../handlers/refactor';
+import { createDraftBranch } from '../handlers/branchDraft';
+import { editBackendCode } from '../handlers/backendEdit';
+import { validateCodexIntent, CodexIntent } from '../utils/intentParser';
+import { logToStudio } from '../studio/logger';
+
+const router = Router();
+
+// Map of available intent handlers
+const intentRouter: Record<string, (payload: any, meta?: any) => Promise<any>> = {
+  diagnostic: runDiagnostics,
+  edit: editBackendCode,
+  refactor: runRefactor,
+  branchDraft: createDraftBranch,
+};
+
+router.post('/codex/intent', async (req: Request, res: Response) => {
+  try {
+    const { prompt, meta } = req.body || {};
+    const parsed: CodexIntent | null = validateCodexIntent(prompt);
+
+    if (!parsed || !(parsed.intent in intentRouter)) {
+      return res.status(400).json({ error: 'Invalid or unknown intent' });
+    }
+
+    const handler = intentRouter[parsed.intent];
+    const result = await handler(parsed.payload, meta);
+
+    logToStudio({
+      action: parsed.intent,
+      source: 'codex-worker-router',
+      result,
+      timestamp: new Date().toISOString(),
+    });
+
+    res.json({ success: true, result });
+  } catch (error: any) {
+    logToStudio({
+      action: 'error',
+      source: 'codex-worker-router',
+      error: error.message,
+      timestamp: new Date().toISOString(),
+    });
+    res.status(500).json({ error: error.message });
+  }
+});
+
+export default router;

--- a/src/studio/logger.ts
+++ b/src/studio/logger.ts
@@ -1,0 +1,17 @@
+import { createServiceLogger } from '../utils/logger';
+
+const logger = createServiceLogger('Studio');
+
+export interface StudioLog {
+  action: string;
+  source: string;
+  result?: any;
+  error?: any;
+  timestamp: string;
+}
+
+export function logToStudio(log: StudioLog): void {
+  const { action, source, result, error, timestamp } = log;
+  const context = { result, error, timestamp };
+  logger.info(`${source} - ${action}`, context);
+}

--- a/src/utils/intentParser.ts
+++ b/src/utils/intentParser.ts
@@ -1,0 +1,26 @@
+export interface CodexIntent {
+  intent: string;
+  payload: any;
+}
+
+// Very basic intent parser expecting `intent:payload` or JSON
+export function validateCodexIntent(prompt: string | undefined): CodexIntent | null {
+  if (!prompt || typeof prompt !== 'string') return null;
+
+  const colonIndex = prompt.indexOf(':');
+  if (colonIndex === -1) {
+    return { intent: prompt.trim(), payload: {} };
+  }
+
+  const intent = prompt.slice(0, colonIndex).trim();
+  const payloadRaw = prompt.slice(colonIndex + 1).trim();
+
+  let payload: any = payloadRaw;
+  try {
+    payload = JSON.parse(payloadRaw);
+  } catch {
+    // keep as string
+  }
+
+  return { intent, payload };
+}

--- a/src/webhooks/openai.ts
+++ b/src/webhooks/openai.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import { handleCatchError, sendSuccessResponse } from '../utils/response';
+
+const router = Router();
+
+// Basic OpenAI webhook handler - logs event and acknowledges receipt
+router.post('/openai', async (req, res) => {
+  try {
+    const event = req.body;
+    console.log('[OPENAI-WEBHOOK] Event received', event);
+
+    sendSuccessResponse(res, 'OpenAI webhook received', { event });
+  } catch (error: any) {
+    handleCatchError(res, error, 'OpenAI webhook');
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add codex-worker router with intent routing
- implement stub handlers and intent parser
- add simple Studio logger
- handle OpenAI webhook events
- wire webhook router into the main Express app

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885e697b090832592afbc19823afab1