### PR TITLE
Add fallback scheduler for undefined worker instructions

### DIFF
--- a/src/workers/default-scheduler.ts
+++ b/src/workers/default-scheduler.ts
@@ -1,0 +1,38 @@
+import cron from 'node-cron';
+import { createServiceLogger } from '../utils/logger';
+import { executionEngine } from '../services/execution-engine';
+import { DispatchInstruction } from '../services/ai-dispatcher';
+
+const logger = createServiceLogger('DefaultScheduler');
+
+/**
+ * Initialize a fallback scheduler for instructions missing worker identities.
+ */
+export function initializeFallbackScheduler(instruction: DispatchInstruction): void {
+  const schedule = instruction.schedule;
+  if (!schedule) {
+    logger.error('No schedule provided for fallback scheduler');
+    return;
+  }
+
+  const taskId = `fallback_${Date.now()}`;
+
+  try {
+    cron.schedule(
+      schedule,
+      async () => {
+        logger.warning('Executing fallback scheduled instruction', { taskId });
+        await executionEngine.executeInstruction({
+          ...instruction,
+          action: 'execute',
+          worker: undefined
+        });
+      },
+      { timezone: 'UTC' }
+    );
+
+    logger.warning('Fallback scheduler initialized', { taskId, schedule });
+  } catch (error: any) {
+    logger.error('Failed to initialize fallback scheduler', error);
+  }
+}


### PR DESCRIPTION
## Summary
- add `initializeFallbackScheduler` utility
- fallback to `defaultScheduler` when schedule instructions have no worker

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6886a8d7c8288325880a56aac3088ddc