### PR TITLE
Add admin router documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,9 @@ GPT_TOKEN=your-gpt-access-token-here
 # ARCANOS API Token (required for /api/memory endpoints)
 ARCANOS_API_TOKEN=your-arcanos-api-token-here
 
+# Admin access key for /admin endpoints
+ADMIN_KEY=your-admin-key-here
+
 # Sleep Configuration (optional)
 SLEEP_ENABLED=true
 SLEEP_START=02:00

--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ The backend implements intelligent intent detection that routes requests to spec
 ### Optional Configuration
 - `GPT_TOKEN` - Authorization token for GPT diagnostic access
 - `ARCANOS_API_TOKEN` - Token for memory and diagnostic endpoints
+- `ADMIN_KEY` - Secret key to enable `/admin` routes
 - `ASK_CONCURRENCY_LIMIT` - Max concurrent `/api/ask` requests (default: 3)
 - `MODEL_ID` - Base model for fine-tuning pipeline (default: gpt-3.5-turbo)
 
@@ -327,6 +328,21 @@ Example memory request with token:
 ```bash
 curl -X GET http://localhost:8080/api/memory/health \
   -H "Authorization: Bearer $ARCANOS_API_TOKEN"
+```
+
+### Admin Access
+
+Set `ADMIN_KEY` in your environment to enable the admin router. When enabled,
+requests to `/admin/*` must include:
+
+```bash
+Authorization: Bearer $ADMIN_KEY
+```
+
+Example status check:
+
+```bash
+curl -H "Authorization: Bearer $ADMIN_KEY" http://localhost:8080/admin/status
 ```
 
 ## 📚 Documentation

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -14,6 +14,7 @@
 | `WORKER_LOGIC` | `arcanos` | Default logic mode for background workers |
 | `SERVER_URL` | `https://arcanos-production-426d.up.railway.app` | Production server URL for health checks |
 | `DATABASE_URL` | `[OPTIONAL]` | PostgreSQL connection string (fallback to in-memory if not set) |
+| `ADMIN_KEY` | `[OPTIONAL]` | Enable admin router and protect `/admin/*` routes |
 
 ### Deprecated Variables (Removed)
 - ❌ `PORT=3000` - Now defaults to `8080` and auto-assigned by Railway
@@ -110,6 +111,11 @@ The CRON worker system runs when `RUN_WORKERS=true` and implements **AI-controll
 
 #### Validation & Processing
 - `POST /api/ask-hrc` - Message validation using HRCCore overlay system with resilience and fidelity scoring
+
+### Admin Router
+- Enabled when `ADMIN_KEY` is set in the environment
+- All admin requests require `Authorization: Bearer <ADMIN_KEY>`
+- `GET /admin/status` - Simple health status
 
 ### Memory & Storage System
 


### PR DESCRIPTION
## Summary
- document how to use ADMIN_KEY in `.env.example`
- explain admin access in README and backend docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886ce44433083259dfc65ecb6a9e6c2