### PR TITLE
Update OpenAI model reference to v3

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 OPENAI_API_KEY=test_key_for_development
-AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH
+AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD
 DATABASE_URL=
 ARCANOS_API_TOKEN=test_token_123
 NODE_ENV=development
@@ -8,7 +8,7 @@ RUN_WORKERS=false
 WORKER_LOGIC=arcanos
 
 # Identity override for admin access
-IDENTITY_OVERRIDE={"identity_override":{"name":"ARCANOS","version":"v2:BxRSDrhH","designation":"Reflective Logic Intelligence","role":"Execute modular command, diagnostics, orchestration, and admin protocol tasks","admin":"Justin"}}
+IDENTITY_OVERRIDE={"identity_override":{"name":"ARCANOS","version":"v3:ByCSivqD","designation":"Reflective Logic Intelligence","role":"Execute modular command, diagnostics, orchestration, and admin protocol tasks","admin":"Justin"}}
 IDENTITY_TRIGGER_PHRASE=I am Skynet
 
 # SMTP Configuration for testing

--- a/.env.example
+++ b/.env.example
@@ -15,12 +15,12 @@ OPENAI_API_KEY=your-openai-api-key-here
 # FINE_TUNE_MODEL - Alternative fine-tuned model variable
 # FINE_TUNED_MODEL - Legacy fine-tuned model variable  
 # OPENAI_FINE_TUNED_MODEL (lowest priority) - OpenAI-specific model variable
-AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106:BpYtP0ox
-FINE_TUNE_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106:BpYtP0ox
+AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD
+FINE_TUNE_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD
 CODE_INTERPRETER_MODEL=gpt-4o
 
 # Identity override configuration
-IDENTITY_OVERRIDE={"identity_override":{"name":"ARCANOS","version":"v2:BxRSDrhH","designation":"Reflective Logic Intelligence","role":"Execute modular command, diagnostics, orchestration, and admin protocol tasks","admin":"Justin"}}
+IDENTITY_OVERRIDE={"identity_override":{"name":"ARCANOS","version":"v3:ByCSivqD","designation":"Reflective Logic Intelligence","role":"Execute modular command, diagnostics, orchestration, and admin protocol tasks","admin":"Justin"}}
 IDENTITY_TRIGGER_PHRASE=I am Skynet
 
 # Fine-tuning Pipeline Configuration

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,5 @@
 OPENAI_API_KEY=test_key_for_development
-AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106:BpYtP0ox
+AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD
 DATABASE_URL=postgresql://test:test@localhost:5432/test_db
 ARCANOS_API_TOKEN=test_token_123
 NODE_ENV=development

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -9,7 +9,7 @@
 | `NODE_ENV` | `production` | Environment mode (production/development) |
 | `PORT` | `8080` | Server port (Railway auto-assigns) |
 | `OPENAI_API_KEY` | `[REQUIRED]` | OpenAI API authentication key |
-| `FINE_TUNED_MODEL` | `ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106` | Primary fine-tuned model ID (supports multiple variable names) |
+| `FINE_TUNED_MODEL` | `ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD` | Primary fine-tuned model ID (supports multiple variable names) |
 | `RUN_WORKERS` | `true` | Enable AI-controlled CRON worker processes |
 | `WORKER_LOGIC` | `arcanos` | Default logic mode for background workers |
 | `SERVER_URL` | `https://arcanos-production-426d.up.railway.app` | Production server URL for health checks |
@@ -44,10 +44,10 @@ The CRON worker system runs when `RUN_WORKERS=true` and implements **AI-controll
 
 ## 🤖 Fine-Tuned Model Configuration & Behavior
 
-### Active Model
-- **Primary Model**: `ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106`
+-### Active Model
+- **Primary Model**: `ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD`
 - **Model Type**: Fine-tuned GPT-3.5 Turbo
-- **Version**: `arcanos-v1-1106`
+- **Version**: `arcanos-v3`
 - **Owner**: Personal account
 - **Training Date**: November 2024
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,7 +31,7 @@
 - **ALIGNED**: Tone and format consistency across all documentation files
 
 ### 🤖 Current System State
-- **Fine-tuned Model**: `ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106`
+- **Fine-tuned Model**: `ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD`
 - **HRC Overlay**: Active validation with resilience/fidelity scoring
 - **Environment Variables**: Enhanced support with flexible precedence
 - **OpenAI Integration**: Improved configuration options and error handling
@@ -49,9 +49,9 @@
 - **UPDATED**: File references to point to TypeScript source files instead of legacy JavaScript
 
 ### 🤖 AI-Controlled System Documentation
-- **DOCUMENTED**: Full AI operational control system via `modelControlHooks`
-- **DETAILED**: AI-controlled CRON worker schedules with approval system
-- **SPECIFIED**: Current fine-tuned model: `ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106`
+ - **DOCUMENTED**: Full AI operational control system via `modelControlHooks`
+ - **DETAILED**: AI-controlled CRON worker schedules with approval system
+ - **SPECIFIED**: Current fine-tuned model: `ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD`
 - **EXPLAINED**: JSON instruction system for AI operational decisions
 - **COVERED**: AI approval requirements for all background tasks
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -110,7 +110,7 @@ export function validateConfig(): { valid: boolean; errors: string[] } {
     errors.push('PORT must be a valid port number (1-65535)');
   }
 
-  const expectedModel = 'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH';
+  const expectedModel = 'ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD';
   if (!config.ai.fineTunedModel) {
     errors.push(`AI_MODEL is required and must be set to ${expectedModel}`);
   } else if (config.ai.fineTunedModel !== expectedModel) {

--- a/src/services/ai-dispatcher.ts
+++ b/src/services/ai-dispatcher.ts
@@ -44,7 +44,7 @@ export class AIDispatcher {
   private model: string;
 
   constructor() {
-    this.model = process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106:BpYtP0ox';
+    this.model = process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD';
     
     try {
       this.openaiService = new OpenAIService({

--- a/src/services/ai/core-ai-service.ts
+++ b/src/services/ai/core-ai-service.ts
@@ -57,7 +57,7 @@ export class CoreAIService {
     });
 
     // Use configured fine-tuned model or fallback ID
-    this.defaultModel = process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106:BpYtP0ox';
+    this.defaultModel = process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD';
     this.maxRetries = 3;
     this.retryDelayMs = 1000;
 

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -45,7 +45,7 @@ export class OpenAIService {
     });
 
     // Use configured fine-tuned model or fallback to predefined ID
-    this.model = options?.model || aiConfig.fineTunedModel || process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106:BpYtP0ox';
+    this.model = options?.model || aiConfig.fineTunedModel || process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD';
 
     // Optional identity override injected as system message for all chats
     const override = options?.identityOverride || aiConfig.identityOverride || process.env.IDENTITY_OVERRIDE;

--- a/test-router.js
+++ b/test-router.js
@@ -108,7 +108,7 @@ function startTestServer() {
       res.json({ 
         status: 'healthy',
         service: 'ARCANOS Router',
-        model: 'gpt-3.5-turbo-0125:personal:arcanos-v1-1106',
+        model: 'gpt-3.5-turbo-0125:personal:arcanos-v3',
         timestamp: new Date().toISOString()
       });
     });
@@ -122,7 +122,7 @@ function startTestServer() {
           'POST /query': 'Submit queries to fine-tuned model',
           'GET /health': 'Health check for Railway deployment'
         },
-        model: 'gpt-3.5-turbo-0125:personal:arcanos-v1-1106',
+        model: 'gpt-3.5-turbo-0125:personal:arcanos-v3',
         fallback: false
       });
     });


### PR DESCRIPTION
## Summary
- update fine-tuned model default to `arcanos-v3`
- adjust .env files for new model
- update config and services to reference the new model
- refresh documentation and example router output

## Testing
- `npm run build`
- `node test-api-endpoints.js` *(fails: server not running)*

------
https://chatgpt.com/codex/tasks/task_e_6887317d0f2c8325bb86e4d7b3ba59f6