### PR TITLE
Add explicit routing workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,17 @@ The backend implements intelligent intent detection that routes requests to spec
 - `WORKER_LOGIC` - Logic mode for background workers (default: `arcanos`). Set to another value to override.
 - `SERVER_URL` - Server URL for health checks (default: http://localhost:8080)
 
+### Available Workers
+
+The worker registry exposes several built-in workers with explicit routing logic. Each worker is bound to a known endpoint or schedule so the dispatcher can route requests correctly.
+
+| Worker | Type | Route/Interval |
+| ------ | ---- | -------------- |
+| `emailDispatcher` | onDemand | `/email/send` |
+| `maintenanceScheduler` | recurring | weekly |
+| `scheduled_emails_worker` | cron | `/email/schedule` |
+| `auditProcessor` | logic | CLEAR mode |
+
 ### Sleep & Wake Configuration
 - `SLEEP_ENABLED` - Enable sleep mode (default: false)
 - `SLEEP_START` - Sleep start time in HH:MM format (default: 02:00)

--- a/src/services/execution-engine.ts
+++ b/src/services/execution-engine.ts
@@ -182,10 +182,18 @@ export class ExecutionEngine {
     }
 
     if (!workerName) {
-      workerName = process.env.FALLBACK_WORKER || 'defaultWorker';
-      console.warn(
-        `[ExecutionEngine] Missing workerName - using fallback ${workerName}`
-      );
+      return {
+        success: false,
+        error: 'Worker name required for scheduling',
+      };
+    }
+
+    const dynamicWorker = getDynamicWorker(workerName);
+    if (!dynamicWorker) {
+      return {
+        success: false,
+        error: `Unknown worker: ${workerName}`,
+      };
     }
 
     try {

--- a/src/worker-init.ts
+++ b/src/worker-init.ts
@@ -47,7 +47,15 @@ async function initializeAIControlledWorkers() {
   logger.info('Initializing AI-controlled worker system with enhanced workers');
   
   // Register available workers with AI control system (including new workers)
-  const availableWorkers = ['memorySync', 'goalWatcher', 'clearTemp', 'auditProcessor', 'maintenanceScheduler', 'emailDispatcher'];
+  const availableWorkers = [
+    'memorySync',
+    'goalWatcher',
+    'clearTemp',
+    'auditProcessor',
+    'maintenanceScheduler',
+    'emailDispatcher',
+    'scheduled_emails_worker'
+  ];
   
   for (const workerName of availableWorkers) {
     logger.info('Registering worker with AI control system', { workerName });
@@ -116,7 +124,15 @@ async function startWorkers() {
     'worker-startup',
     { 
       reason: 'RUN_WORKERS environment variable is true',
-      requestedWorkers: ['memorySync', 'goalWatcher', 'clearTemp', 'auditProcessor', 'maintenanceScheduler']
+      requestedWorkers: [
+        'memorySync',
+        'goalWatcher',
+        'clearTemp',
+        'auditProcessor',
+        'maintenanceScheduler',
+        'emailDispatcher',
+        'scheduled_emails_worker'
+      ]
     },
     {
       userId: 'system',

--- a/workers/auditProcessor.js
+++ b/workers/auditProcessor.js
@@ -1,0 +1,23 @@
+const { createServiceLogger } = require('../dist/utils/logger');
+let runStreamAudit;
+try {
+  ({ runStreamAudit } = require('../dist/workers/audit/stream-audit-worker'));
+} catch {
+  ({ runStreamAudit } = require('../src/workers/audit/stream-audit-worker'));
+}
+const logger = createServiceLogger('AuditProcessorWorker');
+
+module.exports = async function auditProcessor(payload) {
+  logger.info('Executing auditProcessor worker');
+  if (!payload || !payload.message) {
+    logger.warning('No audit message provided');
+    return;
+  }
+  try {
+    await runStreamAudit(payload);
+    logger.success('Audit completed');
+  } catch (err) {
+    logger.error('Audit processing failed', err);
+    throw err;
+  }
+};

--- a/workers/emailDispatcher.js
+++ b/workers/emailDispatcher.js
@@ -1,0 +1,23 @@
+const { createServiceLogger } = require('../dist/utils/logger');
+let dispatchEmail;
+try {
+  ({ dispatchEmail } = require('../dist/workers/email/email-dispatcher'));
+} catch {
+  ({ dispatchEmail } = require('../src/workers/email/email-dispatcher'));
+}
+const logger = createServiceLogger('EmailDispatcherWorker');
+
+module.exports = async function emailDispatcher(payload) {
+  logger.info('Executing emailDispatcher worker');
+  if (!payload || !payload.to || !payload.subject || !payload.message) {
+    logger.warning('Invalid email payload, aborting dispatch');
+    return;
+  }
+  try {
+    await dispatchEmail(payload);
+    logger.success('Email dispatched', { to: payload.to });
+  } catch (err) {
+    logger.error('Email dispatch failed', err);
+    throw err;
+  }
+};

--- a/workers/maintenanceScheduler.js
+++ b/workers/maintenanceScheduler.js
@@ -1,0 +1,19 @@
+const { createServiceLogger } = require('../dist/utils/logger');
+let MaintenanceSchedulerWorker;
+try {
+  ({ maintenanceSchedulerWorker: MaintenanceSchedulerWorker } = require('../dist/workers/maintenance-scheduler'));
+} catch {
+  ({ maintenanceSchedulerWorker: MaintenanceSchedulerWorker } = require('../src/workers/maintenance-scheduler'));
+}
+const logger = createServiceLogger('MaintenanceSchedulerWorker');
+
+module.exports = async function maintenanceScheduler() {
+  logger.info('Executing maintenanceScheduler worker');
+  try {
+    await MaintenanceSchedulerWorker.start();
+    logger.success('Maintenance scheduler started');
+  } catch (err) {
+    logger.error('Maintenance scheduler failed', err);
+    throw err;
+  }
+};

--- a/workers/modules/auditProcessor.js
+++ b/workers/modules/auditProcessor.js
@@ -1,0 +1,2 @@
+const handler = require('../auditProcessor');
+module.exports = { name: 'auditProcessor', handler };

--- a/workers/modules/emailDispatcher.js
+++ b/workers/modules/emailDispatcher.js
@@ -1,0 +1,2 @@
+const handler = require('../emailDispatcher');
+module.exports = { name: 'emailDispatcher', handler };

--- a/workers/modules/maintenanceScheduler.js
+++ b/workers/modules/maintenanceScheduler.js
@@ -1,0 +1,2 @@
+const handler = require('../maintenanceScheduler');
+module.exports = { name: 'maintenanceScheduler', handler };

--- a/workers/modules/scheduled_emails_worker.js
+++ b/workers/modules/scheduled_emails_worker.js
@@ -1,0 +1,2 @@
+const handler = require('../scheduled_emails_worker');
+module.exports = { name: 'scheduled_emails_worker', handler };

--- a/workers/scheduled_emails_worker.js
+++ b/workers/scheduled_emails_worker.js
@@ -1,0 +1,23 @@
+const { createServiceLogger } = require('../dist/utils/logger');
+let scheduleEmailWorker;
+try {
+  ({ scheduleEmailWorker } = require('../dist/workers/email/schedule-email-worker'));
+} catch {
+  ({ scheduleEmailWorker } = require('../src/workers/email/schedule-email-worker'));
+}
+const logger = createServiceLogger('ScheduledEmailsWorker');
+
+module.exports = async function scheduled_emails_worker(options) {
+  logger.info('Executing scheduled_emails_worker');
+  if (!options || !options.cron || !options.request) {
+    logger.error('Invalid schedule options');
+    throw new Error('invalid_schedule');
+  }
+  const task = scheduleEmailWorker(options);
+  if (!task) {
+    logger.error('emailDispatcher not registered, schedule rejected');
+    throw new Error('dispatch_unavailable');
+  }
+  logger.success('Scheduled emailDispatcher task');
+  return task;
+};


### PR DESCRIPTION
## Summary
- add workers for `emailDispatcher`, `maintenanceScheduler`, `scheduled_emails_worker`, `auditProcessor`
- load new workers in `workerRegistry` with metadata
- ensure schedule handler rejects missing workers
- register new workers in `worker-init`
- document available workers

## Testing
- `npm test`
- `node test-workers.js`


------
https://chatgpt.com/codex/tasks/task_e_688742f697948325b59528b93dd80762