### PR TITLE
Fix worker context fallback and OpenAI initialization

### DIFF
--- a/src/services/openai-worker-orchestrator.ts
+++ b/src/services/openai-worker-orchestrator.ts
@@ -75,11 +75,15 @@ async function orchestrateWorker(task: unknown): Promise<string | null> {
       logger.info(`Known workers: ${KNOWN_WORKERS.join(', ')}`);
     }
 
-    // Check OpenAI availability
+    // Check OpenAI availability and attempt lazy initialization if needed
     if (!openai) {
-      const error = `OpenAI client not available - ${initializationError || 'Unknown initialization error'}`;
-      logger.error(`❌ ${error}`);
-      throw new Error(error);
+      initializeOpenAIClient();
+
+      if (!openai) {
+        const error = `OpenAI client not available - ${initializationError || 'Unknown initialization error'}`;
+        logger.error(`❌ ${error}`);
+        throw new Error(error);
+      }
     }
 
     // Validate OpenAI orchestration parameters

--- a/src/worker-init.ts
+++ b/src/worker-init.ts
@@ -175,10 +175,18 @@ async function startBackgroundWorkers(): Promise<void> {
     let startedCount = 0;
     
     for (const workerName of workersToStart) {
-      const workerCtx = activeWorkers.get(workerName);
+      let workerCtx = activeWorkers.get(workerName);
       if (!workerCtx) {
-        logger.warning(`⚠️ Worker context not found for ${workerName}`);
-        continue;
+        logger.warning(`⚠️ Worker context not found for ${workerName} - creating placeholder`);
+        workerCtx = {
+          instance: null,
+          started: false,
+          registeredAt: Date.now(),
+          lastError: 'context_missing',
+          retryCount: 0,
+          system: 'legacy'
+        };
+        activeWorkers.set(workerName, workerCtx);
       }
 
       if (workerCtx.started) {


### PR DESCRIPTION
## Summary
- improve resilience when starting legacy workers
- lazily reinitialize OpenAI client during worker orchestration
- pass verification and build

## Testing
- `node verify-railway.js`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887d8ea21108325a1cc58b1a5cfd16b