### PR TITLE
Improve log visibility via log relay

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import aiRoutes from './routes/ai';
 import memoryRouter from './routes/memory';
 import systemRouter from './routes/system';
 import codexRouter from './routes/codex';
+import logsRouter from './routes/logs';
 import openaiWebhookRouter from './webhooks/openai';
 import { enableAdminControl, getAdminRouter } from './system/auth';
 
@@ -144,6 +145,7 @@ app.use('/api', router);
 app.use('/api/memory', requireApiToken, memoryRouter);
 app.use('/system', systemRouter);
 app.use('/codex', codexRouter);
+app.use('/logs', logsRouter);
 app.use('/webhooks', openaiWebhookRouter);
 
 // Error handling middleware (must be last)

--- a/src/routes/logs.ts
+++ b/src/routes/logs.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { getRecentLogs } from '../services/log-relay';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.json({ logs: getRecentLogs() });
+});
+
+export default router;

--- a/src/services/log-relay.ts
+++ b/src/services/log-relay.ts
@@ -1,0 +1,30 @@
+import { EventEmitter } from 'events';
+import type { LogLevel } from '../utils/logger';
+
+export interface LogRecord {
+  timestamp: string;
+  level: LogLevel;
+  service: string;
+  message: string;
+  context?: any;
+}
+
+const logEmitter = new EventEmitter();
+const logBuffer: LogRecord[] = [];
+const MAX_LOGS = 200;
+
+export function relayLog(record: LogRecord): void {
+  logBuffer.push(record);
+  if (logBuffer.length > MAX_LOGS) {
+    logBuffer.shift();
+  }
+  logEmitter.emit('log', record);
+}
+
+export function getRecentLogs(): LogRecord[] {
+  return [...logBuffer];
+}
+
+export function onLog(listener: (record: LogRecord) => void): void {
+  logEmitter.on('log', listener);
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -3,6 +3,8 @@
  * Consolidates repeated logging patterns
  */
 
+import { relayLog } from '../services/log-relay';
+
 export type LogLevel = 'info' | 'success' | 'warning' | 'error' | 'debug';
 
 /**
@@ -35,27 +37,67 @@ export class ServiceLogger {
   }
 
   info(message: string, context?: any): void {
-    console.log(this.formatMessage('info', message, context));
+    const formatted = this.formatMessage('info', message, context);
+    console.log(formatted);
+    relayLog({
+      timestamp: new Date().toISOString(),
+      level: 'info',
+      service: this.serviceName,
+      message,
+      context,
+    });
   }
 
   success(message: string, context?: any): void {
-    console.log(this.formatMessage('success', message, context));
+    const formatted = this.formatMessage('success', message, context);
+    console.log(formatted);
+    relayLog({
+      timestamp: new Date().toISOString(),
+      level: 'success',
+      service: this.serviceName,
+      message,
+      context,
+    });
   }
 
   warning(message: string, context?: any): void {
-    console.warn(this.formatMessage('warning', message, context));
+    const formatted = this.formatMessage('warning', message, context);
+    console.warn(formatted);
+    relayLog({
+      timestamp: new Date().toISOString(),
+      level: 'warning',
+      service: this.serviceName,
+      message,
+      context,
+    });
   }
 
   error(message: string, error?: any, context?: any): void {
-    const errorContext = error instanceof Error 
-      ? { ...context, error: error.message } 
+    const errorContext = error instanceof Error
+      ? { ...context, error: error.message }
       : { ...context, error };
-    console.error(this.formatMessage('error', message, errorContext));
+    const formatted = this.formatMessage('error', message, errorContext);
+    console.error(formatted);
+    relayLog({
+      timestamp: new Date().toISOString(),
+      level: 'error',
+      service: this.serviceName,
+      message,
+      context: errorContext,
+    });
   }
 
   debug(message: string, context?: any): void {
     if (process.env.NODE_ENV === 'development') {
-      console.log(this.formatMessage('debug', message, context));
+      const formatted = this.formatMessage('debug', message, context);
+      console.log(formatted);
+      relayLog({
+        timestamp: new Date().toISOString(),
+        level: 'debug',
+        service: this.serviceName,
+        message,
+        context,
+      });
     }
   }
 }
@@ -68,14 +110,32 @@ export const arcanosLogger = {
    * Log service operation start
    */
   serviceStart(serviceName: string, operation: string, context?: any): void {
-    console.log(`🚀 ${serviceName} - Starting ${operation}`, context ? JSON.stringify(context) : '');
+    const message = `🚀 ${serviceName} - Starting ${operation}`;
+    const contextStr = context ? JSON.stringify(context) : '';
+    console.log(message, contextStr);
+    relayLog({
+      timestamp: new Date().toISOString(),
+      level: 'info',
+      service: serviceName,
+      message: `Starting ${operation}`,
+      context,
+    });
   },
 
   /**
    * Log service operation success
    */
   serviceSuccess(serviceName: string, operation: string, context?: any): void {
-    console.log(`✅ ${serviceName} - Successfully completed ${operation}`, context ? JSON.stringify(context) : '');
+    const message = `✅ ${serviceName} - Successfully completed ${operation}`;
+    const contextStr = context ? JSON.stringify(context) : '';
+    console.log(message, contextStr);
+    relayLog({
+      timestamp: new Date().toISOString(),
+      level: 'success',
+      service: serviceName,
+      message: `Completed ${operation}`,
+      context,
+    });
   },
 
   /**
@@ -85,6 +145,13 @@ export const arcanosLogger = {
     const errorMessage = error instanceof Error ? error.message : String(error);
     const logContext = { ...context, error: errorMessage };
     console.error(`❌ ${serviceName} - ${operation} error:`, JSON.stringify(logContext));
+    relayLog({
+      timestamp: new Date().toISOString(),
+      level: 'error',
+      service: serviceName,
+      message: `${operation} error`,
+      context: logContext,
+    });
   },
 
   /**
@@ -92,6 +159,13 @@ export const arcanosLogger = {
    */
   openaiError(serviceName: string, response: any): void {
     console.error(`❌ OpenAI error in ${serviceName} service:`, response.error);
+    relayLog({
+      timestamp: new Date().toISOString(),
+      level: 'error',
+      service: serviceName,
+      message: 'OpenAI error',
+      context: { error: response.error },
+    });
   },
 
   /**
@@ -101,6 +175,13 @@ export const arcanosLogger = {
     const icon = success ? '✅' : '❌';
     const status = success ? 'successful' : 'failed';
     console.log(`${icon} Database ${operation} ${status}`, details ? JSON.stringify(details) : '');
+    relayLog({
+      timestamp: new Date().toISOString(),
+      level: success ? 'success' : 'error',
+      service: 'Database',
+      message: `${operation} ${status}`,
+      context: details,
+    });
   },
 
   /**
@@ -110,6 +191,13 @@ export const arcanosLogger = {
     console.log(`💾 [MEMORY-SNAPSHOT] ${operation}:`, {
       ...data,
       timestamp: new Date().toISOString()
+    });
+    relayLog({
+      timestamp: new Date().toISOString(),
+      level: 'info',
+      service: 'Memory',
+      message: `Snapshot ${operation}`,
+      context: data,
     });
   }
 };


### PR DESCRIPTION
## Summary
- add new log relay service to stream and store logs
- broadcast log messages through relay in logger utility
- expose `/logs` endpoint for dashboard access

## Testing
- `npm run build`
- `npm test`
- `node - <<'EOF'
const { createServiceLogger } = require('./dist/utils/logger');
const { onLog, getRecentLogs } = require('./dist/services/log-relay');
const logger = createServiceLogger('Test');
onLog(record => console.log('LOG-STREAM', record));
logger.info('hello world');
console.log('Recent logs', getRecentLogs());
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6887dce3ec5883258d837f3ae10ef03e