### PR TITLE
Add repeatable worker orchestration

### DIFF
--- a/REPEATABLE_ORCHESTRATION_GUIDE.md
+++ b/REPEATABLE_ORCHESTRATION_GUIDE.md
@@ -1,0 +1,40 @@
+# Repeatable Worker Orchestration Guide
+
+This guide explains how to run a continuous worker orchestration loop in ARCANO’s backend. The process re-registers workers, confirms routing with the AI model and records the results.
+
+## Overview
+The orchestration loop performs these steps for each known worker:
+
+1. **Re-register every worker every 60 seconds** using the existing `registerWorker` function.
+2. **Ping the AI model** via `safeOrchestrateWorker` to confirm that routing succeeds.
+3. **Retry failed orchestrations** automatically through the fallback logic inside `safeOrchestrateWorker`.
+4. **Timestamp each routing record** so you can trace when a worker was last confirmed.
+5. **Log all routing results** into the diagnostic registry for later inspection.
+
+## Usage
+
+Import the helper and start the loop:
+
+```typescript
+import { startRepeatableOrchestration } from './services/repeatable-orchestration';
+
+// Start a 60 second orchestration cycle
+startRepeatableOrchestration();
+```
+
+The diagnostic registry keeps the most recent records in memory:
+
+```typescript
+import { getDiagnosticRecords } from './services/diagnostic-registry';
+
+const records = getDiagnosticRecords();
+console.log(records);
+```
+
+## Diagnostic Registry Fields
+- `worker` – name of the worker that was routed
+- `status` – `success` or `failed`
+- `timestamp` – ISO timestamp of the orchestration attempt
+- `error` – optional error message if the attempt failed
+
+This simple loop makes orchestrations repeatable and observable without adding heavy dependencies.

--- a/src/services/diagnostic-registry.ts
+++ b/src/services/diagnostic-registry.ts
@@ -1,0 +1,28 @@
+import { EventEmitter } from 'events';
+
+export interface DiagnosticRecord {
+  worker: string;
+  status: 'success' | 'failed';
+  timestamp: string;
+  error?: string;
+}
+
+const registry: DiagnosticRecord[] = [];
+const emitter = new EventEmitter();
+const MAX_RECORDS = 500;
+
+export function logRoutingRecord(record: DiagnosticRecord): void {
+  registry.push(record);
+  if (registry.length > MAX_RECORDS) {
+    registry.shift();
+  }
+  emitter.emit('record', record);
+}
+
+export function getDiagnosticRecords(): DiagnosticRecord[] {
+  return [...registry];
+}
+
+export function onDiagnosticRecord(listener: (record: DiagnosticRecord) => void): void {
+  emitter.on('record', listener);
+}

--- a/src/services/repeatable-orchestration.ts
+++ b/src/services/repeatable-orchestration.ts
@@ -1,0 +1,66 @@
+import { KNOWN_WORKERS } from '../utils/worker-validation';
+import { registerWorker, safeOrchestrateWorker } from './openai-worker-orchestrator';
+import { createServiceLogger } from '../utils/logger';
+import { logRoutingRecord } from './diagnostic-registry';
+
+const logger = createServiceLogger('RepeatableOrchestrator');
+
+export interface RoutingRecord {
+  worker: string;
+  status: 'success' | 'failed';
+  timestamp: string;
+  error?: string;
+}
+
+async function confirmRouting(worker: string): Promise<boolean> {
+  try {
+    await safeOrchestrateWorker({ name: worker });
+    logRoutingRecord({ worker, status: 'success', timestamp: new Date().toISOString() });
+    logger.success(`Routing confirmed for ${worker}`);
+    return true;
+  } catch (err: any) {
+    logger.warning(`Routing check failed for ${worker}: ${err.message}`);
+    logRoutingRecord({ worker, status: 'failed', timestamp: new Date().toISOString(), error: err.message });
+    return false;
+  }
+}
+
+async function registerAndConfirm(worker: string): Promise<void> {
+  try {
+    await registerWorker(worker, safeOrchestrateWorker);
+    logger.info(`Worker ${worker} re-registered`);
+  } catch (err: any) {
+    logger.warning(`Registration failed for ${worker}: ${err.message}`);
+  }
+
+  const routed = await confirmRouting(worker);
+  if (!routed) {
+    try {
+      await safeOrchestrateWorker({ name: worker });
+      logRoutingRecord({ worker, status: 'success', timestamp: new Date().toISOString() });
+      logger.success(`Fallback orchestration succeeded for ${worker}`);
+    } catch (fallbackErr: any) {
+      logger.error(`Fallback orchestration failed for ${worker}`, fallbackErr.message);
+      logRoutingRecord({
+        worker,
+        status: 'failed',
+        timestamp: new Date().toISOString(),
+        error: fallbackErr.message,
+      });
+    }
+  }
+}
+
+export async function runOrchestrationCycle(): Promise<void> {
+  for (const worker of KNOWN_WORKERS) {
+    await registerAndConfirm(worker);
+  }
+}
+
+export function startRepeatableOrchestration(intervalMs = 60000): void {
+  runOrchestrationCycle().catch(err => logger.error('Initial orchestration error', err.message));
+  setInterval(() => {
+    runOrchestrationCycle().catch(err => logger.error('Orchestration cycle error', err.message));
+  }, intervalMs);
+  logger.info(`Repeatable orchestration running every ${intervalMs / 1000}s`);
+}


### PR DESCRIPTION
## Summary
- implement diagnostic registry for routing records
- add repeatable orchestration service that re-registers workers and checks routing
- document how to use the repeatable orchestration loop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887e46785988325848b0a70ad4cf1ed