### PR TITLE
Add JSON sanitization for MaintenanceScheduler

### DIFF
--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,0 +1,11 @@
+/**
+ * Utility helpers for JSON processing across the project
+ */
+
+/**
+ * Remove markdown code fences around JSON strings.
+ * This is useful when models wrap JSON output in ```json code blocks.
+ */
+export function sanitizeJsonString(input: string): string {
+  return input.replace(/```json|```/g, '').trim();
+}

--- a/src/workers/maintenance-scheduler.ts
+++ b/src/workers/maintenance-scheduler.ts
@@ -6,6 +6,7 @@
 import { coreAIService } from '../services/ai/core-ai-service';
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 import { createServiceLogger } from '../utils/logger';
+import { sanitizeJsonString } from '../utils/json';
 import fs from 'fs';
 import path from 'path';
 import * as cron from 'node-cron';
@@ -348,7 +349,8 @@ Please analyze and provide:
     }
 
     try {
-      const parsed = JSON.parse(result.content);
+      const cleaned = sanitizeJsonString(result.content);
+      const parsed = JSON.parse(cleaned);
       const schema = z.object({
         issues: z.array(z.string()).optional().default([]),
         actions: z.array(z.string()).optional().default([]),


### PR DESCRIPTION
## Summary
- create `sanitizeJsonString` helper to strip markdown code fences
- sanitize maintenance worker AI response before JSON parsing

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68881073c5248325a056eb7b7d2b8acc