### PR TITLE
Fix fine-tune routing fallback

### DIFF
--- a/src/handlers/core-handler.ts
+++ b/src/handlers/core-handler.ts
@@ -41,15 +41,20 @@ export async function askHandler(req: Request, res: Response): Promise<void> {
 
   try {
     if (useFineTuned || /finetune|ft:/i.test(query)) {
-      const openaiDirect = getOpenAIClient();
-      const completion = await openaiDirect.chat.completions.create({
-        model: aiConfig.fineTunedModel || "ft:gpt-3.5-turbo-0125:your-org:model-id", // replace with actual ID
-        messages: [{ role: "user", content: query }],
-        temperature: 0.7,
-      });
-      const response = completion.choices[0]?.message?.content || "";
-      res.json({ response: frontend ? stripReflections(response) : response });
-      return;
+      try {
+        const openaiDirect = getOpenAIClient();
+        const completion = await openaiDirect.chat.completions.create({
+          model: aiConfig.fineTunedModel || "ft:gpt-3.5-turbo-0125:your-org:model-id", // replace with actual ID
+          messages: [{ role: "user", content: query }],
+          temperature: 0.7,
+        });
+        const response = completion.choices[0]?.message?.content || "";
+        res.json({ response: frontend ? stripReflections(response) : response });
+        return;
+      } catch (ftError) {
+        console.error('Fine-tuned route failed, falling back to reflective logic:', ftError);
+        // Fall through to reflective logic
+      }
     }
 
     const raw = await runReflectiveLogic(query);


### PR DESCRIPTION
## Summary
- handle errors when routing through the fine-tuned model
- fall back to reflective logic if the fine-tuned call fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888621e20dc8325a4da82f976558b4f