### PR TITLE
Update to arcanos-v2 model

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 OPENAI_API_KEY=test_key_for_development
-AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD
+AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH
 DATABASE_URL=
 ARCANOS_API_TOKEN=test_token_123
 NODE_ENV=development
@@ -8,7 +8,7 @@ RUN_WORKERS=false
 WORKER_LOGIC=arcanos
 
 # Identity override for admin access
-IDENTITY_OVERRIDE={"identity_override":{"name":"ARCANOS","version":"v3:ByCSivqD","designation":"Reflective Logic Intelligence","role":"Execute modular command, diagnostics, orchestration, and admin protocol tasks","admin":"Justin"}}
+IDENTITY_OVERRIDE={"identity_override":{"name":"ARCANOS","version":"v2:BxRSDrhH","designation":"Reflective Logic Intelligence","role":"Execute modular command, diagnostics, orchestration, and admin protocol tasks","admin":"Justin"}}
 IDENTITY_TRIGGER_PHRASE=I am Skynet
 
 # SMTP Configuration for testing

--- a/.env.example
+++ b/.env.example
@@ -15,12 +15,12 @@ OPENAI_API_KEY=your-openai-api-key-here
 # FINE_TUNE_MODEL - Alternative fine-tuned model variable
 # FINE_TUNED_MODEL - Legacy fine-tuned model variable  
 # OPENAI_FINE_TUNED_MODEL (lowest priority) - OpenAI-specific model variable
-AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD
-FINE_TUNE_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD
+AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH
+FINE_TUNE_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH
 CODE_INTERPRETER_MODEL=gpt-4o
 
 # Identity override configuration
-IDENTITY_OVERRIDE={"identity_override":{"name":"ARCANOS","version":"v3:ByCSivqD","designation":"Reflective Logic Intelligence","role":"Execute modular command, diagnostics, orchestration, and admin protocol tasks","admin":"Justin"}}
+IDENTITY_OVERRIDE={"identity_override":{"name":"ARCANOS","version":"v2:BxRSDrhH","designation":"Reflective Logic Intelligence","role":"Execute modular command, diagnostics, orchestration, and admin protocol tasks","admin":"Justin"}}
 IDENTITY_TRIGGER_PHRASE=I am Skynet
 
 # Fine-tuning Pipeline Configuration

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,5 @@
 OPENAI_API_KEY=test_key_for_development
-AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD
+AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH
 DATABASE_URL=postgresql://test:test@localhost:5432/test_db
 ARCANOS_API_TOKEN=test_token_123
 NODE_ENV=development

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -9,7 +9,7 @@
 | `NODE_ENV` | `production` | Environment mode (production/development) |
 | `PORT` | `8080` | Server port (Railway auto-assigns) |
 | `OPENAI_API_KEY` | `[REQUIRED]` | OpenAI API authentication key |
-| `FINE_TUNED_MODEL` | `ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD` | Primary fine-tuned model ID (supports multiple variable names) |
+| `FINE_TUNED_MODEL` | `ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH` | Primary fine-tuned model ID (supports multiple variable names) |
 | `RUN_WORKERS` | `true` | Enable AI-controlled CRON worker processes |
 | `WORKER_LOGIC` | `arcanos` | Default logic mode for background workers |
 | `SERVER_URL` | `https://arcanos-production-426d.up.railway.app` | Production server URL for health checks |
@@ -45,9 +45,9 @@ The CRON worker system runs when `RUN_WORKERS=true` and implements **AI-controll
 ## 🤖 Fine-Tuned Model Configuration & Behavior
 
 -### Active Model
-- **Primary Model**: `ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD`
+- **Primary Model**: `ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH`
 - **Model Type**: Fine-tuned GPT-3.5 Turbo
-- **Version**: `arcanos-v3`
+- **Version**: `arcanos-v2`
 - **Owner**: Personal account
 - **Training Date**: November 2024
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,7 +31,7 @@
 - **ALIGNED**: Tone and format consistency across all documentation files
 
 ### 🤖 Current System State
-- **Fine-tuned Model**: `ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD`
+- **Fine-tuned Model**: `ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH`
 - **HRC Overlay**: Active validation with resilience/fidelity scoring
 - **Environment Variables**: Enhanced support with flexible precedence
 - **OpenAI Integration**: Improved configuration options and error handling
@@ -51,7 +51,7 @@
 ### 🤖 AI-Controlled System Documentation
  - **DOCUMENTED**: Full AI operational control system via `modelControlHooks`
  - **DETAILED**: AI-controlled CRON worker schedules with approval system
- - **SPECIFIED**: Current fine-tuned model: `ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD`
+ - **SPECIFIED**: Current fine-tuned model: `ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH`
 - **EXPLAINED**: JSON instruction system for AI operational decisions
 - **COVERED**: AI approval requirements for all background tasks
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -110,7 +110,7 @@ export function validateConfig(): { valid: boolean; errors: string[] } {
     errors.push('PORT must be a valid port number (1-65535)');
   }
 
-  const expectedModel = 'ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD';
+  const expectedModel = 'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH';
   if (!config.ai.fineTunedModel) {
     errors.push(`AI_MODEL is required and must be set to ${expectedModel}`);
   } else if (config.ai.fineTunedModel !== expectedModel) {

--- a/src/handlers/ask-handler.ts
+++ b/src/handlers/ask-handler.ts
@@ -55,7 +55,7 @@ async function runFineTunedModel(prompt: string): Promise<string> {
   });
 
   const completion = await openaiClient.chat.completions.create({
-    model: aiConfig.fineTunedModel || "ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD",
+    model: aiConfig.fineTunedModel || "ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH",
     messages: [{ role: "user", content: prompt }],
     temperature: 0.7,
   });

--- a/src/handlers/ask-handler.ts.backup
+++ b/src/handlers/ask-handler.ts.backup
@@ -105,7 +105,7 @@ export const askHandler = async (req: Request, res: Response) => {
       try {
         const openai = getOpenAIClient();
         const completion = await openai.chat.completions.create({
-          model: aiConfig.fineTunedModel || "ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD", 
+          model: aiConfig.fineTunedModel || "ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH", 
           messages: [{ role: "user", content: userInput }],
           temperature: 0.7,
         });

--- a/src/services/ai-dispatcher.ts
+++ b/src/services/ai-dispatcher.ts
@@ -64,7 +64,7 @@ export class AIDispatcher {
   private model: string;
 
   constructor() {
-    this.model = process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD';
+    this.model = process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH';
     
     try {
       this.openaiService = new OpenAIService({

--- a/src/services/ai/core-ai-service.ts
+++ b/src/services/ai/core-ai-service.ts
@@ -57,7 +57,7 @@ export class CoreAIService {
     });
 
     // Use configured fine-tuned model or fallback ID
-    this.defaultModel = process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD';
+    this.defaultModel = process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH';
     this.maxRetries = 3;
     this.retryDelayMs = 1000;
 

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -45,7 +45,7 @@ export class OpenAIService {
     });
 
     // Use configured fine-tuned model or fallback to predefined ID
-    this.model = options?.model || aiConfig.fineTunedModel || process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD';
+    this.model = options?.model || aiConfig.fineTunedModel || process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH';
 
     // Optional identity override injected as system message for all chats
     const override = options?.identityOverride || aiConfig.identityOverride || process.env.IDENTITY_OVERRIDE;

--- a/src/services/optimized-ai-dispatcher.ts
+++ b/src/services/optimized-ai-dispatcher.ts
@@ -58,7 +58,7 @@ export class OptimizedAIDispatcher {
   private dispatchLocks: Map<string, boolean> = new Map();
 
   constructor() {
-    this.model = process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD';
+    this.model = process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH';
     
     try {
       this.openaiService = new OpenAIService({

--- a/test-core-handler-finetune.js
+++ b/test-core-handler-finetune.js
@@ -153,7 +153,7 @@ function testModelConfiguration() {
   
   // Simulate the model selection logic
   const aiConfig = {
-    fineTunedModel: 'ft:gpt-3.5-turbo-0125:personal:arcanos-v3:ByCSivqD'
+    fineTunedModel: 'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH'
   };
   
   const selectedModel = aiConfig.fineTunedModel || "ft:gpt-3.5-turbo-0125:your-org:model-id";

--- a/test-router.js
+++ b/test-router.js
@@ -108,7 +108,7 @@ function startTestServer() {
       res.json({ 
         status: 'healthy',
         service: 'ARCANOS Router',
-        model: 'gpt-3.5-turbo-0125:personal:arcanos-v3',
+        model: 'gpt-3.5-turbo-0125:personal:arcanos-v2',
         timestamp: new Date().toISOString()
       });
     });
@@ -122,7 +122,7 @@ function startTestServer() {
           'POST /query': 'Submit queries to fine-tuned model',
           'GET /health': 'Health check for Railway deployment'
         },
-        model: 'gpt-3.5-turbo-0125:personal:arcanos-v3',
+        model: 'gpt-3.5-turbo-0125:personal:arcanos-v2',
         fallback: false
       });
     });


### PR DESCRIPTION
## Summary
- update environment files to use the `arcanos-v2` fine-tuned model
- refresh docs and changelog with new model ID
- set expected model in config and service defaults
- update ask handler, dispatchers, and tests

## Testing
- `npm run build` *(fails: cannot find module declarations)*
- `npm test`
- `./test-api-endpoints.sh`

------
https://chatgpt.com/codex/tasks/task_e_6888816c419c83258871f80db4006657