### PR TITLE
Add cron registration API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import memoryRouter from './routes/memory';
 import systemRouter from './routes/system';
 import codexRouter from './routes/codex';
 import logsRouter from './routes/logs';
+import cronRouter from './routes/cron';
 import openaiWebhookRouter from './webhooks/openai';
 import githubWebhookRouter from './webhooks/github';
 import { enableAdminControl, getAdminRouter } from './system/auth';
@@ -147,6 +148,7 @@ app.use('/api/memory', requireApiToken, memoryRouter);
 app.use('/system', systemRouter);
 app.use('/codex', codexRouter);
 app.use('/logs', logsRouter);
+app.use('/cron', cronRouter);
 app.use('/webhooks', openaiWebhookRouter);
 app.use('/webhooks', githubWebhookRouter);
 

--- a/src/routes/cron.ts
+++ b/src/routes/cron.ts
@@ -1,0 +1,69 @@
+import { Router, Request, Response } from 'express';
+import cron from 'node-cron';
+import { executionEngine } from '../services/execution-engine';
+import { isValidWorker } from '../services/worker-manager';
+import { activeWorkers } from '../worker-init';
+import { createServiceLogger } from '../utils/logger';
+
+const router = Router();
+const logger = createServiceLogger('CronRouter');
+
+function validateSchedule(expr: string): boolean {
+  try {
+    return cron.validate(expr);
+  } catch {
+    return false;
+  }
+}
+
+router.post('/register', async (req: Request, res: Response) => {
+  const { worker, schedule, parameters = {} } = req.body || {};
+
+  if (!worker || !schedule) {
+    return res.status(400).json({
+      error: 'worker and schedule are required',
+    });
+  }
+
+  const workerName = String(worker);
+
+  if (!isValidWorker(workerName)) {
+    return res.status(400).json({
+      error: `Invalid worker name: ${workerName}`,
+    });
+  }
+
+  if (!activeWorkers.has(workerName)) {
+    return res.status(400).json({
+      error: `Unregistered worker: ${workerName}`,
+    });
+  }
+
+  if (!validateSchedule(schedule)) {
+    return res.status(400).json({
+      error: 'Invalid cron expression',
+    });
+  }
+
+  try {
+    const result = executionEngine.handleSchedule({
+      action: 'schedule',
+      worker: workerName,
+      schedule,
+      parameters,
+    });
+
+    if (result.success) {
+      logger.success('Cron job registered', { worker: workerName, schedule });
+      res.json({ status: 'registered', worker: workerName, schedule });
+    } else {
+      logger.error('Cron schedule failed', result.error, { worker: workerName });
+      res.status(500).json({ error: result.error });
+    }
+  } catch (error: any) {
+    logger.error('Cron registration error', error, { worker: workerName });
+    res.status(500).json({ error: error.message });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- implement `/cron/register` endpoint for dynamic cron job scheduling
- mount cron router in server

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688925dd80148325a9c4c924cee04f44