### PR TITLE
Fix dynamic import usage in ai-patch-system

### DIFF
--- a/src/services/memory.js
+++ b/src/services/memory.js
@@ -1,0 +1,1 @@
+module.exports = require('./memory.ts');


### PR DESCRIPTION
## Summary
- add a helper for dynamic imports with a CommonJS fallback
- update ai-patch-system to use the helper
- add `src/services/memory.js` shim so dev mode finds the module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889f43dba808325b288380d1f592354