### PR TITLE
Add GitHub access verifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "patch:push": "npx ts-node patch-push-system.ts",
     "patch:push:mock": "npx ts-node patch-push-system-mock.ts",
     "patch:push:integrated": "npx ts-node patch-push-system-integrated.ts",
+    "github:verify": "node scripts/verify-github-access.js",
     "ci:build": "NODE_OPTIONS='--max_old_space_size=256' npm install --omit=dev && npm run build"
   },
   "dependencies": {

--- a/scripts/verify-github-access.js
+++ b/scripts/verify-github-access.js
@@ -1,0 +1,33 @@
+// Diagnostics: Verify GitHub Token and Repo Access
+// Usage: node scripts/verify-github-access.js [owner/repo]
+// The script checks whether the provided GitHub token can access the repository.
+
+const repo = process.argv[2] || 'pbjustin/Arcanos';
+const token = process.env.GITHUB_TOKEN;
+
+async function verifyAccess() {
+  try {
+    const response = await fetch(`https://api.github.com/repos/${repo}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github.v3+json',
+        'User-Agent': 'AI-Diagnostics'
+      }
+    });
+
+    if (response.ok) {
+      const info = await response.json();
+      console.log('✅ GitHub access verified:', info.full_name);
+    } else {
+      console.error(`❌ GitHub token failed: ${response.status} - ${response.statusText}`);
+      const text = await response.text();
+      console.error('Response:', text);
+      process.exitCode = 1;
+    }
+  } catch (err) {
+    console.error('❌ GitHub access check error:', err.message);
+    process.exitCode = 1;
+  }
+}
+
+verifyAccess();


### PR DESCRIPTION
## Summary
- add a utility script to confirm GitHub token access
- expose the script via `npm run github:verify`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a8983f4a8832587e9ecfff5e0299c