### PR TITLE
Add PR diagnostics logger

### DIFF
--- a/pr-diagnostics.ts
+++ b/pr-diagnostics.ts
@@ -1,0 +1,50 @@
+// PATCH: Inject PR Diagnostics Logger
+// Logs PR push attempts, GitHub response status, and any failure codes
+
+import fs from 'fs';
+import path from 'path';
+import { pushPRToGitHub } from './services/git';
+import { buildPatchSet } from './services/ai-reflections';
+
+(async () => {
+  try {
+    const patch = await buildPatchSet({ useMemory: true });
+    const prResponse = await pushPRToGitHub(patch, 'main');
+
+    const logEntry = {
+      timestamp: new Date().toISOString(),
+      status: '✅ PR Push Attempted',
+      response: prResponse,
+    };
+
+    if (!fs.existsSync('logs')) {
+      fs.mkdirSync('logs');
+    }
+
+    fs.writeFileSync(
+      path.join(__dirname, 'logs', `pr-log-${Date.now()}.json`),
+      JSON.stringify(logEntry, null, 2)
+    );
+
+    console.log('📦 PR Push Logged');
+  } catch (error: any) {
+    const errorLog = {
+      timestamp: new Date().toISOString(),
+      status: '❌ PR Push Failed',
+      error: error.message,
+      stack: error.stack,
+    };
+
+    if (!fs.existsSync('logs')) {
+      fs.mkdirSync('logs');
+    }
+
+    fs.writeFileSync(
+      path.join(__dirname, 'logs', `pr-error-${Date.now()}.json`),
+      JSON.stringify(errorLog, null, 2)
+    );
+
+    console.error('❌ PR Logging Failed:', error.message);
+  }
+})();
+

--- a/services/git.ts
+++ b/services/git.ts
@@ -183,3 +183,21 @@ This PR was generated using the stateless patch system that bypasses memory lock
     };
   }
 }
+
+/**
+ * Convenience wrapper to push a patch as a PR to GitHub
+ * using default settings for stateless operations
+ */
+export async function pushPRToGitHub(patch: any, baseBranch = 'main'): Promise<PRResult> {
+  const branchName = `ai-diff-${Date.now()}`;
+  const commitMessage = 'AI Patch Update';
+  return generatePR({
+    patch,
+    branchName,
+    commitMessage,
+    forcePush: true,
+    verifyLock: false,
+    baseBranch
+  });
+}
+


### PR DESCRIPTION
## Summary
- add wrapper function `pushPRToGitHub` to simplify stateless PR pushes
- create `pr-diagnostics.ts` script for logging PR attempts and outcomes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ab19d982c83258f3a928e61d17b65