### PR TITLE
Add dispatcher with file I/O bypass

### DIFF
--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -1,0 +1,30 @@
+// PATCH: Fix Dispatcher Recursion and Separate File I/O
+// Ensures diagnostics and memory reads don't recurse through logic mode
+
+import { handleLogic } from './routes/logic';
+import { handleFileRead } from './routes/io';
+import { Request, Response } from 'express';
+
+export async function dispatcher(req: Request, res: Response) {
+  try {
+    const routeType = req.headers['x-request-type'] || 'logic';
+    const payload = req.body;
+
+    if (routeType === 'file') {
+      // Bypass logic layer for safe diagnostics, memory, and I/O reads
+      const result = await handleFileRead(payload);
+      return res.json({ status: '✅ File I/O routed', result });
+    }
+
+    // Default logic handler
+    const result = await handleLogic(payload);
+    return res.json({ status: '✅ Logic executed', result });
+
+  } catch (err: any) {
+    return res.status(500).json({
+      status: '❌ Dispatcher Error',
+      message: err.message,
+      stack: err.stack,
+    });
+  }
+}

--- a/src/routes/io.ts
+++ b/src/routes/io.ts
@@ -1,0 +1,15 @@
+import path from 'path';
+import { promises as fs } from 'fs';
+
+const BASE_DIR = path.join(process.cwd(), 'storage');
+
+export async function handleFileRead(payload: any): Promise<any> {
+  const file = payload?.file;
+  if (!file || typeof file !== 'string') {
+    throw new Error('file path required');
+  }
+  const safePath = file.replace(/(\.\.|\/)*/g, '');
+  const filePath = path.join(BASE_DIR, safePath);
+  const data = await fs.readFile(filePath, 'utf8');
+  return { file: safePath, data };
+}

--- a/src/routes/logic.ts
+++ b/src/routes/logic.ts
@@ -1,0 +1,6 @@
+import { processArcanosRequest } from '../services/arcanos-router';
+
+export async function handleLogic(payload: any): Promise<any> {
+  const { message = '', domain = 'general', useRAG = true, useHRC = true } = payload || {};
+  return await processArcanosRequest({ message, domain, useRAG, useHRC });
+}


### PR DESCRIPTION
## Summary
- implement dispatcher to avoid recursion when serving file reads
- add simple file I/O handler
- add logic handler wrapper around `processArcanosRequest`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ab980b5588325971c36fa95348cda