### PR TITLE
Add Codex prompt helper

### DIFF
--- a/src/services/codexService.ts
+++ b/src/services/codexService.ts
@@ -1,0 +1,23 @@
+import { OpenAI } from 'openai';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+export async function runCodexPrompt(prompt: string, model = 'gpt-4') {
+  try {
+    const response = await openai.chat.completions.create({
+      model,
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.2,
+    });
+
+    return response.choices[0].message?.content || '❌ No Codex output.';
+  } catch (err: any) {
+    console.error('Codex error:', err.message);
+    return '❌ Codex request failed.';
+  }
+}


### PR DESCRIPTION
## Summary
- implement a simple `runCodexPrompt` helper for GPT‑4 code prompts

## Testing
- `npm test`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_688ac8016bc88325bc385e69b24a1c2a