### PR TITLE
Implement initializeBackend helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -269,3 +269,4 @@ export { saveGameGuide } from './services/game-guides';
 
 // Export AI patch system for external usage
 export { aiPatchSystem, createAIPatch } from './services/ai-patch-system';
+export { initializeBackend } from './initializeBackend';

--- a/src/initializeBackend.ts
+++ b/src/initializeBackend.ts
@@ -1,0 +1,41 @@
+import { installNLPInterpreter } from './modules/nlp-interpreter';
+import { installPagedOutputHandler } from './modules/paged-output-handler';
+import { createServiceLogger } from './utils/logger';
+
+export interface BackendInitializationOptions {
+  environment?: string;
+  modules?: string[];
+  integrations?: Record<string, any>;
+  audit?: Record<string, any>;
+  config?: Record<string, any>;
+  memory?: Record<string, any>;
+}
+
+const logger = createServiceLogger('BackendInit');
+
+export function initializeBackend(options: BackendInitializationOptions): void {
+  // Set environment
+  if (options.environment) {
+    process.env.NODE_ENV = options.environment;
+    logger.info(`Environment set to ${options.environment}`);
+  }
+
+  const modules = options.modules || [];
+  if (modules.includes('nlp-interpreter')) {
+    installNLPInterpreter({ enablePromptTranslation: true });
+    logger.success('NLP interpreter initialized');
+  }
+  if (modules.includes('paged-output-handler')) {
+    installPagedOutputHandler({ maxPayloadSize: options.config?.maxPayload || 2048 });
+    logger.success('Paged output handler initialized');
+  }
+
+  // Placeholder handlers for other modules
+  ['dispatcher-core', 'audit-router', 'commit-logger'].forEach((name) => {
+    if (modules.includes(name)) {
+      logger.info(`Module ${name} requested but no implementation found`);
+    }
+  });
+
+  logger.info('Backend initialization complete');
+}


### PR DESCRIPTION
## Summary
- add `initializeBackend` function for bootstrapping modules
- export initializer in main index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b21393a7483259a5f81c5354be37e