### PR TITLE
Trigger AI reflection on server sleep

### DIFF
--- a/src/events/system-events.ts
+++ b/src/events/system-events.ts
@@ -1,0 +1,13 @@
+import { EventEmitter } from 'events';
+
+const systemEmitter = new EventEmitter();
+
+export function onServerSleep(listener: () => void): void {
+  systemEmitter.on('server-sleep', listener);
+}
+
+export function emitServerSleep(): void {
+  systemEmitter.emit('server-sleep');
+}
+
+export { systemEmitter };

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,9 @@ import './worker-init';
 // Import AI reflection handler (initializes 8:30 AM daily schedule)
 import './services/backend-ai-reflection-handler';
 
+// Trigger self-reflection when entering sleep mode
+import './sleep-self-reflection';
+
 // Import sleep manager
 import { sleepManager } from './services/sleep-manager';
 

--- a/src/services/reflection-engine.ts
+++ b/src/services/reflection-engine.ts
@@ -1,0 +1,30 @@
+import { reflect } from './ai';
+import { createServiceLogger } from '../utils/logger';
+
+export interface ReflectionTriggerOptions {
+  source?: string;
+  force?: boolean;
+  log?: boolean;
+  memoryTarget?: string;
+}
+
+const logger = createServiceLogger('ReflectionEngine');
+
+export async function triggerSelfReflection(options: ReflectionTriggerOptions = {}): Promise<void> {
+  const { source = 'manual', log = false, memoryTarget = 'long-term' } = options;
+
+  try {
+    const snapshot = await reflect({
+      label: `${source}_reflection_${Date.now()}`,
+      persist: true,
+      includeStack: true,
+      targetPath: `ai_outputs/reflections/${memoryTarget}/`
+    });
+
+    if (log) {
+      logger.info(`Reflection completed from ${source}`, { timestamp: snapshot.timestamp });
+    }
+  } catch (error: any) {
+    logger.error(`Reflection failed from ${source}`, error);
+  }
+}

--- a/src/services/sleep-manager.ts
+++ b/src/services/sleep-manager.ts
@@ -4,6 +4,7 @@
 
 import cron from 'node-cron';
 import { getCurrentSleepWindowStatus, shouldReduceServerActivity, logSleepWindowStatus } from './sleep-config';
+import { emitServerSleep } from '../events/system-events';
 import { modelControlHooks } from './model-control-hooks';
 import { workerStatusService } from './worker-status';
 
@@ -89,6 +90,16 @@ export class SleepManager {
     if (this.maintenanceTasksScheduled) {
       return;
     }
+
+    // Emit server-sleep event at the start of the sleep window (7 AM ET)
+    cron.schedule(
+      '0 7 * * *',
+      () => {
+        console.log('[SLEEP-MANAGER] Emitting server-sleep event');
+        emitServerSleep();
+      },
+      { timezone: 'America/New_York' }
+    );
 
     // Memory sync and snapshot - every 2 hours during sleep window
     cron.schedule('0 */2 * * *', async () => {

--- a/src/sleep-self-reflection.ts
+++ b/src/sleep-self-reflection.ts
@@ -1,0 +1,12 @@
+import { onServerSleep } from './events/system-events';
+import { triggerSelfReflection } from './services/reflection-engine';
+
+onServerSleep(() => {
+  console.log('[Reflection Trigger] Server is entering sleep mode. Initiating reflection...');
+  triggerSelfReflection({
+    source: 'server-sleep',
+    force: true,
+    log: true,
+    memoryTarget: 'long-term'
+  });
+});


### PR DESCRIPTION
## Summary
- add system events emitter to publish `server-sleep`
- add `reflection-engine` helper to execute a reflection cycle
- emit `server-sleep` from the sleep manager at 7AM ET
- trigger reflection when the server-sleep event fires

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c28ff80348325ae572ea27c330ef7