### PR TITLE
Add hourly reflection scheduler

### DIFF
--- a/backend/scheduler/reflection-task.ts
+++ b/backend/scheduler/reflection-task.ts
@@ -1,0 +1,15 @@
+import { schedule } from 'node-cron';
+import { triggerReflectionDump, checkServerState } from '../services/reflection-engine';
+
+// Run every hour on the hour
+schedule('0 * * * *', async () => {
+  const state = await checkServerState();
+
+  if (state === 'ACTIVE') {
+    console.log('[Reflection] Running periodic hourly reflection...');
+    await triggerReflectionDump({ mode: 'incremental', reason: 'hourly' });
+  } else if (state === 'SLEEP_PENDING') {
+    console.log('[Reflection] Server sleep detected — performing full memory sweep.');
+    await triggerReflectionDump({ mode: 'full', reason: 'server_shutdown' });
+  }
+});

--- a/backend/services/reflection-engine.ts
+++ b/backend/services/reflection-engine.ts
@@ -1,0 +1,24 @@
+import { reflect } from '../../src/services/ai';
+import { getCurrentSleepWindowStatus } from '../../src/services/sleep-config';
+
+export type ServerState = 'ACTIVE' | 'SLEEP_PENDING';
+
+export interface ReflectionDumpOptions {
+  mode: 'incremental' | 'full';
+  reason: string;
+}
+
+export async function checkServerState(): Promise<ServerState> {
+  const status = getCurrentSleepWindowStatus();
+  return status.inSleepWindow ? 'SLEEP_PENDING' : 'ACTIVE';
+}
+
+export async function triggerReflectionDump(options: ReflectionDumpOptions): Promise<void> {
+  const { mode, reason } = options;
+  await reflect({
+    label: `${reason}_${mode}_dump_${Date.now()}`,
+    persist: true,
+    includeStack: true,
+    targetPath: `ai_outputs/reflections/${mode}/`
+  });
+}


### PR DESCRIPTION
## Summary
- implement basic reflection engine and hourly cron task
- add server state check using sleep window config

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688c341bb1ac8325b932104e7c9ec042