### PR TITLE
Add uptime tracker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import { serverService } from './services/server';
 import { chatGPTUserWhitelist } from './services/chatgpt-user-whitelist';
 import { diagnosticsService } from './services/diagnostics';
 import { memoryMonitor } from './services/memory-monitor';
+import { recordUptime, getLastUptime } from './utils/uptime';
 
 // Handlers (for initialization)
 import { memoryHandler } from './handlers/memory-handler';
@@ -194,6 +195,11 @@ process.on("unhandledRejection", (reason, promise) => {
 // Server startup with optimized initialization
 serverService.start(app, PORT).then(async () => {
   console.log(`[SERVER] Running on port ${PORT}`);
+  const lastBoot = getLastUptime();
+  recordUptime();
+  if (lastBoot) {
+    console.log(`[UPTIME] Previous boot at ${lastBoot}`);
+  }
   console.log(`[INFO] ENV:`, {
     NODE_ENV: config.server.nodeEnv,
     PORT: config.server.port,

--- a/src/utils/uptime.ts
+++ b/src/utils/uptime.ts
@@ -1,0 +1,13 @@
+import fs from 'fs'
+
+const UPTIME_LOG = './.uptime'
+
+export function recordUptime() {
+  const now = new Date().toISOString()
+  fs.writeFileSync(UPTIME_LOG, now)
+  console.log(`[UPTIME] Boot recorded at ${now}`)
+}
+
+export function getLastUptime(): string | null {
+  return fs.existsSync(UPTIME_LOG) ? fs.readFileSync(UPTIME_LOG, 'utf-8') : null
+}


### PR DESCRIPTION
## Summary
- record server startup time in `.uptime`
- log previous boot time on server startup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ce8f333bc8325994905aad77a320a