### PR TITLE
Add memory watchdog

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import { serverService } from './services/server';
 import { chatGPTUserWhitelist } from './services/chatgpt-user-whitelist';
 import { diagnosticsService } from './services/diagnostics';
 import { memoryMonitor } from './services/memory-monitor';
+import { runMemoryWatchdog } from './services/memory-watchdog';
 
 // Handlers (for initialization)
 import { memoryHandler } from './handlers/memory-handler';
@@ -242,6 +243,7 @@ serverService.start(app, PORT).then(async () => {
   const memStats = process.memoryUsage();
   console.log('🧠 [MEMORY] Initial RSS:', (memStats.rss / 1024 / 1024).toFixed(2), 'MB');
   memoryMonitor.start();
+  runMemoryWatchdog();
   
   // Railway-specific logging
   if (config.railway.environment) {

--- a/src/services/memory-watchdog.ts
+++ b/src/services/memory-watchdog.ts
@@ -1,0 +1,16 @@
+const MEMORY_THRESHOLD_MB = 512;
+
+import { dispatchTask } from '../utils/executionGuard';
+
+export function runMemoryWatchdog() {
+  setInterval(() => {
+    const usage = process.memoryUsage();
+    const heapMb = Math.round(usage.heapUsed / 1024 / 1024);
+    if (heapMb > MEMORY_THRESHOLD_MB) {
+      console.warn(`[WATCHDOG] High memory usage: ${heapMb} MB`);
+      dispatchTask('system.memory.snapshot', { usage: heapMb }, 'high');
+      // Optional: restart or garbage collection signal
+    }
+  }, 60 * 1000); // Every 60s
+}
+


### PR DESCRIPTION
## Summary
- add a memory watchdog service that dispatches a snapshot when heap use rises above 512MB
- start the watchdog alongside the existing memory monitor

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ce9a73a1c832598bcdcf745272af8