### PR TITLE
Add uptime and memory watchdog demo

### DIFF
--- a/examples/run-watchdog.ts
+++ b/examples/run-watchdog.ts
@@ -1,0 +1,5 @@
+import { recordUptime } from './uptime';
+import { runMemoryWatchdog } from './watchdog';
+
+recordUptime();
+runMemoryWatchdog();

--- a/examples/uptime.ts
+++ b/examples/uptime.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Records process uptime to storage/uptime.log at a fixed interval.
+ */
+export function recordUptime(intervalMs = 60_000) {
+  const dir = path.join(__dirname, '../storage');
+  const file = path.join(dir, 'uptime.log');
+  fs.mkdirSync(dir, { recursive: true });
+
+  const log = () => {
+    const seconds = Math.round(process.uptime());
+    const stamp = new Date().toISOString();
+    fs.appendFileSync(file, `${stamp} uptime=${seconds}s\n`);
+  };
+
+  log();
+  setInterval(log, intervalMs);
+}

--- a/examples/watchdog.ts
+++ b/examples/watchdog.ts
@@ -1,0 +1,14 @@
+/**
+ * Simple memory watchdog that logs usage every interval.
+ */
+export function runMemoryWatchdog(intervalMs = 60_000) {
+  const log = () => {
+    const mem = process.memoryUsage();
+    const rss = (mem.rss / 1024 / 1024).toFixed(2);
+    const heap = (mem.heapUsed / 1024 / 1024).toFixed(2);
+    console.log(`\uD83D\uDEE1 Memory Watchdog -> RSS: ${rss}MB Heap: ${heap}MB`);
+  };
+
+  log();
+  setInterval(log, intervalMs);
+}


### PR DESCRIPTION
## Summary
- add `recordUptime` helper to log process uptime
- add simple memory watchdog
- demonstrate both utilities with a small example script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ce9e942a08325aac4a3f601fa408d