### PR TITLE
Add intent routing and dispatcher

### DIFF
--- a/src/utils/intentDispatcher.ts
+++ b/src/utils/intentDispatcher.ts
@@ -1,0 +1,49 @@
+import OpenAI from 'openai';
+import { routeByIntent, type IntentMode } from './routeByIntent';
+
+// Initialize OpenAI client with API key from environment
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export interface DispatchResult {
+  mode: IntentMode;
+  model: string;
+  response: any;
+}
+
+/**
+ * Determine mode using `routeByIntent` and dispatch to the appropriate model.
+ * Logs the decision path and surfaces any errors.
+ */
+export async function intentDispatcher(prompt: string): Promise<DispatchResult> {
+  const mode = routeByIntent(prompt);
+  console.log(`[intentDispatcher] Routing prompt to mode: ${mode}`);
+
+  let model = 'gpt-4';
+  switch (mode) {
+    case 'audit':
+      model = 'gpt-3.5-turbo';
+      break;
+    case 'codegen':
+      model = process.env.CODEGEN_MODEL || 'gpt-4';
+      break;
+    case 'sim':
+      model = 'gpt-4';
+      break;
+    case 'write':
+    default:
+      model = 'gpt-4';
+      break;
+  }
+
+  try {
+    const response = await openai.chat.completions.create({
+      model,
+      messages: [{ role: 'user', content: prompt }]
+    });
+
+    return { mode, model, response };
+  } catch (error) {
+    console.error('[intentDispatcher] Error dispatching prompt:', error);
+    throw error;
+  }
+}

--- a/src/utils/routeByIntent.ts
+++ b/src/utils/routeByIntent.ts
@@ -1,0 +1,32 @@
+// Utility to decide how a prompt should be handled
+// Returns one of: 'write', 'audit', 'codegen', or 'sim'
+
+export type IntentMode = 'write' | 'audit' | 'codegen' | 'sim';
+
+/**
+ * Basic keyword routing for prompts.
+ * - codegen: references to code, GitHub Actions, or languages
+ * - audit: mentions analysis or CLEAR framework
+ * - sim: asks for simulations or hypothetical behavior
+ * - write: default catch-all
+ */
+export function routeByIntent(prompt: string): IntentMode {
+  const text = prompt.toLowerCase();
+
+  // Code generation or devops related keywords
+  if (/\b(code|github actions?|javascript|typescript|python|programming|algorithm)\b/.test(text)) {
+    return 'codegen';
+  }
+
+  // Audit style requests
+  if (/(analyze|audit|evaluate|c\.l\.e\.a\.r)/.test(text)) {
+    return 'audit';
+  }
+
+  // Simulation or hypothetical scenarios
+  if (/(simulate|simulation|hypothetical|what if|agent actions?|agent behaviour|agent behavior)/.test(text)) {
+    return 'sim';
+  }
+
+  return 'write';
+}


### PR DESCRIPTION
## Summary
- add `routeByIntent` helper to classify prompts by keywords
- implement `intentDispatcher` to select OpenAI model based on intent

## Testing
- `bash .codex/setup.sh`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d0b891e248325b7ad3aef4ee1a2ac