### PR TITLE
Implement handler map for openai dispatch

### DIFF
--- a/src/utils/dispatchOpenAIRequest.ts
+++ b/src/utils/dispatchOpenAIRequest.ts
@@ -1,6 +1,11 @@
-export type SupportedMode = 'write' | 'sim' | 'audit' | 'build';
+export type SupportedMode = 'write' | 'sim' | 'audit' | 'codegen';
 
-const VALID_MODES: Set<SupportedMode> = new Set(['write', 'sim', 'audit', 'build']);
+const VALID_MODES: Set<SupportedMode> = new Set([
+  'write',
+  'sim',
+  'audit',
+  'codegen'
+]);
 
 /**
  * Log which handler was selected for debugging.
@@ -13,6 +18,7 @@ function logHandlerTrace(mode: SupportedMode): void {
 
 interface DispatchOptions {
   mode?: string;
+  payload?: any;
   [key: string]: any;
 }
 
@@ -20,7 +26,7 @@ interface DispatchOptions {
  * Validate the provided mode and route to the correct handler.
  * Falls back to 'write' if an unsupported mode is supplied.
  */
-export function dispatchOpenAIRequest({ mode = 'write', ...rest }: DispatchOptions) {
+export function dispatchOpenAIRequest({ mode = 'write', payload }: DispatchOptions) {
   if (!VALID_MODES.has(mode as SupportedMode)) {
     console.warn(`Unsupported mode '${mode}', defaulting to 'write'`);
     mode = 'write';
@@ -28,12 +34,40 @@ export function dispatchOpenAIRequest({ mode = 'write', ...rest }: DispatchOptio
 
   logHandlerTrace(mode as SupportedMode);
 
-  return routeToCorrectHandler(mode as SupportedMode, rest);
+  return routeToCorrectHandler(mode as SupportedMode, payload);
 }
 
 /** Placeholder routing implementation */
-function routeToCorrectHandler(mode: SupportedMode, rest: any) {
-  // In the real system this would call the specific handler for each mode.
-  // For now we just return a descriptive object for testing.
-  return { mode, args: rest };
+type ModeHandler = (payload: any) => any;
+
+function runWriteHandler(payload: any) {
+  // Placeholder implementation for write mode
+  return { handler: 'write', payload };
+}
+
+function runSimulationHandler(payload: any) {
+  // Placeholder implementation for simulation mode
+  return { handler: 'sim', payload };
+}
+
+function runAuditHandler(payload: any) {
+  // Placeholder implementation for audit mode
+  return { handler: 'audit', payload };
+}
+
+function runCodegenHandler(payload: any) {
+  // Placeholder implementation for code generation mode
+  return { handler: 'codegen', payload };
+}
+
+const handlerMap: Record<SupportedMode, ModeHandler> = {
+  write: runWriteHandler,
+  sim: runSimulationHandler,
+  audit: runAuditHandler,
+  codegen: runCodegenHandler
+};
+
+function routeToCorrectHandler(mode: SupportedMode, payload: any) {
+  const handler = handlerMap[mode] || runWriteHandler;
+  return handler(payload);
 }


### PR DESCRIPTION
## Summary
- update openAI dispatch util to support a handler map
- add placeholder mode handlers and rename `build` mode to `codegen`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d2083efe883259621db34613dcfcf