### PR TITLE
feat: add web fetch handler and integration

### DIFF
--- a/src/handlers/webFetchHandler.ts
+++ b/src/handlers/webFetchHandler.ts
@@ -1,0 +1,41 @@
+import OpenAI from 'openai';
+import { fetchWebSearch } from '../utils/webSearch';
+import { storeMemory } from '../services/memory';
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export async function webFetchHandler(query: string, context: any = {}) {
+  if (!/(latest|current|news)/i.test(query)) return null;
+
+  try {
+    const rawSearch = await fetchWebSearch(query);
+    const summary = await openai.chat.completions.create({
+      model: 'gpt-4',
+      messages: [
+        { role: 'system', content: 'Summarize the following search results for high-trust use in AI synthesis.' },
+        { role: 'user', content: rawSearch },
+      ],
+      temperature: 0.4,
+    });
+
+    const content = summary.choices?.[0]?.message?.content?.trim() || '[no result]';
+
+    await storeMemory(`external/web_${Date.now()}`, {
+      type: 'external',
+      source: 'webSearch',
+      prompt: query,
+      content,
+      context,
+    });
+
+    return {
+      source: 'WebFetchHandler',
+      injected: true,
+      summary: content,
+      original: rawSearch,
+    };
+  } catch (error: any) {
+    console.error('Web fetch handler failed:', error.message);
+    return null;
+  }
+}

--- a/src/utils/openaiRequestHandler.ts
+++ b/src/utils/openaiRequestHandler.ts
@@ -1,6 +1,7 @@
 import OpenAI from 'openai';
 import type { ChatCompletionCreateParams, ChatCompletionMessageParam } from 'openai/resources';
 import { runDeepResearch } from '../modules/deepResearchHandler';
+import { webFetchHandler } from '../handlers/webFetchHandler';
 
 export type Mode = 'write' | 'sim' | 'audit' | 'codegen' | 'deepresearch';
 
@@ -54,6 +55,10 @@ const handlers: Record<Mode, (query: string, context: Record<string, any>) => Pr
 };
 
 export async function handleOpenAIRequest({ query, mode = 'write', context = {} }: RequestOptions) {
+  if (/(latest|news|current)/i.test(query)) {
+    const webResult = await webFetchHandler(query, context);
+    if (webResult) return webResult;
+  }
   const handler = handlers[mode];
   if (!handler) {
     return {

--- a/src/utils/webSearch.ts
+++ b/src/utils/webSearch.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+export async function fetchWebSearch(query: string): Promise<string> {
+  try {
+    const url = `https://r.jina.ai/https://www.google.com/search?q=${encodeURIComponent(query)}`;
+    const res = await axios.get(url, { timeout: 10000 });
+    const text = typeof res.data === 'string' ? res.data : JSON.stringify(res.data);
+    return text.replace(/<[^>]+>/g, ' ').slice(0, 2000);
+  } catch (error: any) {
+    console.error('Web search failed:', error.message);
+    return `No results for ${query}`;
+  }
+}


### PR DESCRIPTION
## Summary
- add web search utility to fetch search result text
- add web fetch handler that summarizes results via GPT-4 and stores them in memory
- integrate handler into openAI request dispatcher for queries mentioning latest news or current events

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d9ba07f4483258660559e7826d0ae