### PR TITLE
Lock fine-tuned model routing

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,4 @@
 OPENAI_API_KEY=test_key_for_development
-AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH
 DATABASE_URL=
 ARCANOS_API_TOKEN=test_token_123
 NODE_ENV=development

--- a/.env.example
+++ b/.env.example
@@ -20,14 +20,7 @@ GITHUB_WEBHOOK_SECRET=your-webhook-secret-here
 ENABLE_GITHUB_ACTIONS=true
 GITHUB_INTEGRATION=true
 ALLOW_WEBHOOKS=true
-# Fine-tuned model configuration (in order of precedence):
-# AI_MODEL (highest priority) - Primary fine-tuned model 
-# FINE_TUNE_MODEL - Alternative fine-tuned model variable
-# FINE_TUNED_MODEL - Legacy fine-tuned model variable  
-# OPENAI_FINE_TUNED_MODEL (lowest priority) - OpenAI-specific model variable
-AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH
-FINE_TUNE_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH
-CODE_INTERPRETER_MODEL=gpt-4o
+# Fine-tuned model is now locked internally to arcanos-v2 [BxRSDrhH]
 
 # Identity override configuration
 IDENTITY_OVERRIDE={"identity_override":{"name":"ARCANOS","version":"v2:BxRSDrhH","designation":"Reflective Logic Intelligence","role":"Execute modular command, diagnostics, orchestration, and admin protocol tasks","admin":"Justin"}}

--- a/src/config/ai-model.ts
+++ b/src/config/ai-model.ts
@@ -1,0 +1,21 @@
+import OpenAI from 'openai';
+
+export const ARCANOS_MODEL_ALIAS = 'arcanos-v2';
+export const ARCANOS_MODEL_ID = 'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH';
+
+export async function callArcanosModel(openai: OpenAI, params: any) {
+  console.log('[ARCANOS] Routed to fine-tuned model: arcanos-v2 [BxRSDrhH]');
+  try {
+    return await openai.chat.completions.create({ ...params, model: ARCANOS_MODEL_ALIAS });
+  } catch (error: any) {
+    if (
+      error?.status === 404 ||
+      error?.code === 'model_not_found' ||
+      error?.error?.code === 'model_not_found'
+    ) {
+      console.warn('[ARCANOS] Alias failed, retrying with full model ID');
+      return await openai.chat.completions.create({ ...params, model: ARCANOS_MODEL_ID });
+    }
+    throw error;
+  }
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,6 @@
 // Centralized Configuration Management for ARCANOS Backend
 import { safeImport } from '../utils/safeImport';
+import { ARCANOS_MODEL_ID } from './ai-model';
 
 const dotenv = safeImport<typeof import('dotenv')>('dotenv');
 import type { IdentityOverride } from '../types/IdentityOverride';
@@ -76,7 +77,7 @@ export const config: Config = {
   },
   ai: {
     openaiApiKey: process.env.OPENAI_API_KEY,
-    fineTunedModel: process.env.AI_MODEL || process.env.FINE_TUNE_MODEL || process.env.FINE_TUNED_MODEL || process.env.OPENAI_FINE_TUNED_MODEL,
+    fineTunedModel: ARCANOS_MODEL_ID,
     gptToken: process.env.GPT_TOKEN,
     identityOverride: parseIdentityOverride(process.env.IDENTITY_OVERRIDE),
     identityTriggerPhrase: process.env.IDENTITY_TRIGGER_PHRASE || 'I am Skynet',
@@ -153,16 +154,9 @@ export function validateConfig(): { valid: boolean; errors: string[] } {
     console.warn('⚠️ GITHUB_WEBHOOK_SECRET not set - webhook signature verification will be skipped');
   }
 
-  const expectedModel = 'gpt-4-turbo';
-  if (!config.ai.fineTunedModel) {
-    errors.push(`AI_MODEL is required and should be set to a supported model like ${expectedModel}`);
-  } else {
-    // Validate model is from supported list
-    const supportedModels = ['gpt-4', 'gpt-4-turbo', 'gpt-4o', 'gpt-3.5-turbo'];
-    const isSupported = supportedModels.some(model => config.ai.fineTunedModel?.includes(model));
-    if (!isSupported) {
-      errors.push(`AI_MODEL must be a supported model: ${supportedModels.join(', ')}`);
-    }
+  const expectedModel = ARCANOS_MODEL_ID;
+  if (config.ai.fineTunedModel !== expectedModel) {
+    errors.push(`Fine-tuned model must be locked to ${expectedModel}`);
   }
 
   return {

--- a/src/routes/ai.ts
+++ b/src/routes/ai.ts
@@ -3,6 +3,7 @@
 import { Router } from 'express';
 import path from 'path';
 import { modelControlHooks } from '../services/model-control-hooks';
+import { callArcanosModel } from '../config/ai-model';
 import { sendErrorResponse, sendSuccessResponse, handleServiceResult, handleCatchError } from '../utils/response';
 import { codeInterpreterService } from '../services/ai-service-consolidated';
 import { gameGuideService } from '../services/game-guide';
@@ -300,8 +301,7 @@ router.post('/ask', async (req, res) => {
         return sendErrorResponse(res, 400, 'Prompt is required for write mode');
       }
 
-      const generated = await openai.chat.completions.create({
-        model: 'ft:gpt-3.5-turbo-0125:personal:arcanos-v2',
+      const generated = await callArcanosModel(openai, {
         messages: [
           {
             role: 'system',

--- a/src/services/ai-dispatcher.ts
+++ b/src/services/ai-dispatcher.ts
@@ -2,6 +2,7 @@
 // Replaces static logic, conditionals, and routing trees with AI-controlled decision making
 
 import { getUnifiedOpenAI, type ChatMessage } from './unified-openai';
+import { ARCANOS_MODEL_ALIAS } from '../config/ai-model';
 
 // Helper to resolve workers from schedule keys
 function resolveWorkerFromKey(key: string): string | null {
@@ -63,12 +64,10 @@ export class AIDispatcher {
   private model: string;
 
   constructor() {
-    this.model = process.env.AI_MODEL || 'gpt-4-turbo';
-    
+    this.model = ARCANOS_MODEL_ALIAS;
+
     try {
-      this.unifiedOpenAI = getUnifiedOpenAI({
-        model: this.model,
-      });
+      this.unifiedOpenAI = getUnifiedOpenAI();
       console.log('🤖 AI Dispatcher initialized with model:', this.model);
     } catch (error) {
       console.warn('⚠️ AI Dispatcher initialized without OpenAI (testing mode):', error);

--- a/src/services/ai-service-consolidated.ts
+++ b/src/services/ai-service-consolidated.ts
@@ -6,6 +6,7 @@
 
 import { getUnifiedOpenAI, type ChatMessage, type ChatOptions, type CodeInterpreterResult } from './unified-openai';
 import { createServiceLogger } from '../utils/logger';
+import { ARCANOS_MODEL_ALIAS } from '../config/ai-model';
 
 const logger = createServiceLogger('AIServiceConsolidated');
 
@@ -26,7 +27,7 @@ export class CodeInterpreterService {
   private model: string;
 
   constructor() {
-    this.model = process.env.CODE_INTERPRETER_MODEL || 'gpt-4';
+    this.model = ARCANOS_MODEL_ALIAS;
   }
 
   async run(prompt: string): Promise<CodeInterpreterResult> {
@@ -61,9 +62,9 @@ export class CoreAIService {
   private defaultModel: string;
 
   constructor() {
-    this.defaultModel = process.env.AI_MODEL || 'gpt-4-turbo';
-    logger.info('Core AI Service initialized with unified backend', { 
-      model: this.defaultModel 
+    this.defaultModel = ARCANOS_MODEL_ALIAS;
+    logger.info('Core AI Service initialized with unified backend', {
+      model: this.defaultModel
     });
   }
 
@@ -88,7 +89,7 @@ export class CoreAIService {
       }
 
       const response = await openaiService.chat(messages, {
-        model: config.model || this.defaultModel,
+        model: this.defaultModel,
         maxTokens: config.maxTokens || 1000,
         temperature: config.temperature || 0.7,
       });

--- a/src/services/arcanos-v1-interface.ts
+++ b/src/services/arcanos-v1-interface.ts
@@ -157,7 +157,7 @@ export async function getActiveModel(): Promise<ArcanosModel | null> {
     }
 
     // Check if a fine-tuned model is configured
-    const fineTunedModel = aiConfig.fineTunedModel || process.env.AI_MODEL || process.env.FINE_TUNE_MODEL || process.env.FINE_TUNED_MODEL || process.env.OPENAI_FINE_TUNED_MODEL;
+    const fineTunedModel = aiConfig.fineTunedModel;
     if (!fineTunedModel) {
       console.warn("No fine-tuned model configured");
       return null;
@@ -191,7 +191,7 @@ export async function askArcanosV1_Safe({
   useHRC?: boolean;
 }): Promise<{ response: string; model?: string }> {
   // Get the actual model name from environment (if available)
-  const modelName = process.env.AI_MODEL || process.env.FINE_TUNE_MODEL || process.env.FINE_TUNED_MODEL || process.env.OPENAI_FINE_TUNED_MODEL;
+  const modelName = aiConfig.fineTunedModel;
   
   const model = await getActiveModel(); // ← Your current backend model hook
 

--- a/src/services/backend-ai-reflection-handler.ts
+++ b/src/services/backend-ai-reflection-handler.ts
@@ -5,6 +5,7 @@ import path from 'path';
 
 // OpenAI SDK integration
 import OpenAI from 'openai';
+import { callArcanosModel } from '../config/ai-model';
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
@@ -38,8 +39,7 @@ function performSelfReflection(): void {
 async function generateReflection(): Promise<any> {
   try {
 
-    const response = await openai.chat.completions.create({
-      model: process.env.FINE_TUNE_MODEL || 'gpt-4',
+    const response = await callArcanosModel(openai, {
       messages: [
         {
           role: 'system',

--- a/src/services/self-reflection.ts
+++ b/src/services/self-reflection.ts
@@ -1,5 +1,6 @@
 import { databaseService } from './database';
 import cron from 'node-cron';
+import { ARCANOS_MODEL_ID } from '../config/ai-model';
 
 interface ReflectionEntry {
   timestamp: string;
@@ -24,7 +25,7 @@ export class SelfReflectionService {
       content: reflection,
       context_id,
       interaction_id,
-      source: process.env.FINE_TUNE_MODEL || 'unknown'
+      source: ARCANOS_MODEL_ID
     };
     this.pending.push(entry);
     await this.persist();

--- a/src/utils/intentDispatcher.ts
+++ b/src/utils/intentDispatcher.ts
@@ -1,5 +1,6 @@
 import OpenAI from 'openai';
 import { routeByIntent, type IntentMode } from './routeByIntent';
+import { callArcanosModel } from '../config/ai-model';
 
 // Initialize OpenAI client with API key from environment
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
@@ -18,30 +19,12 @@ export async function intentDispatcher(prompt: string): Promise<DispatchResult> 
   const mode = routeByIntent(prompt);
   console.log(`[intentDispatcher] Routing prompt to mode: ${mode}`);
 
-  let model = 'gpt-4';
-  switch (mode) {
-    case 'audit':
-      model = 'gpt-3.5-turbo';
-      break;
-    case 'codegen':
-      model = process.env.CODEGEN_MODEL || 'gpt-4';
-      break;
-    case 'sim':
-      model = 'gpt-4';
-      break;
-    case 'write':
-    default:
-      model = 'gpt-4';
-      break;
-  }
-
   try {
-    const response = await openai.chat.completions.create({
-      model,
+    const response = await callArcanosModel(openai, {
       messages: [{ role: 'user', content: prompt }]
     });
 
-    return { mode, model, response };
+    return { mode, model: 'arcanos-v2', response };
   } catch (error) {
     console.error('[intentDispatcher] Error dispatching prompt:', error);
     throw error;

--- a/src/utils/openaiRequestHandler.ts
+++ b/src/utils/openaiRequestHandler.ts
@@ -1,5 +1,6 @@
 import OpenAI from 'openai';
 import type { ChatCompletionCreateParams, ChatCompletionMessageParam } from 'openai/resources';
+import { callArcanosModel } from '../config/ai-model';
 import { runDeepResearch } from '../modules/deepResearchHandler';
 import { webFetchHandler } from '../handlers/webFetchHandler';
 
@@ -18,28 +19,28 @@ if (!apiKey) {
 
 const openai = new OpenAI({ apiKey });
 
-function buildParams(message: string, temperature: number, model: string): ChatCompletionCreateParams {
+function buildParams(message: string, temperature: number): ChatCompletionCreateParams {
   const messages: ChatCompletionMessageParam[] = [{ role: 'user', content: message }];
-  return { model, messages, temperature };
+  return { messages, temperature } as ChatCompletionCreateParams;
 }
 
 async function runWriteHandler(query: string) {
-  return openai.chat.completions.create(buildParams(query, 0.7, 'gpt-4'));
+  return callArcanosModel(openai, buildParams(query, 0.7));
 }
 
 async function runSimHandler(query: string, context: Record<string, any>) {
   const simPrompt = `Simulate the following scenario:\n\n${query}\n\nContext: ${JSON.stringify(context)}`;
-  return openai.chat.completions.create(buildParams(simPrompt, 0.75, 'gpt-4'));
+  return callArcanosModel(openai, buildParams(simPrompt, 0.75));
 }
 
 async function runAuditHandler(query: string) {
   const auditPrompt = `Audit this logic using CLEAR:\n\n${query}`;
-  return openai.chat.completions.create(buildParams(auditPrompt, 0.3, 'gpt-3.5-turbo'));
+  return callArcanosModel(openai, buildParams(auditPrompt, 0.3));
 }
 
 async function runCodegenHandler(query: string) {
   const codePrompt = `Generate clean code:\n\n${query}`;
-  return openai.chat.completions.create(buildParams(codePrompt, 0.2, 'gpt-4'));
+  return callArcanosModel(openai, buildParams(codePrompt, 0.2));
 }
 
 async function runDeepResearchHandler(query: string, context: Record<string, any>) {


### PR DESCRIPTION
## Summary
- centralize ARCANOS fine-tuned model constants with retry logic and logging
- remove ENV-driven model fallbacks and route all dispatchers to the locked model
- update /ask endpoint and backend services to call OpenAI with alias fallback and full ID

## Testing
- `npm test`
- `npm run build`
- `node -e "const OpenAI=require('openai');const openai=new OpenAI({ apiKey: 'test' });(async()=>{try{await openai.chat.completions.create({model:'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH',messages:[{role:'user',content:\"What's up?\"}]});}catch(e){console.error('Sample call error:',e.status||'',e.code||e.error?.code||'',e.message);}})();"`


------
https://chatgpt.com/codex/tasks/task_e_688dbe6814b483259b46c4fb29561027