### PR TITLE
chore: remove deprecated cache-min setting

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 logs-dir=./npm_logs
 prefer-offline=true
-cache-min=999999


### PR DESCRIPTION
## Summary
- remove deprecated cache-min from .npmrc to rely on prefer-offline
- upgrade global npm to v11.5.2

## Testing
- `npm -v`
- `git status --short package-lock.json`
- `npm test`
- `cat /tmp/npm-update.log`


------
https://chatgpt.com/codex/tasks/task_e_688dcf23154483259ed4b20bc0610c59