### PR TITLE
feat: add runtime memory diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ For CI environments like Railway, use the optimized build script:
 npm run ci:build
 ```
 
+### Memory Diagnostics
+The default start script launches Node with `--expose-gc` so garbage collection can be
+triggered and memory usage logged. These diagnostics run only when `NODE_ENV` is not
+set to `production`.
+
+
 ## API Endpoints
 
 ### Core Endpoints

--- a/diagnostics.js
+++ b/diagnostics.js
@@ -1,0 +1,51 @@
+const os = require('os');
+const isProd = process.env.NODE_ENV === 'production';
+
+// Check Node.js version
+if (!isProd) {
+  const [major, minor] = process.versions.node.split('.').map(Number);
+  if (major < 20 || (major === 20 && minor < 13)) {
+    console.warn(`Node.js v${process.versions.node} detected. Please upgrade to LTS v20.13 or later.`);
+  }
+}
+
+const hasGC = typeof global.gc === 'function';
+if (!hasGC && !isProd) {
+  console.warn('Garbage collection is not exposed. Run Node with --expose-gc to enable manual GC.');
+}
+
+// Trigger GC every 60 seconds if available
+if (hasGC) {
+  setInterval(() => {
+    try {
+      global.gc();
+    } catch (err) {
+      if (!isProd) {
+        console.warn('Failed to run garbage collection:', err);
+      }
+    }
+  }, 60_000).unref();
+}
+
+if (!isProd) {
+  // Log memory usage every 30 seconds
+  const logMemory = () => {
+    const mem = process.memoryUsage();
+    const heapUsed = mem.heapUsed / 1024 / 1024;
+    const heapTotal = mem.heapTotal / 1024 / 1024;
+    const rss = mem.rss / 1024 / 1024;
+    console.log(`[Memory] Heap ${heapUsed.toFixed(2)} MB / ${heapTotal.toFixed(2)} MB, RSS ${rss.toFixed(2)} MB`);
+
+    const heapUsageRatio = mem.heapTotal ? mem.heapUsed / mem.heapTotal : 0;
+    const rssUsageRatio = mem.rss / os.totalmem();
+
+    if (heapUsageRatio > 0.83) {
+      console.warn(`[Memory] Warning: Heap usage ${(heapUsageRatio * 100).toFixed(2)}% exceeds 83%`);
+    }
+    if (rssUsageRatio > 0.25) {
+      console.warn(`[Memory] Warning: RSS ${(rssUsageRatio * 100).toFixed(2)}% exceeds 25% of system memory`);
+    }
+  };
+
+  setInterval(logMemory, 30_000).unref();
+}

--- a/index.js
+++ b/index.js
@@ -3,6 +3,9 @@
 
 console.log('🤖 ARCANOS: Delegating full operational control to AI model...');
 
+// Memory diagnostics and garbage collection helpers
+require('./diagnostics');
+
 // All logic has been moved to TypeScript AI-controlled backend
 // This ensures the fine-tuned ARCANOS model has complete operational control
 require('./dist/index.js');

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "node --expose-gc index.js",
     "start:main": "node dist/main.js",
     "start:agent-control": "DEPLOY_MODE=agent-control node dist/main.js",
     "start:railway": "node --max-old-space-size=7168 dist/index.js",


### PR DESCRIPTION
## Summary
- add diagnostics module to trigger garbage collection and log memory usage
- enable `--expose-gc` in start script and wire diagnostics into app entry
- document running memory diagnostics and keep logs out of production

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e588311d48325bf6a2c1c6c8d695b