### PR TITLE
Add memory monitoring and manual garbage collection

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ console.log('🤖 ARCANOS: Delegating full operational control to AI model...');
 
 // Memory diagnostics and garbage collection helpers
 require('./diagnostics');
+require('./memory.js');
 
 // All logic has been moved to TypeScript AI-controlled backend
 // This ensures the fine-tuned ARCANOS model has complete operational control

--- a/memory.js
+++ b/memory.js
@@ -1,0 +1,30 @@
+function enableGC() {
+  if (typeof global.gc === 'function') {
+    setInterval(() => {
+      global.gc();
+      console.log('[Memory] Manual garbage collection triggered.');
+    }, 60000);
+  } else {
+    console.warn('[Memory] GC not exposed. Use --expose-gc flag.');
+  }
+}
+
+function memoryMonitor(threshold = 0.83) {
+  setInterval(() => {
+    const mem = process.memoryUsage();
+    const heapUsed = mem.heapUsed / mem.heapTotal;
+    const rssRatio = mem.rss / (mem.heapTotal + mem.external + mem.arrayBuffers);
+
+    if (heapUsed > threshold) {
+      console.warn(`[Memory] High heap usage: ${(heapUsed * 100).toFixed(1)}%`);
+    }
+    if (rssRatio > 0.25) {
+      console.warn(`[Memory] High RSS ratio: ${(rssRatio * 100).toFixed(1)}%`);
+    }
+  }, 30000);
+}
+
+enableGC();
+memoryMonitor();
+
+module.exports = { enableGC, memoryMonitor };


### PR DESCRIPTION
## Summary
- add `memory.js` to trigger manual garbage collection and monitor heap/RSS usage
- load `memory.js` from `index.js` so diagnostics run on startup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e5f12581c8325bf9ecf75981333c1