### PR TITLE
chore: expose gc via node options

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,7 @@ OPENAI_API_KEY=test_key_for_development
 DATABASE_URL=
 ARCANOS_API_TOKEN=test_token_123
 NODE_ENV=development
+NODE_OPTIONS=--expose-gc=true
 PORT=8080
 RUN_WORKERS=false
 WORKER_LOGIC=arcanos

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Environment variables
 NODE_ENV=development
+NODE_OPTIONS=--expose-gc=true
 PORT=8080
 
 # Railway Configuration (GitHub Copilot + Postman Compatible)

--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,3 @@
 OPENAI_API_KEY=test_key
+
+NODE_OPTIONS=--expose-gc=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ FROM node:20.11.1-alpine AS builder
 # Set working directory
 WORKDIR /app
 
+# Enable garbage collection access
+ENV NODE_OPTIONS=--expose-gc=true
+
 # Copy package files and .npmrc for dependency installation
 COPY package*.json .npmrc ./
 
@@ -34,6 +37,7 @@ FROM node:20.11.1-alpine AS production
 
 # Set production environment
 ENV NODE_ENV=production
+ENV NODE_OPTIONS=--expose-gc=true
 
 # Create non-root user for security
 RUN addgroup -g 1001 -S nodejs && \

--- a/railway.json
+++ b/railway.json
@@ -9,9 +9,9 @@
   },
   "build": {
     "builder": "NIXPACKS",
-    "buildCommand": "NODE_OPTIONS=--max_old_space_size=256 npm install --omit=dev && npm run build",
+    "buildCommand": "NODE_OPTIONS=\"--max_old_space_size=256 --expose-gc=true\" npm install --omit=dev && npm run build",
     "env": {
-      "NODE_OPTIONS": "--max_old_space_size=2048"
+      "NODE_OPTIONS": "--max_old_space_size=2048 --expose-gc=true"
     }
   },
   "postDeployCommand": "bash ./scripts/postdeploy.sh",
@@ -19,7 +19,8 @@
     "production": {
       "variables": {
         "NODE_ENV": "production",
-        "PORT": "3000"
+        "PORT": "3000",
+        "NODE_OPTIONS": "--expose-gc=true"
       }
     }
   },


### PR DESCRIPTION
## Summary
- expose Node.js garbage collector via NODE_OPTIONS
- propagate GC flag in env files and Railway configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e65f39de48325b67b02407e8a1b68