### PR TITLE
fix: ensure gc availability with fallback loader

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,7 @@ OPENAI_API_KEY=test_key_for_development
 DATABASE_URL=
 ARCANOS_API_TOKEN=test_token_123
 NODE_ENV=development
+NODE_OPTIONS=--require ./fallback-gc-loader --expose-gc
 PORT=8080
 RUN_WORKERS=false
 WORKER_LOGIC=arcanos

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Environment variables
 NODE_ENV=development
+NODE_OPTIONS=--require ./fallback-gc-loader --expose-gc
 PORT=8080
 
 # Railway Configuration (GitHub Copilot + Postman Compatible)

--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,3 @@
 OPENAI_API_KEY=test_key
+
+NODE_OPTIONS=--require ./fallback-gc-loader --expose-gc

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,14 @@ FROM node:20.11.1-alpine AS builder
 # Set working directory
 WORKDIR /app
 
+# Enable garbage collection access with fallback loader
+ENV NODE_OPTIONS="--require ./fallback-gc-loader --expose-gc"
+
 # Copy package files and .npmrc for dependency installation
-COPY package*.json .npmrc ./
+COPY package*.json .npmrc fallback-gc-loader.js ./
 
 # Install production dependencies with capped memory
-RUN NODE_OPTIONS=--max_old_space_size=256 npm install --omit=dev --no-audit --no-fund
+RUN NODE_OPTIONS="--max_old_space_size=256 --require ./fallback-gc-loader --expose-gc" npm install --omit=dev --no-audit --no-fund
 
 # Copy source code
 COPY src/ ./src/
@@ -34,6 +37,7 @@ FROM node:20.11.1-alpine AS production
 
 # Set production environment
 ENV NODE_ENV=production
+ENV NODE_OPTIONS="--require ./fallback-gc-loader --expose-gc"
 
 # Create non-root user for security
 RUN addgroup -g 1001 -S nodejs && \
@@ -43,10 +47,10 @@ RUN addgroup -g 1001 -S nodejs && \
 WORKDIR /app
 
 # Copy package files and .npmrc
-COPY package*.json .npmrc ./
+COPY package*.json .npmrc fallback-gc-loader.js ./
 
 # Install only production dependencies with capped memory
-RUN NODE_OPTIONS=--max_old_space_size=256 npm install --omit=dev --no-audit --no-fund
+RUN NODE_OPTIONS="--max_old_space_size=256 --require ./fallback-gc-loader --expose-gc" npm install --omit=dev --no-audit --no-fund
 
 # Copy built application from builder stage
 COPY --from=builder /app/dist ./dist

--- a/fallback-gc-loader.js
+++ b/fallback-gc-loader.js
@@ -1,0 +1,15 @@
+try {
+  if (!global.gc) {
+    console.warn("\u26a0\ufe0f GC not exposed. Attempting to re-run with --expose-gc...");
+    const { spawn } = require('child_process');
+    spawn(process.execPath, ['--expose-gc', ...process.argv.slice(1)], {
+      stdio: 'inherit',
+      env: { ...process.env, GC_RELOADED: '1' }
+    });
+    process.exit(0);
+  } else {
+    console.log("\u2705 GC is available.");
+  }
+} catch (err) {
+  console.error("\ud83d\udea8 Failed to re-initialize with --expose-gc:", err);
+}

--- a/railway.json
+++ b/railway.json
@@ -9,9 +9,9 @@
   },
   "build": {
     "builder": "NIXPACKS",
-    "buildCommand": "NODE_OPTIONS=--max_old_space_size=256 npm install --omit=dev && npm run build",
+    "buildCommand": "NODE_OPTIONS=\"--max_old_space_size=256 --require ./fallback-gc-loader --expose-gc\" npm install --omit=dev && npm run build",
     "env": {
-      "NODE_OPTIONS": "--max_old_space_size=2048"
+      "NODE_OPTIONS": "--max_old_space_size=2048 --require ./fallback-gc-loader --expose-gc"
     }
   },
   "postDeployCommand": "bash ./scripts/postdeploy.sh",
@@ -19,7 +19,8 @@
     "production": {
       "variables": {
         "NODE_ENV": "production",
-        "PORT": "3000"
+        "PORT": "3000",
+        "NODE_OPTIONS": "--require ./fallback-gc-loader --expose-gc"
       }
     }
   },


### PR DESCRIPTION
## Summary
- add fallback loader to relaunch with `--expose-gc` if GC unavailable
- correct `NODE_OPTIONS` in env, Dockerfile, and Railway config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e65f39de48325b67b02407e8a1b68