### PR TITLE
Integrate manual memory monitoring

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ console.log('🤖 ARCANOS: Delegating full operational control to AI model...');
 // Memory diagnostics and garbage collection helpers
 require('./diagnostics');
 require('./memory.js');
+const memoryManager = require('./utils/memoryManager');
+setInterval(memoryManager.monitorMemory, 15000); // Monitor every 15s
 
 // All logic has been moved to TypeScript AI-controlled backend
 // This ensures the fine-tuned ARCANOS model has complete operational control

--- a/utils/memoryManager.js
+++ b/utils/memoryManager.js
@@ -1,0 +1,55 @@
+const os = require('os');
+
+const memoryState = {
+  lastGC: 0,
+  heapLimitMB: parseInt(process.env.HEAP_LIMIT_MB || 300), // Default: 300MB
+  usageBufferMB: 20,
+  gcCooldownMs: 30000,
+};
+
+function getHeapStats() {
+  const mem = process.memoryUsage();
+  return {
+    rss: (mem.rss / 1024 / 1024).toFixed(2),
+    heapUsed: (mem.heapUsed / 1024 / 1024).toFixed(2),
+    heapTotal: (mem.heapTotal / 1024 / 1024).toFixed(2),
+    external: (mem.external / 1024 / 1024).toFixed(2),
+  };
+}
+
+function shouldTriggerGC() {
+  const heapUsedMB = process.memoryUsage().heapUsed / 1024 / 1024;
+  const timeSinceLastGC = Date.now() - memoryState.lastGC;
+  return heapUsedMB > (memoryState.heapLimitMB - memoryState.usageBufferMB)
+    && timeSinceLastGC > memoryState.gcCooldownMs;
+}
+
+function performGC() {
+  if (typeof global.gc !== 'function') {
+    console.warn('[MEMORY] GC not exposed. Start Node with --expose-gc');
+    return;
+  }
+  global.gc();
+  memoryState.lastGC = Date.now();
+  console.log('[MEMORY] Manual GC triggered');
+}
+
+function monitorMemory() {
+  const stats = getHeapStats();
+  console.log(`[MEMORY] RSS: ${stats.rss}MB, Heap Used: ${stats.heapUsed}MB / ${memoryState.heapLimitMB}MB`);
+
+  if (shouldTriggerGC()) {
+    performGC();
+  }
+
+  // Optional fail-safe
+  const heapUsedMB = parseFloat(stats.heapUsed);
+  if (heapUsedMB > memoryState.heapLimitMB + 50) {
+    console.warn('[MEMORY] CRITICAL: Heap usage too high, exiting to prevent crash...');
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  monitorMemory,
+};


### PR DESCRIPTION
## Summary
- add memoryManager utility to track heap usage and invoke manual GC
- wire memory monitoring into Node entrypoint for periodic checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e770b36c88325b96dcca4a7180dd9