### PR TITLE
feat: add memory monitoring and chat endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "start": "node --expose-gc index.js",
+    "start": "node --max-old-space-size=6144 --expose-gc index.js",
     "start:main": "node dist/main.js",
     "start:agent-control": "DEPLOY_MODE=agent-control node dist/main.js",
     "start:railway": "node --max-old-space-size=7168 dist/index.js",


### PR DESCRIPTION
## Summary
- add Express server with OpenAI chat completion endpoint
- monitor memory and trigger GC when usage exceeds threshold
- start script increases old space to 6 GB and exposes GC

## Testing
- `npm test`
- `npm start` and `curl http://localhost:3000/health`
- `curl -X POST http://localhost:3000/chat` (fails: Connection error)


------
https://chatgpt.com/codex/tasks/task_e_688ea2563c288325b02e339e299492ba