### PR TITLE
refactor: migrate memory modules to esm

### DIFF
--- a/memory/actions/saveThread.js
+++ b/memory/actions/saveThread.js
@@ -1,9 +1,9 @@
-const threads = require('../modules/threads');
+import threads from '../modules/threads.js';
 
-module.exports = async function saveThread({ id, tags = [], state = {} }) {
+export default async function saveThread({ id, tags = [], state = {} }) {
   if (!id) {
     return { error: 'id is required' };
   }
   const thread = { id, tags, state, timestamp: new Date().toISOString() };
   return threads.save(id, thread);
-};
+}

--- a/memory/actions/syncToPostgres.js
+++ b/memory/actions/syncToPostgres.js
@@ -1,15 +1,17 @@
-const { Pool } = require('pg');
-const pool = new Pool();
-const shortterm = require('../modules/shortterm');
-const emotions = require('../modules/emotions');
-const goals = require('../modules/goals');
-const identity = require('../modules/identity');
+import { Pool } from 'pg';
+import shortterm from '../modules/shortterm.js';
+import emotions from '../modules/emotions.js';
+import goals from '../modules/goals.js';
+import identity from '../modules/identity.js';
 
-module.exports = async function syncToPostgres() {
+const pool = new Pool();
+
+export default async function syncToPostgres() {
   const state = await shortterm.read();
   state.emotions = await emotions.read();
   state.goals = await goals.read();
   state.identity = await identity.read();
+
   for (const [key, value] of Object.entries(state)) {
     await pool.query(
       `INSERT INTO memory (key, value) VALUES ($1,$2) ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
@@ -17,4 +19,4 @@ module.exports = async function syncToPostgres() {
     );
   }
   return { success: true };
-};
+}

--- a/memory/modules/email_diagnostics.js
+++ b/memory/modules/email_diagnostics.js
@@ -1,21 +1,25 @@
-const fs = require('fs').promises;
-const path = require('path');
-const { logEvent } = require('../logEvent');
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { logEvent } from '../logEvent.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FILE = path.join(__dirname, '../state/email_diagnostics.json');
 
-module.exports = {
-  async read() {
-    try {
-      const data = await fs.readFile(FILE, 'utf8');
-      return JSON.parse(data);
-    } catch {
-      return {};
-    }
-  },
-  async add(entry) {
-    const data = await this.read();
-    data[entry.diagnosticId] = entry;
-    await fs.writeFile(FILE, JSON.stringify(data, null, 2));
-    await logEvent('email_diagnostics');
+export async function read() {
+  try {
+    const data = await fs.readFile(FILE, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return {};
   }
-};
+}
+
+export async function add(entry) {
+  const data = await read();
+  data[entry.diagnosticId] = entry;
+  await fs.writeFile(FILE, JSON.stringify(data, null, 2));
+  await logEvent('email_diagnostics');
+}
+
+export default { read, add };

--- a/memory/modules/emotions.js
+++ b/memory/modules/emotions.js
@@ -1,19 +1,23 @@
-const fs = require('fs').promises;
-const path = require('path');
-const { logEvent } = require('../logEvent');
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { logEvent } from '../logEvent.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FILE = path.join(__dirname, '../state/emotions.json');
 
-module.exports = {
-  async read() {
-    try {
-      const data = await fs.readFile(FILE, 'utf8');
-      return JSON.parse(data);
-    } catch {
-      return {};
-    }
-  },
-  async write(data) {
-    await fs.writeFile(FILE, JSON.stringify(data, null, 2));
-    await logEvent('emotions');
+export async function read() {
+  try {
+    const data = await fs.readFile(FILE, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return {};
   }
-};
+}
+
+export async function write(data) {
+  await fs.writeFile(FILE, JSON.stringify(data, null, 2));
+  await logEvent('emotions');
+}
+
+export default { read, write };

--- a/memory/modules/identity.js
+++ b/memory/modules/identity.js
@@ -1,15 +1,16 @@
-const shortterm = require('./shortterm');
-const { logEvent } = require('../logEvent');
+import shortterm from './shortterm.js';
+import { logEvent } from '../logEvent.js';
 
-module.exports = {
-  async read() {
-    const data = await shortterm.read();
-    return data.identity || {};
-  },
-  async write(identity) {
-    const data = await shortterm.read();
-    data.identity = identity;
-    await shortterm.write(data);
-    await logEvent('identity');
-  },
-};
+export async function read() {
+  const data = await shortterm.read();
+  return data.identity || {};
+}
+
+export async function write(identity) {
+  const data = await shortterm.read();
+  data.identity = identity;
+  await shortterm.write(data);
+  await logEvent('identity');
+}
+
+export default { read, write };

--- a/memory/modules/longterm.js
+++ b/memory/modules/longterm.js
@@ -1,19 +1,23 @@
-const fs = require('fs').promises;
-const path = require('path');
-const { logEvent } = require('../logEvent');
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { logEvent } from '../logEvent.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FILE = path.join(__dirname, '../state/context.db');
 
-module.exports = {
-  async read() {
-    try {
-      const data = await fs.readFile(FILE, 'utf8');
-      return JSON.parse(data);
-    } catch {
-      return {};
-    }
-  },
-  async write(data) {
-    await fs.writeFile(FILE, JSON.stringify(data, null, 2));
-    await logEvent('longterm');
-  },
-};
+export async function read() {
+  try {
+    const data = await fs.readFile(FILE, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return {};
+  }
+}
+
+export async function write(data) {
+  await fs.writeFile(FILE, JSON.stringify(data, null, 2));
+  await logEvent('longterm');
+}
+
+export default { read, write };

--- a/memory/modules/manifest.js
+++ b/memory/modules/manifest.js
@@ -1,21 +1,25 @@
-const fs = require('fs').promises;
-const path = require('path');
-const { logEvent } = require('../logEvent');
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { logEvent } from '../logEvent.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FILE = path.join(__dirname, '../state/manifest.json');
 
-module.exports = {
-  async read() {
-    try {
-      const data = await fs.readFile(FILE, 'utf8');
-      return JSON.parse(data);
-    } catch {
-      return [];
-    }
-  },
-  async add(entry) {
-    const manifest = await this.read();
-    manifest.push({ ...entry, timestamp: new Date().toISOString() });
-    await fs.writeFile(FILE, JSON.stringify(manifest, null, 2));
-    await logEvent('manifest');
+export async function read() {
+  try {
+    const data = await fs.readFile(FILE, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return [];
   }
-};
+}
+
+export async function add(entry) {
+  const manifest = await read();
+  manifest.push({ ...entry, timestamp: new Date().toISOString() });
+  await fs.writeFile(FILE, JSON.stringify(manifest, null, 2));
+  await logEvent('manifest');
+}
+
+export default { read, add };

--- a/memory/modules/receipt_fail_map.js
+++ b/memory/modules/receipt_fail_map.js
@@ -1,21 +1,25 @@
-const fs = require('fs').promises;
-const path = require('path');
-const { logEvent } = require('../logEvent');
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { logEvent } from '../logEvent.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FILE = path.join(__dirname, '../state/receipt_fail_map.json');
 
-module.exports = {
-  async read() {
-    try {
-      const data = await fs.readFile(FILE, 'utf8');
-      return JSON.parse(data);
-    } catch {
-      return {};
-    }
-  },
-  async flag(email) {
-    const map = await this.read();
-    map[email] = (map[email] || 0) + 1;
-    await fs.writeFile(FILE, JSON.stringify(map, null, 2));
-    await logEvent('receipt_fail_map');
+export async function read() {
+  try {
+    const data = await fs.readFile(FILE, 'utf8');
+    return JSON.parse(data);
+  } catch {
+    return {};
   }
-};
+}
+
+export async function flag(email) {
+  const map = await read();
+  map[email] = (map[email] || 0) + 1;
+  await fs.writeFile(FILE, JSON.stringify(map, null, 2));
+  await logEvent('receipt_fail_map');
+}
+
+export default { read, flag };

--- a/memory/modules/threads.js
+++ b/memory/modules/threads.js
@@ -1,21 +1,23 @@
-const shortterm = require('./shortterm');
-const { logEvent } = require('../logEvent');
+import shortterm from './shortterm.js';
+import { logEvent } from '../logEvent.js';
 
-module.exports = {
-  async read() {
-    const data = await shortterm.read();
-    return data.threads || {};
-  },
-  async write(threads) {
-    const data = await shortterm.read();
-    data.threads = threads;
-    await shortterm.write(data);
-    await logEvent('threads');
-  },
-  async save(id, thread) {
-    const threads = await this.read();
-    threads[id] = thread;
-    await this.write(threads);
-    return { saved: true, id };
-  },
-};
+export async function read() {
+  const data = await shortterm.read();
+  return data.threads || {};
+}
+
+export async function write(threads) {
+  const data = await shortterm.read();
+  data.threads = threads;
+  await shortterm.write(data);
+  await logEvent('threads');
+}
+
+export async function save(id, thread) {
+  const threads = await read();
+  threads[id] = thread;
+  await write(threads);
+  return { saved: true, id };
+}
+
+export default { read, write, save };

--- a/src/ai-reflection-scheduler.ts
+++ b/src/ai-reflection-scheduler.ts
@@ -1,10 +1,10 @@
 // AI Reflection Scheduler + Long-Term Memory (OpenAI SDK Compliant)
 // Summary: Triggers self-reflection every 40 minutes, stores results persistently, and prunes snapshots older than 7 days
 
-import { reflect } from './services/ai';
-import { writeToRepo } from './utils/git';
-import { pruneOldReflections } from './utils/cleanup';
-import { createServiceLogger } from './utils/logger';
+import { reflect } from './services/ai/index.js';
+import { writeToRepo } from './utils/git.js';
+import { pruneOldReflections } from './utils/cleanup.js';
+import { createServiceLogger } from './utils/logger.js';
 
 const logger = createServiceLogger('AIReflectionScheduler');
 

--- a/src/codex-integrator.ts
+++ b/src/codex-integrator.ts
@@ -8,7 +8,7 @@ let enabled = false;
 export async function enableCodexInterface(): Promise<void> {
   if (enabled) return;
   try {
-    const { mountArcanosInternal } = await import('../scripts/codex-internal' as any);
+    const { mountArcanosInternal } = await import('../scripts/codex-internal.js' as any);
     mountArcanosInternal();
     enabled = true;
     console.log('[CODEX-INTEGRATOR] Codex interface enabled');

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,9 +1,9 @@
 // Centralized Configuration Management for ARCANOS Backend
-import { safeImport } from '../utils/safeImport';
-import { ARCANOS_MODEL_ID } from './ai-model';
+import { safeImport } from '../utils/safeImport.js';
+import { ARCANOS_MODEL_ID } from './ai-model.js';
 
-const dotenv = safeImport<typeof import('dotenv')>('dotenv');
-import type { IdentityOverride } from '../types/IdentityOverride';
+const dotenv = await safeImport<typeof import('dotenv')>('dotenv');
+import type { IdentityOverride } from '../types/IdentityOverride.js';
 
 // Load environment variables if dotenv is available
 dotenv?.config();

--- a/src/dispatcher.ts
+++ b/src/dispatcher.ts
@@ -3,15 +3,15 @@
 // Ensures smooth routing for Codex, audit-mode diagnostics, and AI-bound services
 
 import { Request, Response } from 'express';
-import { handleCodexPrompt } from './services/codex';
-import { handleAudit } from './services/audit';
-import { diagnosticsService } from './services/diagnostics';
-import { handleLogic as handleGenericLogic } from './routes/logic';
-import { installNLPInterpreter, getNLPInterpreter } from './modules/nlp-interpreter';
-import { installPagedOutputHandler, getPagedOutputHandler } from './modules/paged-output-handler';
-import { installMemoryAuditStreamSerializer } from './modules/memory-audit-stream-serializer';
-import dispatchService, { type ServiceTask, createManualOverrideTask, requiresAIRouting } from './services/ai-service-dispatcher';
-import { runDeepResearch } from './modules/deepResearchHandler';
+import { handleCodexPrompt } from './services/codex.js';
+import { handleAudit } from './services/audit.js';
+import { diagnosticsService } from './services/diagnostics.js';
+import { handleLogic as handleGenericLogic } from './routes/logic.js';
+import { installNLPInterpreter, getNLPInterpreter } from './modules/nlp-interpreter.js';
+import { installPagedOutputHandler, getPagedOutputHandler } from './modules/paged-output-handler.js';
+import { installMemoryAuditStreamSerializer } from './modules/memory-audit-stream-serializer.js';
+import dispatchService, { type ServiceTask, createManualOverrideTask, requiresAIRouting } from './services/ai-service-dispatcher.js';
+import { runDeepResearch } from './modules/deepResearchHandler.js';
 
 // Install NLP interpreter with default configuration
 installNLPInterpreter({

--- a/src/handlers/ask-handler.ts
+++ b/src/handlers/ask-handler.ts
@@ -1,10 +1,10 @@
 import { Request, Response } from 'express';
-import { getUnifiedOpenAI, type FunctionDefinition } from '../services/unified-openai';
-import { selectModel } from '../utils/model-router';
-import { diagnosticsService } from '../services/diagnostics';
-import { GameGuideService } from '../services/game-guide';
-import { MemoryStorage } from '../storage/memory-storage';
-import { aiConfig } from '../config';
+import { getUnifiedOpenAI, type FunctionDefinition } from '../services/unified-openai.js';
+import { selectModel } from '../utils/model-router.js';
+import { diagnosticsService } from '../services/diagnostics.js';
+import { GameGuideService } from '../services/game-guide.js';
+import { MemoryStorage } from '../storage/memory-storage.js';
+import { aiConfig } from '../config/index.js';
 
 // Unified stripReflections helper for frontend filtering
 function stripReflections(response: string): string {

--- a/src/handlers/audit-handler.ts
+++ b/src/handlers/audit-handler.ts
@@ -2,8 +2,8 @@
 // Ensures logging when triggered and malformed response tracking
 
 import { Request, Response } from 'express';
-import { ArcanosAuditService } from '../services/arcanos-audit';
-import { getNLPInterpreter } from '../modules/nlp-interpreter';
+import { ArcanosAuditService } from '../services/arcanos-audit.js';
+import { getNLPInterpreter } from '../modules/nlp-interpreter.js';
 
 export class AuditHandler {
   private auditService: ArcanosAuditService;

--- a/src/handlers/core-handler.ts
+++ b/src/handlers/core-handler.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
-import { getUnifiedOpenAI } from '../services/unified-openai';
-import { aiConfig } from '../config';
+import { getUnifiedOpenAI } from '../services/unified-openai.js';
+import { aiConfig } from '../config/index.js';
 
 // Use unified OpenAI service
 const unifiedOpenAI = getUnifiedOpenAI();

--- a/src/handlers/diagnostic-handler.ts
+++ b/src/handlers/diagnostic-handler.ts
@@ -2,7 +2,7 @@
 // Ensures readiness logging during startup and route recovery
 
 import { Request, Response } from 'express';
-import { diagnosticsService } from '../services/diagnostics';
+import { diagnosticsService } from '../services/diagnostics.js';
 
 export class DiagnosticHandler {
   private diagnosticLog: any[] = [];

--- a/src/handlers/diagnostics.ts
+++ b/src/handlers/diagnostics.ts
@@ -1,4 +1,4 @@
-import { diagnosticsService } from '../services/diagnostics';
+import { diagnosticsService } from '../services/diagnostics.js';
 
 export async function runDiagnostics(payload: any): Promise<any> {
   const command = typeof payload === 'string' ? payload : payload?.command;

--- a/src/handlers/generic-handler.ts
+++ b/src/handlers/generic-handler.ts
@@ -1,6 +1,6 @@
 import OpenAI from 'openai';
-import '../services/clarke-handler'; // Import to ensure ClarkeHandler is available
-import { genericFallback, ClarkeHandler } from '../services/clarke-handler';
+import '../services/clarke-handler.js'; // Import to ensure ClarkeHandler is available
+import { genericFallback, ClarkeHandler } from '../services/clarke-handler.js';
 
 // Use the new resilience handler pattern
 let openai: ClarkeHandler;

--- a/src/handlers/guide-handler.ts
+++ b/src/handlers/guide-handler.ts
@@ -5,9 +5,9 @@
  */
 
 import { Request, Response } from 'express';
-import { getMemory } from '../services/memory';
-import { formatGuideChunks } from '../utils/formatter';
-import { recoverGameGuide, isMalformed } from '../utils/output-recovery';
+import { getMemory } from '../services/memory.js';
+import { formatGuideChunks } from '../utils/formatter.js';
+import { recoverGameGuide, isMalformed } from '../utils/output-recovery.js';
 
 export interface GuideSection {
   sections: string[];

--- a/src/handlers/memory-handler.ts
+++ b/src/handlers/memory-handler.ts
@@ -3,8 +3,8 @@
 // Enhanced with GPT-4 fallback for malformed memory outputs
 
 import { Request, Response } from 'express';
-import { memoryOperations } from '../services/memory-operations';
-import { recoverOutput } from '../utils/output-recovery';
+import { memoryOperations } from '../services/memory-operations.js';
+import { recoverOutput } from '../utils/output-recovery.js';
 
 export class MemoryHandler {
   async handleMemoryRequest(req: Request, res: Response): Promise<void> {

--- a/src/handlers/route-recovery.ts
+++ b/src/handlers/route-recovery.ts
@@ -3,11 +3,11 @@
 
 import { Express, Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
-import { memoryHandler } from './memory-handler';
-import { writeHandler } from './write-handler';
-import { auditHandler } from './audit-handler';
-import { diagnosticHandler } from './diagnostic-handler';
-import { createServiceLogger } from '../utils/logger';
+import { memoryHandler } from './memory-handler.js';
+import { writeHandler } from './write-handler.js';
+import { auditHandler } from './audit-handler.js';
+import { diagnosticHandler } from './diagnostic-handler.js';
+import { createServiceLogger } from '../utils/logger.js';
 
 const logger = createServiceLogger('RouteRecovery');
 
@@ -336,7 +336,7 @@ export class RouteRecovery {
       switch (route) {
         case '/memory':
           // Bootstrap memory handler
-          const { memoryHandler } = await import('./memory-handler');
+          const { memoryHandler } = await import('./memory-handler.js');
           // Check if initialize method exists, otherwise skip
           if (typeof (memoryHandler as any).initialize === 'function') {
             await (memoryHandler as any).initialize();
@@ -345,7 +345,7 @@ export class RouteRecovery {
 
         case '/write':
           // Bootstrap write handler
-          const { writeHandler } = await import('./write-handler');
+          const { writeHandler } = await import('./write-handler.js');
           // Check if initialize method exists, otherwise skip
           if (typeof (writeHandler as any).initialize === 'function') {
             await (writeHandler as any).initialize();
@@ -354,7 +354,7 @@ export class RouteRecovery {
 
         case '/audit':
           // Bootstrap audit handler
-          const { auditHandler } = await import('./audit-handler');
+          const { auditHandler } = await import('./audit-handler.js');
           // Check if initialize method exists, otherwise skip
           if (typeof (auditHandler as any).initialize === 'function') {
             await (auditHandler as any).initialize();
@@ -363,7 +363,7 @@ export class RouteRecovery {
 
         case '/diagnostic':
           // Bootstrap diagnostic handler with enhanced recovery
-          const { diagnosticHandler } = await import('./diagnostic-handler');
+          const { diagnosticHandler } = await import('./diagnostic-handler.js');
           // Check if performFullBootstrap method exists, otherwise use basic recovery
           if (typeof (diagnosticHandler as any).performFullBootstrap === 'function') {
             const diagnosticResult = await (diagnosticHandler as any).performFullBootstrap();

--- a/src/handlers/webFetchHandler.ts
+++ b/src/handlers/webFetchHandler.ts
@@ -1,8 +1,8 @@
 import OpenAI from 'openai';
-import '../services/clarke-handler'; // Import to ensure ClarkeHandler is available
-import { genericFallback, ClarkeHandler } from '../services/clarke-handler';
-import { fetchWebSearch } from '../utils/webSearch';
-import { storeMemory } from '../services/memory';
+import '../services/clarke-handler.js'; // Import to ensure ClarkeHandler is available
+import { genericFallback, ClarkeHandler } from '../services/clarke-handler.js';
+import { fetchWebSearch } from '../utils/webSearch.js';
+import { storeMemory } from '../services/memory.js';
 
 // Use the new resilience handler pattern
 let openai: ClarkeHandler;

--- a/src/handlers/write-handler.ts
+++ b/src/handlers/write-handler.ts
@@ -2,7 +2,7 @@
 // Content validation and OpenAI SDK-compatible write operations
 
 import { Request, Response } from 'express';
-import { ArcanosWriteService } from '../services/arcanos-write';
+import { ArcanosWriteService } from '../services/arcanos-write.js';
 
 export class WriteHandler {
   private writeService: ArcanosWriteService;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,60 +5,63 @@ import express from 'express';
 import path from 'path';
 import bodyParser from 'body-parser';
 import cors from 'cors';
+import { fileURLToPath } from 'url';
 
 // Centralized configuration
 import { config, validateConfig, getEnvironmentStatus } from './config/index.js';
-import { applyCLEAROverlay } from './modules/clear-overlay';
+import { applyCLEAROverlay } from './modules/clear-overlay.js';
 
 // Core route modules (extracted for better modularity)
-import router from './routes/index';
-import mainRoutes from './routes/main';
-import aiRoutes from './routes/ai';
-import memoryRouter from './routes/memory';
-import guidesRouter from './routes/guides';
-import systemRouter from './routes/system';
-import codexRouter from './routes/codex';
-import logsRouter from './routes/logs';
-import webFallbackRouter from './routes/web-fallback';
-import webLookupAndSummarizeRouter from './modules/webLookupAndSummarize';
-import researchRouter from './modules/research';
-import openaiWebhookRouter from './webhooks/openai';
-import githubWebhookRouter from './webhooks/github';
-import { enableAdminControl, getAdminRouter } from './system/auth';
+import router from './routes/index.js';
+import mainRoutes from './routes/main.js';
+import aiRoutes from './routes/ai.js';
+import memoryRouter from './routes/memory.js';
+import guidesRouter from './routes/guides.js';
+import systemRouter from './routes/system.js';
+import codexRouter from './routes/codex.js';
+import logsRouter from './routes/logs.js';
+import webFallbackRouter from './routes/web-fallback.js';
+import webLookupAndSummarizeRouter from './modules/webLookupAndSummarize.js';
+import researchRouter from './modules/research.js';
+import openaiWebhookRouter from './webhooks/openai.js';
+import githubWebhookRouter from './webhooks/github.js';
+import { enableAdminControl, getAdminRouter } from './system/auth.js';
 
 // Middleware
-import { requireApiToken } from './middleware/api-token';
-import { chatGPTUserMiddleware } from './middleware/chatgpt-user';
-import { errorHandler, notFoundHandler } from './middleware/error-handler';
-import { performanceMiddleware } from './utils/performance';
+import { requireApiToken } from './middleware/api-token.js';
+import { chatGPTUserMiddleware } from './middleware/chatgpt-user.js';
+import { errorHandler, notFoundHandler } from './middleware/error-handler.js';
+import { performanceMiddleware } from './utils/performance.js';
 
 // Services
-import { databaseService } from './services/database';
-import { serverService } from './services/server';
-import { chatGPTUserWhitelist } from './services/chatgpt-user-whitelist';
-import { diagnosticsService } from './services/diagnostics';
-import { memoryMonitor } from './services/memory-monitor';
-import { recordUptime, getLastUptime } from './utils/uptime';
+import { databaseService } from './services/database.js';
+import { serverService } from './services/server.js';
+import { chatGPTUserWhitelist } from './services/chatgpt-user-whitelist.js';
+import { diagnosticsService } from './services/diagnostics.js';
+import { memoryMonitor } from './services/memory-monitor.js';
+import { recordUptime, getLastUptime } from './utils/uptime.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Handlers (for initialization)
-import { memoryHandler } from './handlers/memory-handler';
-import { routeRecovery } from './handlers/route-recovery';
+import { memoryHandler } from './handlers/memory-handler.js';
+import { routeRecovery } from './handlers/route-recovery.js';
 
 // Import system modules
-import './services/database-connection';
-import './services/cron-worker';
-import './worker-init';
+import './services/database-connection.js';
+import './services/cron-worker.js';
+import './worker-init.js';
 
 // Import AI reflection handler (initializes 8:30 AM daily schedule)
-import './services/backend-ai-reflection-handler';
+import './services/backend-ai-reflection-handler.js';
 
 // Trigger self-reflection when entering sleep mode
-import './sleep-self-reflection';
+import './sleep-self-reflection.js';
 
 // Import sleep manager
-import { sleepManager } from './services/sleep-manager';
+import { sleepManager } from './services/sleep-manager.js';
 // Schedule pre-sleep preparation tasks
-import './services/sleep-prep';
+import './services/sleep-prep.js';
 
 // Validate configuration on startup
 const configValidation = validateConfig();
@@ -131,7 +134,7 @@ app.get('/health', (_, res) => res.send('✅ OK'));
 
 // Performance monitoring endpoint
 app.get('/performance', async (_req, res) => {
-  const { performanceMonitor } = await import('./utils/performance');
+  const { performanceMonitor } = await import('./utils/performance.js');
   const metrics = performanceMonitor.getMetrics();
   const memoryStatus = performanceMonitor.getMemoryPressureStatus();
   const sleepStatus = sleepManager.getSleepStatus();
@@ -259,21 +262,21 @@ serverService.start(app, PORT).then(async () => {
 export default app;
 
 // Export the ARCANOS V1 Safe Interface for direct usage
-export { askArcanosV1_Safe, getActiveModel, ArcanosModel } from './services/arcanos-v1-interface';
+export { askArcanosV1_Safe, getActiveModel, ArcanosModel } from './services/arcanos-v1-interface.js';
 
 // Export sleep schedule functions for copilot integration
-export { getCoreSleepWindow } from './services/sleep-config';
+export { getCoreSleepWindow } from './services/sleep-config.js';
 
 // Export email service functions for global access
-export { sendEmail, verifyEmailConnection, getEmailSender, getEmailTransportType } from './services/email';
-export { selfReflectionService } from './services/self-reflection';
+export { sendEmail, verifyEmailConnection, getEmailSender, getEmailTransportType } from './services/email.js';
+export { selfReflectionService } from './services/self-reflection.js';
 
 // Export backend AI reflection handler
-export { reflectIfScheduled } from './services/backend-ai-reflection-handler';
+export { reflectIfScheduled } from './services/backend-ai-reflection-handler.js';
 
 // Export game guide storage functionality
-export { saveGameGuide } from './services/game-guides';
+export { saveGameGuide } from './services/game-guides.js';
 
 // Export AI patch system for external usage
-export { aiPatchSystem, createAIPatch } from './services/ai-patch-system';
-export { initializeBackend } from './initializeBackend';
+export { aiPatchSystem, createAIPatch } from './services/ai-patch-system.js';
+export { initializeBackend } from './initializeBackend.js';

--- a/src/initializeBackend.ts
+++ b/src/initializeBackend.ts
@@ -1,7 +1,7 @@
-import { installNLPInterpreter } from './modules/nlp-interpreter';
-import { installPagedOutputHandler } from './modules/paged-output-handler';
-import { installMemoryAuditStreamSerializer } from './modules/memory-audit-stream-serializer';
-import { createServiceLogger } from './utils/logger';
+import { installNLPInterpreter } from './modules/nlp-interpreter.js';
+import { installPagedOutputHandler } from './modules/paged-output-handler.js';
+import { installMemoryAuditStreamSerializer } from './modules/memory-audit-stream-serializer.js';
+import { createServiceLogger } from './utils/logger.js';
 
 export interface BackendInitializationOptions {
   environment?: string;

--- a/src/intents/send_email.ts
+++ b/src/intents/send_email.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { sendEmail } from '../services/email';
+import { sendEmail } from '../services/email.js';
 
 export async function sendEmailIntent(req: Request, res: Response) {
   const { to, subject, body } = req.body;

--- a/src/intents/send_email_and_respond.ts
+++ b/src/intents/send_email_and_respond.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
-import { sendEmail } from '../services/email';
-import { getUnifiedOpenAI, type ChatMessage } from '../services/unified-openai';
-import { aiConfig } from '../config';
+import { sendEmail } from '../services/email.js';
+import { getUnifiedOpenAI, type ChatMessage } from '../services/unified-openai.js';
+import { aiConfig } from '../config/index.js';
 
 let unifiedOpenAI: ReturnType<typeof getUnifiedOpenAI> | null = null;
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,7 +3,9 @@ import { promises as fsp } from 'fs';
 import path from 'path';
 import zlib from 'zlib';
 import { pipeline } from 'stream/promises';
+import { fileURLToPath } from 'url';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const LOG_DIR = path.resolve(__dirname, '../logs');
 const MAX_LOG_SIZE_MB = 5;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,15 +1,15 @@
 // ARCANOS Main Entry Point - GitHub Integration Enabled
 // This is the main entry point as specified in the requirements
 
-import './index';
+import './index.js';
 // Import the AI Reflection Scheduler to enable it
-import './ai-reflection-scheduler';
+import './ai-reflection-scheduler.js';
 
 // Export main ARCANOS interface for external usage
-export { askArcanosV1_Safe, getActiveModel, ArcanosModel } from './services/arcanos-v1-interface';
-export { githubWebhookService } from './services/github-webhook-service';
-export { githubActionsService, executeGitHubAction } from './services/github-actions-service';
-export { aiReflectionScheduler } from './ai-reflection-scheduler';
+export { askArcanosV1_Safe, getActiveModel, ArcanosModel } from './services/arcanos-v1-interface.js';
+export { githubWebhookService } from './services/github-webhook-service.js';
+export { githubActionsService, executeGitHubAction } from './services/github-actions-service.js';
+export { aiReflectionScheduler } from './ai-reflection-scheduler.js';
 
 console.log('🤖 ARCANOS Main Entry Point - Full Backend Controller Ready');
 console.log('📋 GitHub Integration Features:');

--- a/src/memoryScheduler.ts
+++ b/src/memoryScheduler.ts
@@ -1,4 +1,4 @@
-import { dispatchJob } from './services/execution-engine';
+import { dispatchJob } from './services/execution-engine.js';
 
 export async function scheduleMemoryWorker(tag: string, payload: any, delay: number = 0) {
   const timestamp = new Date(Date.now() + delay).toISOString();

--- a/src/middleware/chatgpt-user.ts
+++ b/src/middleware/chatgpt-user.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { chatGPTUserWhitelist } from '../services/chatgpt-user-whitelist';
+import { chatGPTUserWhitelist } from '../services/chatgpt-user-whitelist.js';
 
 // Define the exact ChatGPT-User agent string
 const CHATGPT_USER_AGENT = 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ChatGPT-User/1.0; +https://openai.com/bot';

--- a/src/middleware/diagnostics.ts
+++ b/src/middleware/diagnostics.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { createServiceLogger } from '../utils/logger'
+import { createServiceLogger } from '../utils/logger.js'
 
 const logger = createServiceLogger('DiagnosticsMiddleware')
 

--- a/src/modules/deepResearchHandler.ts
+++ b/src/modules/deepResearchHandler.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai';
-import { getMemory, storeMemory } from '../services/memory';
+import { getMemory, storeMemory } from '../services/memory.js';
 
 /**
  * Structured result for the deep research flow

--- a/src/modules/memory-audit-stream-serializer.ts
+++ b/src/modules/memory-audit-stream-serializer.ts
@@ -5,7 +5,7 @@ export interface MemoryAuditStreamConfig {
   logTrunc?: number;
 }
 
-import { splitResponse } from '../utils/response-splitter';
+import { splitResponse } from '../utils/response-splitter.js';
 import { Response } from 'express';
 
 export class MemoryAuditStreamSerializer {

--- a/src/modules/overlay.ts
+++ b/src/modules/overlay.ts
@@ -1,4 +1,4 @@
-import { HRCCore } from './hrc';
+import { HRCCore } from './hrc.js';
 
 export interface OverlayResult {
   allowed: boolean;

--- a/src/modules/paged-output-handler.ts
+++ b/src/modules/paged-output-handler.ts
@@ -1,4 +1,4 @@
-import { splitResponse } from '../utils/response-splitter';
+import { splitResponse } from '../utils/response-splitter.js';
 
 export interface PagedOutputConfig {
   maxPayloadSize?: number;

--- a/src/modules/research.ts
+++ b/src/modules/research.ts
@@ -7,8 +7,8 @@
 
 import axios from "axios";
 import express from "express";
-import { getUnifiedOpenAI } from "../services/unified-openai";
-import { storeMemory } from "../services/memory";
+import { getUnifiedOpenAI } from "../services/unified-openai.js";
+import { storeMemory } from "../services/memory.js";
 
 const router = express.Router();
 

--- a/src/modules/webLookupAndSummarize.ts
+++ b/src/modules/webLookupAndSummarize.ts
@@ -5,8 +5,8 @@
 
 import axios from "axios";
 import express from "express";
-import { getUnifiedOpenAI } from "../services/unified-openai";
-import { storeMemory, getMemory } from "../services/memory"; // Update paths as needed
+import { getUnifiedOpenAI } from "../services/unified-openai.js";
+import { storeMemory, getMemory } from "../services/memory.js"; // Update paths as needed
 
 const router = express.Router();
 

--- a/src/plugins/email.ts
+++ b/src/plugins/email.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { sendEmail } from '../services/email'
+import { sendEmail } from '../services/email.js'
 
 export interface EmailPayload {
   to: string

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,5 +1,5 @@
-import reversePlugin from './reverse-plugin';
-import { pluginManager } from '../services/plugin-manager';
+import reversePlugin from './reverse-plugin.js';
+import { pluginManager } from '../services/plugin-manager.js';
 
 let loaded = false;
 

--- a/src/plugins/reverse-plugin.ts
+++ b/src/plugins/reverse-plugin.ts
@@ -1,4 +1,4 @@
-import { ArcanosPlugin, PluginRequest, PluginResponse } from '../services/plugin-manager';
+import { ArcanosPlugin, PluginRequest, PluginResponse } from '../services/plugin-manager.js';
 
 const reversePlugin: ArcanosPlugin = {
   name: 'reverse',

--- a/src/resilience-handler-example.ts
+++ b/src/resilience-handler-example.ts
@@ -4,8 +4,8 @@
  * as specified in the problem statement.
  */
 
-import './services/clarke-handler'; // Import to ensure ClarkeHandler is attached to OpenAI namespace
-import { genericFallback, ClarkeHandler } from './services/clarke-handler';
+import './services/clarke-handler.js'; // Import to ensure ClarkeHandler is attached to OpenAI namespace
+import { genericFallback, ClarkeHandler } from './services/clarke-handler.js';
 import OpenAI from 'openai';
 
 /**

--- a/src/routes/ai.ts
+++ b/src/routes/ai.ts
@@ -2,15 +2,17 @@
 // Enhanced with GPT-4 fallback for malformed or incomplete outputs
 import { Router } from 'express';
 import path from 'path';
-import { modelControlHooks } from '../services/model-control-hooks';
-import { sendErrorResponse, sendSuccessResponse, handleServiceResult, handleCatchError } from '../utils/response';
-import { codeInterpreterService } from '../services/ai-service-consolidated';
-import { gameGuideService } from '../services/game-guide';
-import { recoverOutput, recoverJSON } from '../utils/output-recovery';
-import { runValidationPipeline } from '../services/ai-validation-pipeline'; // [AI-PATCH: RAG+HRC+CLEAR]
+import { fileURLToPath } from 'url';
+import { modelControlHooks } from '../services/model-control-hooks.js';
+import { sendErrorResponse, sendSuccessResponse, handleServiceResult, handleCatchError } from '../utils/response.js';
+import { codeInterpreterService } from '../services/ai-service-consolidated.js';
+import { gameGuideService } from '../services/game-guide.js';
+import { recoverOutput, recoverJSON } from '../utils/output-recovery.js';
+import { runValidationPipeline } from '../services/ai-validation-pipeline.js'; // [AI-PATCH: RAG+HRC+CLEAR]
 
 
 const router = Router();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 
 // Fine-tune routing status endpoint
@@ -19,7 +21,7 @@ router.get('/finetune-status', async (req, res) => {
   const sessionId = req.headers['x-session-id'] as string || 'default';
   
   try {
-    const { fineTuneRoutingService } = await import('../services/finetune-routing');
+    const { fineTuneRoutingService } = await import('../services/finetune-routing.js');
     
     const isActive = await fineTuneRoutingService.isFineTuneRoutingActive(userId, sessionId);
     const statusMessage = await fineTuneRoutingService.getStatusMessage(userId, sessionId);
@@ -232,7 +234,7 @@ router.post('/ai-patch', async (req, res) => {
   }
 
   try {
-    const { aiPatchSystem } = await import('../services/ai-patch-system');
+    const { aiPatchSystem } = await import('../services/ai-patch-system.js');
     
     const result = await aiPatchSystem.processPatch({
       content,
@@ -259,7 +261,7 @@ router.post('/ai-patch', async (req, res) => {
 // GET /ai-patch/status - Get AI Patch System status
 router.get('/ai-patch/status', async (req, res) => {
   try {
-    const { aiPatchSystem } = await import('../services/ai-patch-system');
+    const { aiPatchSystem } = await import('../services/ai-patch-system.js');
     
     const status = await aiPatchSystem.getSystemStatus();
     
@@ -273,7 +275,7 @@ router.get('/ai-patch/status', async (req, res) => {
 // POST /ai-patch/retry - Manually trigger retry queue processing
 router.post('/ai-patch/retry', async (req, res) => {
   try {
-    const { aiPatchSystem } = await import('../services/ai-patch-system');
+    const { aiPatchSystem } = await import('../services/ai-patch-system.js');
     
     await aiPatchSystem.processRetryQueue();
     const status = await aiPatchSystem.getRetryQueueStatus();

--- a/src/routes/assistants.ts
+++ b/src/routes/assistants.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { openAIAssistantsService } from '../services/openai-assistants';
+import { openAIAssistantsService } from '../services/openai-assistants.js';
 
 const router = express.Router();
 

--- a/src/routes/canon.ts
+++ b/src/routes/canon.ts
@@ -5,9 +5,11 @@
 import { Router, Request, Response } from 'express';
 import * as fs from 'fs';
 import * as path from 'path';
-import { logEndpointCall } from '../services/endpoint-logger';
+import { logEndpointCall } from '../services/endpoint-logger.js';
+import { fileURLToPath } from 'url';
 
 // Use project-relative path since /containers is not accessible
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CANON_PATH = path.join(__dirname, '../../storage/canon');
 const router = Router();
 

--- a/src/routes/codex-worker-router.ts
+++ b/src/routes/codex-worker-router.ts
@@ -1,10 +1,10 @@
 import { Router, Request, Response } from 'express';
-import { runDiagnostics } from '../handlers/diagnostics';
-import { runRefactor } from '../handlers/refactor';
-import { createDraftBranch } from '../handlers/branchDraft';
-import { editBackendCode } from '../handlers/backendEdit';
-import { validateCodexIntent, CodexIntent } from '../utils/intentParser';
-import { logToStudio } from '../studio/logger';
+import { runDiagnostics } from '../handlers/diagnostics.js';
+import { runRefactor } from '../handlers/refactor.js';
+import { createDraftBranch } from '../handlers/branchDraft.js';
+import { editBackendCode } from '../handlers/backendEdit.js';
+import { validateCodexIntent, CodexIntent } from '../utils/intentParser.js';
+import { logToStudio } from '../studio/logger.js';
 
 const router = Router();
 

--- a/src/routes/codex.ts
+++ b/src/routes/codex.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
-import { modelControlHooks, memoryControl } from '../services/model-control-hooks';
-import { sendErrorResponse, sendSuccessResponse, handleCatchError } from '../utils/response';
+import { modelControlHooks, memoryControl } from '../services/model-control-hooks.js';
+import { sendErrorResponse, sendSuccessResponse, handleCatchError } from '../utils/response.js';
 
 const router = Router();
 

--- a/src/routes/guides.ts
+++ b/src/routes/guides.ts
@@ -3,9 +3,9 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { fetchGuideHandler } from '../handlers/guide-handler';
-import { saveGameGuide, fetchGuideSegment } from '../services/game-guides';
-import { sendSuccessResponse, sendErrorResponse, handleCatchError } from '../utils/response';
+import { fetchGuideHandler } from '../handlers/guide-handler.js';
+import { saveGameGuide, fetchGuideSegment } from '../services/game-guides.js';
+import { sendSuccessResponse, sendErrorResponse, handleCatchError } from '../utils/response.js';
 
 const router = Router();
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,13 +1,13 @@
 import { Router } from 'express';
-import { modelControlHooks } from '../services/model-control-hooks';
-import { diagnosticsService } from '../services/diagnostics';
-import { workerStatusService } from '../services/worker-status';
-import { sendEmail, verifyEmailConnection, getEmailSender, getEmailTransportType } from '../services/email';
-import { sendEmailIntent } from '../intents/send_email';
-import { sendEmailAndRespond } from '../intents/send_email_and_respond';
-import { runValidationPipeline } from '../services/ai-validation-pipeline'; // [AI-PATCH: RAG+HRC+CLEAR]
-import { handleInternetResult } from '../utils/internet-lookup';
-import assistantsRouter from './assistants';
+import { modelControlHooks } from '../services/model-control-hooks.js';
+import { diagnosticsService } from '../services/diagnostics.js';
+import { workerStatusService } from '../services/worker-status.js';
+import { sendEmail, verifyEmailConnection, getEmailSender, getEmailTransportType } from '../services/email.js';
+import { sendEmailIntent } from '../intents/send_email.js';
+import { sendEmailAndRespond } from '../intents/send_email_and_respond.js';
+import { runValidationPipeline } from '../services/ai-validation-pipeline.js'; // [AI-PATCH: RAG+HRC+CLEAR]
+import { handleInternetResult } from '../utils/internet-lookup.js';
+import assistantsRouter from './assistants.js';
 
 const router = Router();
 

--- a/src/routes/job-limit.ts
+++ b/src/routes/job-limit.ts
@@ -1,10 +1,10 @@
 import { Router, Request, Response } from 'express';
-import { delay } from '../utils/delay';
+import { delay } from '../utils/delay.js';
 import { 
   createRateLimitMiddleware, 
   asyncHandler, 
   requestTimingMiddleware 
-} from '../middleware/modern-middleware';
+} from '../middleware/modern-middleware.js';
 
 const router = Router();
 

--- a/src/routes/job-queue.ts
+++ b/src/routes/job-queue.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { enqueue } from '../services/jobQueue';
+import { enqueue } from '../services/jobQueue.js';
 
 const router = Router();
 

--- a/src/routes/logic.ts
+++ b/src/routes/logic.ts
@@ -1,4 +1,4 @@
-import { processArcanosRequest } from '../services/arcanos-router';
+import { processArcanosRequest } from '../services/arcanos-router.js';
 
 export async function handleLogic(payload: any): Promise<any> {
   const { message = '', domain = 'general', useRAG = true, useHRC = true } = payload || {};

--- a/src/routes/logs.ts
+++ b/src/routes/logs.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { getRecentLogs } from '../services/log-relay';
+import { getRecentLogs } from '../services/log-relay.js';
 
 const router = Router();
 

--- a/src/routes/main.ts
+++ b/src/routes/main.ts
@@ -1,14 +1,14 @@
 // ARCANOS Main Routes - Extracted from index.ts for better modularity
 import { Router } from 'express';
-import { memoryHandler } from '../handlers/memory-handler';
-import { auditHandler } from '../handlers/audit-handler';
-import { diagnosticHandler } from '../handlers/diagnostic-handler';
-import { writeHandler } from '../handlers/write-handler';
-import { routeRecovery } from '../handlers/route-recovery';
-import { getChatGPTUserDiagnostics } from '../middleware/chatgpt-user';
-import { getPagedOutputHandler } from '../modules/paged-output-handler';
-import { memoryOperations } from '../services/memory-operations';
-import { getMemoryAuditStreamSerializer } from '../modules/memory-audit-stream-serializer';
+import { memoryHandler } from '../handlers/memory-handler.js';
+import { auditHandler } from '../handlers/audit-handler.js';
+import { diagnosticHandler } from '../handlers/diagnostic-handler.js';
+import { writeHandler } from '../handlers/write-handler.js';
+import { routeRecovery } from '../handlers/route-recovery.js';
+import { getChatGPTUserDiagnostics } from '../middleware/chatgpt-user.js';
+import { getPagedOutputHandler } from '../modules/paged-output-handler.js';
+import { memoryOperations } from '../services/memory-operations.js';
+import { getMemoryAuditStreamSerializer } from '../modules/memory-audit-stream-serializer.js';
 import fs from 'fs';
 import path from 'path';
 

--- a/src/routes/memory.ts
+++ b/src/routes/memory.ts
@@ -1,8 +1,8 @@
 import { Router, Request, Response } from 'express';
-import { databaseService, SaveMemoryRequest, LoadMemoryRequest } from '../services/database';
-import { fallbackMemory } from '../services/memory';
-import { sendErrorResponse, sendSuccessResponse, handleCatchError } from '../utils/response';
-import { arcanosLogger } from '../utils/logger';
+import { databaseService, SaveMemoryRequest, LoadMemoryRequest } from '../services/database.js';
+import { fallbackMemory } from '../services/memory.js';
+import { sendErrorResponse, sendSuccessResponse, handleCatchError } from '../utils/response.js';
+import { arcanosLogger } from '../utils/logger.js';
 
 const router = Router();
 const useDatabase = !!process.env.DATABASE_URL;

--- a/src/routes/plugins.ts
+++ b/src/routes/plugins.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
-import { loadPlugins } from '../plugins';
-import { pluginManager } from '../services/plugin-manager';
-import { MemoryStorage } from '../storage/memory-storage';
+import { loadPlugins } from '../plugins/index.js';
+import { pluginManager } from '../services/plugin-manager.js';
+import { MemoryStorage } from '../storage/memory-storage.js';
 
 const router = Router();
 let pluginsLoaded = false;

--- a/src/routes/query-router.ts
+++ b/src/routes/query-router.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from 'express';
-import { askArcanosV1_Safe } from '../services/arcanos-v1-interface';
-import { createServiceLogger } from '../utils/logger';
+import { askArcanosV1_Safe } from '../services/arcanos-v1-interface.js';
+import { createServiceLogger } from '../utils/logger.js';
 
 const router = express.Router();
 const logger = createServiceLogger('QueryRouter');

--- a/src/routes/system.ts
+++ b/src/routes/system.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
-import { sleepManager } from '../services/sleep-manager';
-import { getCurrentSleepWindowStatus, logSleepWindowStatus } from '../services/sleep-config';
-import { diagnosticsService } from '../services/diagnostics';
+import { sleepManager } from '../services/sleep-manager.js';
+import { getCurrentSleepWindowStatus, logSleepWindowStatus } from '../services/sleep-config.js';
+import { diagnosticsService } from '../services/diagnostics.js';
 
 const router = Router();
 

--- a/src/routes/web-fallback.ts
+++ b/src/routes/web-fallback.ts
@@ -4,9 +4,9 @@
  */
 
 import { Router } from 'express';
-import { webFallbackToGPT, getWebFallbackService } from '../services/web-fallback';
-import { sendErrorResponse, sendSuccessResponse } from '../utils/response';
-import { requireApiToken } from '../middleware/api-token';
+import { webFallbackToGPT, getWebFallbackService } from '../services/web-fallback.js';
+import { sendErrorResponse, sendSuccessResponse } from '../utils/response.js';
+import { requireApiToken } from '../middleware/api-token.js';
 
 const router = Router();
 

--- a/src/services/action-router.ts
+++ b/src/services/action-router.ts
@@ -1,8 +1,8 @@
-import { executionEngine } from './execution-engine';
-import { DispatchInstruction } from './ai-dispatcher';
-import { createServiceLogger } from '../utils/logger';
-import { memoryOperations } from './memory-operations';
-import { activeWorkers } from '../worker-init';
+import { executionEngine } from './execution-engine.js';
+import { DispatchInstruction } from './ai-dispatcher.js';
+import { createServiceLogger } from '../utils/logger.js';
+import { memoryOperations } from './memory-operations.js';
+import { activeWorkers } from '../worker-init.js';
 import * as cron from 'node-cron';
 
 const logger = createServiceLogger('ActionRouter');

--- a/src/services/ai-dispatcher.ts
+++ b/src/services/ai-dispatcher.ts
@@ -1,8 +1,8 @@
 // ARCANOS AI Dispatcher - Unified dispatch system that sends all requests to fine-tuned model
 // Replaces static logic, conditionals, and routing trees with AI-controlled decision making
 
-import { getUnifiedOpenAI, type ChatMessage } from './unified-openai';
-import { ARCANOS_MODEL_ID } from '../config/ai-model'; // PATCHED: full model ID
+import { getUnifiedOpenAI, type ChatMessage } from './unified-openai.js';
+import { ARCANOS_MODEL_ID } from '../config/ai-model.js'; // PATCHED: full model ID
 
 // Helper to resolve workers from schedule keys
 function resolveWorkerFromKey(key: string): string | null {

--- a/src/services/ai-service-consolidated.ts
+++ b/src/services/ai-service-consolidated.ts
@@ -4,9 +4,9 @@
  * Uses the unified OpenAI service for all operations
  */
 
-import { getUnifiedOpenAI, type ChatMessage, type ChatOptions, type CodeInterpreterResult } from './unified-openai';
-import { createServiceLogger } from '../utils/logger';
-import { ARCANOS_MODEL_ID } from '../config/ai-model'; // PATCHED: full model ID
+import { getUnifiedOpenAI, type ChatMessage, type ChatOptions, type CodeInterpreterResult } from './unified-openai.js';
+import { createServiceLogger } from '../utils/logger.js';
+import { ARCANOS_MODEL_ID } from '../config/ai-model.js'; // PATCHED: full model ID
 
 const logger = createServiceLogger('AIServiceConsolidated');
 
@@ -222,4 +222,4 @@ export const unifiedAIService = {
 };
 
 // Export types
-export type { CodeInterpreterResult } from './unified-openai';
+export type { CodeInterpreterResult } from './unified-openai.js';

--- a/src/services/ai-service-dispatcher.ts
+++ b/src/services/ai-service-dispatcher.ts
@@ -10,8 +10,8 @@
  * - OpenAI SDK v5.10+ compatible
  */
 
-import { createServiceLogger } from '../utils/logger';
-import { aiDispatcher, type DispatchRequest, type DispatchResponse } from '../services/ai-dispatcher';
+import { createServiceLogger } from '../utils/logger.js';
+import { aiDispatcher, type DispatchRequest, type DispatchResponse } from '../services/ai-dispatcher.js';
 
 const logger = createServiceLogger('AIServiceDispatcher');
 
@@ -249,7 +249,7 @@ async function executeInstruction(instruction: any, originalTask: ServiceTask): 
  * Execute memory worker
  */
 async function executeMemoryWorker(task: ServiceTask): Promise<any> {
-  const { handle } = await import('../workers/memoryWorker');
+  const { handle } = await import('../workers/memoryWorker.js');
   
   const memoryTask = {
     action: (task.action as 'store' | 'retrieve' | 'delete' | 'sync' | 'snapshot') || 'retrieve',
@@ -268,7 +268,7 @@ async function executeMemoryWorker(task: ServiceTask): Promise<any> {
  * Execute API worker
  */
 async function executeApiWorker(task: ServiceTask): Promise<any> {
-  const { handle } = await import('../workers/apiWorker');
+  const { handle } = await import('../workers/apiWorker.js');
   
   const apiTask = {
     action: (task.action as 'request' | 'webhook' | 'proxy' | 'batch' | 'monitor') || 'request',
@@ -291,7 +291,7 @@ async function executeApiWorker(task: ServiceTask): Promise<any> {
 async function executeDefaultWorkerOverride(task: ServiceTask): Promise<ServiceResponse> {
   logger.warning('[OVERRIDE] Executing fallback defaultWorker...');
   
-  const { handle, isAuthorized } = await import('../workers/defaultWorker');
+  const { handle, isAuthorized } = await import('../workers/defaultWorker.js');
   
   if (!isAuthorized(task.context?.manualOverride)) {
     throw new Error('DefaultWorker access denied: Manual override not properly authorized');
@@ -333,15 +333,15 @@ async function executeWorkerByName(workerName: string, taskData: any): Promise<a
 
   switch (workerName) {
     case 'memorySync':
-      const { default: memorySync } = await import('../workers/memorySync');
+      const { default: memorySync } = await import('../workers/memorySync.js');
       return await memorySync();
 
     case 'goalWatcher':
-      const { default: goalWatcher } = await import('../workers/goalWatcher');
+      const { default: goalWatcher } = await import('../workers/goalWatcher.js');
       return await goalWatcher();
 
     case 'clearTemp':
-      const { default: clearTemp } = await import('../workers/clearTemp');
+      const { default: clearTemp } = await import('../workers/clearTemp.js');
       return await clearTemp();
 
     default:

--- a/src/services/ai-validation-pipeline.ts
+++ b/src/services/ai-validation-pipeline.ts
@@ -1,6 +1,6 @@
-import { getUnifiedOpenAI, type ChatMessage } from './unified-openai';
-import { runDeepResearch } from '../modules/deepResearchHandler';
-import { webFetchHandler } from '../handlers/webFetchHandler';
+import { getUnifiedOpenAI, type ChatMessage } from './unified-openai.js';
+import { runDeepResearch } from '../modules/deepResearchHandler.js';
+import { webFetchHandler } from '../handlers/webFetchHandler.js';
 
 export interface ValidationAudit {
   contextBlock?: string;

--- a/src/services/ai-worker-refactor.ts
+++ b/src/services/ai-worker-refactor.ts
@@ -1,9 +1,9 @@
 // AI Worker System Refactor - Using Unified OpenAI Service
 // Unified worker orchestration with modular control hooks and fallback dispatch
 
-import { getUnifiedOpenAI, type ChatMessage } from './unified-openai';
-import { createServiceLogger } from '../utils/logger';
-import { validateWorkerTask } from '../utils/worker-validation';
+import { getUnifiedOpenAI, type ChatMessage } from './unified-openai.js';
+import { createServiceLogger } from '../utils/logger.js';
+import { validateWorkerTask } from '../utils/worker-validation.js';
 
 const logger = createServiceLogger('AIWorkerRefactor');
 

--- a/src/services/ai/index.ts
+++ b/src/services/ai/index.ts
@@ -3,11 +3,11 @@
  * Exports reflect function for the AI Reflection Scheduler
  */
 
-import { coreAIService } from '../ai-service-consolidated';
-import { selfReflectionService } from '../self-reflection';
-import { getNLPInterpreter } from '../../modules/nlp-interpreter';
-import { saveMemory } from '../memory';
-import type { ChatMessage } from '../unified-openai';
+import { coreAIService } from '../ai-service-consolidated.js';
+import { selfReflectionService } from '../self-reflection.js';
+import { getNLPInterpreter } from '../../modules/nlp-interpreter.js';
+import { saveMemory } from '../memory.js';
+import type { ChatMessage } from '../unified-openai.js';
 
 export interface ReflectionOptions {
   label: string;
@@ -115,4 +115,4 @@ export async function reflect(options: ReflectionOptions): Promise<ReflectionSna
 }
 
 // Re-export consolidated AI service for direct access
-export { coreAIService } from '../ai-service-consolidated';
+export { coreAIService } from '../ai-service-consolidated.js';

--- a/src/services/arcanos-audit.ts
+++ b/src/services/arcanos-audit.ts
@@ -1,9 +1,9 @@
 // ARCANOS:AUDIT - Content validation and audit service
 // Handles requests that require validation, checking, or auditing
 
-import { getUnifiedOpenAI, type ChatMessage } from './unified-openai';
-import { aiConfig } from '../config';
-import { HRCCore } from '../modules/hrc';
+import { getUnifiedOpenAI, type ChatMessage } from './unified-openai.js';
+import { aiConfig } from '../config/index.js';
+import { HRCCore } from '../modules/hrc.js';
 
 export interface AuditRequest {
   message: string;

--- a/src/services/arcanos-router.ts
+++ b/src/services/arcanos-router.ts
@@ -1,10 +1,10 @@
 // ARCANOS Intent-Based Router
 // Routes inputs to ARCANOS:WRITE or ARCANOS:AUDIT based on intent analysis
 
-import { IntentAnalyzer, IntentType } from './intent-analyzer';
-import { ArcanosWriteService, WriteRequest } from './arcanos-write';
-import { ArcanosAuditService, AuditRequest } from './arcanos-audit';
-import { diagnosticsService } from './diagnostics';
+import { IntentAnalyzer, IntentType } from './intent-analyzer.js';
+import { ArcanosWriteService, WriteRequest } from './arcanos-write.js';
+import { ArcanosAuditService, AuditRequest } from './arcanos-audit.js';
+import { diagnosticsService } from './diagnostics.js';
 
 export interface RouterRequest {
   message: string;

--- a/src/services/arcanos-v1-interface.ts
+++ b/src/services/arcanos-v1-interface.ts
@@ -2,11 +2,11 @@
 // Purpose: Safe, fallback-proof logic interface for model routing
 // Enhanced with GPT-4 fallback for malformed outputs
 
-import { getUnifiedOpenAI } from './unified-openai';
-import { HRCCore } from '../modules/hrc';
-import { MemoryStorage } from '../storage/memory-storage';
-import { aiConfig } from '../config';
-import { recoverOutput } from '../utils/output-recovery';
+import { getUnifiedOpenAI } from './unified-openai.js';
+import { HRCCore } from '../modules/hrc.js';
+import { MemoryStorage } from '../storage/memory-storage.js';
+import { aiConfig } from '../config/index.js';
+import { recoverOutput } from '../utils/output-recovery.js';
 
 // Model interface that all models must implement
 export interface ArcanosModel {

--- a/src/services/arcanos-write.ts
+++ b/src/services/arcanos-write.ts
@@ -1,10 +1,10 @@
 // ARCANOS:WRITE - Narrative content generation service
 // Handles requests that have narrative intent
 
-import { getUnifiedOpenAI, type ChatMessage } from './unified-openai';
-import { aiConfig } from '../config';
-import { MemoryStorage } from '../storage/memory-storage';
-import { arcanosLogger, createServiceLogger } from '../utils/logger';
+import { getUnifiedOpenAI, type ChatMessage } from './unified-openai.js';
+import { aiConfig } from '../config/index.js';
+import { MemoryStorage } from '../storage/memory-storage.js';
+import { arcanosLogger, createServiceLogger } from '../utils/logger.js';
 
 const logger = createServiceLogger('ARCANOS:WRITE');
 

--- a/src/services/audit.ts
+++ b/src/services/audit.ts
@@ -1,4 +1,4 @@
-import { ArcanosAuditService } from './arcanos-audit';
+import { ArcanosAuditService } from './arcanos-audit.js';
 
 const auditService = new ArcanosAuditService();
 

--- a/src/services/backend-ai-reflection-handler.ts
+++ b/src/services/backend-ai-reflection-handler.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 // OpenAI SDK integration
 import OpenAI from 'openai';
-import { callArcanosModel } from '../config/ai-model';
+import { callArcanosModel } from '../config/ai-model.js';
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 

--- a/src/services/clarke-handler.ts
+++ b/src/services/clarke-handler.ts
@@ -5,8 +5,8 @@
  */
 
 import OpenAI from 'openai';
-import { getGPT4FallbackService } from './gpt4-fallback';
-import { createServiceLogger } from '../utils/logger';
+import { getGPT4FallbackService } from './gpt4-fallback.js';
+import { createServiceLogger } from '../utils/logger.js';
 
 const logger = createServiceLogger('ClarkeHandler');
 
@@ -258,7 +258,7 @@ export class ClarkeHandler {
 // Module augmentation to add ClarkeHandler to OpenAI namespace
 declare module 'openai' {
   namespace OpenAI {
-    export const ClarkeHandler: typeof import('./clarke-handler').ClarkeHandler;
+    export const ClarkeHandler: typeof import('./clarke-handler.js').ClarkeHandler;
   }
 }
 

--- a/src/services/codex.ts
+++ b/src/services/codex.ts
@@ -1,4 +1,4 @@
-import { getUnifiedOpenAI } from './unified-openai';
+import { getUnifiedOpenAI } from './unified-openai.js';
 
 export async function handleCodexPrompt(payload: any): Promise<any> {
   const { prompt, model = 'gpt-4' } = payload || {};

--- a/src/services/content-normalizer.ts
+++ b/src/services/content-normalizer.ts
@@ -1,5 +1,5 @@
-import { getMemory, saveMemory } from './memory';
-import { aiDispatcher } from './ai-dispatcher';
+import { getMemory, saveMemory } from './memory.js';
+import { aiDispatcher } from './ai-dispatcher.js';
 
 interface GuideOptions {
   defaultAction: string;

--- a/src/services/cron-worker.ts
+++ b/src/services/cron-worker.ts
@@ -3,10 +3,10 @@
 
 import cron from 'node-cron';
 import axios from 'axios';
-import { workerStatusService } from './worker-status';
-import { modelControlHooks } from './model-control-hooks';
-import { openAIAssistantsService } from './openai-assistants';
-import { serviceAlreadyRegistered } from './service-registry';
+import { workerStatusService } from './worker-status.js';
+import { modelControlHooks } from './model-control-hooks.js';
+import { openAIAssistantsService } from './openai-assistants.js';
+import { serviceAlreadyRegistered } from './service-registry.js';
 
 const SERVER_URL =
   process.env.SERVER_URL ||
@@ -292,7 +292,7 @@ async function executePatchRetry(): Promise<void> {
     console.log('[AI-PATCH-RETRY] Running AI-approved patch retry processing');
     
     // Import and execute patch retry processing
-    const { aiPatchSystem } = await import('./ai-patch-system');
+    const { aiPatchSystem } = await import('./ai-patch-system.js');
     await aiPatchSystem.processRetryQueue();
     
     const status = await aiPatchSystem.getRetryQueueStatus();

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1,6 +1,9 @@
 import { Pool, PoolClient } from 'pg';
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export interface MemoryStateEntry {
   id: string;

--- a/src/services/diagnostics.ts
+++ b/src/services/diagnostics.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import axios from 'axios';
-import { getQueueAudit, getQueueStats } from './jobQueue';
+import { getQueueAudit, getQueueStats } from './jobQueue.js';
 
 const execAsync = promisify(exec);
 

--- a/src/services/email-diagnostic.ts
+++ b/src/services/email-diagnostic.ts
@@ -1,11 +1,11 @@
 import { randomUUID } from 'crypto';
-import { sendEmail } from './email';
-import { sendEmailFallback } from '../plugins/email';
-import { createServiceLogger } from '../utils/logger';
+import { sendEmail } from './email.js';
+import { sendEmailFallback } from '../plugins/email.js';
+import { createServiceLogger } from '../utils/logger.js';
 
 async function getReceiptFailMap() {
   try {
-    const module = await import('../../memory/modules/receipt_fail_map' as any);
+    const module = await import('../../memory/modules/receipt_fail_map.js' as any);
     return module;
   } catch {
     return { flag: async () => {} }; // Mock implementation
@@ -14,7 +14,7 @@ async function getReceiptFailMap() {
 
 async function getEmailDiagnostics() {
   try {
-    const module = await import('../../memory/modules/email_diagnostics' as any);
+    const module = await import('../../memory/modules/email_diagnostics.js' as any);
     return module;
   } catch {
     return { add: async () => {} }; // Mock implementation

--- a/src/services/email-dispatch.ts
+++ b/src/services/email-dispatch.ts
@@ -1,6 +1,6 @@
-import { createServiceLogger } from '../utils/logger'
-import { sendEmailPrimary, sendEmailFallback, EmailPayload } from '../plugins/email'
-import { trackDiagnostics } from '../middleware/diagnostics'
+import { createServiceLogger } from '../utils/logger.js'
+import { sendEmailPrimary, sendEmailFallback, EmailPayload } from '../plugins/email.js'
+import { trackDiagnostics } from '../middleware/diagnostics.js'
 
 const logger = createServiceLogger('EmailDispatch')
 

--- a/src/services/execution-engine.ts
+++ b/src/services/execution-engine.ts
@@ -1,17 +1,17 @@
 // ARCANOS Execution Engine - Streamlined for OpenAI SDK patterns
 // Provides efficient execution for AI-controlled operations
 
-import { DispatchInstruction } from './ai-dispatcher';
-import { getUnifiedOpenAI } from './unified-openai';
-import { aiConfig } from '../config';
-import { memoryOperations } from './memory-operations';
-import { diagnosticsService } from './diagnostics';
-import { workerStatusService } from './worker-status';
+import { DispatchInstruction } from './ai-dispatcher.js';
+import { getUnifiedOpenAI } from './unified-openai.js';
+import { aiConfig } from '../config/index.js';
+import { memoryOperations } from './memory-operations.js';
+import { diagnosticsService } from './diagnostics.js';
+import { workerStatusService } from './worker-status.js';
 import * as cron from 'node-cron';
-import { databaseService } from './database';
-import { isValidWorker } from './worker-manager';
-import { activeWorkers } from '../worker-init';
-import { createServiceLogger } from '../utils/logger';
+import { databaseService } from './database.js';
+import { isValidWorker } from './worker-manager.js';
+import { activeWorkers } from '../worker-init.js';
+import { createServiceLogger } from '../utils/logger.js';
 
 const logger = createServiceLogger('ExecutionEngine');
 
@@ -71,7 +71,7 @@ export class ExecutionEngine {
       }
 
       // Route action using centralized action router
-      const { routeAction } = await import('./action-router');
+      const { routeAction } = await import('./action-router.js');
       return await routeAction(instruction);
 
     } catch (error: any) {

--- a/src/services/game-guide.ts
+++ b/src/services/game-guide.ts
@@ -1,5 +1,5 @@
-import { getUnifiedOpenAI } from './unified-openai';
-import { createServiceLogger } from '../utils/logger';
+import { getUnifiedOpenAI } from './unified-openai.js';
+import { createServiceLogger } from '../utils/logger.js';
 
 const logger = createServiceLogger('GameGuideService');
 

--- a/src/services/game-guides.ts
+++ b/src/services/game-guides.ts
@@ -3,7 +3,7 @@
  * Designed for ARCANOS memory backend with OpenAI SDK compliance
  */
 
-import { saveMemory, getMemory } from './memory';
+import { saveMemory, getMemory } from './memory.js';
 
 export interface SaveGameGuideParams {
   gameId: string;

--- a/src/services/github-actions-service.ts
+++ b/src/services/github-actions-service.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { config } from '../config';
+import { config } from '../config/index.js';
 
 interface GitHubActionTrigger {
   repo: string; // Format: "owner/repo"

--- a/src/services/github-webhook-service.ts
+++ b/src/services/github-webhook-service.ts
@@ -1,7 +1,7 @@
-import { config } from '../config';
-import { askArcanosV1_Safe } from './arcanos-v1-interface';
-import { executeGitHubAction } from './github-actions-service';
-import { getUnifiedOpenAI } from './unified-openai';
+import { config } from '../config/index.js';
+import { askArcanosV1_Safe } from './arcanos-v1-interface.js';
+import { executeGitHubAction } from './github-actions-service.js';
+import { getUnifiedOpenAI } from './unified-openai.js';
 
 const unifiedOpenAI = getUnifiedOpenAI();
 

--- a/src/services/gpt4-fallback.ts
+++ b/src/services/gpt4-fallback.ts
@@ -6,8 +6,8 @@
  * hand off to GPT-4 for reprocessing into valid JSON or structured markdown
  */
 
-import { getUnifiedOpenAI } from './unified-openai';
-import { createServiceLogger } from '../utils/logger';
+import { getUnifiedOpenAI } from './unified-openai.js';
+import { createServiceLogger } from '../utils/logger.js';
 
 const logger = createServiceLogger('GPT4Fallback');
 

--- a/src/services/init.ts
+++ b/src/services/init.ts
@@ -3,7 +3,7 @@
  * Provides a unified interface for initializing different types of workers
  */
 
-import { createServiceLogger } from '../utils/logger';
+import { createServiceLogger } from '../utils/logger.js';
 
 const logger = createServiceLogger('WorkerInit');
 
@@ -25,7 +25,7 @@ export async function initializeWorker(workerName: string): Promise<void> {
   try {
     switch (workerName) {
       case 'goalTracker': {
-        const { goalTrackerWorker } = await import('../workers/goal-tracker');
+        const { goalTrackerWorker } = await import('../workers/goal-tracker.js');
         await goalTrackerWorker.start();
         initializedWorkers.set(workerName, true);
         logger.success(`✅ ${workerName} initialized successfully`);
@@ -33,7 +33,7 @@ export async function initializeWorker(workerName: string): Promise<void> {
       }
 
       case 'maintenanceScheduler': {
-        const { maintenanceSchedulerWorker } = await import('../workers/maintenance-scheduler');
+        const { maintenanceSchedulerWorker } = await import('../workers/maintenance-scheduler.js');
         await maintenanceSchedulerWorker.start();
         initializedWorkers.set(workerName, true);
         logger.success(`✅ ${workerName} initialized successfully`);
@@ -42,7 +42,7 @@ export async function initializeWorker(workerName: string): Promise<void> {
 
       case 'emailDispatcher':
         // Email dispatcher is a function-based worker, we initialize it by ensuring it's available
-        const { dispatchEmail } = await import('../workers/email/email-dispatcher');
+        const { dispatchEmail } = await import('../workers/email/email-dispatcher.js');
         logger.info('Email dispatcher service is now available');
         initializedWorkers.set(workerName, true);
         logger.success(`✅ ${workerName} initialized successfully`);
@@ -50,7 +50,7 @@ export async function initializeWorker(workerName: string): Promise<void> {
 
       case 'auditProcessor':
         // Audit processor is a function-based worker, we initialize it by making it available
-        const { runStreamAudit } = await import('../workers/audit/stream-audit-worker');
+        const { runStreamAudit } = await import('../workers/audit/stream-audit-worker.js');
         logger.info('Audit processor service is now available');
         initializedWorkers.set(workerName, true);
         logger.success(`✅ ${workerName} initialized successfully`);

--- a/src/services/log-relay.ts
+++ b/src/services/log-relay.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import type { LogLevel } from '../utils/logger';
+import type { LogLevel } from '../utils/logger.js';
 
 export interface LogRecord {
   timestamp: string;

--- a/src/services/memory-monitor.ts
+++ b/src/services/memory-monitor.ts
@@ -1,6 +1,6 @@
-import { performanceMonitor } from '../utils/performance';
+import { performanceMonitor } from '../utils/performance.js';
 import { getHeapStatistics } from 'v8';
-import { maybeReflect } from '../utils/executionGuard';
+import { maybeReflect } from '../utils/executionGuard.js';
 
 class MemoryMonitor {
   private logIntervalId?: NodeJS.Timeout;

--- a/src/services/memory-normalizer.ts
+++ b/src/services/memory-normalizer.ts
@@ -2,7 +2,7 @@
 // Purpose: Every time storeMemory() is called, auto-index the entry using normalized aliases
 // Example: 'baldurs gate 3' → also stores alias keys like 'bg3', 'baldur', 'baldurs_gate_3'
 
-import { writeMemory, indexMemory } from "./memory"; // adjust as needed
+import { writeMemory, indexMemory } from "./memory.js"; // adjust as needed
 
 function normalizeAliases(topic: string): string[] {
   const base = topic.toLowerCase();

--- a/src/services/memory-operations.ts
+++ b/src/services/memory-operations.ts
@@ -3,9 +3,9 @@
  * Streamlined memory handling following OpenAI assistant patterns
  */
 
-import { coreAIService } from './ai-service-consolidated';
-import { createServiceLogger } from '../utils/logger';
-import { databaseService } from './database';
+import { coreAIService } from './ai-service-consolidated.js';
+import { createServiceLogger } from '../utils/logger.js';
+import { databaseService } from './database.js';
 
 const logger = createServiceLogger('MemoryOperations');
 

--- a/src/services/memory-scheduler.ts
+++ b/src/services/memory-scheduler.ts
@@ -1,5 +1,5 @@
 // Fix: Ensure module declarations and unlock npm registry access
-import type { ScheduleTask } from '../types/scheduler';
+import type { ScheduleTask } from '../types/scheduler.js';
 
 export const scheduleRegistry = new Map<string, ScheduleTask['value']>();
 

--- a/src/services/memory.ts
+++ b/src/services/memory.ts
@@ -3,8 +3,8 @@
  * Provides simplified interface for async memory operations compatible with OpenAI SDK patterns
  */
 
-import { databaseService } from './database';
-import { MemoryStorage } from '../storage/memory-storage';
+import { databaseService } from './database.js';
+import { MemoryStorage } from '../storage/memory-storage.js';
 
 // Shared fallback memory instance to ensure consistency across modules
 export const fallbackMemory = new MemoryStorage();

--- a/src/services/model-control-hooks.ts
+++ b/src/services/model-control-hooks.ts
@@ -1,8 +1,8 @@
 // ARCANOS Model Control Hooks - Unified control interface for AI model to manage system operations
 // Provides hooks for memory management, audits, cron triggers, and worker orchestration
 
-import { aiDispatcher, DispatchRequest } from './ai-dispatcher';
-import { executionEngine, ExecutionResult } from './execution-engine';
+import { aiDispatcher, DispatchRequest } from './ai-dispatcher.js';
+import { executionEngine, ExecutionResult } from './execution-engine.js';
 
 export interface ModelControlContext {
   userId?: string;

--- a/src/services/modern-worker-init.ts
+++ b/src/services/modern-worker-init.ts
@@ -1,10 +1,10 @@
 // Modern Worker Initialization - Refactored for OpenAI SDK v1.0.0 compatibility
 // Replaces outdated orchestration logic with modular control hooks and unified fallback
 
-import { refactorAIWorkerSystem, RefactoredAIWorkerSystem, OptimizedScheduleFormat } from './ai-worker-refactor';
-import { createServiceLogger } from '../utils/logger';
-import { isTrue } from '../utils/env';
-import { workerStatusService } from './worker-status';
+import { refactorAIWorkerSystem, RefactoredAIWorkerSystem, OptimizedScheduleFormat } from './ai-worker-refactor.js';
+import { createServiceLogger } from '../utils/logger.js';
+import { isTrue } from '../utils/env.js';
+import { workerStatusService } from './worker-status.js';
 
 const logger = createServiceLogger('ModernWorkerInit');
 

--- a/src/services/openai-assistants.ts
+++ b/src/services/openai-assistants.ts
@@ -15,7 +15,7 @@ export interface AssistantMap {
 }
 
 export class OpenAIAssistantsService {
-  private unifiedOpenAI: ReturnType<typeof import('./unified-openai').getUnifiedOpenAI>;
+  private unifiedOpenAI: ReturnType<typeof import('./unified-openai.js').getUnifiedOpenAI>;
   private configPath: string;
 
   constructor() {

--- a/src/services/reflection-engine.ts
+++ b/src/services/reflection-engine.ts
@@ -1,5 +1,5 @@
-import { reflect } from './ai';
-import { createServiceLogger } from '../utils/logger';
+import { reflect } from './ai/index.js';
+import { createServiceLogger } from '../utils/logger.js';
 
 export interface ReflectionTriggerOptions {
   source?: string;

--- a/src/services/reflection-memory.ts
+++ b/src/services/reflection-memory.ts
@@ -1,7 +1,7 @@
 // Patch: Resilient Reflection Memory Handling
 // Ensures safe memory serialization, fallback recovery, and OpenAI-compatible logic
 
-import { storeMemory, getMemory } from "./memory";
+import { storeMemory, getMemory } from "./memory.js";
 
 // 🔐 Safe serializer to prevent malformed writes
 function safeSerialize(obj: any): string {

--- a/src/services/self-reflection.ts
+++ b/src/services/self-reflection.ts
@@ -1,6 +1,6 @@
-import { databaseService } from './database';
+import { databaseService } from './database.js';
 import cron from 'node-cron';
-import { ARCANOS_MODEL_ID } from '../config/ai-model';
+import { ARCANOS_MODEL_ID } from '../config/ai-model.js';
 
 interface ReflectionEntry {
   timestamp: string;

--- a/src/services/server.ts
+++ b/src/services/server.ts
@@ -1,8 +1,8 @@
 import express from 'express';
 import * as http from 'http';
 import { promisify } from 'util';
-import { databaseService } from './database';
-import { isTrue } from '../utils/env';
+import { databaseService } from './database.js';
+import { isTrue } from '../utils/env.js';
 
 export class ServerService {
   private server: http.Server | null = null;

--- a/src/services/sleep-handlers.ts
+++ b/src/services/sleep-handlers.ts
@@ -1,5 +1,5 @@
-import { reflect } from './ai';
-import { selfReflectionService } from './self-reflection';
+import { reflect } from './ai/index.js';
+import { selfReflectionService } from './self-reflection.js';
 
 /**
  * Run an AI reflection sweep before sleep.

--- a/src/services/sleep-manager.ts
+++ b/src/services/sleep-manager.ts
@@ -3,10 +3,10 @@
 // Sleep Window: 7:00 AM to 2:00 PM Eastern Time daily
 
 import cron from 'node-cron';
-import { getCurrentSleepWindowStatus, shouldReduceServerActivity, logSleepWindowStatus } from './sleep-config';
-import { emitServerSleep } from '../events/system-events';
-import { modelControlHooks } from './model-control-hooks';
-import { workerStatusService } from './worker-status';
+import { getCurrentSleepWindowStatus, shouldReduceServerActivity, logSleepWindowStatus } from './sleep-config.js';
+import { emitServerSleep } from '../events/system-events.js';
+import { modelControlHooks } from './model-control-hooks.js';
+import { workerStatusService } from './worker-status.js';
 
 export interface SleepManagerConfig {
   enabled: boolean;
@@ -181,7 +181,7 @@ export class SleepManager {
    */
   private async runMemorySyncSnapshot(): Promise<void> {
     try {
-      const memorySync = await import('../../dist/workers/memorySync' as any);
+      const memorySync = await import('../../dist/workers/memorySync.js' as any);
       await memorySync.default();
     } catch (error) {
       console.warn('Memory sync worker not available:', error);
@@ -216,7 +216,7 @@ export class SleepManager {
    */
   private async runGoalWatcherAudit(): Promise<void> {
     try {
-      const goalWatcher = await import('../../dist/workers/goalWatcher' as any);
+      const goalWatcher = await import('../../dist/workers/goalWatcher.js' as any);
       await goalWatcher.default();
     } catch (error) {
       console.warn('Goal watcher worker not available:', error);
@@ -247,7 +247,7 @@ export class SleepManager {
    */
   private async runClearTempLogs(): Promise<void> {
     try {
-      const clearTemp = await import('../../dist/workers/clearTemp' as any);
+      const clearTemp = await import('../../dist/workers/clearTemp.js' as any);
       await clearTemp.default();
     } catch (error) {
       console.warn('Clear temp worker not available:', error);
@@ -279,7 +279,7 @@ export class SleepManager {
    */
   private async runCodeImprovementSuggestions(): Promise<void> {
     try {
-      const codeImprovement = await import('../../dist/workers/codeImprovement' as any);
+      const codeImprovement = await import('../../dist/workers/codeImprovement.js' as any);
       await codeImprovement.default();
     } catch (error) {
       console.warn('Code improvement worker not available:', error);

--- a/src/services/sleep-prep.ts
+++ b/src/services/sleep-prep.ts
@@ -1,6 +1,6 @@
 import cron from 'node-cron';
-import { runReflectionSweep, finalizeMemoryWrite, queueSleepTasks } from './sleep-handlers';
-import { ServiceLogger } from '../utils/logger';
+import { runReflectionSweep, finalizeMemoryWrite, queueSleepTasks } from './sleep-handlers.js';
+import { ServiceLogger } from '../utils/logger.js';
 
 const logger = new ServiceLogger('SleepPrep');
 

--- a/src/services/unified-openai.ts
+++ b/src/services/unified-openai.ts
@@ -14,7 +14,7 @@
  */
 
 import OpenAI from 'openai';
-import { ARCANOS_MODEL_ID } from '../config/ai-model';
+import { ARCANOS_MODEL_ID } from '../config/ai-model.js';
 import type { 
   ChatCompletionCreateParams,
   ChatCompletionMessageParam,
@@ -31,7 +31,7 @@ import type {
 import type {
   Run
 } from 'openai/resources/beta/threads/runs';
-import { createServiceLogger } from '../utils/logger';
+import { createServiceLogger } from '../utils/logger.js';
 
 const logger = createServiceLogger('UnifiedOpenAI');
 

--- a/src/services/web-fallback.ts
+++ b/src/services/web-fallback.ts
@@ -5,8 +5,8 @@
  */
 
 import axios from "axios";
-import { getUnifiedOpenAI } from './unified-openai';
-import { createServiceLogger } from '../utils/logger';
+import { getUnifiedOpenAI } from './unified-openai.js';
+import { createServiceLogger } from '../utils/logger.js';
 
 const logger = createServiceLogger('WebFallback');
 

--- a/src/services/worker-manager.ts
+++ b/src/services/worker-manager.ts
@@ -1,7 +1,7 @@
 // Worker registration and dispatch utilities
 // Adds name validation and per-worker dispatch locking
 
-import { AIDispatcher } from './ai-dispatcher';
+import { AIDispatcher } from './ai-dispatcher.js';
 
 // Use a Set for active workers
 const activeWorkers: Set<string> = new Set();

--- a/src/services/worker-status.ts
+++ b/src/services/worker-status.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 
 async function getManifest() {
   try {
-    return await import('../../memory/modules/manifest' as any);
+    return await import('../../memory/modules/manifest.js' as any);
   } catch {
     return { add: async () => {} }; // Mock implementation
   }

--- a/src/sleep-self-reflection.ts
+++ b/src/sleep-self-reflection.ts
@@ -1,5 +1,5 @@
-import { onServerSleep } from './events/system-events';
-import { triggerSelfReflection } from './services/reflection-engine';
+import { onServerSleep } from './events/system-events.js';
+import { triggerSelfReflection } from './services/reflection-engine.js';
 
 onServerSleep(() => {
   console.log('[Reflection Trigger] Server is entering sleep mode. Initiating reflection...');

--- a/src/standalone-worker-orchestrator.ts
+++ b/src/standalone-worker-orchestrator.ts
@@ -1,4 +1,4 @@
-import { getUnifiedOpenAI } from './services/unified-openai';
+import { getUnifiedOpenAI } from './services/unified-openai.js';
 
 const unifiedOpenAI = getUnifiedOpenAI();
 

--- a/src/storage/memory-storage.ts
+++ b/src/storage/memory-storage.ts
@@ -1,4 +1,4 @@
-import { databaseService } from '../services/database';
+import { databaseService } from '../services/database.js';
 
 export interface MemoryEntry {
   id: string;

--- a/src/studio/logger.ts
+++ b/src/studio/logger.ts
@@ -1,4 +1,4 @@
-import { createServiceLogger } from '../utils/logger';
+import { createServiceLogger } from '../utils/logger.js';
 
 const logger = createServiceLogger('Studio');
 

--- a/src/utils/cleanup.ts
+++ b/src/utils/cleanup.ts
@@ -3,8 +3,8 @@
  * Manages reflection memory and file cleanup based on age
  */
 
-import { databaseService } from '../services/database';
-import { getMemory, saveMemory } from '../services/memory';
+import { databaseService } from '../services/database.js';
+import { getMemory, saveMemory } from '../services/memory.js';
 import { DateTime } from 'luxon';
 
 export interface PruneOptions {

--- a/src/utils/executionGuard.ts
+++ b/src/utils/executionGuard.ts
@@ -15,7 +15,7 @@ export function shouldRun(taskId: string, intervalMs: number): boolean {
   return false;
 }
 
-import { enqueue } from '../services/jobQueue';
+import { enqueue } from '../services/jobQueue.js';
 
 export interface QueuedTask {
   name: string;

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -3,8 +3,8 @@
  * Uses existing GitHub integration for stable operations
  */
 
-import { pushFileWithStability } from './githubPushStable';
-import type { ReflectionSnapshot } from '../services/ai';
+import { pushFileWithStability } from './githubPushStable.js';
+import type { ReflectionSnapshot } from '../services/ai/index.js';
 
 export interface WriteToRepoOptions {
   path: string;

--- a/src/utils/githubPushStable.ts
+++ b/src/utils/githubPushStable.ts
@@ -1,5 +1,5 @@
 import { Octokit } from "@octokit/rest";
-import { writeMemory, getMemory } from "../services/memory";
+import { writeMemory, getMemory } from "../services/memory.js";
 
 const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
 

--- a/src/utils/intentDispatcher.ts
+++ b/src/utils/intentDispatcher.ts
@@ -1,6 +1,6 @@
 import OpenAI from 'openai';
-import { routeByIntent, type IntentMode } from './routeByIntent';
-import { callArcanosModel, ARCANOS_MODEL_ID } from '../config/ai-model';
+import { routeByIntent, type IntentMode } from './routeByIntent.js';
+import { callArcanosModel, ARCANOS_MODEL_ID } from '../config/ai-model.js';
 
 // Initialize OpenAI client with API key from environment
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -3,8 +3,8 @@
  * Consolidates repeated logging patterns
  */
 
-import { relayLog } from '../services/log-relay';
-import { normalizeMemoryUsage } from './memory-normalizer';
+import { relayLog } from '../services/log-relay.js';
+import { normalizeMemoryUsage } from './memory-normalizer.js';
 
 export type LogLevel = 'info' | 'success' | 'warning' | 'error' | 'debug';
 

--- a/src/utils/model-router.ts
+++ b/src/utils/model-router.ts
@@ -1,5 +1,5 @@
-import { aiConfig } from '../config';
-import { routeByIntent } from './routeByIntent';
+import { aiConfig } from '../config/index.js';
+import { routeByIntent } from './routeByIntent.js';
 
 /**
  * Determine which OpenAI model should handle a prompt.

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,5 +1,5 @@
-import { createServiceLogger } from './logger';
-import { isTrue } from './env';
+import { createServiceLogger } from './logger.js';
+import { isTrue } from './env.js';
 
 const logger = createServiceLogger('Network');
 

--- a/src/utils/openaiRequestHandler.ts
+++ b/src/utils/openaiRequestHandler.ts
@@ -1,8 +1,8 @@
 import OpenAI from 'openai';
 import type { ChatCompletionCreateParams, ChatCompletionMessageParam } from 'openai/resources';
-import { callArcanosModel } from '../config/ai-model';
-import { runDeepResearch } from '../modules/deepResearchHandler';
-import { webFetchHandler } from '../handlers/webFetchHandler';
+import { callArcanosModel } from '../config/ai-model.js';
+import { runDeepResearch } from '../modules/deepResearchHandler.js';
+import { webFetchHandler } from '../handlers/webFetchHandler.js';
 
 export type Mode = 'write' | 'sim' | 'audit' | 'codegen' | 'deepresearch';
 

--- a/src/utils/output-recovery.ts
+++ b/src/utils/output-recovery.ts
@@ -3,8 +3,8 @@
  * Provides easy integration of GPT-4 fallback functionality across the codebase
  */
 
-import { getGPT4FallbackService, FallbackOptions, FallbackResult } from '../services/gpt4-fallback';
-import { createServiceLogger } from './logger';
+import { getGPT4FallbackService, FallbackOptions, FallbackResult } from '../services/gpt4-fallback.js';
+import { createServiceLogger } from './logger.js';
 
 const logger = createServiceLogger('OutputRecovery');
 

--- a/src/utils/overlay-diagnostics.ts
+++ b/src/utils/overlay-diagnostics.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import { createServiceLogger } from './logger';
+import { createServiceLogger } from './logger.js';
+import { fileURLToPath } from 'url';
 
 const logger = createServiceLogger('OverlayDiagnostics');
 
@@ -10,6 +11,7 @@ const logger = createServiceLogger('OverlayDiagnostics');
  * event so the AI can diagnose missing hooks.
  */
 export async function checkModelControlHooks(): Promise<boolean> {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const hooksPath = path.join(__dirname, '../services/model-control-hooks.js');
   const exists = fs.existsSync(hooksPath);
 

--- a/src/utils/safeImport.ts
+++ b/src/utils/safeImport.ts
@@ -1,12 +1,11 @@
-import { createServiceLogger } from './logger';
-import { networkAllowed } from './network';
+import { createServiceLogger } from './logger.js';
+import { networkAllowed } from './network.js';
 
 const logger = createServiceLogger('ModuleLoader');
 
-export function safeImport<T = any>(moduleName: string): T | null {
+export async function safeImport<T = any>(moduleName: string): Promise<T | null> {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require(moduleName) as T;
+    return (await import(moduleName)) as T;
   } catch (err: any) {
     if (err.code === 'MODULE_NOT_FOUND') {
       logger.error(`Module "${moduleName}" not found`, err);

--- a/src/webhooks/github.ts
+++ b/src/webhooks/github.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from 'express';
-import { handleCatchError, sendSuccessResponse } from '../utils/response';
-import { githubWebhookService } from '../services/github-webhook-service';
-import { config } from '../config';
+import { handleCatchError, sendSuccessResponse } from '../utils/response.js';
+import { githubWebhookService } from '../services/github-webhook-service.js';
+import { config } from '../config/index.js';
 
 const router = Router();
 

--- a/src/webhooks/openai.ts
+++ b/src/webhooks/openai.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { handleCatchError, sendSuccessResponse } from '../utils/response';
+import { handleCatchError, sendSuccessResponse } from '../utils/response.js';
 
 const router = Router();
 

--- a/src/worker-init.ts
+++ b/src/worker-init.ts
@@ -1,13 +1,13 @@
 // AI-Controlled Worker Initialization - Refactored for OpenAI SDK v1.0.0 compatibility
-import { workerStatusService } from './services/worker-status';
-import { modelControlHooks } from './services/model-control-hooks';
-import { isTrue } from './utils/env';
-import { goalTrackerWorker } from './workers/goal-tracker';
-import { maintenanceSchedulerWorker } from './workers/maintenance-scheduler';
-import { createServiceLogger } from './utils/logger';
-import { registerWorker } from './services/worker-manager';
-import { memory } from './services/memory-scheduler';
-import type { ScheduleTask } from './types/scheduler';
+import { workerStatusService } from './services/worker-status.js';
+import { modelControlHooks } from './services/model-control-hooks.js';
+import { isTrue } from './utils/env.js';
+import { goalTrackerWorker } from './workers/goal-tracker.js';
+import { maintenanceSchedulerWorker } from './workers/maintenance-scheduler.js';
+import { createServiceLogger } from './utils/logger.js';
+import { registerWorker } from './services/worker-manager.js';
+import { memory } from './services/memory-scheduler.js';
+import type { ScheduleTask } from './types/scheduler.js';
 import { execSync } from 'child_process';
 
 // Auto-install missing types if running locally
@@ -25,12 +25,12 @@ import {
   getModernWorkerStatus,
   registerModernWorker,
   orchestrateModernWorker
-} from './services/modern-worker-init';
+} from './services/modern-worker-init.js';
 import { 
   validateWorkerDispatch, 
   isKnownWorker, 
   KNOWN_WORKERS 
-} from './utils/worker-validation';
+} from './utils/worker-validation.js';
 
 // Simplified worker registry - explicit and persistent
 const activeWorkers = new Map<string, { 

--- a/src/workers/apiWorker.ts
+++ b/src/workers/apiWorker.ts
@@ -3,8 +3,8 @@
  * Integrated with AI dispatcher for intelligent API routing and processing
  */
 
-import { createServiceLogger } from '../utils/logger';
-import { exponentialDelay } from '../utils/delay';
+import { createServiceLogger } from '../utils/logger.js';
+import { exponentialDelay } from '../utils/delay.js';
 import axios from 'axios';
 
 const logger = createServiceLogger('ApiWorker');

--- a/src/workers/audit/stream-audit-worker.ts
+++ b/src/workers/audit/stream-audit-worker.ts
@@ -1,8 +1,9 @@
-import { coreAIService } from '../../services/ai-service-consolidated';
-import type { ChatMessage } from '../../services/unified-openai';
+import { fileURLToPath } from 'url';
+import { coreAIService } from '../../services/ai-service-consolidated.js';
+import type { ChatMessage } from '../../services/unified-openai.js';
 import fs from 'fs';
 import path from 'path';
-import { createServiceLogger } from '../../utils/logger';
+import { createServiceLogger } from '../../utils/logger.js';
 
 const logger = createServiceLogger('StreamAuditWorker');
 
@@ -86,7 +87,7 @@ export async function runStreamAudit({ message, domain = 'general', logFilePath 
 }
 
 // Allow running directly from node
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const [, , ...args] = process.argv;
   const message = args.join(' ') || 'Audit this message.';
   runStreamAudit({ message }).catch(err => {

--- a/src/workers/clearTemp.ts
+++ b/src/workers/clearTemp.ts
@@ -1,9 +1,10 @@
+import { fileURLToPath } from 'url';
 /**
  * Clear Temp Worker - Handles cleanup of temporary files and logs
  * This file provides the interface expected by sleep-manager
  */
 
-import { createServiceLogger } from '../utils/logger';
+import { createServiceLogger } from '../utils/logger.js';
 import fs from 'fs';
 import path from 'path';
 
@@ -123,7 +124,7 @@ async function cleanupDirectory(dirPath: string): Promise<number> {
 }
 
 // Allow running directly from node
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   clearTemp().catch(err => {
     logger.error('Clear temp execution failed', err);
     process.exit(1);

--- a/src/workers/codeImprovement.ts
+++ b/src/workers/codeImprovement.ts
@@ -1,10 +1,11 @@
+import { fileURLToPath } from 'url';
 /**
  * Code Improvement Worker - Generates daily code improvement suggestions
  * This file provides the interface expected by sleep-manager
  */
 
-import { createServiceLogger } from '../utils/logger';
-import { delay } from '../utils/delay';
+import { createServiceLogger } from '../utils/logger.js';
+import { delay } from '../utils/delay.js';
 import fs from 'fs';
 import path from 'path';
 
@@ -118,7 +119,7 @@ async function cleanupOldSuggestions(storageDir: string): Promise<void> {
 }
 
 // Allow running directly from node
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   codeImprovement().catch(err => {
     logger.error('Code improvement execution failed', err);
     process.exit(1);

--- a/src/workers/defaultWorker.ts
+++ b/src/workers/defaultWorker.ts
@@ -4,7 +4,7 @@
  * WARNING: This worker should not be used in normal operation
  */
 
-import { createServiceLogger } from '../utils/logger';
+import { createServiceLogger } from '../utils/logger.js';
 
 const logger = createServiceLogger('DefaultWorker');
 

--- a/src/workers/email/email-dispatcher.ts
+++ b/src/workers/email/email-dispatcher.ts
@@ -1,9 +1,9 @@
-import { coreAIService } from '../../services/ai-service-consolidated';
-import type { ChatMessage } from '../../services/unified-openai';
+import { coreAIService } from '../../services/ai-service-consolidated.js';
+import type { ChatMessage } from '../../services/unified-openai.js';
 import fs from 'fs';
 import path from 'path';
-import { createServiceLogger } from '../../utils/logger';
-import { sendEmail } from '../../services/email';
+import { createServiceLogger } from '../../utils/logger.js';
+import { sendEmail } from '../../services/email.js';
 
 const logger = createServiceLogger('EmailDispatcher');
 

--- a/src/workers/email/schedule-email-worker.ts
+++ b/src/workers/email/schedule-email-worker.ts
@@ -1,11 +1,11 @@
 import cron from 'node-cron';
-import { createServiceLogger } from '../../utils/logger';
+import { createServiceLogger } from '../../utils/logger.js';
 
 let registry: Map<string, any> | undefined;
 
 (async () => {
   try {
-    const module = await import('../../../workers/workerRegistry' as any);
+    const module = await import('../../../workers/workerRegistry.js' as any);
     registry = module.workerRegistry;
   } catch {
     registry = undefined;

--- a/src/workers/goal-tracker.ts
+++ b/src/workers/goal-tracker.ts
@@ -1,12 +1,13 @@
+import { fileURLToPath } from 'url';
 /**
  * Goal Tracker Worker - Monitors and tracks user goals using OpenAI SDK
  * Uses streaming for long-running goal analysis operations
  */
 
-import { coreAIService } from '../services/ai-service-consolidated';
-import type { ChatMessage } from '../services/unified-openai';
-import { createServiceLogger } from '../utils/logger';
-import { databaseService } from '../services/database';
+import { coreAIService } from '../services/ai-service-consolidated.js';
+import type { ChatMessage } from '../services/unified-openai.js';
+import { createServiceLogger } from '../utils/logger.js';
+import { databaseService } from '../services/database.js';
 import fs from 'fs';
 import path from 'path';
 
@@ -286,7 +287,7 @@ Extract specific actionable recommendations and return them as a JSON array.`
 export const goalTrackerWorker = new GoalTrackerWorker();
 
 // Allow running directly from node
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const [, , userId] = process.argv;
   if (!userId) {
     console.log('Usage: node goal-tracker.js <userId>');

--- a/src/workers/goalWatcher.ts
+++ b/src/workers/goalWatcher.ts
@@ -1,10 +1,11 @@
+import { fileURLToPath } from 'url';
 /**
  * Goal Watcher Worker - Bridge to goal-tracker functionality
  * This file provides the interface expected by sleep-manager
  */
 
-import { goalTrackerWorker } from './goal-tracker';
-import { createServiceLogger } from '../utils/logger';
+import { goalTrackerWorker } from './goal-tracker.js';
+import { createServiceLogger } from '../utils/logger.js';
 
 const logger = createServiceLogger('GoalWatcher');
 
@@ -46,7 +47,7 @@ export default async function goalWatcher(): Promise<void> {
 }
 
 // Allow running directly from node
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   goalWatcher().catch(err => {
     logger.error('Goal watcher execution failed', err);
     process.exit(1);

--- a/src/workers/maintenance-scheduler.ts
+++ b/src/workers/maintenance-scheduler.ts
@@ -1,14 +1,15 @@
+import { fileURLToPath } from 'url';
 /**
  * Maintenance Scheduler Worker - AI-driven system maintenance using OpenAI SDK
  * Handles automated system maintenance, cleanup, and optimization tasks
  */
 
-import { coreAIService } from '../services/ai-service-consolidated';
-import type { ChatMessage } from '../services/unified-openai';
-import { createServiceLogger } from '../utils/logger';
-import { sanitizeJsonString } from '../utils/json';
-import { normalizeMemoryUsage } from '../utils/memory-normalizer';
-import { delay } from '../utils/delay';
+import { coreAIService } from '../services/ai-service-consolidated.js';
+import type { ChatMessage } from '../services/unified-openai.js';
+import { createServiceLogger } from '../utils/logger.js';
+import { sanitizeJsonString } from '../utils/json.js';
+import { normalizeMemoryUsage } from '../utils/memory-normalizer.js';
+import { delay } from '../utils/delay.js';
 import fs from 'fs';
 import path from 'path';
 import * as cron from 'node-cron';
@@ -549,7 +550,7 @@ Please analyze and provide:
 export const maintenanceSchedulerWorker = new MaintenanceSchedulerWorker();
 
 // Allow running directly from node
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const [, , taskId] = process.argv;
   
   if (taskId) {

--- a/src/workers/memorySync.ts
+++ b/src/workers/memorySync.ts
@@ -1,10 +1,11 @@
+import { fileURLToPath } from 'url';
 /**
  * Memory Sync Worker - Handles memory synchronization and snapshots
  * This file provides the interface expected by sleep-manager
  */
 
-import { createServiceLogger } from '../utils/logger';
-import { normalizeMemoryUsage } from '../utils/memory-normalizer';
+import { createServiceLogger } from '../utils/logger.js';
+import { normalizeMemoryUsage } from '../utils/memory-normalizer.js';
 import fs from 'fs';
 import path from 'path';
 
@@ -91,7 +92,7 @@ async function cleanupOldSnapshots(storageDir: string): Promise<void> {
 }
 
 // Allow running directly from node
-if (require.main === module) {
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   memorySync().catch(err => {
     logger.error('Memory sync execution failed', err);
     process.exit(1);

--- a/src/workers/memoryWorker.ts
+++ b/src/workers/memoryWorker.ts
@@ -3,8 +3,8 @@
  * Integrated with AI dispatcher for intelligent memory management
  */
 
-import { createServiceLogger } from '../utils/logger';
-import { normalizeMemoryUsage } from '../utils/memory-normalizer';
+import { createServiceLogger } from '../utils/logger.js';
+import { normalizeMemoryUsage } from '../utils/memory-normalizer.js';
 import fs from 'fs';
 import path from 'path';
 


### PR DESCRIPTION
## Summary
- rewrite legacy memory modules and actions to use pure ESM syntax
- add explicit `.js` extensions and async dynamic imports for config bootstrap
- update server entry imports to match ESM module resolution
- ensure all relative imports include `.js` extensions and replace CommonJS globals like `__dirname`

## Testing
- `npm run build`
- `OPENAI_API_KEY=dummy node --max-old-space-size=7168 dist/index.js`

------
https://chatgpt.com/codex/tasks/task_e_688eee70ffe48325b2de887ca20cc76b