### PR TITLE
chore: add explicit extensions for esm

### DIFF
--- a/ai-control-elevation.ts
+++ b/ai-control-elevation.ts
@@ -1,6 +1,6 @@
 // Backend Optimization + AI Control Elevation Command Block
 
-import { optimizeCodebase, removeDeprecated, grantAIAccess } from './src/services/ai/aiControlService';
+import { optimizeCodebase, removeDeprecated, grantAIAccess } from './src/services/ai/aiControlService.js';
 import OpenAI from 'openai';
 
 // Step 1: Initialize OpenAI SDK

--- a/demo-problem-statement.ts
+++ b/demo-problem-statement.ts
@@ -1,9 +1,9 @@
 // AI Reflection Scheduler + Long-Term Memory (OpenAI SDK Compliant)
 // Summary: Triggers self-reflection every 40 minutes, stores results persistently, and prunes snapshots older than 7 days
 
-import { reflect } from './src/services/ai';
-import { writeToRepo } from './src/utils/git';
-import { pruneOldReflections } from './src/utils/cleanup';
+import { reflect } from './src/services/ai/index.js';
+import { writeToRepo } from './src/utils/git.js';
+import { pruneOldReflections } from './src/utils/cleanup.js';
 
 console.log('🧠 Testing Problem Statement Implementation\n');
 

--- a/demo-stateless-pr.ts
+++ b/demo-stateless-pr.ts
@@ -1,8 +1,8 @@
 // Demo: Stateless PR Generation Test
 // Demonstrates the bypass of memory orchestration and force push functionality
 
-import { generatePR } from './services/git';
-import { buildPatchSet } from './services/ai-reflections';
+import { generatePR } from './services/git.js';
+import { buildPatchSet } from './services/ai-reflections.js';
 
 async function demonstrateStatelessPR() {
   console.log('🚀 Starting Stateless PR Generation Demo');

--- a/force-worker-activation.ts
+++ b/force-worker-activation.ts
@@ -1,5 +1,5 @@
 // Patch: Force Worker Activation & Module Init
-import { initializeWorker } from './src/services/init';
+import { initializeWorker } from './src/services/init.js';
 
 const workers = ['goalTracker', 'maintenanceScheduler', 'emailDispatcher', 'auditProcessor'];
 

--- a/patch-push-system-integrated.ts
+++ b/patch-push-system-integrated.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import OpenAI from 'openai';
-import { aiPatchSystem } from './src/services/ai-patch-system';
+import { aiPatchSystem } from './src/services/ai-patch-system.js';
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,

--- a/pr-diagnostics.ts
+++ b/pr-diagnostics.ts
@@ -3,8 +3,8 @@
 
 import fs from 'fs';
 import path from 'path';
-import { pushPRToGitHub } from './services/git';
-import { buildPatchSet } from './services/ai-reflections';
+import { pushPRToGitHub } from './services/git.js';
+import { buildPatchSet } from './services/ai-reflections.js';
 
 (async () => {
   try {

--- a/pr-finalize.ts
+++ b/pr-finalize.ts
@@ -1,9 +1,9 @@
 // PATCH: Finalize GitHub PR Push with Clean Return Serialization
 // Fixes: PR data truncation, memory hydration lag, and broken response formatting
 
-import { generatePR } from './services/git';
-import { buildPatchSet } from './services/ai-reflections';
-import { safeStringify } from './utils/serialization'; // helper to avoid circular JSON
+import { generatePR } from './services/git.js';
+import { buildPatchSet } from './services/ai-reflections.js';
+import { safeStringify } from './utils/serialization.js'; // helper to avoid circular JSON
 
 (async () => {
   try {

--- a/services/ai-reflections.ts
+++ b/services/ai-reflections.ts
@@ -3,8 +3,7 @@
  * Builds patch sets without relying on memory orchestration
  */
 
-import { reflect, ReflectionSnapshot } from '../src/services/ai';
-import { coreAIService } from '../src/services/ai/core-ai-service';
+import { reflect, ReflectionSnapshot, coreAIService } from '../src/services/ai/index.js';
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 
 export interface PatchSetOptions {

--- a/test-ai-service-dispatcher.ts
+++ b/test-ai-service-dispatcher.ts
@@ -3,7 +3,7 @@
  * Validates the new AI-enhanced service dispatcher functionality
  */
 
-import dispatchService, { createManualOverrideTask, requiresAIRouting } from './src/services/ai-service-dispatcher';
+import dispatchService, { createManualOverrideTask, requiresAIRouting } from './src/services/ai-service-dispatcher.js';
 
 async function testAIServiceDispatcher() {
   console.log('🧪 Testing AI Service Dispatcher...\n');

--- a/test-clarke-handler.ts
+++ b/test-clarke-handler.ts
@@ -4,8 +4,8 @@
  * Verifies the resilience pattern works as specified
  */
 
-import './src/services/clarke-handler';
-import { initializeResilienceHandler, exampleUsage } from './src/resilience-handler-example';
+import './src/services/clarke-handler.js';
+import { initializeResilienceHandler, exampleUsage } from './src/resilience-handler-example.js';
 
 async function testClarkeHandler() {
   console.log('🧪 Testing ClarkeHandler Implementation');

--- a/test-reflection-mock.ts
+++ b/test-reflection-mock.ts
@@ -30,10 +30,10 @@ async function testReflectionSchedulerStructure() {
     // Test 1: Import structure
     console.log('1. Testing imports...');
     
-    const { aiReflectionScheduler } = await import('./src/ai-reflection-scheduler');
-    const aiModule = await import('./src/services/ai');
-    const gitModule = await import('./src/utils/git');
-    const cleanupModule = await import('./src/utils/cleanup');
+    const { aiReflectionScheduler } = await import('./src/ai-reflection-scheduler.js');
+    const aiModule = await import('./src/services/ai/index.js');
+    const gitModule = await import('./src/utils/git.js');
+    const cleanupModule = await import('./src/utils/cleanup.js');
 
     console.log('✅ All modules imported successfully');
     console.log('   - AI services module loaded');

--- a/test-reflection-scheduler.ts
+++ b/test-reflection-scheduler.ts
@@ -3,10 +3,10 @@
  * Verifies the implementation works correctly
  */
 
-import { reflect } from './src/services/ai';
-import { writeToRepo } from './src/utils/git';
-import { pruneOldReflections } from './src/utils/cleanup';
-import { aiReflectionScheduler } from './src/ai-reflection-scheduler';
+import { reflect } from './src/services/ai/index.js';
+import { writeToRepo } from './src/utils/git.js';
+import { pruneOldReflections } from './src/utils/cleanup.js';
+import { aiReflectionScheduler } from './src/ai-reflection-scheduler.js';
 
 async function testReflectionComponents() {
   console.log('🧪 Testing AI Reflection Scheduler Components\n');

--- a/test-stateless-pr.ts
+++ b/test-stateless-pr.ts
@@ -1,8 +1,8 @@
 // PATCH: Bypass PR memory lock and force stateless push to GitHub
 // Description: Finalizes commit without relying on orchestration or memory locking routines
 
-import { generatePR } from './services/git';
-import { buildPatchSet } from './services/ai-reflections';
+import { generatePR } from './services/git.js';
+import { buildPatchSet } from './services/ai-reflections.js';
 
 (async () => {
   const patch = await buildPatchSet({ useMemory: false }); // bypass memory orchestration

--- a/test-worker-init.ts
+++ b/test-worker-init.ts
@@ -2,7 +2,7 @@
  * Test script for worker initialization functionality
  */
 
-import { initializeWorker, isWorkerInitialized, getInitializedWorkers, resetWorkerInitialization } from './src/services/init';
+import { initializeWorker, isWorkerInitialized, getInitializedWorkers, resetWorkerInitialization } from './src/services/init.js';
 
 async function testWorkerInitialization() {
   console.log('🧪 Testing Worker Initialization Service');


### PR DESCRIPTION
## Summary
- add explicit `.js` extensions for all root scripts
- consolidate AI reflection imports with `.js` extension

## Testing
- `npm run build`
- `OPENAI_API_KEY=dummy node --max-old-space-size=7168 dist/index.js`

------
https://chatgpt.com/codex/tasks/task_e_688f0759c2e08325b83a8829f6083689