### PR TITLE
Add basic Express server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,68 +1,12 @@
 {
   "name": "arcanos-backend",
   "version": "1.0.0",
-  "type": "module",
-  "main": "dist/main.js",
-  "engines": {
-    "node": ">=20.11.1",
-    "npm": ">=8.0.0"
-  },
+  "main": "server.js",
   "scripts": {
-    "build": "tsc",
-    "start": "node --expose-gc --max-old-space-size=7168 dist/index.js",
-    "start:main": "node dist/main.js",
-    "start:agent-control": "DEPLOY_MODE=agent-control node dist/main.js",
-    "start:railway": "node --max-old-space-size=7168 dist/index.js",
-    "dev": "node --max-old-space-size=7168 -r ts-node/register src/index.ts",
-    "dev:main": "npx ts-node src/main.ts",
-    "dev:agent-control": "DEPLOY_MODE=agent-control npx ts-node src/main.ts",
-    "arc:dispatch": "node bin/arc-dispatch.js",
-    "prisma:generate": "prisma generate",
-    "prisma:push": "prisma db push",
-    "prisma:studio": "prisma studio",
-    "test": "echo \"No tests defined\" && exit 0",
-    "test:ai-control": "node test-ai-control.js",
-    "ai:control-elevation": "npx ts-node ai-control-elevation.ts",
-    "email:diagnostic": "node bin/email-diagnostic.js",
-    "patch:push": "npx ts-node patch-push-system.ts",
-    "patch:push:mock": "npx ts-node patch-push-system-mock.ts",
-    "patch:push:integrated": "npx ts-node patch-push-system-integrated.ts",
-    "github:verify": "node scripts/verify-github-access.js",
-    "ci:build": "NODE_OPTIONS='--max_old_space_size=256' npm install --omit=dev && npm run build"
+    "start": "node server.js",
+    "build": "echo 'No build needed'"
   },
   "dependencies": {
-    "@octokit/rest": "^22.0.0",
-    "@prisma/client": "^6.12.0",
-    "@types/luxon": "^3.6.2",
-    "ajv": "^8.12.0",
-    "axios": "^1.10.0",
-    "body-parser": "^1.20.3",
-    "cors": "^2.8.5",
-    "dotenv": "^16.0.0",
-    "express": "^4.21.2",
-    "formdata-node": "^6.0.3",
-    "iconv-lite": "^0.6.3",
-    "luxon": "^3.7.1",
-    "node-cron": "^4.2.1",
-    "node-fetch": "^3.3.2",
-    "nodemailer": "^7.0.5",
-    "openai": "^4.104.0",
-    "pg": "^8.16.3",
-    "prisma": "^6.12.0",
-    "zod": "^3.22.4"
-  },
-  "devDependencies": {
-    "@types/body-parser": "^1.19.6",
-    "@types/cors": "^2.8.19",
-    "@types/dotenv": "^6.1.1",
-    "@types/express": "^4.17.0",
-    "@types/node": "^20.19.9",
-    "@types/node-cron": "^3.0.11",
-    "@types/nodemailer": "^6.4.17",
-    "@types/pg": "^8.15.4",
-    "nodemon": "^3.1.10",
-    "ts-node": "^10.9.2",
-    "tsx": "^4.0.0",
-    "typescript": "^5.8.3"
+    "express": "^4.18.2"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+
+// Simple health check
+app.get('/health', (req, res) => {
+  res.status(200).send('OK');
+});
+
+// Optional: Basic route
+app.get('/', (req, res) => {
+  res.send('Hello from ARCANOS!');
+});
+
+// Optional: Handle errors
+app.use((err, req, res, next) => {
+  console.error(err.stack);
+  res.status(500).send('Something broke!');
+});
+
+// Start server
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add simple Express server with health and root routes
- minimize package.json to run server directly

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68906ea09ab08325b598be95b5ff0d9d