### PR TITLE
Fix start command to compiled server

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -8,7 +8,7 @@
     }
   },
   "deploy": {
-    "startCommand": "npm run start",
+    "startCommand": "node dist/server.js",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   },


### PR DESCRIPTION
## Summary
- run server directly from built output in Railway deploy configuration

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892dc3e6f98832583ae8785e526da90