### PR TITLE
Fix missing aiCron module and update TypeScript config

### DIFF
--- a/src/logic/aiCron.ts
+++ b/src/logic/aiCron.ts
@@ -1,0 +1,16 @@
+import cron from 'node-cron';
+
+/**
+ * Sets up recurring AI maintenance tasks.
+ * Currently runs a heartbeat log every minute.
+ */
+function initAICron(): void {
+  cron.schedule('* * * * *', () => {
+    console.log('[🤖 AI Cron] heartbeat', new Date().toISOString());
+  });
+}
+
+// Initialize cron tasks on import
+initAICron();
+
+export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": false,
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "strict": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- add minimal aiCron scheduler to prevent runtime crash
- configure TypeScript for Node 20 with NodeNext module resolution

## Testing
- `npm run type-check`
- `npm test` *(fails: Server is not running on localhost:3000)*
- `rm -rf dist && npm run build && node dist/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68939e84dad88325ab25af5c2cd3f8fd