### PR TITLE
feat: migrate arcanos to responses api

### DIFF
--- a/src/logic/arcanos.ts
+++ b/src/logic/arcanos.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai';
-import { createCompletionWithLogging } from '../utils/aiLogger.js';
+import { createResponseWithLogging } from '../utils/aiLogger.js';
 import { runHealthCheck } from '../utils/diagnostics.js';
 
 interface ArcanosResult {
@@ -59,10 +59,10 @@ Current System Status:
 
 ${prompt}`;
 
-  // Use GPT-4 for best diagnostic capabilities
-  const response = await createCompletionWithLogging(client, {
-    model: 'gpt-4',
-    messages: [
+  // Use GPT-4.1 for diagnostic capabilities
+  const response = await createResponseWithLogging(client, {
+    model: 'gpt-4.1-mini',
+    input: [
       {
         role: 'system',
         content: 'You are ARCANOS, an AI operating core. Provide detailed system diagnostics in the exact format requested. Be precise and actionable.'
@@ -73,11 +73,11 @@ ${prompt}`;
       }
     ],
     temperature: 0.1, // Low temperature for consistent diagnostic output
-    max_tokens: 2000,
+    max_output_tokens: 2000,
     stream: false,
   });
 
-  const fullResult = response.choices[0]?.message?.content || '';
+  const fullResult = response.output_text || '';
   
   // Parse the structured response
   const componentStatusMatch = fullResult.match(/✅ Component Status Table\s*([\s\S]*?)(?=🛠|$)/);

--- a/tests/test-arcanos-integration.js
+++ b/tests/test-arcanos-integration.js
@@ -8,11 +8,10 @@ import { arcanosPrompt, runARCANOS } from '../dist/logic/arcanos.js';
 // Mock OpenAI client for testing (without requiring actual API key)
 class MockOpenAI {
   constructor() {
-    this.chat = {
-      completions: {
-        create: async (params) => {
-          // Simulate a realistic ARCANOS response
-          const mockResponse = `
+    this.responses = {
+      create: async (params) => {
+        // Simulate a realistic ARCANOS response
+        const mockResponse = `
 ✅ Component Status Table
 - Node.js Runtime: Running (v${process.version})
 - Memory Usage: ${(process.memoryUsage().heapUsed / 1024 / 1024).toFixed(2)}MB
@@ -34,21 +33,24 @@ class MockOpenAI {
 5. Formatted response in ARCANOS diagnostic format
 `;
 
-          return {
-            choices: [{
-              message: {
-                content: mockResponse.trim()
-              }
-            }],
-            usage: {
-              prompt_tokens: 150,
-              completion_tokens: 200,
-              total_tokens: 350
-            },
-            id: 'mock-response-123',
-            created: Math.floor(Date.now() / 1000)
-          };
-        }
+        return {
+          output: [
+            {
+              id: 'msg-1',
+              role: 'assistant',
+              type: 'message',
+              content: [{ type: 'output_text', text: mockResponse.trim() }]
+            }
+          ],
+          output_text: mockResponse.trim(),
+          usage: {
+            prompt_tokens: 150,
+            completion_tokens: 200,
+            total_tokens: 350
+          },
+          id: 'mock-response-123',
+          created: Math.floor(Date.now() / 1000)
+        };
       }
     };
   }


### PR DESCRIPTION
## Summary
- switch ARCANOS utilities to OpenAI Responses API
- update ARCANOS and Trinity logic to send `input` arrays and parse `output_text`
- adjust integration tests to mock `responses.create`
- use production health and ARCANOS endpoints in API tests

## Testing
- `npm run build`
- `curl -s https://arcanos-v2-production.up.railway.app/health`
- `node tests/test-arcanos.js`
- `node tests/test-arcanos-integration.js`
- `node tests/test-arcanos-api.js`
- `npm test` *(fails: N/A responses for all endpoints)*


------
https://chatgpt.com/codex/tasks/task_e_6893df20d1cc8325809b5308b76a9b6f