### PR TITLE
Align arcanosPrompt with diagnostic prompt format

### DIFF
--- a/src/logic/arcanos.ts
+++ b/src/logic/arcanos.ts
@@ -21,9 +21,9 @@ interface ArcanosResult {
 /**
  * Wrap prompt before sending to GPT-4 with ARCANOS diagnostic format
  */
-export const arcanosPrompt = (userInput: string): string => {
-  return `
-You are ARCANOS — a modular AI operating core. You must interpret, execute, and return precise diagnostics for the following input:
+export const arcanosPrompt = (userInput: string): string => `
+You are ARCANOS — a modular AI operating core.
+Respond with full system diagnostic capability.
 
 [USER COMMAND]
 ${userInput}
@@ -33,7 +33,6 @@ ${userInput}
 - 🛠 Suggested Fixes
 - 🧠 Core Logic Trace
 `;
-};
 
 /**
  * Execute ARCANOS system diagnosis with structured response


### PR DESCRIPTION
## Summary
- Align `arcanosPrompt` message with canonical diagnostic prompt including "Respond with full system diagnostic capability" line
- Preserve structured response requirements for Component Status, Suggested Fixes, and Core Logic Trace

## Testing
- `npm run build`
- `node tests/test-arcanos.js`
- `node tests/test-arcanos-integration.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893f5ff1d008325a1c572d369f9fc4f