### PR TITLE
Add ask API router with diagnostics and finetune helpers

### DIFF
--- a/pages/api/ask.ts
+++ b/pages/api/ask.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { runDiagnostics } from "../../utils/diagnostics";
+import { executeTask } from "../../utils/taskExecutor";
+import { queryFinetune } from "../../utils/fineTune";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { prompt } = req.body || {};
+
+  if (!prompt || typeof prompt !== "string") {
+    return res.status(400).json({ error: "Missing prompt." });
+  }
+
+  const lowerPrompt = prompt.toLowerCase();
+
+  // Run diagnostics
+  if (lowerPrompt.includes("diagnostics")) {
+    const diagnostics = await runDiagnostics();
+    return res.status(200).json(diagnostics);
+  }
+
+  // Execute task
+  if (lowerPrompt.includes("execute") || lowerPrompt.includes("track")) {
+    const output = await executeTask(prompt);
+    return res.status(200).json(output);
+  }
+
+  // Default to fine-tuned AI model
+  const aiResponse = await queryFinetune(prompt);
+  if ((aiResponse as any).error) {
+    return res.status(500).json(aiResponse);
+  }
+  return res.status(200).json(aiResponse);
+}

--- a/utils/diagnostics.ts
+++ b/utils/diagnostics.ts
@@ -1,0 +1,11 @@
+export async function runDiagnostics() {
+  return {
+    system: "ARCANOS V2",
+    apiHealth: "✅ Operational",
+    logicModules: ["WRITE", "BUILD", "SIM", "AUDIT", "GUIDE", "TRACKER"],
+    memoryState: Object.keys(process.env),
+    activeModel: process.env.AI_MODEL,
+    diagnosticsTime: new Date().toISOString(),
+    notes: "AI-brain routing active. All systems normal."
+  };
+}

--- a/utils/fineTune.ts
+++ b/utils/fineTune.ts
@@ -1,0 +1,33 @@
+export async function queryFinetune(prompt: string) {
+  const apiKey = process.env.API_KEY;
+  const model = process.env.AI_MODEL;
+
+  if (!apiKey || !model) {
+    return { error: "Missing API configuration." };
+  }
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: prompt }],
+      }),
+    });
+
+    if (!response.ok) {
+      const errText = await response.text();
+      return { error: `API request failed: ${response.status} ${errText}` };
+    }
+
+    const data = await response.json();
+    return { result: data.choices?.[0]?.message?.content ?? "No response." };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { error: message };
+  }
+}

--- a/utils/taskExecutor.ts
+++ b/utils/taskExecutor.ts
@@ -1,0 +1,20 @@
+export async function executeTask(prompt: string) {
+  const lower = prompt.toLowerCase();
+
+  if (lower.includes("track goal")) {
+    return { task: "Goal Tracker", status: "📌 Goal tracker initialized" };
+  }
+
+  if (lower.includes("summarize")) {
+    return { task: "Summary", status: "🧠 Summary routine activated" };
+  }
+
+  if (lower.includes("generate report")) {
+    return { task: "Report Generator", status: "📄 Report generation started" };
+  }
+
+  return {
+    task: "Unknown",
+    status: "⚠️ Command not recognized. Please rephrase or route to a known module.",
+  };
+}


### PR DESCRIPTION
## Summary
- add Next.js `/api/ask` endpoint to route diagnostics, task execution, and finetuned AI calls
- include task executor utility for goal tracking, summaries, and reports
- add diagnostics helper and finetune wrapper with env validation and error handling

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68940572ddec8325acd96dbf411bde66