### PR TITLE
fix: provide shared worker utilities for modules

### DIFF
--- a/modules/shared/workerUtils.js
+++ b/modules/shared/workerUtils.js
@@ -1,0 +1,1 @@
+export * from '../../workers/shared/workerUtils.js';


### PR DESCRIPTION
## Summary
- add `modules/shared/workerUtils.js` re-export to resolve missing module warnings

## Testing
- `npm run build`
- `npm test`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68956356764c8325a9737d97166c33a7