### PR TITLE
feat: make memory path configurable

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@ OPENAI_API_KEY=
 AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH
 PORT=8080
 NODE_ENV=development
+ARC_MEMORY_PATH=/tmp/arc/memory

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@ PORT=8080
 # Default: /tmp/arc/log (if /var/arc/log is not accessible)
 ARC_LOG_PATH=/tmp/arc/log
 
+# Memory Configuration
+# Directory for ARCANOS memory files
+# Default: /tmp/arc/memory (used if ARC_MEMORY_PATH not set)
+ARC_MEMORY_PATH=/tmp/arc/memory
+
 # Railway Configuration (GitHub Copilot + Postman Compatible)
 RAILWAY_PROJECT=arcanos-core
 API_URL=https://arcanos-v2-production.up.railway.app

--- a/railway.json
+++ b/railway.json
@@ -10,7 +10,10 @@
   "deploy": {
     "startCommand": "node dist/server.js",
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 10
+    "restartPolicyMaxRetries": 10,
+    "env": {
+      "ARC_MEMORY_PATH": "/tmp/arc/memory"
+    }
   },
   "root": "."
 }

--- a/src/services/memoryAware.ts
+++ b/src/services/memoryAware.ts
@@ -33,7 +33,9 @@ export interface MemoryContext {
 }
 
 // Memory storage paths
-const MEMORY_DIR = '/var/arc/memory';
+const MEMORY_DIR = process.env.ARC_MEMORY_PATH || '/tmp/arc/memory';
+// Ensure memory directory exists at runtime
+mkdirSync(MEMORY_DIR, { recursive: true });
 const MEMORY_INDEX_FILE = join(MEMORY_DIR, 'index.json');
 const MEMORY_LOG_FILE = join(MEMORY_DIR, 'memory.log');
 
@@ -48,10 +50,6 @@ function initializeMemory() {
   if (memoryLoaded) return;
 
   try {
-    if (!existsSync(MEMORY_DIR)) {
-      mkdirSync(MEMORY_DIR, { recursive: true });
-    }
-
     if (existsSync(MEMORY_INDEX_FILE)) {
       const data = readFileSync(MEMORY_INDEX_FILE, 'utf-8');
       memoryIndex = JSON.parse(data);

--- a/test-enhanced-features.js
+++ b/test-enhanced-features.js
@@ -109,13 +109,14 @@ try {
   console.log(`   🆔 Request ID: ${auditResult.taskLineage?.requestId}`);
   // Get log directory from environment
   const logDir = process.env.ARC_LOG_PATH || '/tmp/arc/log';
+  const memoryDir = process.env.ARC_MEMORY_PATH || '/tmp/arc/memory';
   
   // Check if log files were created
   const logFiles = [
     `${logDir}/audit.log`,
     `${logDir}/lineage.log`,
-    '/var/arc/memory/index.json',
-    '/var/arc/memory/memory.log'
+    `${memoryDir}/index.json`,
+    `${memoryDir}/memory.log`
   ];
   
   console.log('\n6. Checking Log File Creation...');


### PR DESCRIPTION
## Summary
- use `ARC_MEMORY_PATH` for memory storage with `/tmp/arc/memory` default
- ensure memory directory created recursively
- configure `ARC_MEMORY_PATH` in env files and Railway config

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68958d4c3e78832586a33a7af49007ec