### PR TITLE
Add agent configuration file and ensure build before tests

### DIFF
--- a/agents.json
+++ b/agents.json
@@ -1,0 +1,22 @@
+[
+  {
+    "worker": "ARCANOS_MAINTENANCE_AGENT",
+    "role": "System diagnostics, API health checks, memory fault detection",
+    "frequency": "every 30 minutes",
+    "tasks": [
+      "System Diagnostics",
+      "API Route Ping"
+    ],
+    "fallback_on_failure": "PLUTO"
+  },
+  {
+    "worker": "ARCANOS Overseer",
+    "role": "Memory integrity check, logic validation, prompt audit",
+    "frequency": "every 20 minutes",
+    "tasks": [
+      "Memory Snapshot Sync",
+      "Prompt Logic Audit"
+    ],
+    "fallback_on_failure": "GPT Shell 1"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "rebuild": "npm run clean && npm run build",
-    "test": "npm run probe && node tests/test-arcanos-api.js",
+    "test": "npm run build && npm run probe && node tests/test-arcanos-api.js",
     "type-check": "tsc --noEmit",
     "assistants-sync": "node scripts/assistants-sync.js"
   },


### PR DESCRIPTION
## Summary
- add `agents.json` defining ARCANOS_MAINTENANCE_AGENT and ARCANOS Overseer workers
- run TypeScript build before tests so probe finds compiled files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895b554aea4832598f78e972ac299cd