### PR TITLE
feat: implement GPT-5 shadow mode auditing

### DIFF
--- a/src/services/gpt5Shadow.ts
+++ b/src/services/gpt5Shadow.ts
@@ -1,0 +1,65 @@
+import OpenAI from 'openai';
+import { appendFileSync } from 'fs';
+import { ensureLogDirectory, getGPT5TracePath, getAuditShadowPath } from '../utils/logPath.js';
+import { validateAuditSafeOutput, createAuditSummary } from './auditSafe.js';
+
+export type ShadowTag = 'content_generation' | 'agent_role_check';
+
+async function routeToModule(client: OpenAI, tag: ShadowTag, content: string): Promise<string> {
+  const systemPrompt =
+    tag === 'content_generation'
+      ? 'You are creative_architect, a GPT-5 module for synthesizing content. Mirror the described ARCANOS event and respond.'
+      : 'You are role_alignment_tracker, a GPT-5 module monitoring role adherence and drift. Mirror the described ARCANOS event and respond.';
+
+  const response = await client.chat.completions.create({
+    model: 'gpt-5',
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content }
+    ],
+    temperature: 0.2,
+    max_tokens: 500
+  });
+
+  return response.choices[0]?.message?.content || '';
+}
+
+export async function mirrorDecisionEvent(
+  client: OpenAI,
+  taskId: string,
+  event: string,
+  original: string,
+  tag: ShadowTag
+): Promise<void> {
+  try {
+    const shadowInput = `Event: ${event}\nTask ID: ${taskId}\nOriginal Data: ${original}`;
+    const gpt5Output = await routeToModule(client, tag, shadowInput);
+
+    ensureLogDirectory();
+    const timestamp = new Date().toISOString();
+    appendFileSync(
+      getGPT5TracePath(),
+      `${timestamp} | ${taskId} | ${event} | ${tag} | ${gpt5Output.replace(/\n/g, ' ')}\n`
+    );
+
+    const delta =
+      original === gpt5Output
+        ? 'MATCH'
+        : `ARC: ${createAuditSummary(original)} | GPT5: ${createAuditSummary(gpt5Output)}`;
+
+    let line = `${timestamp} | ${taskId} | ${event} | ${delta}`;
+    if (!validateAuditSafeOutput(gpt5Output, { auditSafeMode: true })) {
+      line += ' | REJECTED_AUDIT';
+    }
+    appendFileSync(getAuditShadowPath(), line + '\n');
+  } catch (err) {
+    ensureLogDirectory();
+    const timestamp = new Date().toISOString();
+    const msg = err instanceof Error ? err.message : 'Unknown error';
+    appendFileSync(
+      getAuditShadowPath(),
+      `${timestamp} | ${taskId} | ${event} | FALLBACK:${msg}\n`
+    );
+  }
+}
+

--- a/src/utils/logPath.ts
+++ b/src/utils/logPath.ts
@@ -47,6 +47,22 @@ export function getFeedbackLogPath(): string {
 }
 
 /**
+ * Get the GPT-5 trace output log file path
+ */
+export function getGPT5TracePath(): string {
+  const logDir = getLogPath();
+  return path.join(logDir, 'gpt5_trace_output');
+}
+
+/**
+ * Get the audit shadow log file path
+ */
+export function getAuditShadowPath(): string {
+  const logDir = getLogPath();
+  return path.join(logDir, 'audit_shadow_log');
+}
+
+/**
  * Ensure the log directory exists
  */
 export function ensureLogDirectory(): void {


### PR DESCRIPTION
## Summary
- add GPT-5 shadow module to mirror ARCANOS events and compare output
- route content and role events to modular GPT-5 tools with logging
- extend log path utility for GPT-5 trace and audit shadow files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895c6fe1798832590cd941671e7153e