### PR TITLE
Re-enable GPT-5 shadow mode with memory-safe fallback

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -12,7 +12,8 @@
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10,
     "env": {
-      "ARC_MEMORY_PATH": "/tmp/arc/memory"
+      "ARC_MEMORY_PATH": "/tmp/arc/memory",
+      "ARC_SHADOW_MODE": "enabled"
     }
   },
   "root": "."

--- a/src/services/shadowControl.ts
+++ b/src/services/shadowControl.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import path from 'path';
+import { ensureLogDirectory, getAuditShadowPath, getLogPath } from '../utils/logPath.js';
+import { checkMemoryIntegrity } from './memoryAware.js';
+
+const DISABLE_FLAG_FILE = path.join(getLogPath(), 'shadow_disabled');
+
+let shadowEnabled = (process.env.ARC_SHADOW_MODE || 'enabled') !== 'disabled' && !fs.existsSync(DISABLE_FLAG_FILE);
+
+export function isShadowModeEnabled(): boolean {
+  return shadowEnabled && !fs.existsSync(DISABLE_FLAG_FILE);
+}
+
+export function disableShadowMode(reason: string = 'unknown'): void {
+  shadowEnabled = false;
+  ensureLogDirectory();
+  try {
+    fs.writeFileSync(DISABLE_FLAG_FILE, reason);
+    fs.appendFileSync(getAuditShadowPath(), `${new Date().toISOString()} | SHADOW_DISABLED | ${reason}\n`);
+  } catch {
+    // ignore file system errors
+  }
+  console.warn(`⚠️ [SHADOW] Disabled: ${reason}`);
+}
+
+export function enableShadowMode(): void {
+  ensureLogDirectory();
+  shadowEnabled = true;
+  try {
+    if (fs.existsSync(DISABLE_FLAG_FILE)) fs.unlinkSync(DISABLE_FLAG_FILE);
+    fs.appendFileSync(getAuditShadowPath(), `${new Date().toISOString()} | SHADOW_ENABLED\n`);
+  } catch {
+    // ignore errors
+  }
+}
+
+export function ensureShadowReady(): boolean {
+  if (!isShadowModeEnabled()) return false;
+  const healthy = checkMemoryIntegrity();
+  if (!healthy) {
+    disableShadowMode('memory_fault');
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- add shadow control module with persistent enable/disable state and memory integrity checks
- sanitize memory index on load and expose integrity checker
- update GPT-5 shadow service to use control module and auto-disable on faults
- enable shadow mode in Railway config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68966a138e448325b3fe2b4d1f6b0167