### PR TITLE
fix: use correct OpenAI token limit parameter

### DIFF
--- a/src/logic/arcanos.ts
+++ b/src/logic/arcanos.ts
@@ -410,7 +410,7 @@ export async function runARCANOS(
         }
       ],
       temperature: 0.1, // Low temperature for consistent diagnostic output
-      max_completion_tokens: 2000,
+      max_tokens: 2000,
     });
 
     finalResult = response.choices[0]?.message?.content || '';
@@ -434,7 +434,7 @@ export async function runARCANOS(
         }
       ],
       temperature: 0.1,
-      max_completion_tokens: 2000,
+      max_tokens: 2000,
     });
 
     finalResult = response.choices[0]?.message?.content || '';

--- a/src/logic/trinity.ts
+++ b/src/logic/trinity.ts
@@ -97,7 +97,7 @@ export async function runThroughBrain(
       { role: 'user', content: auditSafePrompt }
     ],
     temperature: 0.2,
-    max_completion_tokens: 500
+    max_tokens: 500
   });
   const framedRequest = intakeResponse.choices[0]?.message?.content || auditSafePrompt;
   const actualModel = intakeResponse.activeModel || arcanosModel;
@@ -123,7 +123,7 @@ export async function runThroughBrain(
       { role: 'user', content: 'Provide the final ARCANOS response.' }
     ],
     temperature: 0.2,
-    max_completion_tokens: 1000
+    max_tokens: 1000
   });
   const finalText = finalResponse.choices[0]?.message?.content || '';
 

--- a/src/services/gpt4Shadow.ts
+++ b/src/services/gpt4Shadow.ts
@@ -19,7 +19,7 @@ async function routeToModule(client: OpenAI, tag: ShadowTag, content: string): P
       { role: 'user', content }
     ],
     temperature: 0.2,
-    max_completion_tokens: 500
+    max_tokens: 500
   });
 
   return response.choices[0]?.message?.content || '';

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -224,7 +224,7 @@ export const createGPT5Reasoning = async (
         ...(systemPrompt ? [{ role: 'system' as const, content: systemPrompt }] : []),
         { role: 'user' as const, content: prompt }
       ],
-      max_completion_tokens: 1024,
+      max_tokens: 1024,
       // Temperature omitted to use default (1) for GPT-5
     });
     

--- a/src/services/secureReasoningEngine.ts
+++ b/src/services/secureReasoningEngine.ts
@@ -89,7 +89,7 @@ Your output should be structured, clear, and free of any confidential or securit
         }
       ],
       temperature: 0.3, // Balanced for reasoning consistency
-      max_completion_tokens: 2000
+      max_tokens: 2000
     });
 
     const rawAnalysis = response.choices[0]?.message?.content || '';

--- a/tests/worker-demo.js
+++ b/tests/worker-demo.js
@@ -59,7 +59,7 @@ try {
 
 console.log('\n✅ Worker Configuration Summary:');
 console.log('   - Environment variables properly set');
-console.log('   - GPT-5 reasoning with correct parameters (max_completion_tokens: 1024, temperature: 1)');
+console.log('   - GPT-5 reasoning with correct parameters (max_tokens: 1024, temperature: 1)');
 console.log('   - ARCANOS core logic integration working');
 console.log('   - Worker task follows problem statement workflow');
 console.log('   - Workers start automatically when RUN_WORKERS = "true"');


### PR DESCRIPTION
## Summary
- replace unsupported `max_completion_tokens` with `max_tokens` in OpenAI client calls
- ensure token limits honored across ARCANOS logic and worker utilities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68979015e0c4832180fb856d9827d096