### PR TITLE
Add default max completion tokens to fallback handler

### DIFF
--- a/src/services/fallbackHandler.ts
+++ b/src/services/fallbackHandler.ts
@@ -1,0 +1,55 @@
+interface FallbackRequest {
+  prompt: string;
+  max_completion_tokens?: number;
+  temperature?: number;
+  model?: string;
+}
+
+/**
+ * Handle fallback request by ensuring token parameter defaults.
+ * Adds default max_completion_tokens when missing.
+ */
+export function handleFallbackRequest(request: FallbackRequest) {
+  const {
+    prompt,
+    max_completion_tokens = 1024,
+    temperature = 0.7,
+    model = 'gpt-5'
+  } = request;
+
+  // Log diagnostic for transparency
+  console.log(`[FallbackHandler] Model: ${model}, Tokens: ${max_completion_tokens}`);
+
+  // Pass safe, guaranteed parameters to GPT-5
+  return callModelAPI({
+    model,
+    prompt,
+    max_completion_tokens,
+    temperature
+  });
+}
+
+// Example API caller (replace with your actual ARCANOS→GPT-5 call)
+async function callModelAPI(payload: {
+  model: string;
+  prompt: string;
+  max_completion_tokens: number;
+  temperature: number;
+}) {
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
+      },
+      body: JSON.stringify(payload)
+    });
+    return await res.json();
+  } catch (error) {
+    console.error('[FallbackHandler] Error:', error);
+    throw error;
+  }
+}
+
+export default { handleFallbackRequest };


### PR DESCRIPTION
## Summary
- ensure fallback handler adds a default `max_completion_tokens` value when one isn't provided
- forward safe parameters to the model API with diagnostics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6897c3b0e6cc832190a6b194a849a96f