### PR TITLE
feat: add worker job logging and OpenAI wrapper

### DIFF
--- a/src/routes/sdk.ts
+++ b/src/routes/sdk.ts
@@ -29,13 +29,20 @@ async function importWorkerFunctions(): Promise<WorkerModule> {
         failed: [],
         retryCount: 1
       }),
-      dispatchJob: async (workerId: string, jobType: string, jobData: any) => ({
-        success: true,
-        workerId,
-        jobType,
-        processedAt: new Date().toISOString(),
-        result: `Mock job ${jobType} processed by ${workerId}`
-      }),
+      dispatchJob: async (workerId: string, jobType: string, jobData: any) => {
+        if (workerId === 'worker.queue' || workerId === 'task-processor') {
+          // @ts-ignore Dynamic worker import without types
+          const worker = await import('../../workers/taskProcessor.js');
+          return worker.processTask(jobData);
+        }
+        return {
+          success: true,
+          workerId,
+          jobType,
+          processedAt: new Date().toISOString(),
+          result: `Mock job ${jobType} processed by ${workerId}`
+        };
+      },
       getWorkerStatus: () => ({
         count: 4,
         healthy: 4,


### PR DESCRIPTION
## Summary
- add `callOpenAI` helper with token fallback support
- log worker job lifecycle data to `job_data` with start/completion hooks
- route SDK dispatches to task processor worker

## Testing
- `npm test`
- `curl -s -X POST -H "Content-Type: application/json" -d '{"workerId":"worker.queue","jobType":"diagnostic_test","jobData":{"type":"diagnostic_test","input":"Generate a system health summary"}}' http://localhost:8080/sdk/jobs/dispatch`


------
https://chatgpt.com/codex/tasks/task_b_6897d6a94f38832195f09d2fed51dd11