### PR TITLE
feat: add API timeouts and DB retry safeguards for workers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,7 @@ DATABASE_URL=postgresql://arcanos:arcanos@localhost:5432/arcanos
 RUN_WORKERS=true
 WORKER_LOGIC=arcanos
 SERVER_URL=http://localhost:8080
+WORKER_API_TIMEOUT_MS=30000
 
 # GPT API Access Token (for diagnostics endpoint)
 GPT_TOKEN=your-gpt-access-token-here


### PR DESCRIPTION
## Summary
- enforce configurable API timeouts and retries across worker OpenAI calls
- guard worker job loops against stalls and infinite iterations
- add database connection retries with safe client release

## Testing
- `npm test`
- `WORKER_API_TIMEOUT_MS=1000 node - <<'NODE'
const API_TIMEOUT_MS = parseInt(process.env.WORKER_API_TIMEOUT_MS || '30000',10);
console.log('timeout setting', API_TIMEOUT_MS);
async function simulate(){
  try{
    await Promise.race([
      new Promise(() => {}),
      new Promise((_,reject)=>setTimeout(()=>reject(new Error('API request timed out')), API_TIMEOUT_MS))
    ]);
  }catch(err){
    console.log('caught', err.message);
  }
}
simulate();
NODE`
- `DATABASE_URL=postgresql://invalid node - <<'NODE'
import { initializeDatabase, query } from './dist/db.js';

(async () => {
  const ok = await initializeDatabase();
  console.log('initialized', ok);
  try {
    await query('SELECT 1');
  } catch (err) {
    console.log('query failed', err.message);
  }
})();
NODE`


------
https://chatgpt.com/codex/tasks/task_b_6897e72029f8832181e141be5149d668