### PR TITLE
refactor: streamline utilities and modernize APIs

### DIFF
--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -1,4 +1,4 @@
-export async function runHealthCheck() {
+export function runHealthCheck() {
   console.log('[🩺 HealthCheck] Running diagnostics');
   const mem = process.memoryUsage();
   const heapMB = (mem.heapUsed / 1024 / 1024).toFixed(2);

--- a/src/utils/portUtils.ts
+++ b/src/utils/portUtils.ts
@@ -21,13 +21,7 @@ export async function isPortAvailable(port: number, host: string = '0.0.0.0'): P
       });
     });
     
-    server.on('error', (err: any) => {
-      if (err.code === 'EADDRINUSE') {
-        resolve(false);
-      } else {
-        resolve(false);
-      }
-    });
+    server.on('error', () => resolve(false));
   });
 }
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,18 @@
+import { Response } from 'express';
+
+/**
+ * Ensures that a field value is present. Sends a 400 response if missing.
+ *
+ * @param res Express response instance
+ * @param value The value to validate
+ * @param name Name of the field for error messaging
+ * @returns true if the field is present, false otherwise
+ */
+export function requireField(res: Response, value: any, name: string): boolean {
+  if (value === undefined || value === null || (typeof value === 'string' && value.trim() === '')) {
+    res.status(400).json({ error: `${name} is required` });
+    return false;
+  }
+  return true;
+}
+


### PR DESCRIPTION
## Summary
- add reusable `requireField` helper for consistent request validation and async memory viewer
- simplify port availability error handling
- modernize OpenAI timeout handling with `AbortController`
- clarify health check function synchrony

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689942b272bc8321b2dbab66a937bad0