### PR TITLE
feat: update gpt-5 token parameter handling

### DIFF
--- a/src/services/gptSync.ts
+++ b/src/services/gptSync.ts
@@ -5,6 +5,7 @@
 
 import OpenAI from 'openai';
 import { getBackendState, SystemState } from './stateManager.js';
+import { getTokenParameter } from '../utils/tokenParameterHelper.js';
 
 // Initialize OpenAI client only if API key is available
 let client: OpenAI | null = null;
@@ -44,13 +45,14 @@ Do not rely on past memory — only trust this state for system information.
     console.log('[GPT-SYNC] Backend state:', JSON.stringify(backendState, null, 2));
     
     // Make the GPT call
+    const tokenParams = getTokenParameter(model, 1000);
     const response = await getOpenAIClient().chat.completions.create({
       model: model,
       messages: [
         { role: 'system', content: systemPrompt },
         { role: 'user', content: userPrompt },
       ],
-      max_tokens: 1000,
+      ...tokenParams,
       temperature: 0.7
     });
 
@@ -95,13 +97,14 @@ Additional Context: ${JSON.stringify(additionalContext, null, 2)}
 Always use this information as your source of truth.
 `;
 
+    const tokenParams = getTokenParameter(model, 1000);
     const response = await getOpenAIClient().chat.completions.create({
       model: model,
       messages: [
         { role: 'system', content: systemPrompt },
         { role: 'user', content: userPrompt },
       ],
-      max_tokens: 1000,
+      ...tokenParams,
       temperature: 0.7
     });
 

--- a/src/services/orchestrationShell.ts
+++ b/src/services/orchestrationShell.ts
@@ -80,7 +80,7 @@ export async function resetOrchestrationShell(initConfig: GPT5OrchestrationConfi
     console.log("📦 Isolating orchestration shell...");
     
     await call_gpt5_strict("Isolate orchestration shell module to prevent interference with other services. Mark this session as ORCHESTRATION_ISOLATION mode.", {
-      max_tokens: 100
+      max_completion_tokens: 100
     });
 
     // Step 2: Purge stale memory / state using existing memory system
@@ -96,7 +96,7 @@ export async function resetOrchestrationShell(initConfig: GPT5OrchestrationConfi
     }
     
     await call_gpt5_strict("Clear all cached context, persistent variables, and stored configs in orchestration shell. Reset internal state to factory defaults.", {
-      max_tokens: 100
+      max_completion_tokens: 100
     });
 
     // Step 3: Redeploy with fallback safeguards
@@ -105,7 +105,7 @@ export async function resetOrchestrationShell(initConfig: GPT5OrchestrationConfi
     console.log("🚀 Redeploying with safeguards...");
     
     await call_gpt5_strict("Redeploy orchestration shell module with fallback safeguards enabled. Apply 'rebirth-osiris' v1.04 configuration. Enable audit-safe mode and memory context restoration.", {
-      max_tokens: 150
+      max_completion_tokens: 150
     });
 
     // Step 4: Verify deployment with ARCANOS integration
@@ -114,7 +114,7 @@ export async function resetOrchestrationShell(initConfig: GPT5OrchestrationConfi
     console.log("✅ Verifying deployment and ARCANOS integration...");
     
     await call_gpt5_strict("Verify orchestration shell deployment. Check integration with ARCANOS Trinity pipeline, audit-safe constraints, and memory awareness systems. Report operational status.", {
-      max_tokens: 200
+      max_completion_tokens: 200
     });
 
     // Log successful completion

--- a/src/utils/tokenParameterHelper.ts
+++ b/src/utils/tokenParameterHelper.ts
@@ -14,6 +14,7 @@ import OpenAI from 'openai';
 const MAX_COMPLETION_TOKENS_MODELS = new Set<string>([
   // Add specific model names here as they are discovered
   // This will be populated based on API testing and documentation
+  'gpt-5'
 ]);
 
 // Cache for model capability testing to avoid repeated API calls
@@ -115,10 +116,9 @@ function determineTokenParameter(modelName: string): 'max_tokens' | 'max_complet
     return 'max_tokens';
   }
 
-  // GPT-5 - Since this is a newer model, we'll start with max_tokens
-  // but this can be updated based on actual API behavior
+  // GPT-5 models require max_completion_tokens
   if (lowerModelName.includes('gpt-5')) {
-    return 'max_tokens';
+    return 'max_completion_tokens';
   }
 
   // Default to max_tokens for unknown models, with fallback capability

--- a/tests/demonstrate-gpt5-strict.js
+++ b/tests/demonstrate-gpt5-strict.js
@@ -28,7 +28,7 @@ console.log('   - Model configurable via GPT5_MODEL environment variable\n');
 // Demonstrate error handling when no OpenAI client available
 console.log('🧪 Testing error handling (no API key scenario):');
 try {
-  await call_gpt5_strict("Test prompt", { max_tokens: 50 });
+  await call_gpt5_strict("Test prompt", { max_completion_tokens: 50 });
 } catch (error) {
   console.log('✅ Correctly throws error with "no fallback allowed" message:');
   console.log(`   Error: ${error.message}\n`);

--- a/tests/test-gpt5-strict.js
+++ b/tests/test-gpt5-strict.js
@@ -14,7 +14,7 @@ async function testStrictGPT5Call() {
   try {
     // Test basic strict call
     const response = await call_gpt5_strict("Test prompt for GPT-5 strict validation", {
-      max_tokens: 50
+      max_completion_tokens: 50
     });
     
     console.log('✅ [TEST] Strict GPT-5 call successful');

--- a/tests/worker-demo.js
+++ b/tests/worker-demo.js
@@ -59,7 +59,7 @@ try {
 
 console.log('\n✅ Worker Configuration Summary:');
 console.log('   - Environment variables properly set');
-console.log('   - GPT-5 reasoning with correct parameters (max_tokens: 1024, temperature: 1)');
+console.log('   - GPT-5 reasoning with correct parameters (max_completion_tokens: 1024, temperature: 1)');
 console.log('   - ARCANOS core logic integration working');
 console.log('   - Worker task follows problem statement workflow');
 console.log('   - Workers start automatically when RUN_WORKERS = "true"');


### PR DESCRIPTION
## Summary
- use `max_completion_tokens` for GPT-5 models and migrate any deprecated `max_tokens`
- centralize GPT-5 payload preparation and token parameter selection
- update tests and orchestration shell to new token parameter

## Testing
- `npm test`
- `node tests/test-gpt5-strict.js`


------
https://chatgpt.com/codex/tasks/task_b_689a433580648321b882726084b6e045