### PR TITLE
Add strict fallback enforcement patch

### DIFF
--- a/fallback_threshold_patch.js
+++ b/fallback_threshold_patch.js
@@ -1,0 +1,20 @@
+// fallback_threshold_patch.js
+// Tightens fallback so GPT-5 is only bypassed if completely unreachable
+// Adds confirmation log before model switch
+
+import { getModelStatus, switchModel, logEvent } from './arc_core.js';
+
+export default async function enforceFortressFallback() {
+    logEvent('FORTRESS fallback enforcement initiated.');
+
+    const gpt5Status = await getModelStatus('GPT-5');
+
+    if (gpt5Status === 'unreachable') {
+        logEvent('GPT-5 unreachable. Confirmation check passed.');
+        await switchModel('FallbackModel');
+        logEvent('Model switched to FallbackModel.');
+    } else {
+        logEvent('GPT-5 operational. No fallback engaged.');
+    }
+}
+


### PR DESCRIPTION
## Summary
- Introduce `enforceFortressFallback` to only switch models when GPT-5 is unreachable
- Log initiation, confirmation, and switch actions for fallback handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689ac5d98b0883219d750544aa9889ea