### PR TITLE
Add Siri query endpoint

### DIFF
--- a/src/routes/siri.ts
+++ b/src/routes/siri.ts
@@ -1,0 +1,47 @@
+import express, { Request, Response } from 'express';
+import { runThroughBrain } from '../logic/trinity.js';
+import {
+  validateAIRequest,
+  handleAIError,
+  logRequestFeedback,
+  StandardAIRequest,
+  StandardAIResponse,
+  ErrorResponse
+} from '../utils/requestHandler.js';
+
+const router = express.Router();
+
+interface SiriRequest extends StandardAIRequest {
+  query: string;
+  sessionId?: string;
+  overrideAuditSafe?: string;
+}
+
+interface SiriResponse extends StandardAIResponse {
+  content: string;
+}
+
+const handleSiriRequest = async (
+  req: Request<{}, SiriResponse | ErrorResponse, SiriRequest>,
+  res: Response<SiriResponse | ErrorResponse>
+) => {
+  const { sessionId, overrideAuditSafe } = req.body;
+
+  const validation = validateAIRequest(req, res, 'siri');
+  if (!validation) return;
+
+  const { client: openai, input } = validation;
+
+  logRequestFeedback(input, 'siri');
+
+  try {
+    const output = await runThroughBrain(openai, input, sessionId, overrideAuditSafe);
+    return res.json({ ...output, content: output.result });
+  } catch (err) {
+    handleAIError(err, input, 'siri', res);
+  }
+};
+
+router.post('/siri', (req, res) => handleSiriRequest(req, res));
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import sdkRouter from './routes/sdk.js';
 import heartbeatRouter from './routes/heartbeat.js';
 import orchestrationRouter from './routes/orchestration.js';
 import statusRouter from './routes/status.js';
+import siriRouter from './routes/siri.js';
 
 // Validate required environment variables at startup
 console.log("[🔥 ARCANOS STARTUP] Server boot sequence triggered.");
@@ -86,6 +87,7 @@ app.use('/', workersRouter);
 app.use('/', heartbeatRouter);
 app.use('/', orchestrationRouter);
 app.use('/', statusRouter);
+app.use('/', siriRouter);
 app.use('/sdk', sdkRouter);
 
 /**
@@ -155,13 +157,14 @@ async function initializeServer() {
     }
     console.log('🔧 Core Routes:');
     console.log('   🔌 /ask - AI query endpoint');
-    console.log('   🔌 /arcanos - Main AI interface'); 
+    console.log('   🔌 /arcanos - Main AI interface');
     console.log('   🔌 /ai-endpoints - AI processing endpoints');
     console.log('   🔌 /memory - Memory management');
     console.log('   🔌 /workers/* - Worker management');
     console.log('   🔌 /orchestration/* - GPT-5 Orchestration Shell');
     console.log('   🔌 /sdk/* - OpenAI SDK interface');
     console.log('   🔌 /status - System state (Backend Sync)');
+    console.log('   🔌 /siri - Siri query endpoint');
     console.log('   🔌 /health - System health');
     console.log('===============================\n');
 

--- a/src/utils/requestHandler.ts
+++ b/src/utils/requestHandler.ts
@@ -12,6 +12,7 @@ export interface StandardAIRequest {
   userInput?: string;
   content?: string;
   text?: string;
+  query?: string;
   sessionId?: string;
   overrideAuditSafe?: string;
 }
@@ -43,7 +44,7 @@ export interface ErrorResponse {
  * Extract input text from various possible field names in request body
  */
 export function extractInput(body: StandardAIRequest): string | null {
-  return body.prompt || body.userInput || body.content || body.text || null;
+  return body.prompt || body.userInput || body.content || body.text || body.query || null;
 }
 
 /**
@@ -61,7 +62,7 @@ export function validateAIRequest(
   
   if (!input || typeof input !== 'string') {
     res.status(400).json({ 
-      error: `Missing or invalid input in request body. Use 'prompt', 'userInput', 'content', or 'text' field.` 
+      error: `Missing or invalid input in request body. Use 'prompt', 'userInput', 'content', 'text', or 'query' field.`
     });
     return null;
   }

--- a/tests/test-arcanos-api.js
+++ b/tests/test-arcanos-api.js
@@ -104,6 +104,7 @@ async function testArcanosAPI() {
     const endpoints = [
       { name: 'ask', path: '/ask', payload: { prompt: 'Test the ask endpoint' } },
       { name: 'arcanos', path: '/arcanos', payload: { userInput: 'Run system diagnosis.' } },
+      { name: 'siri', path: '/siri', payload: { query: 'Hello from Siri' } },
       { name: 'write', path: '/write', payload: { prompt: 'Generate test content' } },
       { name: 'guide', path: '/guide', payload: { prompt: 'Provide guidance' } },
       { name: 'audit', path: '/audit', payload: { prompt: 'Audit the system' } },
@@ -183,6 +184,7 @@ async function testArcanosAPI() {
     console.log('- Heartbeat endpoint (/heartbeat) logging and acknowledgement');
     console.log('- Ask endpoint (/ask) with ARCANOS shell injection');
     console.log('- ARCANOS endpoint (/arcanos) with structured diagnostics');
+    console.log('- Siri endpoint (/siri) for voice queries');
     console.log('- Write endpoint (/write) for content generation');
     console.log('- Guide endpoint (/guide) for step-by-step guidance');
     console.log('- Audit endpoint (/audit) for analysis and evaluation');


### PR DESCRIPTION
## Summary
- add `/siri` route for Siri Shortcut integration
- support `query` field in request handler
- test Siri endpoint through API suite

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689d4d508b98832187e1c947398e493b