### PR TITLE
Add Backstage Booker module and router

### DIFF
--- a/src/modules/backstage/booker.ts
+++ b/src/modules/backstage/booker.ts
@@ -1,0 +1,140 @@
+import { randomUUID } from 'crypto';
+
+export interface Wrestler {
+  name: string;
+  overall: number; // rating 0-100
+}
+
+export interface MatchInput {
+  wrestler1: string;
+  wrestler2: string;
+  matchType: string;
+  kayfabeMode?: boolean;
+}
+
+export interface MatchResultBase {
+  match: string;
+  interference: string | null;
+  rating: string; // 1.0-5.0
+}
+
+export interface KayfabeResult extends MatchResultBase {
+  result: string;
+  via: string;
+}
+
+export interface RealResult extends MatchResultBase {
+  winner: string;
+  loser: string;
+  probability: Record<string, string>;
+}
+
+// Internal in-memory stores
+const events: Array<{ id: string; data: any }> = [];
+let roster: Wrestler[] = [];
+const storylines: Array<any> = [];
+
+/**
+ * Books an event by storing the payload and returning an id.
+ */
+export async function bookEvent(data: any): Promise<string> {
+  const id = randomUUID();
+  events.push({ id, data });
+  return id;
+}
+
+/**
+ * Updates the roster. Existing wrestlers are replaced, new ones added.
+ */
+export async function updateRoster(wrestlers: Wrestler[]): Promise<Wrestler[]> {
+  wrestlers.forEach(w => {
+    const idx = roster.findIndex(r => r.name === w.name);
+    if (idx >= 0) {
+      roster[idx] = w;
+    } else {
+      roster.push(w);
+    }
+  });
+  return roster;
+}
+
+/**
+ * Tracks storyline information by appending to the internal array.
+ */
+export async function trackStoryline(data: any): Promise<any[]> {
+  storylines.push(data);
+  return storylines;
+}
+
+/**
+ * Simulates a wrestling match using wrestler overalls and optional
+ * probability modifiers. Can optionally return kayfabe-style results.
+ */
+export async function simulateMatch(
+  match: MatchInput,
+  rosters: Wrestler[],
+  winProbModifier = 0
+): Promise<KayfabeResult | RealResult> {
+  const { wrestler1, wrestler2, matchType, kayfabeMode = false } = match;
+
+  const w1 = rosters.find(r => r.name === wrestler1);
+  const w2 = rosters.find(r => r.name === wrestler2);
+
+  if (!w1 || !w2) {
+    throw new Error('One or both wrestlers not found in roster');
+  }
+
+  let w1Chance = w1.overall / (w1.overall + w2.overall);
+  let w2Chance = 1 - w1Chance;
+
+  w1Chance = Math.min(Math.max(w1Chance + winProbModifier, 0), 1);
+  w2Chance = 1 - w1Chance;
+
+  let interference: string | null = null;
+  if (Math.random() < 0.1 && rosters.length > 0) {
+    interference = rosters[Math.floor(Math.random() * rosters.length)].name;
+    if (Math.random() > 0.5) {
+      w1Chance = Math.min(Math.max(w1Chance + 0.15, 0), 1);
+    } else {
+      w1Chance = Math.min(Math.max(w1Chance - 0.15, 0), 1);
+    }
+    w2Chance = 1 - w1Chance;
+  }
+
+  const roll = Math.random();
+  const winner = roll < w1Chance ? wrestler1 : wrestler2;
+  const loser = winner === wrestler1 ? wrestler2 : wrestler1;
+  const rating = (Math.random() * 4 + 1).toFixed(1);
+
+  if (kayfabeMode) {
+    return {
+      match: `${wrestler1} vs ${wrestler2} (${matchType})`,
+      result: `${winner} wins`,
+      via: 'Pinfall',
+      interference,
+      rating
+    };
+  }
+
+  return {
+    match: `${wrestler1} vs ${wrestler2} (${matchType})`,
+    winner,
+    loser,
+    probability: {
+      [wrestler1]: w1Chance.toFixed(2),
+      [wrestler2]: w2Chance.toFixed(2)
+    },
+    interference,
+    rating
+  };
+}
+
+export const BackstageBooker = {
+  bookEvent,
+  updateRoster,
+  trackStoryline,
+  simulateMatch
+};
+
+export default BackstageBooker;
+

--- a/src/routes/backstage.ts
+++ b/src/routes/backstage.ts
@@ -1,0 +1,58 @@
+import express, { Request, Response } from 'express';
+import BackstageBooker, { MatchInput, Wrestler } from '../modules/backstage/booker.js';
+
+const router = express.Router();
+
+// Entry point for Backstage Booker
+router.get('/', (_req: Request, res: Response) => {
+  res.json({
+    status: 'success',
+    module: 'Backstage Booker',
+    role: 'entrypoint',
+    timestamp: Date.now()
+  });
+});
+
+// Book Event
+router.post('/book-event', async (req: Request, res: Response) => {
+  try {
+    const eventID = await BackstageBooker.bookEvent(req.body);
+    res.status(200).json({ success: true, eventID });
+  } catch (error: any) {
+    res.status(500).json({ success: false, error: error.message });
+  }
+});
+
+// Simulate Match
+router.post('/simulate-match', async (req: Request, res: Response) => {
+  try {
+    const { match, rosters, winProbModifier }: { match: MatchInput; rosters: Wrestler[]; winProbModifier?: number } = req.body;
+    const result = await BackstageBooker.simulateMatch(match, rosters, winProbModifier || 0);
+    res.status(200).json({ success: true, result });
+  } catch (error: any) {
+    res.status(500).json({ success: false, error: error.message });
+  }
+});
+
+// Update Roster
+router.post('/update-roster', async (req: Request, res: Response) => {
+  try {
+    const roster = await BackstageBooker.updateRoster(req.body as Wrestler[]);
+    res.status(200).json({ success: true, roster });
+  } catch (error: any) {
+    res.status(500).json({ success: false, error: error.message });
+  }
+});
+
+// Track Storyline
+router.post('/track-storyline', async (req: Request, res: Response) => {
+  try {
+    const storyline = await BackstageBooker.trackStoryline(req.body);
+    res.status(200).json({ success: true, storyline });
+  } catch (error: any) {
+    res.status(500).json({ success: false, error: error.message });
+  }
+});
+
+export default router;
+

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import heartbeatRouter from './routes/heartbeat.js';
 import orchestrationRouter from './routes/orchestration.js';
 import statusRouter from './routes/status.js';
 import siriRouter from './routes/siri.js';
+import backstageRouter from './routes/backstage.js';
 
 // Validate required environment variables at startup
 console.log("[🔥 ARCANOS STARTUP] Server boot sequence triggered.");
@@ -88,6 +89,7 @@ app.use('/', heartbeatRouter);
 app.use('/', orchestrationRouter);
 app.use('/', statusRouter);
 app.use('/', siriRouter);
+app.use('/backstage', backstageRouter);
 app.use('/sdk', sdkRouter);
 
 /**


### PR DESCRIPTION
## Summary
- add BackstageBooker service for event booking, roster updates and storyline tracking
- expose Backstage Booker API with match simulation and management endpoints
- wire Backstage Booker router into main server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d748ec1848321b4d854a37fcc5919