### PR TITLE
Add match simulation engine and express route

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,7 @@
+{
+  "name": "backstage-booker",
+  "version": "1.3.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "packages": {}
+}

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
   "dependencies": {
     "@types/node": "^24.2.1",
     "@types/pg": "^8.15.5",
+    "body-parser": "1.20.2",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
-    "express": "^5.1.0",
+    "express": "4.18.2",
     "node-cron": "^4.2.1",
     "openai": "^5.12.2",
     "pg": "^8.16.3"

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const router = express.Router();
+const matchEngine = require('./services/matchengine');
+
+router.post('/book-event', async (req, res) => {
+    res.status(501).json({ success: false, error: 'Not implemented' });
+});
+
+router.post('/simulate-match', async (req, res) => {
+    try {
+        const result = await matchEngine.simulateMatch(req.body.match, req.body.rosters, req.body.winProbModifier || 0);
+        res.status(200).json({ success: true, result });
+    } catch (error) {
+        res.status(500).json({ success: false, error: error.message });
+    }
+});
+
+router.post('/update-roster', async (req, res) => {
+    res.status(501).json({ success: false, error: 'Not implemented' });
+});
+
+router.post('/track-storyline', async (req, res) => {
+    res.status(501).json({ success: false, error: 'Not implemented' });
+});
+
+module.exports = router;

--- a/src/services/matchengine.js
+++ b/src/services/matchengine.js
@@ -1,0 +1,61 @@
+module.exports.simulateMatch = async function(match, rosters, winProbModifier = 0) {
+    const { wrestler1, wrestler2, matchType, kayfabeMode = false } = match;
+
+    const w1 = rosters.find(r => r.name === wrestler1);
+    const w2 = rosters.find(r => r.name === wrestler2);
+
+    if (!w1 || !w2) {
+        throw new Error("One or both wrestlers not found in roster");
+    }
+
+    let w1Chance = w1.overall / (w1.overall + w2.overall);
+    let w2Chance = 1 - w1Chance;
+
+    w1Chance += winProbModifier;
+    w2Chance -= winProbModifier;
+
+    w1Chance = Math.max(0, Math.min(1, w1Chance));
+    w2Chance = 1 - w1Chance;
+
+    let interference = null;
+    if (Math.random() < 0.1) {
+        interference = rosters[Math.floor(Math.random() * rosters.length)].name;
+        if (Math.random() > 0.5) {
+            w1Chance += 0.15;
+            w2Chance -= 0.15;
+        } else {
+            w1Chance -= 0.15;
+            w2Chance += 0.15;
+        }
+        w1Chance = Math.max(0, Math.min(1, w1Chance));
+        w2Chance = 1 - w1Chance;
+    }
+
+    const roll = Math.random();
+    const winner = roll < w1Chance ? wrestler1 : wrestler2;
+    const loser = winner === wrestler1 ? wrestler2 : wrestler1;
+
+    const rating = (Math.random() * 4 + 1).toFixed(1);
+
+    if (kayfabeMode) {
+        return {
+            match: `${wrestler1} vs ${wrestler2} (${matchType})`,
+            result: `${winner} wins`,
+            via: "Pinfall",
+            interference,
+            rating
+        };
+    } else {
+        return {
+            match: `${wrestler1} vs ${wrestler2} (${matchType})`,
+            winner,
+            loser,
+            probability: {
+                [wrestler1]: w1Chance.toFixed(2),
+                [wrestler2]: w2Chance.toFixed(2)
+            },
+            interference,
+            rating
+        };
+    }
+};


### PR DESCRIPTION
## Summary
- add express 4.x and body-parser dependencies
- introduce match simulation service with interference handling
- expose /simulate-match route and placeholders for additional endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689df34eedf483218630753aaea6313d