### PR TITLE
feat: add audit manager module

### DIFF
--- a/modules/auditManager.js
+++ b/modules/auditManager.js
@@ -1,0 +1,31 @@
+const auditLogger = require('../modules/auditLogger');
+const memory = require('../memory/middleware');
+const fallbackChecker = require('../system/fallbackChecker'); // Adjust pathing as needed
+
+let lastSnapshot = null;
+
+module.exports = {
+  enableAudit: () => {
+    setInterval(() => {
+      memory.read('audit_snapshot')
+        .then(snapshot => {
+          lastSnapshot = snapshot;
+          console.log('Audit snapshot retrieved:', snapshot);
+        });
+    }, 60000); // Adjust timing if needed
+  },
+
+  auditEvent: (agent, action, meta) => {
+    auditLogger.log(`${agent} performed: ${action}`, meta);
+  },
+
+  verifyFallback: () => {
+    fallbackChecker.check()
+      .then(result => {
+        if (!result) {
+          console.error('FALLBACK FAILURE: Rolling back...');
+          memory.write('audit_snapshot', lastSnapshot); // Optional - rollback audit state
+        }
+      });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "license": "MIT",
   "dependencies": {
     "@types/node": "^24.2.1",
-    "@types/pg": "^8.15.5",
     "body-parser": "1.20.2",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
@@ -39,10 +38,12 @@
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
-    "@types/dotenv": "^6.1.1",
+    "@types/dotenv": "^8.2.0",
     "@types/express": "^5.0.3",
     "@types/node-cron": "^3.0.11",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "@types/pg": "^8.6.6",
+    "@types/openai": "^3.0.0"
   },
   "engines": {
     "node": ">=18.0.0",


### PR DESCRIPTION
## Summary
- add audit manager to snapshot state and log audit events
- specify type declarations for dotenv, pg, and openai

## Testing
- `npm install` (fails: Not Found - GET https://registry.npmjs.org/@types%2fopenai)
- `npm test` (fails: Cannot find module 'dotenv' or its type declarations)


------
https://chatgpt.com/codex/tasks/task_b_689e30a092508321be0c237b90180e90