### PR TITLE
fix: handle read-only bypass in audit safe mode

### DIFF
--- a/modules/security/audit-config.js
+++ b/modules/security/audit-config.js
@@ -25,14 +25,20 @@ function classifyRisk(request) {
 function handler(request) {
   // Owner override bypass
   if (isOwnerOverride(request)) {
-    logger.info(`Owner override detected — executing request without hard block`);
+    logger.info(`Owner override detected — executing without hard block`);
     return { allowed: true, mode: 'OVERRIDE', logOnly: true };
   }
 
   // Relaxed session mode
   if (request.sessionFlags && request.sessionFlags.includes('audit_relaxed_session')) {
-    logger.info(`Audit Relaxed Mode active for this session`);
+    logger.info(`Audit Relaxed Mode active — lighter restrictions applied`);
     return { allowed: true, mode: 'RELAXED', logOnly: true };
+  }
+
+  // Read-only bypass fix
+  if (request.type === 'read-only' || request.outputOnly) {
+    logger.info(`Read-only request detected — bypassing strict mode`);
+    return { allowed: true, mode: 'READ_ONLY_BYPASS', logOnly: true };
   }
 
   // Two-layer audit filtering
@@ -49,5 +55,5 @@ function handler(request) {
 // Attach handler to config
 auditConfig.handler = handler;
 
-logger.info(`✅ Audit Safe Mode patch applied: Owner override, layered filtering, relaxed session, adaptive thresholds`);
+logger.info(`✅ Audit Safe Mode patch v1.043 applied — read-only bypass fixed`);
 module.exports = auditConfig;


### PR DESCRIPTION
## Summary
- ensure read-only or output-only requests bypass strict blocking while logging
- clarify audit log messages for relaxed session and owner override

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689f6384c9188321ba604400862e5e19