### PR TITLE
Add authenticated diagnostics bridge server

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ node utils/pin_memory_resource.js --label MY_LABEL --type task --file ./workflow
 
 ### Diagnostics & Monitoring
 - `POST /api/diagnostics` - Natural language diagnostic commands
+- `POST /api/arcanos/diagnostics` - Backend bridge with token auth
 - `GET /system/diagnostics` - System diagnostics information
 - `GET /system/workers` - Worker status information
 - `GET /sync/diagnostics` - GPT-accessible system metrics
@@ -250,6 +251,14 @@ or
 ```json
 {
   "command": "Check available memory"
+}
+```
+
+#### Backend Bridge Diagnostics (`/api/arcanos/diagnostics`)
+```json
+{
+  "command": "Run health check",
+  "params": {}
 }
 ```
 
@@ -494,6 +503,7 @@ curl http://localhost:8080/health
 
 ### Diagnostic & Management
 - `POST /api/diagnostics` - Natural language system commands
+- `POST /api/arcanos/diagnostics` - Authenticated backend diagnostics bridge
 - `GET /system/workers` - Background process monitoring (verify workers after setting `RUN_WORKERS=true`)
 - `GET /system/diagnostics` - Comprehensive system diagnostics
 - `GET /sync/diagnostics` - GPT-accessible system metrics

--- a/backend-bridge.js
+++ b/backend-bridge.js
@@ -1,0 +1,50 @@
+import express from 'express';
+import crypto from 'crypto';
+
+const app = express();
+app.use(express.json());
+
+// ✅ Secure token (store in environment variable)
+const AUTH_TOKEN = process.env.ARCANOS_AUTH_TOKEN;
+
+// ✅ Simple authentication middleware
+function authenticate(req, res, next) {
+  const token = req.headers['x-arcanos-token'];
+  if (!token || token !== AUTH_TOKEN) {
+    return res.status(403).json({ error: 'Unauthorized' });
+  }
+  next();
+}
+
+// ✅ Fallback handler with retry logic
+async function runWithRetry(taskFn, retries = 3) {
+  let attempt = 0;
+  while (attempt < retries) {
+    try {
+      return await taskFn();
+    } catch (err) {
+      attempt++;
+      if (attempt >= retries) throw err;
+    }
+  }
+}
+
+// ✅ Diagnostic endpoint
+app.post('/api/arcanos/diagnostics', authenticate, async (req, res) => {
+  const { command, params } = req.body;
+  try {
+    const result = await runWithRetry(async () => {
+      // Your backend AI's diagnostic function here
+      return await global.backendAI.runCommand(command, params);
+    });
+    res.json({ success: true, result });
+  } catch (err) {
+    res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+// ✅ Start the bridge server
+const PORT = process.env.PORT || 4000;
+app.listen(PORT, () => {
+  console.log(`Arcanos backend bridge running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- introduce standalone Express bridge with token auth and retryable diagnostics endpoint
- document new `/api/arcanos/diagnostics` route and request format

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689f8d5f13e88321a22e467e92d4f0ce