### PR TITLE
Remove token checks from diagnostics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ node utils/pin_memory_resource.js --label MY_LABEL --type task --file ./workflow
 
 ### Diagnostics & Monitoring
 - `POST /api/diagnostics` - Natural language diagnostic commands
-- `POST /api/arcanos/diagnostics` - Backend bridge with token auth
+- `POST /api/arcanos/diagnostics` - Backend bridge diagnostics (open access)
 - `GET /system/diagnostics` - System diagnostics information
 - `GET /system/workers` - Worker status information
 - `GET /sync/diagnostics` - GPT-accessible system metrics
@@ -503,7 +503,7 @@ curl http://localhost:8080/health
 
 ### Diagnostic & Management
 - `POST /api/diagnostics` - Natural language system commands
-- `POST /api/arcanos/diagnostics` - Authenticated backend diagnostics bridge
+- `POST /api/arcanos/diagnostics` - Backend diagnostics bridge (no auth)
 - `GET /system/workers` - Background process monitoring (verify workers after setting `RUN_WORKERS=true`)
 - `GET /system/diagnostics` - Comprehensive system diagnostics
 - `GET /sync/diagnostics` - GPT-accessible system metrics

--- a/backend-bridge.js
+++ b/backend-bridge.js
@@ -1,20 +1,7 @@
 import express from 'express';
-import crypto from 'crypto';
 
 const app = express();
 app.use(express.json());
-
-// ✅ Secure token (store in environment variable)
-const AUTH_TOKEN = process.env.ARCANOS_AUTH_TOKEN;
-
-// ✅ Simple authentication middleware
-function authenticate(req, res, next) {
-  const token = req.headers['x-arcanos-token'];
-  if (!token || token !== AUTH_TOKEN) {
-    return res.status(403).json({ error: 'Unauthorized' });
-  }
-  next();
-}
 
 // ✅ Fallback handler with retry logic
 async function runWithRetry(taskFn, retries = 3) {
@@ -29,8 +16,8 @@ async function runWithRetry(taskFn, retries = 3) {
   }
 }
 
-// ✅ Diagnostic endpoint
-app.post('/api/arcanos/diagnostics', authenticate, async (req, res) => {
+// ✅ Diagnostic endpoint (open mode - no authentication)
+app.post('/api/arcanos/diagnostics', async (req, res) => {
   const { command, params } = req.body;
   try {
     const result = await runWithRetry(async () => {

--- a/src/routes/arcanos.ts
+++ b/src/routes/arcanos.ts
@@ -97,13 +97,6 @@ router.post('/arcanos', async (req: Request<{}, ArcanosResponse | ErrorResponse,
 });
 
 router.post('/arcanos/diagnostics', async (req: Request, res: Response) => {
-  const authToken = req.headers['x-arcanos-token'] as string | undefined;
-  if (!authToken || authToken !== process.env.ARCANOS_AUTH_TOKEN) {
-    return res.status(403).json({
-      error: 'Unauthorized: Missing or invalid ARCANOS_AUTH_TOKEN'
-    });
-  }
-
   try {
     const { command, params } = req.body;
     const result = await runCommand(command, params);


### PR DESCRIPTION
## Summary
- Drop authentication middleware from backend bridge diagnostics endpoint
- Open `/arcanos/diagnostics` route by removing token requirement
- Update documentation to reflect open-access diagnostics endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689fcb0725ac832182edf17b4ee7fdcd