### PR TITLE
Reset /api/arcanos/ask endpoint without auth checks

### DIFF
--- a/src/routes/arcanos.ts
+++ b/src/routes/arcanos.ts
@@ -121,23 +121,18 @@ router.post('/arcanos', async (req: Request<{}, ArcanosResponse | ErrorResponse,
   }
 });
 
+// Reset: /ask endpoint with no token or IP checks
 router.post('/api/arcanos/ask', async (
   req: Request<{}, ArcanosAskEndpointResponse, ArcanosAskRequest>,
   res: Response<ArcanosAskEndpointResponse>
 ) => {
   try {
     const { prompt } = req.body;
-
-    if (!prompt || typeof prompt !== 'string') {
-      return res.status(400).json({ success: false, error: 'Missing or invalid prompt in request body' });
-    }
-
     const result = await handleArcanosPrompt(prompt);
     res.json({ success: true, result });
   } catch (err) {
     console.error('ARCANOS /ask error:', err);
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    res.status(500).json({ success: false, error: message });
+    res.status(500).json({ success: false, error: (err as Error).message });
   }
 });
 


### PR DESCRIPTION
## Summary
- simplify `/api/arcanos/ask` route and remove prompt validation, opening it without token/IP checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a00f28faa08321a6aef4af5b072c90