### PR TITLE
feat: add API arcanos ask route

### DIFF
--- a/src/routes/api-arcanos.ts
+++ b/src/routes/api-arcanos.ts
@@ -1,0 +1,31 @@
+import express, { Request, Response } from 'express';
+import { handleArcanosPrompt } from '../services/arcanosPrompt.js';
+
+const router = express.Router();
+
+interface AskBody {
+  prompt: string;
+}
+
+/**
+ * Minimal ARCANOS ask endpoint used by external services.
+ * Returns a success flag and the raw result from the core handler.
+ */
+router.post('/ask', async (
+  req: Request<{}, { success: boolean; result?: any; error?: string }, AskBody>,
+  res: Response<{ success: boolean; result?: any; error?: string }>
+) => {
+  try {
+    const { prompt } = req.body;
+    if (!prompt || typeof prompt !== 'string') {
+      return res.status(400).json({ success: false, error: 'Missing or invalid prompt' });
+    }
+    const result = await handleArcanosPrompt(prompt);
+    return res.json({ success: true, result });
+  } catch (err: any) {
+    return res.status(500).json({ success: false, error: err.message });
+  }
+});
+
+export default router;
+

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import orchestrationRouter from './routes/orchestration.js';
 import statusRouter from './routes/status.js';
 import siriRouter from './routes/siri.js';
 import backstageRouter from './routes/backstage.js';
+import apiArcanosRouter from './routes/api-arcanos.js';
 
 // Validate required environment variables at startup
 console.log("[🔥 ARCANOS STARTUP] Server boot sequence triggered.");
@@ -91,6 +92,7 @@ app.use('/', statusRouter);
 app.use('/', siriRouter);
 app.use('/backstage', backstageRouter);
 app.use('/sdk', sdkRouter);
+app.use('/api/arcanos', apiArcanosRouter);
 
 /**
  * Bootstraps the Express application and all worker services.

--- a/src/services/arcanosPrompt.ts
+++ b/src/services/arcanosPrompt.ts
@@ -1,0 +1,27 @@
+import { getOpenAIClient, generateMockResponse } from './openai.js';
+import { runThroughBrain } from '../logic/trinity.js';
+
+/**
+ * Handles a basic ARCANOS prompt by routing it through the Trinity brain.
+ * Falls back to a mocked response when the OpenAI client isn't available.
+ *
+ * @param prompt - User provided prompt text
+ * @returns AI response object
+ */
+export async function handleArcanosPrompt(prompt: string) {
+  if (!prompt || typeof prompt !== 'string') {
+    throw new Error('Invalid prompt');
+  }
+
+  const client = getOpenAIClient();
+
+  // When no OpenAI API key is configured we return a mock response
+  if (!client) {
+    return generateMockResponse(prompt, 'ask');
+  }
+
+  // Route the prompt through the main Trinity brain processing
+  const output = await runThroughBrain(client, prompt);
+  return output;
+}
+

--- a/tests/test-arcanos-api.js
+++ b/tests/test-arcanos-api.js
@@ -145,8 +145,24 @@ async function testArcanosAPI() {
       }
     }
 
+    // Test /api/arcanos/ask endpoint separately (simplified response format)
+    console.log(`\n${4 + endpoints.length}. Testing api/arcanos/ask endpoint...`);
+    try {
+      const { stdout } = await execAsync(`curl -s -X POST ${baseUrl}/api/arcanos/ask -H "Content-Type: application/json" -d '{"prompt":"Hello from api"}'`);
+      const apiAskResponse = JSON.parse(stdout);
+      if (apiAskResponse.success && apiAskResponse.result) {
+        console.log('✅ api/arcanos/ask endpoint: PASSED');
+      } else {
+        console.log('❌ api/arcanos/ask endpoint invalid response:', apiAskResponse);
+        throw new Error('api/arcanos/ask endpoint validation failed');
+      }
+    } catch (error) {
+      console.log('❌ api/arcanos/ask endpoint test failed:', error.message);
+      throw error;
+    }
+
     // Test input validation
-    console.log(`\n${4 + endpoints.length}. Testing validation (missing input)...`);
+    console.log(`\n${5 + endpoints.length}. Testing validation (missing input)...`);
     try {
       const { stdout } = await execAsync(`curl -s -X POST ${baseUrl}/ask -H "Content-Type: application/json" -d '{}'`);
       const response = JSON.parse(stdout);
@@ -163,7 +179,7 @@ async function testArcanosAPI() {
     }
 
     // Test malformed JSON handling
-    console.log(`\n${5 + endpoints.length}. Testing malformed JSON handling...`);
+    console.log(`\n${6 + endpoints.length}. Testing malformed JSON handling...`);
     try {
       const { stdout } = await execAsync(`curl -s -X POST ${baseUrl}/ask -H "Content-Type: application/json" -d 'invalid json'`);
       const response = JSON.parse(stdout);
@@ -189,6 +205,7 @@ async function testArcanosAPI() {
     console.log('- Guide endpoint (/guide) for step-by-step guidance');
     console.log('- Audit endpoint (/audit) for analysis and evaluation');
     console.log('- Sim endpoint (/sim) for simulations and modeling');
+    console.log('- API Arcanos ask endpoint (/api/arcanos/ask) for basic queries');
     console.log('- Input validation works correctly');
     console.log('- Malformed requests handled gracefully');
     console.log('- Mock responses when OPENAI_API_KEY not configured');
@@ -203,7 +220,7 @@ async function testArcanosAPI() {
   } finally {
     // Clean up - kill the server process
     if (serverProcess) {
-      console.log('\n12. Cleaning up server process...');
+      console.log('\n14. Cleaning up server process...');
       serverProcess.kill('SIGTERM');
       await new Promise(resolve => setTimeout(resolve, 1000));
     }


### PR DESCRIPTION
## Summary
- expose simplified `/api/arcanos/ask` endpoint
- centralize prompt handling with `handleArcanosPrompt`
- test coverage for new API route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a01979b49c8321b9688f0785dae622