### PR TITLE
feat: add Backstage Booker bootloader activation

### DIFF
--- a/src/modules/backstage/bootloader.ts
+++ b/src/modules/backstage/bootloader.ts
@@ -1,0 +1,73 @@
+/**
+ * Fallback bootloader activation for Backstage Booker module.
+ * Ensures module is reactivated safely if it enters a BOOT_FAILED state.
+ */
+
+export type ModuleStatus = 'ACTIVE' | 'INACTIVE' | 'BOOT_FAILED';
+
+export interface ActivationOptions {
+  force?: boolean;
+  bypassIsolation?: boolean;
+  safeMode?: boolean;
+}
+
+export interface Kernel {
+  checkModuleStatus(moduleId: string): Promise<ModuleStatus>;
+  activateModule(
+    moduleId: string,
+    options?: ActivationOptions
+  ): Promise<{ success: boolean }>;
+}
+
+export interface Audit {
+  log: (message?: any, ...optionalParams: any[]) => void;
+  warn: (message?: any, ...optionalParams: any[]) => void;
+  error: (message?: any, ...optionalParams: any[]) => void;
+}
+
+/**
+ * Attempts to activate the Backstage Booker module if it failed to boot.
+ *
+ * @param kernel Kernel interface used to query and activate modules.
+ * @param audit Logging interface for audit purposes (defaults to console).
+ * @param moduleId Module identifier, defaults to `backstage_booker`.
+ * @returns Whether the module ended up active.
+ */
+export async function activateBackstageBooker(
+  kernel: Kernel,
+  audit: Audit = console,
+  moduleId = 'backstage_booker'
+): Promise<boolean> {
+  try {
+    const status = await kernel.checkModuleStatus(moduleId);
+
+    if (status === 'BOOT_FAILED') {
+      audit.log(
+        `[ARCANOS] Detected ${moduleId} in BOOT_FAILED. Attempting safe reactivation...`
+      );
+
+      const result = await kernel.activateModule(moduleId, {
+        force: true,
+        bypassIsolation: true,
+        safeMode: true
+      });
+
+      if (result.success) {
+        audit.log(`[ARCANOS] ✅ ${moduleId} reactivated successfully.`);
+        return true;
+      }
+
+      audit.warn(
+        `[ARCANOS] ⚠️ Fallback activation failed. Manual inspection required.`
+      );
+      return false;
+    }
+
+    audit.log(`[ARCANOS] ${moduleId} already in ${status} state.`);
+    return status === 'ACTIVE';
+  } catch (err) {
+    audit.error(`[ARCANOS] ❌ Activation exception:`, err);
+    return false;
+  }
+}
+

--- a/src/modules/backstage/kernel.ts
+++ b/src/modules/backstage/kernel.ts
@@ -1,0 +1,23 @@
+import { Kernel, ModuleStatus, ActivationOptions } from './bootloader.js';
+
+// Simple in-memory kernel implementation used for bootstrapping.
+// In real deployments this should interface with the actual system kernel.
+const moduleState: Record<string, ModuleStatus> = {
+  backstage_booker: 'BOOT_FAILED'
+};
+
+const kernel: Kernel = {
+  async checkModuleStatus(moduleId: string): Promise<ModuleStatus> {
+    return moduleState[moduleId] ?? 'INACTIVE';
+  },
+  async activateModule(
+    moduleId: string,
+    _options: ActivationOptions = {}
+  ): Promise<{ success: boolean }> {
+    moduleState[moduleId] = 'ACTIVE';
+    return { success: true };
+  }
+};
+
+export default kernel;
+

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,8 @@ import statusRouter from './routes/status.js';
 import siriRouter from './routes/siri.js';
 import backstageRouter from './routes/backstage.js';
 import apiArcanosRouter from './routes/api-arcanos.js';
+import { activateBackstageBooker } from './modules/backstage/bootloader.js';
+import backstageKernel from './modules/backstage/kernel.js';
 
 // Validate required environment variables at startup
 console.log("[🔥 ARCANOS STARTUP] Server boot sequence triggered.");
@@ -117,7 +119,10 @@ async function initializeServer() {
     
     // Initialize workers first
     const workerResults = await initializeWorkers();
-    
+
+    // Ensure Backstage Booker module is active
+    await activateBackstageBooker(backstageKernel);
+
     console.log(`[🔌 ARCANOS DB] Database Status: ${workerResults.database.connected ? 'Connected' : 'Disconnected'}`);
     if (workerResults.database.error) {
       console.log(`[🔌 ARCANOS DB] Database Error: ${workerResults.database.error}`);


### PR DESCRIPTION
## Summary
- add bootloader helper that reactivates Backstage Booker when boot fails
- provide simple kernel stub for module status/activation
- integrate fallback activation into server startup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1278fe23c83259725cea2422e1dd0