### PR TITLE
feat: remove confirmation gate from ask endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Arcanos is designed as an **AI-managed backend**. A fine-tuned GPT model control
 
 ## 🛡️ OpenAI Terms of Service Compliance
 
-**Important:** All sensitive API endpoints now require explicit user confirmation to ensure compliance with OpenAI's Terms of Service. This prevents GPT applications from executing actions automatically without user consent.
+**Important:** Most sensitive API endpoints now require explicit user confirmation to ensure compliance with OpenAI's Terms of Service. This prevents GPT applications from executing actions automatically without user consent. The `/ask` endpoint is exempt and can be used without confirmation.
 
 ### Required Confirmation Header
 
-For all sensitive operations (AI queries, data modifications, worker executions), you **must** include the confirmation header:
+For all sensitive operations (data modifications, worker executions), you **must** include the confirmation header. The `/ask` endpoint no longer requires this header:
 
 ```bash
 x-confirmed: yes
@@ -18,14 +18,15 @@ x-confirmed: yes
 
 ### Example Requests
 
-#### ✅ Correct Usage (With Confirmation)
+#### Ask endpoint (no confirmation required)
 ```bash
-# AI chat endpoint
 curl -X POST http://localhost:8080/ask \
   -H "Content-Type: application/json" \
-  -H "x-confirmed: yes" \
   -d '{"prompt": "Hello, how are you?"}'
+```
 
+#### Operations requiring confirmation
+```bash
 # Memory save operation
 curl -X POST http://localhost:8080/memory/save \
   -H "Content-Type: application/json" \
@@ -39,30 +40,12 @@ curl -X POST http://localhost:8080/workers/run/analyzer \
   -d '{"input": "data to analyze"}'
 ```
 
-#### ❌ Incorrect Usage (Without Confirmation)
-```bash
-# This will return 403 Forbidden
-curl -X POST http://localhost:8080/ask \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "Hello, how are you?"}'
-
-# Response:
-{
-  "error": "Confirmation required",
-  "message": "This endpoint requires explicit user confirmation. Please include the header: x-confirmed: yes",
-  "code": "CONFIRMATION_REQUIRED",
-  "endpoint": "/ask",
-  "method": "POST"
-}
-```
-
 ### Protected Endpoints
 
 The following endpoints require the `x-confirmed: yes` header:
 
 **AI Processing Endpoints:**
-- `POST /ask` - AI query endpoint
-- `POST /brain` - AI brain endpoint  
+- `POST /brain` - AI brain endpoint
 - `POST /arcanos` - Main AI interface
 - `POST /api/arcanos/ask` - Simple query processing
 - `POST /write`, `/guide`, `/audit`, `/sim` - AI processing endpoints
@@ -83,8 +66,9 @@ The following endpoints require the `x-confirmed: yes` header:
 
 ### Safe Endpoints (No Confirmation Required)
 
-These diagnostic and read-only endpoints remain accessible without confirmation:
+These endpoints remain accessible without confirmation:
 
+- `POST /ask` - AI query endpoint
 - `GET /health` - Health check
 - `GET /` - Root endpoint
 - `GET /memory/health`, `/memory/load`, `/memory/list`, `/memory/view` - Memory diagnostics
@@ -99,7 +83,7 @@ These diagnostic and read-only endpoints remain accessible without confirmation:
 When creating Custom GPTs or integrating with the Arcanos backend:
 
 1. **Always prompt the user for confirmation** before making API calls to sensitive endpoints
-2. **Include the confirmation header** in your API calls: `x-confirmed: yes`
+2. **Include the confirmation header** in your API calls when required: `x-confirmed: yes` (not needed for `/ask`)
 3. **Handle 403 responses gracefully** and inform users about the confirmation requirement
 4. **Use safe endpoints** for health checks and diagnostics without confirmation
 
@@ -109,7 +93,7 @@ User: "Can you analyze this data for me?"
 GPT: "I can help analyze your data. To proceed with this operation, I need your explicit confirmation. 
      Should I proceed with the analysis? (This will call the backend API with your data)"
 User: "Yes, proceed"
-GPT: [Makes API call with x-confirmed: yes header]
+GPT: [Makes API call with confirmation header if required]
 ```
 
 ## ✅ Recent Refactoring (v1.0.0)

--- a/scripts/scan-confirm-gate-compliance.js
+++ b/scripts/scan-confirm-gate-compliance.js
@@ -30,7 +30,8 @@ const SAFE_PATTERNS = [
   /GET.*\/orchestration\/status/,
   /GET.*\/sdk\/diagnostics/,
   /GET.*\/sdk\/workers\/status/,
-  /GET.*\/backstage/
+  /GET.*\/backstage/,
+  /POST\s+\/ask$/
 ];
 
 function extractRoutes(filePath) {

--- a/src/routes/ask.ts
+++ b/src/routes/ask.ts
@@ -70,10 +70,10 @@ const handleAIRequest = async (
   }
 };
 
-// Primary ask endpoint routed through the Trinity brain
-router.post('/ask', confirmGate, (req, res) => handleAIRequest(req, res, 'ask'));
+// Primary ask endpoint routed through the Trinity brain (no confirmation required)
+router.post('/ask', (req, res) => handleAIRequest(req, res, 'ask'));
 
-// Brain endpoint (alias for ask with same functionality)
+// Brain endpoint (alias for ask with same functionality) still requires confirmation
 router.post('/brain', confirmGate, (req, res) => handleAIRequest(req, res, 'brain'));
 
 export default router;

--- a/tests/test-arcanos-api.js
+++ b/tests/test-arcanos-api.js
@@ -87,7 +87,7 @@ async function testArcanosAPI() {
           confirmation: 'HEARTBEAT_ENTRY_SUCCESS'
         }
       };
-      const { stdout } = await execAsync(`curl -s -X POST ${baseUrl}/heartbeat -H "Content-Type: application/json" -d '${JSON.stringify(hbPayload)}'`);
+      const { stdout } = await execAsync(`curl -s -X POST ${baseUrl}/heartbeat -H "Content-Type: application/json" -H "x-confirmed: yes" -d '${JSON.stringify(hbPayload)}'`);
       const hbResponse = JSON.parse(stdout);
       if (hbResponse.message && hbResponse.message.includes('HEARTBEAT_ENTRY_SUCCESS')) {
         console.log('✅ Heartbeat endpoint: PASSED');
@@ -116,7 +116,10 @@ async function testArcanosAPI() {
       console.log(`\n${4 + i}. Testing ${endpoint.name} endpoint (${endpoint.path})...`);
       
       try {
-        const curlCmd = `curl -s -X POST ${baseUrl}${endpoint.path} -H "Content-Type: application/json" -d '${JSON.stringify(endpoint.payload)}'`;
+        const headers = endpoint.path === '/ask'
+          ? '-H "Content-Type: application/json"'
+          : '-H "Content-Type: application/json" -H "x-confirmed: yes"';
+        const curlCmd = `curl -s -X POST ${baseUrl}${endpoint.path} ${headers} -d '${JSON.stringify(endpoint.payload)}'`;
         const { stdout } = await execAsync(curlCmd);
         const response = JSON.parse(stdout);
 

--- a/tests/test-confirm-gate-compliance.js
+++ b/tests/test-confirm-gate-compliance.js
@@ -10,7 +10,6 @@ const axios = require('axios');
 const BASE_URL = 'http://localhost:8080';
 
 const sensitiveEndpoints = [
-  { method: 'POST', path: '/ask', description: 'AI ask endpoint' },
   { method: 'POST', path: '/brain', description: 'AI brain endpoint' },
   { method: 'POST', path: '/arcanos', description: 'Main ARCANOS interface' },
   { method: 'POST', path: '/api/arcanos/ask', description: 'API ARCANOS ask' },
@@ -158,11 +157,11 @@ async function testConfirmGateCompliance() {
     }
   }
 
-  // Test 4: Check for proper error response format
+  // Test 4: Check for proper error response format using a protected endpoint
   console.log('\n4. Testing error response format...');
   totalTests++;
-  const result = await makeRequest('POST', '/ask', {}, { prompt: 'test' });
-  
+  const result = await makeRequest('POST', '/brain', {}, { prompt: 'test' });
+
   if (result.status === 403 && result.data && result.data.code === 'CONFIRMATION_REQUIRED') {
     console.log('✅ Error response has correct format and code');
     passedTests++;


### PR DESCRIPTION
## Summary
- allow `/ask` requests without the `x-confirmed` header while keeping `/brain` gated
- adjust docs, tests and confirm-gate scan to treat `/ask` as a safe endpoint
- update API tests to send confirmation headers for protected routes

## Testing
- `npm test`
- `node scripts/scan-confirm-gate-compliance.js`
- `node tests/test-confirm-gate-compliance.js` *(fails: ReferenceError: require is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68a41b6f66d483258e4c3401d38fb71c