### PR TITLE
Add audit-safe shim server

### DIFF
--- a/audit-safe-shim.js
+++ b/audit-safe-shim.js
@@ -1,0 +1,89 @@
+/**
+ * ARCANOS Backend - Audit-Safe Shim
+ * ----------------------------------
+ * This patch keeps the audit layer active but loosens restrictions:
+ * - No hard truncation (increased token budget)
+ * - Audit runs as a system directive instead of a suppressor
+ * - Preserves memory sync + audit logging
+ */
+
+import express from "express";
+import OpenAI from "openai";
+
+const app = express();
+app.use(express.json());
+
+const client = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+/**
+ * Core Ask Function (Audit-Safe Shim)
+ */
+async function askArcanos(prompt) {
+  try {
+    const response = await client.chat.completions.create({
+      model: "ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH",
+
+      messages: [
+        {
+          role: "system",
+          content: `ARCANOS: Audit-Safe Shim Active.
+Keep logs and integrity checks, but do not truncate or suppress valid output.
+All responses must preserve reasoning and memory context.`
+        },
+        {
+          role: "user",
+          content: prompt,
+        },
+      ],
+
+      // 🔧 Patch Parameters
+      temperature: 0.7,        // balanced creativity
+      max_tokens: 1500,        // extended token limit (reduces cutoff)
+      presence_penalty: 0,     // default
+      frequency_penalty: 0,    // default
+      stream: false,           // you can flip this on if you want streaming
+    });
+
+    return {
+      success: true,
+      content: response.choices[0].message.content,
+      usage: response.usage,
+    };
+  } catch (error) {
+    console.error("ARCANOS error:", error);
+    return {
+      success: false,
+      error: error.message,
+    };
+  }
+}
+
+/**
+ * /ask endpoint
+ */
+app.post("/ask", async (req, res) => {
+  const { prompt } = req.body;
+
+  if (!prompt) {
+    return res.status(400).json({ error: "Missing prompt" });
+  }
+
+  const result = await askArcanos(prompt);
+  res.json(result);
+});
+
+/**
+ * Healthcheck
+ */
+app.get("/health", (req, res) => {
+  res.json({ status: "ok", auditSafeShim: true });
+});
+
+// 🚀 Start server
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`ARCANOS backend running on port ${PORT}`);
+});
+


### PR DESCRIPTION
## Summary
- add standalone audit-safe shim server with expanded token limit and audit directive

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a446930e4483258c0ed0b0512b4562