### PR TITLE
Add ARCANOS audit cycle workflow

### DIFF
--- a/.github/workflows/arcanos-audit-cycle.yml
+++ b/.github/workflows/arcanos-audit-cycle.yml
@@ -1,0 +1,44 @@
+# This workflow enforces ARCANOS auto_audit_0432 cycle = 4 weeks
+# and auto-commits config changes to the repo.
+
+name: Enforce ARCANOS Audit Cycle
+
+on:
+  schedule:
+    # Runs every Sunday at midnight UTC (adjust as needed)
+    - cron: "0 0 * * 0"
+  workflow_dispatch: # allows manual trigger
+
+jobs:
+  enforce-cycle:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Ensure audit config file
+        run: |
+          echo "🔧 Ensuring ARCANOS audit cycle is set to 4WEEK..."
+          CONFIG_FILE="arcanos_audit_config.json"
+          if [ ! -f "$CONFIG_FILE" ]; then
+            echo '{ "module": "auto_audit_0432", "cycle": "4WEEK", "target": "github.com/${{ github.repository }}" }' > $CONFIG_FILE
+          else
+            jq '.cycle = "4WEEK"' $CONFIG_FILE > tmp.$$.json && mv tmp.$$.json $CONFIG_FILE
+          fi
+
+      - name: Commit changes
+        run: |
+          git config --global user.name "arc-automation"
+          git config --global user.email "arc-auto@users.noreply.github.com"
+          git add arcanos_audit_config.json
+          if git commit -m "🔄 Enforce ARCANOS auto_audit_0432 cycle = 4WEEK"; then
+            git push
+          else
+            echo "✅ No changes needed — already set to 4WEEK."
+          fi


### PR DESCRIPTION
## Summary
- add workflow that enforces ARCANOS auto_audit_0432 cycle every four weeks and auto-commits config updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5051e01e8832581cb1e23a0f57fcd