### PR TITLE
feat: add log-only audit-safe mode

### DIFF
--- a/src/services/auditSafeToggle.ts
+++ b/src/services/auditSafeToggle.ts
@@ -1,0 +1,87 @@
+/**
+ * ARCANOS Audit-Safe Toggle Manager
+ * ---------------------------------
+ * Modes:
+ *   - "true"    → strict enforcement
+ *   - "false"   → disabled
+ *   - "passive" → logs only, no blocking
+ *   - "log-only" → logs events without validation warnings
+ *
+ * Compatible with OpenAI SDK (chat/completions).
+ */
+
+import OpenAI from 'openai';
+
+let auditSafeMode: 'true' | 'false' | 'passive' | 'log-only' = 'true'; // default mode
+
+export function setAuditSafeMode(mode: 'true' | 'false' | 'passive' | 'log-only') {
+  if (!['true', 'false', 'passive', 'log-only'].includes(mode)) {
+    throw new Error("Invalid mode. Use 'true', 'false', 'passive', or 'log-only'.");
+  }
+  auditSafeMode = mode;
+  console.log(`🔐 Audit-Safe mode set to: ${auditSafeMode}`);
+}
+
+export function getAuditSafeMode(): 'true' | 'false' | 'passive' | 'log-only' {
+  return auditSafeMode;
+}
+
+// Example persistence handler with Audit-Safe awareness
+export function saveWithAuditCheck<T>(data: T, validator: (data: T) => boolean): T {
+  const mode = getAuditSafeMode();
+
+  if (mode === 'true') {
+    if (!validator(data)) {
+      throw new Error('❌ Audit-Safe rejected invalid data.');
+    }
+    console.log('✅ Audit-Safe validation passed.');
+    return data;
+  }
+
+  if (mode === 'passive') {
+    console.warn('⚠️ Audit-Safe passive mode: logging only.');
+    if (!validator(data)) {
+      console.warn('⚠️ Invalid data would have been blocked in strict mode.');
+    }
+    return data;
+  }
+
+  if (mode === 'log-only') {
+    console.log('📝 Audit-Safe log-only mode: events logged without validation.');
+    if (!validator(data)) {
+      console.log('📝 Invalid data logged without blocking.');
+    }
+    return data;
+  }
+
+  // mode === 'false'
+  console.log('🚨 Audit-Safe disabled. Writing without check.');
+  return data;
+}
+
+export async function interpretCommand(userCommand: string) {
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const response = await client.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [
+      { role: 'system', content: 'You are an AI that maps natural language commands to audit-safe mode toggles.' },
+      { role: 'user', content: userCommand }
+    ]
+  });
+
+  const raw = response.choices[0].message?.content?.trim().toLowerCase();
+  const mode = raw as 'true' | 'false' | 'passive' | 'log-only' | undefined;
+
+  if (mode && ['true', 'false', 'passive', 'log-only'].includes(mode)) {
+    setAuditSafeMode(mode);
+  } else {
+    console.warn('⚠️ Unrecognized command. Mode unchanged.');
+  }
+}
+
+export default {
+  setAuditSafeMode,
+  getAuditSafeMode,
+  saveWithAuditCheck,
+  interpretCommand,
+};

--- a/tests/test-arcanos-api.js
+++ b/tests/test-arcanos-api.js
@@ -184,6 +184,27 @@ async function testArcanosAPI() {
       console.log('✅ Malformed JSON rejected as expected');
     }
 
+    // Test audit-safe log-only mode
+    console.log(`\n${7 + endpoints.length}. Testing audit-safe log-only mode...`);
+    try {
+      const { setAuditSafeMode, getAuditSafeMode, saveWithAuditCheck } = await import('../dist/services/auditSafeToggle.js');
+
+      setAuditSafeMode('log-only');
+      if (getAuditSafeMode() !== 'log-only') {
+        throw new Error('Mode not set to log-only');
+      }
+
+      const result = saveWithAuditCheck('data', () => false);
+      if (result !== 'data') {
+        throw new Error('Data was modified in log-only mode');
+      }
+
+      console.log('✅ Audit-safe log-only mode: PASSED');
+    } catch (error) {
+      console.log('❌ Audit-safe log-only mode test failed:', error.message);
+      throw error;
+    }
+
     console.log('\n🎉 All API endpoint tests passed!');
     console.log('\n📋 Test Summary:');
     console.log('- Health endpoint (/health) works correctly');
@@ -209,7 +230,7 @@ async function testArcanosAPI() {
   } finally {
     // Clean up - kill the server process
     if (serverProcess) {
-      console.log('\n14. Cleaning up server process...');
+      console.log('\n15. Cleaning up server process...');
       serverProcess.kill('SIGTERM');
       await new Promise(resolve => setTimeout(resolve, 1000));
     }


### PR DESCRIPTION
## Summary
- introduce audit-safe toggle manager with new `log-only` mode that records events without validation warnings
- cover log-only behavior in API test suite

## Testing
- `npm test` *(fails: server did not start, test halted while waiting for health check)*

------
https://chatgpt.com/codex/tasks/task_e_68a538c11bd083258d678d571f833bde