### PR TITLE
Use knex migrate for database setup

### DIFF
--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,28 +1,34 @@
-import { readFile } from 'fs/promises';
 import knexPkg from 'knex';
 import 'pg';
 
 const knex = knexPkg.default || knexPkg;
 
-async function runMigrations() {
+async function migrate() {
   const connectionString = process.env.DATABASE_URL;
   if (!connectionString) {
     console.error('DATABASE_URL is not set');
     process.exit(1);
   }
 
-  const db = knex({ client: 'pg', connection: connectionString });
+  const db = knex({
+    client: 'pg',
+    connection: connectionString,
+    migrations: {
+      directory: './migrations',
+    },
+  });
+
   try {
-    const sqlPath = new URL('../migrations/init_db.sql', import.meta.url);
-    const sql = await readFile(sqlPath, 'utf-8');
-    await db.raw(sql);
-    console.log('✅ Database migrations applied');
+    await db.migrate.latest();
+    console.log('✅ Migrations completed successfully');
+    await db.destroy();
+    process.exit(0);
   } catch (err) {
     console.error('❌ Migration failed:', err?.message || err);
+    await db.destroy().catch(() => {});
     process.exit(1);
-  } finally {
-    await db.destroy();
   }
 }
 
-runMigrations();
+migrate();
+


### PR DESCRIPTION
## Summary
- run `knex.migrate.latest()` against `process.env.DATABASE_URL`
- exit with proper codes and tidy up connection

## Testing
- `npm test` *(fails: DATABASE_URL is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a5965c79f883259cc6ec2ac13ad4e0