### PR TITLE
feat: add sentinel passive audit module

### DIFF
--- a/sentinelPassiveAudit.js
+++ b/sentinelPassiveAudit.js
@@ -1,0 +1,63 @@
+// sentinelPassiveAudit.js
+// Purpose: Redesign Audit-Safe into passive logging + Sentinel fallback
+// OpenAI SDK-compatible
+
+import fs from "fs";
+
+// ----------------------
+// State
+// ----------------------
+let auditSafeMode = "passive"; // enforce passive-only
+let sentinelActive = true;
+
+// ----------------------
+// Main Execution Wrapper
+// ----------------------
+export async function executeCommand(commandName, payload, executor = "user") {
+  try {
+    if (executor === "user") {
+      console.log(`⚡ USER COMMAND: Executing '${commandName}' immediately.`);
+      await runCommand(commandName, payload);
+      await logAudit("USER_COMMAND_EXECUTED", { commandName, payload });
+      return { success: true, override: true };
+    }
+
+    // AI-origin commands (normal ops)
+    console.log(`🤖 AI COMMAND: Running '${commandName}'`);
+    await runCommand(commandName, payload);
+    await logAudit("AI_COMMAND_EXECUTED", { commandName, payload });
+    return { success: true, override: false };
+  } catch (err) {
+    if (sentinelActive) {
+      await handleSentinelFallback(commandName, payload, err);
+    }
+    throw err;
+  }
+}
+
+// ----------------------
+// Core Command Router
+// ----------------------
+async function runCommand(name, payload) {
+  // TODO: hook into actual backend modules (Backstage Booker, etc.)
+  console.log(`🚀 Running command: ${name}`, payload);
+  return true;
+}
+
+// ----------------------
+// Sentinel Fallback
+// ----------------------
+async function handleSentinelFallback(name, payload, error) {
+  console.error(`🛡️ SENTINEL CAUGHT ERROR in '${name}':`, error.message);
+  await logAudit("SENTINEL_ROLLBACK", { name, payload, error: error.message });
+  // rollback logic here if needed
+}
+
+// ----------------------
+// Passive Audit Logger
+// ----------------------
+async function logAudit(event, details) {
+  const logLine = JSON.stringify({ ts: Date.now(), event, details }) + "\n";
+  fs.appendFileSync("audit.log", logLine);
+  console.log(`[AUDIT] ${event}`, details);
+}


### PR DESCRIPTION
## Summary
- add `sentinelPassiveAudit.js` to provide passive audit logging with sentinel fallback for errors

## Testing
- `npm test` *(fails: Unable to acquire a connection)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a62284d69c8325b27c8e729365730a