### PR TITLE
Add simple PostgreSQL pool helper

### DIFF
--- a/database.js
+++ b/database.js
@@ -1,0 +1,19 @@
+const { Pool } = require("pg");
+
+// Always connect using DATABASE_URL (Railway connection string)
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL || "postgresql://postgres:BdaNYEBHVpyzlUOmBeBTiRvXwcbbpTYE@postgres-7rdb.railway.internal:5432/railway?sslmode=disable",
+  ssl: process.env.DATABASE_URL?.includes("sslmode=require")
+    ? { rejectUnauthorized: false }
+    : false,
+});
+
+// Test connection
+pool.connect()
+  .then(() => console.log("✅ Connected to PostgreSQL"))
+  .catch(err => {
+    console.error("❌ Database connection failed:", err.message);
+    process.exit(1);
+  });
+
+module.exports = pool;


### PR DESCRIPTION
## Summary
- add database.js with Pool setup using DATABASE_URL

## Testing
- `npx jest --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a62d66d2408325adb888ce78dddc35