### PR TITLE
feat: add script to ensure database schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "dist/server.js",
   "scripts": {
     "probe": "node scripts/probe.js",
+    "db:init": "node scripts/db-init.js",
     "start": "node dist/server.js",
     "dev": "tsc && node dist/server.js",
     "dev:watch": "tsc --watch",

--- a/scripts/db-init.js
+++ b/scripts/db-init.js
@@ -1,0 +1,58 @@
+import pkg from 'pg';
+const { Pool } = pkg;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+async function ensureSchema() {
+  console.log("🔍 Checking database schema...");
+
+  // List of required tables and their creation SQL
+  const requiredTables = {
+    saves: `
+      CREATE TABLE IF NOT EXISTS saves (
+        id SERIAL PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        content JSONB NOT NULL,
+        created_at TIMESTAMP DEFAULT NOW()
+      );
+    `
+    // add more tables here as needed
+  };
+
+  try {
+    for (const [table, createSQL] of Object.entries(requiredTables)) {
+      const res = await pool.query(
+        `SELECT to_regclass($1) AS exists;`,
+        [table]
+      );
+
+      if (!res.rows[0].exists) {
+        console.log(`⚠️  Table "${table}" is missing. Creating...`);
+        await pool.query(createSQL);
+        console.log(`✅ Table "${table}" created successfully.`);
+      } else {
+        console.log(`✔️  Table "${table}" already exists.`);
+      }
+    }
+
+    console.log("✅ Database schema verification complete.");
+  } catch (err) {
+    console.error("❌ Error ensuring schema:", err);
+    process.exit(1); // exit if DB is unreachable
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  ensureSchema()
+    .catch(err => {
+      console.error(err);
+    })
+    .finally(async () => {
+      await pool.end();
+      process.exit(0);
+    });
+}
+
+export default ensureSchema;


### PR DESCRIPTION
## Summary
- add database schema initialization script using pg
- expose `db:init` npm command for easy schema setup

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a637bd6a6c8325b361d9d038ef722c