### PR TITLE
feat: auto-create missing tables

### DIFF
--- a/scripts/db-init.js
+++ b/scripts/db-init.js
@@ -17,8 +17,15 @@ async function ensureSchema() {
         content JSONB NOT NULL,
         created_at TIMESTAMP DEFAULT NOW()
       );
+    `,
+    audit_logs: `
+      CREATE TABLE IF NOT EXISTS audit_logs (
+        id SERIAL PRIMARY KEY,
+        action TEXT NOT NULL,
+        details JSONB,
+        created_at TIMESTAMP DEFAULT NOW()
+      );
     `
-    // add more tables here as needed
   };
 
   try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,7 +22,7 @@ import statusRouter from './routes/status.js';
 import siriRouter from './routes/siri.js';
 import backstageRouter from './routes/backstage.js';
 import apiArcanosRouter from './routes/api-arcanos.js';
-import { verifySchema } from './persistenceManagerHierarchy.js';
+import { verifySchemaOrInit } from './persistenceManagerHierarchy.js';
 import { initializeDatabase } from './db.js';
 
 // Validate required environment variables at startup
@@ -40,7 +40,7 @@ try {
 }
 validateAPIKeyAtStartup(); // Always continue, but log warnings
 
-await verifySchema();
+await verifySchemaOrInit();
 
 console.log(`[🧠 ARCANOS AI] Default Model: ${getDefaultModel()}`);
 console.log(`[🔄 ARCANOS AI] Fallback Model: ${config.ai.fallbackModel}`);


### PR DESCRIPTION
## Summary
- auto-create missing tables during schema verification
- create `audit_logs` table in db-init script
- call new schema verification helper at startup

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a65ee2f7808325bba646d50efd2a66