### PR TITLE
feat: add Notion roster sync service

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An AI-controlled TypeScript backend featuring fine-tuned OpenAI model integratio
 - **AI-Managed Operations**: Fine-tuned GPT model controls all system operations
 - **Intelligent Memory**: PostgreSQL backend with in-memory fallback for persistence
 - **OpenAI SDK v5**: Modern integration with streaming, function calling, and assistants
+- **Notion Database Sync**: Fetch Universe Mode data via the official Notion SDK
 - **Worker System**: AI-controlled CRON scheduling for maintenance and background tasks
 - **TypeScript Architecture**: Modern, type-safe Express.js backend
 
@@ -41,6 +42,7 @@ curl -X POST http://localhost:8080/ask \
 ### Required Environment Variables
 ```bash
 OPENAI_API_KEY=your-openai-api-key-here
+NOTION_API_KEY=your-notion-api-key-here
 AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH  # Default fine-tuned model
 DATABASE_URL=postgresql://user:pass@localhost:5432/arcanos  # Optional - uses in-memory if not set
 ```

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@notionhq/client": "^2.3.0",
         "@types/pg": "^8.15.5",
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
@@ -29,6 +30,19 @@
       "engines": {
         "node": ">=18.0.0",
         "npm": ">=8.0.0"
+      }
+    },
+    "node_modules/@notionhq/client": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-2.3.0.tgz",
+      "integrity": "sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-fetch": "^2.5.10",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@types/body-parser": {
@@ -127,6 +141,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
     "node_modules/@types/pg": {
       "version": "8.15.5",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz",
@@ -192,6 +216,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -271,6 +301,18 @@
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
@@ -336,6 +378,15 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -423,6 +474,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -525,6 +591,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -621,6 +703,21 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -884,6 +981,26 @@
       "license": "ISC",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/object-assign": {
@@ -1405,6 +1522,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -1463,6 +1586,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "author": "Justin",
   "license": "MIT",
   "dependencies": {
+    "@notionhq/client": "^2.3.0",
     "@types/pg": "^8.15.5",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",

--- a/src/services/notionSync.ts
+++ b/src/services/notionSync.ts
@@ -1,0 +1,53 @@
+import { Client as NotionClient } from '@notionhq/client';
+import { getOpenAIClient, getGPT5Model } from './openai.js';
+
+// Initialize Notion client using API key
+const notion = new NotionClient({ auth: process.env.NOTION_API_KEY });
+
+export interface UniverseRoster {
+  count: number;
+  roster: string[];
+}
+
+/**
+ * Query a Notion database and return formatted roster names
+ * @param databaseId - Notion database ID
+ */
+export async function getUniverseRoster(databaseId: string): Promise<UniverseRoster> {
+  if (!process.env.NOTION_API_KEY) {
+    throw new Error('NOTION_API_KEY is not configured');
+  }
+
+  try {
+    const response = await notion.databases.query({ database_id: databaseId });
+
+    const roster = response.results.map((page: any) => {
+      const nameProp = page.properties?.Name?.title;
+      return nameProp?.length > 0 ? nameProp[0].plain_text : 'Unnamed Entry';
+    });
+
+    return { count: roster.length, roster };
+  } catch (error: any) {
+    console.error('[NotionSync] Error fetching Universe Roster:', error.message);
+    throw error;
+  }
+}
+
+/**
+ * Use GPT-5 to analyze roster data
+ */
+export async function analyzeRoster(roster: string[]): Promise<string> {
+  const client = getOpenAIClient();
+  if (!client) {
+    throw new Error('OpenAI client not initialized');
+  }
+
+  const prompt = `You are ARCANOS Universe Mode AI.\nGiven this roster: ${JSON.stringify(roster)},\nsummarize the roster count and highlight notable entries.`;
+
+  const completion = await client.chat.completions.create({
+    model: getGPT5Model(),
+    messages: [{ role: 'user', content: prompt }]
+  });
+
+  return completion.choices[0]?.message?.content ?? '';
+}


### PR DESCRIPTION
## Summary
- integrate official Notion SDK and service for roster queries
- support GPT-5 analysis of roster data via existing OpenAI client
- document Notion integration and environment variables

## Testing
- `npm run type-check`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6bd62ce488325b86fb6c56950cad1