### PR TITLE
feat: add image base64 export utility

### DIFF
--- a/src/utils/exportImageAsBase64.ts
+++ b/src/utils/exportImageAsBase64.ts
@@ -1,0 +1,36 @@
+import { Buffer } from 'node:buffer';
+
+/**
+ * Safely export binary image data as a Base64 string that is
+ * compatible with the OpenAI SDK. The encoded string is padded,
+ * chunked to avoid truncation in long responses, and terminated
+ * with an explicit end-of-image marker.
+ *
+ * @param imageBytes - Raw image bytes
+ * @param chunkSize - Size of each chunk in the output (default: 4096)
+ * @returns Newline-separated Base64 chunks ending with `===EOI===`
+ */
+export function exportImageAsBase64(imageBytes: Buffer | Uint8Array, chunkSize = 4096): string {
+  // Ensure we are working with a Buffer
+  const buffer = Buffer.isBuffer(imageBytes) ? imageBytes : Buffer.from(imageBytes);
+
+  let encoded = buffer.toString('base64');
+
+  // Ensure proper padding (OpenAI requires correctly padded Base64)
+  const remainder = encoded.length % 4;
+  if (remainder) {
+    encoded += '='.repeat(4 - remainder);
+  }
+
+  const chunks: string[] = [];
+  for (let i = 0; i < encoded.length; i += chunkSize) {
+    chunks.push(encoded.slice(i, i + chunkSize));
+  }
+
+  // Append explicit end-of-image marker
+  chunks.push('===EOI===');
+
+  return chunks.join('\n');
+}
+
+export default exportImageAsBase64;

--- a/tests/test-export-image-base64.js
+++ b/tests/test-export-image-base64.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { exportImageAsBase64 } from '../dist/utils/exportImageAsBase64.js';
+
+// Basic runtime test for exportImageAsBase64 utility
+(async () => {
+  const sample = Buffer.from('OpenAI');
+  const result = exportImageAsBase64(sample, 8);
+  console.log('Encoded output:\n', result);
+
+  const lines = result.trim().split('\n');
+  const marker = lines.pop();
+  const base64Data = lines.join('');
+
+  console.log('Marker line:', marker);
+  console.log('Padding valid:', base64Data.length % 4 === 0);
+
+  if (marker === '===EOI===' && base64Data.length % 4 === 0) {
+    console.log('\n✅ exportImageAsBase64 passed basic checks');
+  } else {
+    console.error('\n❌ exportImageAsBase64 failed basic checks');
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add `exportImageAsBase64` utility for safe base64 encoding with chunking and explicit end-of-image marker
- provide runtime test verifying padding and marker detection

## Testing
- `npm run build`
- `node tests/test-export-image-base64.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7d93737bc83258ad4bcdb1515aed6