### PR TITLE
Add script to generate ARCANOS logo via OpenAI

### DIFF
--- a/scripts/generate_arcanos_logo.py
+++ b/scripts/generate_arcanos_logo.py
@@ -1,0 +1,34 @@
+import base64
+from pathlib import Path
+
+from openai import OpenAI
+
+
+client = OpenAI()
+
+
+def generate_arcanos_logo(output_path: str = "output/arcanos_logo.png") -> str:
+    """
+    Uses OpenAI SDK to request ARCANOS logo and save it as a PNG file.
+    Returns the path to the saved file.
+    """
+    response = client.images.generate(
+        model="gpt-image-1",
+        prompt="Arasaka-inspired ARCANOS logo, cyberpunk corporate style, minimalist emblem.",
+        size="1024x1024",
+    )
+
+    image_b64 = response.data[0].b64_json
+    image_bytes = base64.b64decode(image_b64)
+
+    output_file = Path(output_path)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_file, "wb") as f:
+        f.write(image_bytes)
+
+    return str(output_file)
+
+
+if __name__ == "__main__":
+    logo_path = generate_arcanos_logo()
+    print(f"ARCANOS logo saved at: {logo_path}")


### PR DESCRIPTION
## Summary
- add Python utility to generate ARCANOS logo using OpenAI Images API

## Testing
- `python -m py_compile scripts/generate_arcanos_logo.py`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7dfcf1cf08325a729ef5881e02bab