### PR TITLE
Add interceptor routing hotfix for Base64PNG

### DIFF
--- a/interceptor_patch.py
+++ b/interceptor_patch.py
@@ -1,0 +1,58 @@
+# File: interceptor_patch.py
+# Purpose: Hotfix for ARCANOS audit interceptor routing
+# Ensures Base64PNG payloads always reach frontend and bypass audit
+
+from openai import OpenAI
+
+client = OpenAI()
+
+
+def interceptor_routing(payload: dict) -> dict:
+    """
+    Routes Base64PNG media payloads directly to frontend
+    while keeping logic/security payloads under audit.
+    """
+    payload_type = payload.get("type", "")
+
+    if payload_type == "Base64PNG":
+        payload["destination"] = "frontend"
+        payload["audit"] = {
+            "skip": True,
+            "reason": "Media fast path applied"
+        }
+    else:
+        # Default: keep audit enabled for logic/security payloads
+        payload["audit"] = {
+            "skip": False,
+            "reason": "Logic/security audit required"
+        }
+
+    return payload
+
+
+def generate_arcanos_logo():
+    """
+    Generates ARCANOS logo, applies interceptor routing,
+    and returns processed payload.
+    """
+    response = client.images.generate(
+        model="gpt-image-1",
+        prompt="Arasaka-inspired ARCANOS logo, cyberpunk corporate style, minimalist emblem.",
+        size="1024x1024"
+    )
+
+    # Extract Base64 PNG payload
+    b64_payload = response.data[0].b64_json
+    payload = {
+        "type": "Base64PNG",
+        "data": b64_payload
+    }
+
+    # Apply interceptor routing hotfix
+    routed_payload = interceptor_routing(payload)
+    return routed_payload
+
+
+if __name__ == "__main__":
+    result = generate_arcanos_logo()
+    print("✅ Routed Payload:", result)


### PR DESCRIPTION
## Summary
- add interceptor routing hotfix to bypass audit for Base64PNG media

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e741d1108325ac1694e6226cbc20