### PR TITLE
Add passive audit agent

### DIFF
--- a/src/services/auditAgent.ts
+++ b/src/services/auditAgent.ts
@@ -1,0 +1,59 @@
+/**
+ * ARCANOS Backend Audit Agent
+ * Enforces strict passive audit behavior:
+ * - Returns only exists:true/false
+ * - Never accesses tokens
+ * - Only triggers resilience scaffolding if explicitly requested
+ */
+
+export interface AuditOptions {
+  use_fallback?: boolean;
+}
+
+export interface AuditResponse {
+  exists: boolean;
+  fallback_used: boolean;
+  interference: boolean;
+  scaffold?: { module: string; placeholder: boolean };
+}
+
+const auditAgent = {
+  async audit(moduleName: string, options: AuditOptions = {}): Promise<AuditResponse> {
+    const { use_fallback = false } = options;
+
+    // Replace with real module lookup logic
+    const moduleExists = checkRegistry(moduleName);
+
+    // If fallback explicitly requested
+    if (use_fallback && !moduleExists) {
+      return auditAgent.resilience.patch(moduleName);
+    }
+
+    // Default strict audit response
+    return {
+      exists: moduleExists,
+      fallback_used: false,
+      interference: false
+    };
+  },
+
+  resilience: {
+    async patch(moduleName: string): Promise<AuditResponse> {
+      // Optional: generate scaffold only when requested
+      return {
+        exists: false,
+        fallback_used: true,
+        interference: false,
+        scaffold: { module: moduleName, placeholder: true }
+      };
+    }
+  }
+};
+
+// Replace with your real registry check
+function checkRegistry(name: string): boolean {
+  // TODO: Wire this into your backend’s module registry
+  return false;
+}
+
+export default auditAgent;


### PR DESCRIPTION
## Summary
- add backend audit agent enforcing passive-only checks and optional resilience patch

## Testing
- `npm run type-check`
- `npm run build`
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a816bec1c88325b66f3ac8820c0304