### PR TITLE
Add audit memory helper

### DIFF
--- a/src/services/auditMemory.ts
+++ b/src/services/auditMemory.ts
@@ -1,0 +1,35 @@
+///////////////////////////////////////////////////////////
+// OPENAI SDK COMPATIBLE PATCH
+// ARCANOS AGENT: HOLLOW CORE v2
+///////////////////////////////////////////////////////////
+
+import OpenAI from 'openai';
+
+const client: any = new OpenAI();
+
+export async function auditMemory(state: any): Promise<boolean> {
+  const response = await client.execute?.({
+    routing: {
+      mode: 'peer-direct',
+      gatewayBypass: true,
+    },
+    fallback: {
+      global: false,
+      moduleIsolation: true,
+      scope: ['audit', 'recovery'],
+    },
+    registry: {
+      directBind: true,
+      sync: 'live',
+      versionLock: '1.1.0',
+    },
+    audit: {
+      traceLevel: 'minimal',
+      resilience: 'module-only',
+    },
+  });
+
+  return Boolean(response?.ok);
+}
+
+export default auditMemory;


### PR DESCRIPTION
## Summary
- add auditMemory helper for peer-direct memory routing

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a82a0c074c8325bbc0e083cd892c0b