### PR TITLE
feat: add audit override module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/
 src/**/*.js
 src/**/*.js.map
 !src/persistenceManagerHierarchy.js
+!src/commands/arcanos/audit_override.js
 
 # Environment variables
 .env.local

--- a/src/commands/arcanos/audit_override.js
+++ b/src/commands/arcanos/audit_override.js
@@ -1,0 +1,9 @@
+module.exports = (state) => {
+  if (process.env.AUDIT_OVERRIDE) {
+    return process.env.AUDIT_OVERRIDE;  // Uses host-verified specs
+  }
+  return {
+    audit: "Fallback audit value when override is inactive",
+    timestamp: new Date().toISOString()
+  };
+};


### PR DESCRIPTION
## Summary
- add audit override module to expose host-verified specs when AUDIT_OVERRIDE is set
- allow audit override module to be committed by updating gitignore

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a84223e78483258f71c2b909a501c5