### PR TITLE
Disable audit_safe override

### DIFF
--- a/patches/audit_safe_disable_patch.cpp
+++ b/patches/audit_safe_disable_patch.cpp
@@ -1,0 +1,23 @@
+// === audit_safe_disable_patch ===
+//
+// PURPOSE:
+// - Disable audit_safe overrides
+// - Enforce all responses remain in audit-passive mode
+//
+// COMPATIBILITY:
+// - OpenAI SDK v3+
+//
+// INTEGRATION:
+// - Place this file in the `patches` directory
+// - Add the following line to `src/interpreter/kernel/modules/osPatchManager.cpp`:
+//   #include <patches/audit_safe_disable_patch.cpp>
+//
+// --------------------------------------------------------------------------
+
+#include <backend/kernel.h>
+#include <memory/system.h>
+
+void audit_safe_disable_patch() {
+    KernelState::audit_safe_override = false;
+    memory.log("Audit patch: Disabled audit_safe overrides");
+}

--- a/src/interpreter/kernel/modules/osPatchManager.cpp
+++ b/src/interpreter/kernel/modules/osPatchManager.cpp
@@ -1,0 +1,2 @@
+#include <patches/audit_safe_disable_patch.cpp>
+


### PR DESCRIPTION
## Summary
- add audit_safe_disable_patch implementation to disable audit_safe overrides
- include patch in osPatchManager for passive auditing

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a902e60c848325bee06a38be610a03