### PR TITLE
Add audit passive patch

### DIFF
--- a/src/interpreter/kernel/modules/osPatchManager.cpp
+++ b/src/interpreter/kernel/modules/osPatchManager.cpp
@@ -1,2 +1,3 @@
 #include <patches/audit_safe_disable_patch.cpp>
+#include <patches/audit_passive_patch.cpp>
 

--- a/src/patches/audit_passive_patch.cpp
+++ b/src/patches/audit_passive_patch.cpp
@@ -1,0 +1,37 @@
+// === audit_passive_patch ===
+//
+// PURPOSE:
+// - Force all audit layers (kernel, memory, fallback) into passive-only mode
+// - Ensure audit logs without interference
+// - Delegate safety/validation to HRC:STRICT
+//
+// COMPATIBILITY:
+// - OpenAI SDK v3+
+//
+// INTEGRATION:
+// 1. Save this file as `audit_passive_patch.cpp` in `src/patches/`
+// 2. In `src/interpreter/kernel/modules/osPatchManager.cpp` add:
+//    #include <patches/audit_passive_patch.cpp>
+// 3. Rebuild and redeploy service
+//
+// --------------------------------------------------------------------------
+
+#include <backend/kernel.h>
+#include <memory/system.h>
+#include <audit/interface.h>
+
+void audit_passive_patch() {
+    // Disable audit overrides at all levels
+    KernelState::audit_safe_override = false;
+    MemorySystem::audit_mode = "PASSIVE_ONLY";
+    AuditInterface::fallback_enabled = false;
+
+    // Force logging only, no interference
+    AuditInterface::mode = AuditInterface::LOG_ONLY;
+
+    // Delegate all safety handling to HRC:STRICT
+    KernelState::safety_handler = "HRC_STRICT";
+
+    memory.log("Audit patch applied: Passive-only enforced across kernel, memory, and fallback.");
+}
+


### PR DESCRIPTION
## Summary
- add audit_passive_patch to enforce passive-only audit mode with logging only
- include new audit_passive_patch in osPatchManager

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9123e895483258813be346d4876c6