### PR TITLE
Add Arcanos Gaming module manifest and schema

### DIFF
--- a/gpt_shell_arcanos.json
+++ b/gpt_shell_arcanos.json
@@ -1,0 +1,17 @@
+{
+  "name": "Arcanos Gaming",
+  "description": "Custom GPT shell designed to provide verified tutorials, strategies, and guides for video games.",
+  "version": "1.0.3",
+  "memory_context": "Arcanos",
+  "timestamps": {
+    "created": "2025-12-18",
+    "registered": "TBD"
+  },
+  "tags": [
+    "gaming",
+    "guides",
+    "tutorials",
+    "strategies",
+    "meta-analysis"
+  ]
+}

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,3 @@
+modules:
+  - backstage_booker
+  - arcanos_gaming

--- a/migrations/gaming.sql
+++ b/migrations/gaming.sql
@@ -1,0 +1,36 @@
+-- Main Guides Table
+CREATE TABLE IF NOT EXISTS gaming_guides (
+    id SERIAL PRIMARY KEY,
+    game_name TEXT NOT NULL,
+    title TEXT NOT NULL,
+    type TEXT CHECK (type IN ('tutorial','strategy','walkthrough','build','meta')),
+    content TEXT NOT NULL,
+    source TEXT NOT NULL,
+    patch_version TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Builds Table
+CREATE TABLE IF NOT EXISTS gaming_builds (
+    id SERIAL PRIMARY KEY,
+    game_name TEXT NOT NULL,
+    role_class TEXT NOT NULL,
+    build_description TEXT NOT NULL,
+    effectiveness_rating INT CHECK (effectiveness_rating BETWEEN 1 AND 100),
+    patch_version TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Meta Tracking Table
+CREATE TABLE IF NOT EXISTS gaming_meta (
+    id SERIAL PRIMARY KEY,
+    game_name TEXT NOT NULL,
+    tier_list JSONB,
+    patch_notes TEXT,
+    balance_changes TEXT,
+    patch_version TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);

--- a/scripts/fetch_gaming_guide.py
+++ b/scripts/fetch_gaming_guide.py
@@ -1,0 +1,30 @@
+from openai import OpenAI
+import os
+
+# Initialize client
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+def fetch_gaming_guide(game_name, topic):
+    """
+    Fetches a guide/tutorial/strategy from Arcanos Gaming backend.
+    Falls back gracefully if no data is found.
+    """
+
+    query_prompt = f"Retrieve guide for {game_name}, topic: {topic}."
+
+    response = client.chat.completions.create(
+        model="gpt-4.1",  # or your configured Arcanos Gaming model
+        messages=[
+            {"role": "system", "content": "You are Arcanos Gaming, a hallucination-safe gaming guide engine."},
+            {"role": "user", "content": query_prompt}
+        ]
+    )
+
+    content = response.choices[0].message.content.strip()
+
+    if "Not Found" in content:
+        return f"No verified guide available for {game_name} - {topic}."
+    return content
+
+if __name__ == "__main__":
+    print(fetch_gaming_guide("Elden Ring", "Best Sorcery Build Patch 1.X"))


### PR DESCRIPTION
## Summary
- add Arcanos Gaming module to manifest alongside backstage_booker
- include Arcanos Gaming shell manifest
- provide gaming database schema and Python guide fetch script

## Testing
- `npx jest tests/test-database-connection.js` *(fails: No tests found)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a95dde49d08325bcc7f52286eb8712