### PR TITLE
use fine-tuned model

### DIFF
--- a/scripts/migration-repair.js
+++ b/scripts/migration-repair.js
@@ -60,7 +60,7 @@ async function main() {
     }
 
     const response = await openai.chat.completions.create({
-      model: 'gpt-4o-mini',
+      model: 'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH',
       temperature: 0,
       messages: [
         {

--- a/src/services/auditSafeToggle.ts
+++ b/src/services/auditSafeToggle.ts
@@ -81,7 +81,7 @@ export async function interpretCommand(userCommand: string) {
 
   try {
     const response = await client.chat.completions.create({
-      model: 'gpt-4o-mini',
+      model: 'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH',
       messages: [
         { role: 'system', content: 'You are an AI that maps natural language commands to audit-safe mode toggles.' },
         { role: 'user', content: userCommand }

--- a/src/utils/dualModeAudit.ts
+++ b/src/utils/dualModeAudit.ts
@@ -101,7 +101,7 @@ export async function dualModeAudit(
     }
 
     const response = await openai.chat.completions.create({
-      model: 'gpt-4o-mini', // Fixed invalid model name
+      model: 'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH',
       messages: [
         {
           role: 'system',


### PR DESCRIPTION
## Summary
- switch internal OpenAI calls from `gpt-4o-mini` to `ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fd331afc8325b8042f33208fb2ae