### PR TITLE
feat: add generic dependency validator

### DIFF
--- a/scripts/dependencyValidator.ts
+++ b/scripts/dependencyValidator.ts
@@ -1,0 +1,106 @@
+import OpenAI from 'openai';
+import { Pool } from 'pg';
+import { fileURLToPath } from 'url';
+
+/**
+ * Universal Dependency Marker Schema (Checkpoint χ1.3)
+ * Generic for any game build validation.
+ */
+export const universalSchema = {
+  checkpoint: 'χ1.3',
+  rules: {
+    allow_missing_dependencies: false,
+    validate_schema: true,
+    sandbox_first: true,
+  },
+  audit_tags: ['safe_import', 'sandbox_verified', 'arc_gaming_ready'],
+};
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+export interface DependencyMarker {
+  type: string;
+  value: string;
+}
+
+export interface BuildData {
+  game: string;
+  version: string;
+  core_modfile: string;
+  mods: string[];
+}
+
+/**
+ * Insert or update a game's dependency schema.
+ */
+export async function registerSchema(
+  gameTitle: string,
+  version: string,
+  coreModfile: string,
+  markers: DependencyMarker[] = [],
+): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query(
+      `INSERT INTO dependency_schemas
+       (game_title, version, core_modfile, dependency_markers, audit_tags)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (game_title, version) DO UPDATE
+         SET core_modfile = EXCLUDED.core_modfile,
+             dependency_markers = EXCLUDED.dependency_markers,
+             audit_tags = EXCLUDED.audit_tags`,
+      [
+        gameTitle,
+        version,
+        coreModfile,
+        JSON.stringify(markers),
+        JSON.stringify(universalSchema.audit_tags),
+      ],
+    );
+    console.log(`✅ Registered schema for ${gameTitle}`);
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Validate a game build with Arcanos AI.
+ */
+export async function validateBuild(buildData: BuildData): Promise<string> {
+  const response = await openai.chat.completions.create({
+    model: 'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH',
+    messages: [
+      {
+        role: 'system',
+        content: `You are ARCANOS Gaming Validator. Apply checkpoint ${universalSchema.checkpoint} schema for dependency validation.`,
+      },
+      { role: 'user', content: JSON.stringify(buildData) },
+    ],
+  });
+
+  const decision = response.choices[0].message?.content ?? '';
+  console.log('🧠 Validation Result:', decision);
+  return decision;
+}
+
+// Demonstration script that registers a schema and validates a build
+async function main(): Promise<void> {
+  await registerSchema('Generic Game', '1.0.0', 'Base.esm', [
+    { type: 'engine', value: 'Engine v1' },
+  ]);
+
+  await validateBuild({
+    game: 'Generic Game',
+    version: '1.0.0',
+    core_modfile: 'Base.esm',
+    mods: ['ExampleMod'],
+  });
+}
+
+// Run demo when executed directly
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error('❌ Demo failed:', err);
+  });
+}


### PR DESCRIPTION
## Summary
- add reusable dependency validator script for registering schemas and validating builds for any game

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aaca332f2c8325b92b923cd4c75df2