### PR TITLE
feat: add tagged guide generator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ npm run build        # Build TypeScript to dist/
 npm start           # Run production server
 npm run type-check  # TypeScript type checking
 npm test            # Run test suite
+npm run guide:generate -- <entry_key>  # Generate a tagged build guide
 ```
 
 ### Project Structure

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "git:workflow": "npm run build && node run-workflow.js",
     "type-check": "tsc --noEmit",
     "assistants-sync": "npx ts-node scripts/assistants-sync.ts",
-    "repair-migrations": "node scripts/migration-repair.js"
+    "repair-migrations": "node scripts/migration-repair.js",
+    "guide:generate": "node scripts/generate-tagged-guide.js"
   },
   "keywords": [
     "ai",

--- a/scripts/generate-tagged-guide.js
+++ b/scripts/generate-tagged-guide.js
@@ -1,0 +1,85 @@
+import OpenAI from 'openai';
+import pkg from 'pg';
+import dotenv from 'dotenv';
+
+const { Pool } = pkg;
+
+// Load environment variables from .env if available
+dotenv.config();
+
+// Initialize OpenAI client (will throw if key missing when called)
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+// Initialize PG pool if DATABASE_URL provided
+const pool = process.env.DATABASE_URL
+  ? new Pool({ connectionString: process.env.DATABASE_URL })
+  : null;
+
+/**
+ * Fetches an entry from the memory_states table by key.
+ * @param {string} entryKey
+ * @returns {Promise<any|null>} entry_data or null if not found
+ */
+export async function fetchDBEntry(entryKey) {
+  if (!pool) {
+    console.warn('[WARN] DATABASE_URL not set; skipping DB lookup');
+    return null;
+  }
+
+  const result = await pool.query(
+    'SELECT entry_data FROM memory_states WHERE entry_key = $1',
+    [entryKey]
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  return result.rows[0].entry_data;
+}
+
+/**
+ * Generates a player-friendly build guide tagged with [DB] and [AI].
+ * @param {string} entryKey
+ * @returns {Promise<string>} guide text
+ */
+export async function generateTaggedGuide(entryKey) {
+  const dbEntry = await fetchDBEntry(entryKey);
+
+  const response = await openai.chat.completions.create({
+    model: process.env.AI_MODEL || 'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH',
+    messages: [
+      {
+        role: 'system',
+        content:
+          'You are ARCANOS Gaming Guide Generator. Validate against DB first. Tag all outputs with [DB] (from database) or [AI] (inferred reasoning).',
+      },
+      {
+        role: 'user',
+        content: `DB Entry: ${JSON.stringify(dbEntry)}\n\nGenerate a player-friendly build guide.`,
+      },
+    ],
+  });
+
+  return response.choices[0].message.content;
+}
+
+// Allow running from CLI: `node scripts/generate-tagged-guide.js <entry_key>`
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const entryKey = process.argv[2];
+  if (!entryKey) {
+    console.error('Usage: node scripts/generate-tagged-guide.js <entry_key>');
+    process.exit(1);
+  }
+
+  generateTaggedGuide(entryKey)
+    .then((guide) => {
+      console.log('🧠 Tagged Guide:\n', guide);
+    })
+    .catch((err) => {
+      console.error('Error generating guide:', err.message);
+    })
+    .finally(() => {
+      if (pool) pool.end();
+    });
+}


### PR DESCRIPTION
## Summary
- add generate-tagged-guide script to build player guides from DB entries and OpenAI
- expose script via `npm run guide:generate`
- document guide generation in README
- require explicit entry key when running the generator CLI

## Testing
- `node scripts/generate-tagged-guide.js` *(prints usage)*
- `node scripts/generate-tagged-guide.js sample_key` *(fails: Connection error)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab71c93fb08325b6ceec1bb83b542f