### PR TITLE
feat: add query domain guard and OpenAI dispatcher

### DIFF
--- a/src/services/arcanosQueryGuard.ts
+++ b/src/services/arcanosQueryGuard.ts
@@ -1,0 +1,70 @@
+// arcanosQueryGuard.ts
+// Unified domain guard + OpenAI SDK dispatcher with TypeScript support
+
+import OpenAI from "openai";
+
+// ✅ Initialize OpenAI client (uses ARCANOS fine-tuned model)
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+// ----------------------
+// Domain / Category Types
+// ----------------------
+export type Domain = "gaming" | "guides" | "knowledge" | "builds" | "memory patterns" | "audit logs";
+
+export interface QueryInput {
+  prompt: string;
+  domain?: Domain;
+  explicitSystemAccess?: boolean;
+}
+
+export interface GuardedQuery extends QueryInput {
+  domain: Domain;
+}
+
+export const DOMAIN_CATEGORIES = {
+  user: ["gaming", "guides", "knowledge"] as Domain[],
+  system: ["builds", "memory patterns", "audit logs"] as Domain[],
+};
+
+// ----------------------
+// Guard Logic
+// ----------------------
+function detectDomain(query: QueryInput): "user" | "system" {
+  if (!query.domain) return "user";
+  return DOMAIN_CATEGORIES.system.includes(query.domain) ? "system" : "user";
+}
+
+export function guardQuery(query: QueryInput): GuardedQuery {
+  const domainType = detectDomain(query);
+
+  if (domainType === "system" && !query.explicitSystemAccess) {
+    throw new Error(
+      `⚠️ Access to system domain '${query.domain}' denied. Explicit user intent required.`
+    );
+  }
+
+  return {
+    ...query,
+    domain: query.domain || "knowledge", // Default to knowledge
+  };
+}
+
+// ----------------------
+// OpenAI Dispatch Wrapper
+// ----------------------
+export async function dispatchQuery(rawQuery: QueryInput): Promise<string> {
+  const safeQuery = guardQuery(rawQuery);
+
+  const response = await openai.chat.completions.create({
+    model: "ft:gpt-4.1-2025-04-14:personal:arcanos:C8Msdote", // ✅ Your fine-tuned ARCANOS model
+    messages: [
+      { role: "system", content: `Domain: ${safeQuery.domain}` },
+      { role: "user", content: safeQuery.prompt },
+    ],
+    temperature: 0.2,
+  });
+
+  return response.choices[0].message?.content || "";
+}


### PR DESCRIPTION
## Summary
- add guardQuery to restrict system domain access
- support dispatchQuery with fine-tuned model for domain-specific prompts

## Testing
- `npm test` *(fails: jest not found)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ad40fded008325ba07cf2ad0c6be77