### PR TITLE
chore: switch query-finetune to v2 model

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,12 +1,16 @@
 import express from "express";
 import OpenAI from "openai";
 import dotenv from "dotenv";
+import queryFinetuneRouter from "./routes/query-finetune.js";
 
 // Load API key from .env
 dotenv.config();
 
 const app = express();
 app.use(express.json());
+
+// Register query-finetune router
+app.use("/query-finetune", queryFinetuneRouter);
 
 // Initialize OpenAI client
 const openai = new OpenAI({

--- a/backend/routes/query-finetune.js
+++ b/backend/routes/query-finetune.js
@@ -1,0 +1,36 @@
+import express from "express";
+import OpenAI from "openai";
+
+const router = express.Router();
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+// 🔄 Swap v1 → v2 here
+// Old: "ft:gpt-3.5-turbo-0125:personal:arcanos-v1-1106"
+// New:
+const FINETUNE_MODEL = "ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH";
+
+router.post("/", async (req, res) => {
+  try {
+    const { prompt } = req.body;
+
+    const completion = await openai.chat.completions.create({
+      model: FINETUNE_MODEL,
+      messages: [
+        { role: "system", content: "ARCANOS sub-agent (grunt work layer)" },
+        { role: "user", content: prompt },
+      ],
+    });
+
+    res.json({
+      model: FINETUNE_MODEL,
+      response: completion.choices[0].message,
+    });
+  } catch (error) {
+    console.error("Finetune sub-agent failed:", error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+export default router;

--- a/docs/ARCANOS_ROUTING_ARCHITECTURE.md
+++ b/docs/ARCANOS_ROUTING_ARCHITECTURE.md
@@ -2,12 +2,12 @@
 
 ## Overview
 
-The ARCANOS system now implements a sophisticated routing architecture that ensures ALL tasks are processed through the fine-tuned ARCANOS model (`ft:gpt-3.5-turbo-0125:arcanos-v1-1106`) while conditionally leveraging GPT-5 for complex reasoning.
+The ARCANOS system now implements a sophisticated routing architecture that ensures ALL tasks are processed through the fine-tuned ARCANOS model (`ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH`) while conditionally leveraging GPT-5 for complex reasoning.
 
 ## Key Implementation Features
 
 ### 🎯 Primary Model
-- **Model**: `ft:gpt-3.5-turbo-0125:arcanos-v1-1106`
+- **Model**: `ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH`
 - **Role**: Primary routing shell for ALL requests
 - **Fallback**: `gpt-4` (if fine-tuned model unavailable)
 
@@ -53,10 +53,10 @@ The fine-tuned model analyzes each request and decides:
 The system provides comprehensive logging of routing stages:
 
 ```
-🔀 [ARCANOS ROUTING] STARTING | Model: ft:gpt-3.5-turbo-0125:arcanos-v1-1106
+🔀 [ARCANOS ROUTING] STARTING | Model: ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH
 🚀 [GPT-5 INVOCATION] Reason: Complex analysis required
 🔀 [ARCANOS ROUTING] FINAL_FILTERING | Processing GPT-5 output through ARCANOS
-📊 [ROUTING SUMMARY] ARCANOS: ft:gpt-3.5-turbo-0125:arcanos-v1-1106 | GPT-5 Used: true
+📊 [ROUTING SUMMARY] ARCANOS: ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH | GPT-5 Used: true
 ```
 
 ### 🛡️ Security Guarantees
@@ -73,11 +73,11 @@ Enhanced response format includes routing information:
 ```json
 {
   "result": "Final ARCANOS response",
-  "module": "ft:gpt-3.5-turbo-0125:arcanos-v1-1106",
-  "activeModel": "ft:gpt-3.5-turbo-0125:arcanos-v1-1106",
+  "module": "ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH",
+  "activeModel": "ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH",
   "fallbackFlag": false,
   "routingStages": [
-    "ARCANOS-START:ft:gpt-3.5-turbo-0125:arcanos-v1-1106",
+    "ARCANOS-START:ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH",
     "GPT5-INVOCATION:complex-analysis",
     "GPT5-COMPLETED",
     "ARCANOS-FINAL"
@@ -95,12 +95,12 @@ Enhanced response format includes routing information:
 
 ### Environment Variables
 ```bash
-AI_MODEL=ft:gpt-3.5-turbo-0125:arcanos-v1-1106
+AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH
 OPENAI_API_KEY=your-api-key-here
 ```
 
 ### Model Priority
-1. `ft:gpt-3.5-turbo-0125:arcanos-v1-1106` (Primary ARCANOS model)
+1. `ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH` (Primary ARCANOS model)
 2. `gpt-4` (Fallback if fine-tuned model unavailable)
 3. Mock responses (Development mode without API key)
 

--- a/docs/ai-guides/QUERY_FINETUNE_GUIDE.md
+++ b/docs/ai-guides/QUERY_FINETUNE_GUIDE.md
@@ -1,7 +1,7 @@
 # ARCANOS Fine-Tune Routing & Mirror Mode
 
 ## Overview
-This implementation provides direct routing to the ARCANOS fine-tuned model (`arcanos-v1-1106`) with "Mirror Mode" behavior that returns raw, unformatted model responses.
+This implementation provides direct routing to the ARCANOS fine-tuned model (`ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH`) with "Mirror Mode" behavior that returns raw, unformatted model responses.
 
 ## Features
 
@@ -20,7 +20,7 @@ This implementation provides direct routing to the ARCANOS fine-tuned model (`ar
 ```json
 {
   "response": "Raw model response...",
-  "model": "arcanos-v1-1106",
+  "model": "ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH",
   "success": true,
   "timestamp": "2025-07-21T06:50:04.715Z",
   "metadata": {}
@@ -99,7 +99,7 @@ Perfect for:
 - **Error handling:** Returns 400 for empty queries after prefix
 
 ### Model Configuration
-- **Model ID:** `arcanos-v1-1106`
+- **Model ID:** `ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH`
 - **Service:** OpenAI Fine-Tune API
 - **Fallback:** Graceful error handling when service unavailable
 
@@ -130,7 +130,7 @@ This validates:
 Required environment variables:
 ```
 OPENAI_API_KEY=your-openai-api-key
-FINE_TUNED_MODEL=arcanos-v1-1106
+FINE_TUNED_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH
 ```
 
 ## Error Handling

--- a/docs/token-parameter-audit-report.yaml
+++ b/docs/token-parameter-audit-report.yaml
@@ -24,8 +24,6 @@ models_tested:
     parameter_used: max_tokens
   - name: "gpt-5"
     parameter_used: max_tokens
-  - name: "ft:gpt-3.5-turbo-0125:arcanos-v1-1106"
-    parameter_used: max_tokens
   - name: "ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH"
     parameter_used: max_tokens
   - name: "gpt-4o"

--- a/tests/test-query-finetune.js
+++ b/tests/test-query-finetune.js
@@ -120,7 +120,7 @@ const runTests = async () => {
       query: 'Test model ID'
     });
     console.log('   Model from response:', modelValidation.body?.model);
-    console.log('   ✅ Uses arcanos-v1-1106:', modelValidation.body?.model === 'arcanos-v1-1106' ? 'YES' : 'NO');
+    console.log('   ✅ Uses arcanos-v2:', modelValidation.body?.model === 'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH' ? 'YES' : 'NO');
     console.log('');
 
     console.log('🎉 All fine-tune routing tests completed!');

--- a/tests/test-token-parameter-integration.js
+++ b/tests/test-token-parameter-integration.js
@@ -20,7 +20,7 @@ const testModels = [
   'gpt-4',
   'gpt-3.5-turbo',
   'gpt-5',
-  'ft:gpt-3.5-turbo-0125:arcanos-v1-1106',
+  'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH',
   'gpt-4o',
   'gpt-4-turbo'
 ];


### PR DESCRIPTION
## Summary
- use new ARCANOS v2 fine-tune model in query-finetune router
- document v2 model throughout finetune guide and routing docs
- update tests for token parameters and query-finetune to expect v2 model

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad8eee95cc8325a03d2e5324e608fb