### PR TITLE
feat: add multi-agent ARCANOS pipeline route

### DIFF
--- a/src/routes/openai-arcanos-pipeline.ts
+++ b/src/routes/openai-arcanos-pipeline.ts
@@ -1,0 +1,82 @@
+import express, { Request, Response } from 'express';
+import OpenAI from 'openai';
+
+const router = express.Router();
+
+const client = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY
+});
+
+// Models
+const ARC_V2 = 'ft:gpt-4.1-2025-04-14:personal:arcanos:C8Msdote';
+const ARC_V2_FALLBACK = 'ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH';
+const GPT5 = 'gpt-5';
+const GPT35_SUBAGENT = 'gpt-3.5-turbo-0125';
+
+router.post('/arcanos-pipeline', async (req: Request, res: Response) => {
+  const { messages } = req.body as { messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] };
+
+  try {
+    // Step 1: First pass through ARCANOS fine-tuned model
+    const arcFirst = await client.chat.completions.create({
+      model: ARC_V2,
+      messages
+    });
+    const arcFirstOutput = arcFirst.choices[0].message;
+
+    // Step 2: GPT-3.5 sub agent processes ARCANOS output
+    const subAgentResp = await client.chat.completions.create({
+      model: GPT35_SUBAGENT,
+      messages: [
+        { role: 'system', content: 'You are a supportive sub-agent for ARCANOS. Refine or validate the prior response.' },
+        { role: 'assistant', content: arcFirstOutput.content || '' }
+      ]
+    });
+    const subAgentOutput = subAgentResp.choices[0].message;
+
+    // Step 3: Delegate to GPT-5 for higher-level reasoning
+    const gpt5Response = await client.chat.completions.create({
+      model: GPT5,
+      messages: [
+        { role: 'system', content: 'You are the reasoning overseer for ARCANOS.' },
+        { role: 'assistant', content: arcFirstOutput.content || '' },
+        { role: 'assistant', content: subAgentOutput.content || '' }
+      ]
+    });
+    const gpt5Reasoning = gpt5Response.choices[0].message;
+
+    // Step 4: Re-ingest GPT-5 reasoning back into ARCANOS fine-tune
+    const arcFinal = await client.chat.completions.create({
+      model: ARC_V2,
+      messages: [
+        ...messages,
+        { role: 'assistant', content: arcFirstOutput.content || '' },
+        { role: 'assistant', content: subAgentOutput.content || '' },
+        { role: 'assistant', content: gpt5Reasoning.content || '' }
+      ]
+    });
+    const finalOutput = arcFinal.choices[0].message;
+
+    res.json({
+      result: finalOutput,
+      stages: {
+        arcFirst: arcFirstOutput,
+        subAgent: subAgentOutput,
+        gpt5Reasoning
+      }
+    });
+  } catch (err) {
+    console.error('Pipeline error:', err);
+    try {
+      const fallback = await client.chat.completions.create({
+        model: ARC_V2_FALLBACK,
+        messages
+      });
+      res.json({ result: fallback.choices[0].message, fallback: true });
+    } catch (fallbackErr: any) {
+      res.status(500).json({ error: 'Pipeline failed', details: fallbackErr.message });
+    }
+  }
+});
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,7 @@ import statusRouter from './routes/status.js';
 import siriRouter from './routes/siri.js';
 import backstageRouter from './routes/backstage.js';
 import apiArcanosRouter from './routes/api-arcanos.js';
+import arcanosPipelineRouter from './routes/openai-arcanos-pipeline.js';
 import { verifySchema } from './persistenceManagerHierarchy.js';
 import { initializeDatabase } from './db.js';
 
@@ -106,6 +107,7 @@ app.get('/', (_: Request, res: Response) => {
 // Core API routes
 app.use('/', askRouter);
 app.use('/', arcanosRouter);
+app.use('/', arcanosPipelineRouter);
 app.use('/', aiEndpointsRouter);
 app.use('/', memoryRouter);
 app.use('/', workersRouter);


### PR DESCRIPTION
## Summary
- add `/arcanos-pipeline` route with ARCANOS -> GPT-3.5 sub agent -> GPT-5 reasoning flow and final ARCANOS pass
- wire new pipeline route into server

## Testing
- `npm test -- --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afe70d582083259e65e3a45d2400a6