### PR TITLE
Track GPT identities and expose /api/ask endpoint

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,10 @@
+import pg from "pg";
+
+const pool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+export default {
+  query: (text, params) => pool.query(text, params),
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,6 +3,7 @@ import OpenAI from "openai";
 import dotenv from "dotenv";
 import queryFinetuneRouter from "./routes/query-finetune.js";
 import memoryRoutes from "./routes/memory.js";
+import gptRoutes from "./routes/gpt.js";
 
 // Load API key from .env
 dotenv.config();
@@ -10,9 +11,10 @@ dotenv.config();
 const app = express();
 app.use(express.json());
 
-// Register query-finetune router
+// Register routers
 app.use("/query-finetune", queryFinetuneRouter);
 app.use("/memory", memoryRoutes);
+app.use("/api", gptRoutes);
 
 // Initialize OpenAI client
 const openai = new OpenAI({

--- a/backend/models/Identity.js
+++ b/backend/models/Identity.js
@@ -1,0 +1,24 @@
+import db from "../db.js";
+
+export async function findOrRegisterIdentity(gptId, gptVersion) {
+  const now = new Date();
+
+  const result = await db.query(
+    `UPDATE identities
+     SET call_count = call_count + 1, last_seen = $2, gpt_version = $3
+     WHERE gpt_id = $1
+     RETURNING *`,
+    [gptId, now, gptVersion]
+  );
+
+  if (result.rows.length > 0) return result.rows[0];
+
+  const insert = await db.query(
+    `INSERT INTO identities (gpt_id, gpt_version, call_count, last_seen)
+     VALUES ($1, $2, 1, $3)
+     RETURNING *`,
+    [gptId, gptVersion, now]
+  );
+
+  return insert.rows[0];
+}

--- a/backend/routes/gpt.js
+++ b/backend/routes/gpt.js
@@ -1,0 +1,42 @@
+import express from "express";
+import { findOrRegisterIdentity } from "../models/Identity.js";
+import OpenAI from "openai";
+
+const router = express.Router();
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+router.post("/ask", async (req, res) => {
+  const { gptId, gptVersion, prompt, context } = req.body;
+
+  if (!gptId || !prompt) {
+    return res.status(400).json({ error: "gptId and prompt are required" });
+  }
+
+  try {
+    const identity = await findOrRegisterIdentity(gptId, gptVersion);
+
+    const completion = await client.chat.completions.create({
+      model: "ft:gpt-4.1-2025-04-14:personal:arcanos:C8Msdote",
+      messages: [
+        { role: "system", content: "ARCANOS dispatcher active" },
+        { role: "user", content: prompt },
+      ],
+    });
+
+    res.json({
+      result: completion.choices[0].message.content,
+      module: "ARCANOS pipeline",
+      meta: {
+        gptId: identity.gpt_id,
+        version: identity.gpt_version,
+        calls: identity.call_count,
+        lastSeen: identity.last_seen,
+      },
+    });
+  } catch (err) {
+    console.error("Error in /ask:", err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add a Railway-ready Postgres helper
- implement `findOrRegisterIdentity` for GPT call tracking
- expose `/api/ask` route that records GPT usage and forwards prompts to the fine-tuned model

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0208199e08325b810b7217dc037d4