### PR TITLE
Expose GPT ask endpoint at root

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -14,7 +14,7 @@ app.use(express.json());
 // Register routers
 app.use("/query-finetune", queryFinetuneRouter);
 app.use("/memory", memoryRoutes);
-app.use("/api", gptRoutes);
+app.use("/", gptRoutes);
 
 // Initialize OpenAI client
 const openai = new OpenAI({


### PR DESCRIPTION
## Summary
- mount GPT routes at root so `/ask` endpoint is accessible without `/api`

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ba9936788325a6e2f66279e473ee