### PR TITLE
feat: add memory reset hook and tests

### DIFF
--- a/git/hooks/post-merge.sh
+++ b/git/hooks/post-merge.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+node ./patch/clear_memory.js

--- a/patch/clear_memory.js
+++ b/patch/clear_memory.js
@@ -1,0 +1,4 @@
+import { reset } from '../workers/memory.js';
+
+reset();
+console.log('Memory state cleared successfully.');

--- a/test/test_memory_clear.js
+++ b/test/test_memory_clear.js
@@ -1,0 +1,11 @@
+import { write, reset, read } from '../workers/memory.js';
+
+write({ session: 'test-session-123' });
+reset();
+
+const state = read();
+if (state.session !== null) {
+  throw new Error('Memory reset failed!');
+}
+
+console.log('✅ Memory reset test passed.');

--- a/workers/memory.js
+++ b/workers/memory.js
@@ -1,0 +1,17 @@
+const state = {
+  /* ...initial memory state... */
+};
+
+export const read = () => ({ ...state });
+
+export const write = updates => {
+  Object.assign(state, updates);
+};
+
+export const reset = () => {
+  Object.keys(state).forEach(key => {
+    state[key] = null;
+  });
+};
+
+export default { read, write, reset };


### PR DESCRIPTION
## Summary
- add in-memory state helper with read, write and reset helpers
- clear memory via patch script and post-merge Git hook
- test to verify memory resets successfully

## Testing
- `node test/test_memory_clear.js`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b10fe605f08325a2bdf7802081f382