### PR TITLE
feat: enhance GPT module with fine-tuned model

### DIFF
--- a/openai-railway-backend/modules/gpt.js
+++ b/openai-railway-backend/modules/gpt.js
@@ -1,20 +1,37 @@
 const OpenAI = require('openai');
 const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
+// Allow configuring the model via environment variable while defaulting to the
+// project's main fine‑tuned model.
+const DEFAULT_MODEL =
+  process.env.OPENAI_MODEL || 'ft:gpt-4.1-2025-04-14:personal:arcanos:C8Msdote';
+
 module.exports = {
   route: '/gpt',
   description: 'OpenAI GPT Query Module',
-  async handler(payload) {
-    if (!payload.prompt) throw new Error('Missing prompt');
-    const completion = await client.chat.completions.create({
-      model: 'gpt-3.5-turbo',
-      messages: [{ role: 'user', content: payload.prompt }]
-    });
-    return {
-      input: payload.prompt,
-      output: completion.choices[0].message.content
-    };
+
+  async handler(payload = {}) {
+    const { prompt, messages, model, ...params } = payload;
+    const finalMessages = messages ||
+      (prompt ? [{ role: 'user', content: prompt }] : null);
+    if (!finalMessages) throw new Error('Missing prompt or messages');
+
+    try {
+      const completion = await client.chat.completions.create({
+        model: model || DEFAULT_MODEL,
+        messages: finalMessages,
+        ...params
+      });
+
+      return {
+        input: finalMessages,
+        output: completion.choices[0]?.message?.content || ''
+      };
+    } catch (err) {
+      return { error: err.message };
+    }
   },
+
   async handle(payload) {
     return this.handler(payload);
   }


### PR DESCRIPTION
## Summary
- default GPT module to fine-tuned model via `OPENAI_MODEL` env
- support custom messages and options, plus better error handling

## Testing
- `cd openai-railway-backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2963ff5ec83259484e4a3170faf8c