### PR TITLE
docs: document Python module integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,11 @@ docker run -p 8080:8080 -e OPENAI_API_KEY=your-key arcanos
 - **[Database Guide](./docs/ai-guides/DATABASE_IMPLEMENTATION.md)** - Database setup and usage
 - **[Deployment Guide](./docs/deployment/DEPLOYMENT.md)** - Production deployment
 
+## 🐍 Python Module
+
+A companion Python package provides strict GPT-5 reasoning with enforced model usage and automatic maintenance alerts.
+See [ARCANOS_PYTHON_README.md](./ARCANOS_PYTHON_README.md) for installation, configuration, and testing instructions.
+
 ## 🔄 Changelog
 
 See [CHANGELOG.md](./docs/CHANGELOG.md) for detailed version history and recent updates.

--- a/docs/arcanos-overview.md
+++ b/docs/arcanos-overview.md
@@ -11,3 +11,5 @@ Key capabilities include:
 - **AI-Controlled Workers** – Background tasks such as health checks and memory sync run only with AI approval.
 
 In short, Arcanos acts as a comprehensive AI backend where the model plays an active role in system management while exposing a conventional API for clients.
+
+For strict GPT-5 reasoning from Python, the project includes a companion module described in [ARCANOS_PYTHON_README.md](../ARCANOS_PYTHON_README.md). It enforces the fine-tuned model and automatically alerts a maintenance assistant on any failure.


### PR DESCRIPTION
## Summary
- add Python module section to README with link to strict GPT-5 adapter
- mention Python companion module in Arcanos overview

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b32ee5ca8083258fdbe5bd6b2943f3