### PR TITLE
Add module import failure test

### DIFF
--- a/openai-railway-backend/test/module-import-failure.test.js
+++ b/openai-railway-backend/test/module-import-failure.test.js
@@ -1,0 +1,25 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const modulesDir = path.join(__dirname, '..', 'modules');
+
+ test('loadModules handles module import failure', async () => {
+  // create a module that throws on require
+  const badModulePath = path.join(modulesDir, 'badModule.js');
+  fs.writeFileSync(badModulePath, 'throw new Error("bad module");');
+
+  process.env.NODE_ENV = 'test';
+  let warned = false;
+  const originalWarn = console.warn;
+  console.warn = (msg) => { if (msg.includes('Failed to load module')) warned = true; };
+
+  delete require.cache[require.resolve('../server')];
+  require('../server');
+
+  console.warn = originalWarn;
+  fs.unlinkSync(badModulePath);
+
+  assert.ok(warned, 'expected warning for failed module load');
+ });


### PR DESCRIPTION
## Summary
- add a test ensuring the dynamic loader warns when a module throws during import

## Testing
- `npm test tests/placeholder.test.ts`
- `(cd openai-railway-backend && npm test)`

------
https://chatgpt.com/codex/tasks/task_e_68b34a2e23a88325987a257e1e992cb2