### PR TITLE
feat: add OpenAI call service

### DIFF
--- a/services/client.js
+++ b/services/client.js
@@ -1,0 +1,9 @@
+const OpenAI = require("openai");
+
+// Initialize OpenAI client using API key from environment
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+// Adapter to match expected interface with createChatCompletion method
+module.exports = {
+  createChatCompletion: async (params) => openai.chat.completions.create(params),
+};

--- a/services/openai.js
+++ b/services/openai.js
@@ -1,0 +1,12 @@
+module.exports = {
+  callOpenAI: async function (model, payload) {
+    const openai = require("./client"); // Adjust import path if needed
+    const response = await openai.createChatCompletion({
+      model,
+      messages: payload.messages,
+      max_tokens: 1300, // 🔒 Hardcoded limit
+      ...payload.options,
+    });
+    return response.data;
+  },
+};


### PR DESCRIPTION
## Summary
- implement OpenAI chat completion wrapper with hard-coded token limit
- add OpenAI client adapter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4e762b6b88325aaa21c7dd3ba4096