### PR TITLE
fix: ensure full project included in railway builds

### DIFF
--- a/.railwayignore
+++ b/.railwayignore
@@ -1,33 +1,29 @@
-# Development files
-src/
-*.ts
-tsconfig*.json
-.env.example
+# Build artifacts
+node_modules/
+dist/
+build/
 
-# Documentation
-*.md
-CUSTOM_GPT_INTEGRATION.md
-DEPLOYMENT.md
-QUICK_REFERENCE.md
+# Environment files
+.env
+.env.local
+.env.*.local
 
-# Development dependencies
-.github/
-
-# Temporary files
+# Logs and temp files
+logs/
+npm_logs/
 tmp/
 temp/
 *.log
 *.tmp
 
-# Version control
+# Version control and CI files
 .git/
+.github/
 
-# IDE files
+# IDE and OS files
 .vscode/
 .idea/
 *.swp
 *.swo
-
-# OS files
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary
- relax `.railwayignore` to let source, TypeScript, and docs be uploaded
- ignore only build artifacts, temp files, environment configs, and IDE metadata

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b511b1abd48325aa3b06082325235e