### PR TITLE
feat: auto-discover modules and add query router

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,14 @@ GET  /memory/list      # List all memory entries
 ### System Control
 ```bash
 GET  /workers/status   # Worker system status
-GET  /status          # Backend state information  
+GET  /status          # Backend state information
 POST /heartbeat       # System heartbeat (requires confirmation)
+```
+
+### Module Router
+```bash
+POST /modules/<module>  # Call a specific module (e.g., tutor, gaming)
+POST /queryroute        # Dispatch by module name and action
 ```
 
 ### Example Usage


### PR DESCRIPTION
## Summary
- auto-discover modules from the filesystem and register their own endpoints
- provide a central `/queryroute` endpoint that dispatches requests based on module name
- document module router endpoints in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52c5cd7e083258ffd3bccb93e5ee8