### PR TITLE
feat: add chat log storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ GET  /memory/health    # Memory system status
 GET  /memory/list      # List all memory entries
 ```
 
+### Chat Logs
+```bash
+POST /chat/log                 # Persist a chat message
+GET  /chat/log/:conversationId # Retrieve messages for a conversation
+```
+
 ### System Control
 ```bash
 GET  /workers/status   # Worker system status

--- a/backend/README.md
+++ b/backend/README.md
@@ -60,13 +60,14 @@ npm run v3:test     # Run v3.0 tests
 - **Express Server**: Simple HTTP server with JSON middleware
 - **OpenAI Integration**: Direct integration with OpenAI Chat Completions API
 - **Environment Support**: Reads OPENAI_API_KEY from environment variables
+- **Chat Log Persistence**: Stores chat conversations in PostgreSQL (Railway-compatible)
 
 ## Features Comparison
 
 | Feature | v4.0 | v3.0 | Original |
 |---------|------|------|----------|
 | Module System | ✅ | ✅ | ❌ |
-| Database Support | ✅ (PostgreSQL/SQLite) | ✅ (PostgreSQL/SQLite) | ❌ |
+| Database Support | ✅ (PostgreSQL/SQLite) | ✅ (PostgreSQL/SQLite) | ✅ (PostgreSQL) |
 | Rate Limiting | ✅ | ✅ | ❌ |
 | Audit Logging | ✅ | ✅ | ❌ |
 | File Watching | ✅ | ✅ | ❌ |
@@ -163,6 +164,17 @@ The server will start on port 5000 (or the PORT environment variable).
 curl -X POST http://localhost:5000/arcanos \
   -H "Content-Type: application/json" \
   -d '{"prompt": "Analyze this logic problem: If all cats are animals, and some animals are pets, what can we conclude about cats?"}'
+```
+
+**Chat Log Endpoints:**
+```bash
+# Store a message
+curl -X POST http://localhost:5000/chat/log \
+  -H "Content-Type: application/json" \
+  -d '{"conversation_id":"<uuid>","sender_id":"<uuid>","message_text":"Hello"}'
+
+# Retrieve conversation history
+curl http://localhost:5000/chat/log/<conversation_id>
 ```
 
 **Response Format:**

--- a/backend/index.js
+++ b/backend/index.js
@@ -5,6 +5,7 @@ import queryFinetuneRouter from "./routes/query-finetune.js";
 import memoryRoutes from "./routes/memory.js";
 import gptRoutes from "./routes/gpt.js";
 import bookerRoutes from "./routes/booker.js";
+import chatRoutes from "./routes/chat.js";
 
 // Load API key from .env
 dotenv.config();
@@ -16,6 +17,7 @@ app.use(express.json());
 app.use("/query-finetune", queryFinetuneRouter);
 app.use("/memory", memoryRoutes);
 app.use("/api/arcanos-booker", bookerRoutes);
+app.use("/chat", chatRoutes);
 app.use("/", gptRoutes);
 
 // Initialize OpenAI client

--- a/backend/routes/chat.js
+++ b/backend/routes/chat.js
@@ -1,0 +1,43 @@
+import express from 'express';
+import db from '../db.js';
+
+const router = express.Router();
+
+// Save a message to the chat log
+router.post('/log', async (req, res) => {
+  const { conversation_id, sender_id, message_text } = req.body;
+  if (!conversation_id || !sender_id || !message_text) {
+    return res.status(400).json({ error: 'conversation_id, sender_id, and message_text are required' });
+  }
+
+  try {
+    await db.query(
+      `INSERT INTO chat_messages (conversation_id, sender_id, message_text)
+       VALUES ($1, $2, $3)`,
+      [conversation_id, sender_id, message_text]
+    );
+    res.status(201).json({ status: 'stored' });
+  } catch (err) {
+    console.error('[ /chat/log ]', err);
+    res.status(500).json({ error: 'Message store failed', details: err.message });
+  }
+});
+
+// Retrieve messages for a conversation
+router.get('/log/:conversationId', async (req, res) => {
+  try {
+    const { rows } = await db.query(
+      `SELECT id, conversation_id, sender_id, message_text, created_at
+       FROM chat_messages
+       WHERE conversation_id = $1
+       ORDER BY created_at ASC`,
+      [req.params.conversationId]
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error('[ /chat/log/:conversationId ]', err);
+    res.status(500).json({ error: 'Fetch failed', details: err.message });
+  }
+});
+
+export default router;

--- a/migrations/chat_messages.sql
+++ b/migrations/chat_messages.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS chat_messages (
+  id SERIAL PRIMARY KEY,
+  conversation_id UUID NOT NULL,
+  sender_id UUID NOT NULL,
+  message_text TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- add PostgreSQL chat_messages table
- create chat log routes for storing and retrieving conversations
- document chat log endpoints and database usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b66e12bd888325b2ebd3e9f115b55d