### PR TITLE
feat: integrate notion roster into booker

### DIFF
--- a/.env
+++ b/.env
@@ -10,3 +10,7 @@ ARC_MEMORY_PATH=/tmp/arc/memory
 # DATABASE_URL=postgresql://username:password@localhost:5432/mydbname
 ALLOW_ROOT_OVERRIDE=true
 ROOT_OVERRIDE_TOKEN=supersecrettoken
+
+# Notion configuration
+NOTION_API_KEY=
+WWE_DATABASE_ID=

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ LOGIC_ROUTE=/ask
 OPENAI_API_KEY=your-openai-api-key-here
 AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH
 
+# Notion Configuration
+NOTION_API_KEY=your-notion-api-key-here
+WWE_DATABASE_ID=your-notion-wwe-database-id
+
 # GPT-5 Configuration
 GPT5_MODEL=gpt-5
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ curl -X POST http://localhost:8080/ask \
 curl -X POST http://localhost:8080/image \
   -H "Content-Type: application/json" \
   -d '{"prompt": "A sunset over the mountains"}'
+
+# Fetch WWE Universe roster from Notion
+curl http://localhost:8080/booker/roster
 ```
 
 ## ⚙️ Configuration
@@ -49,6 +52,7 @@ curl -X POST http://localhost:8080/image \
 ```bash
 OPENAI_API_KEY=your-openai-api-key-here
 NOTION_API_KEY=your-notion-api-key-here
+WWE_DATABASE_ID=your-notion-wwe-database-id
 AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH  # Default fine-tuned model
 DATABASE_URL=postgresql://user:pass@localhost:5432/arcanos  # Optional - uses in-memory if not set
 ```


### PR DESCRIPTION
## Summary
- fetch WWE roster from Notion with @notionhq/client and feed into storyline generation
- expose `/booker/roster` endpoint to return Notion roster
- document Notion environment variables and usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6a937ad18832590f1ab5717e18c86