### PR TITLE
Add schema synchronization script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "probe": "node scripts/probe.js",
     "db:init": "node scripts/db-init.js",
+    "db:patch": "node scripts/schema-sync.js",
     "start": "node dist/server.js",
     "dev": "tsc && node dist/server.js",
     "dev:watch": "tsc --watch",

--- a/scripts/schema-sync.js
+++ b/scripts/schema-sync.js
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import path from 'path';
+import db from '../backend/db.js';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Load all schema definitions from the /schemas directory
+const schemaDir = path.join(__dirname, 'schemas');
+const schemaFiles = fs.readdirSync(schemaDir).filter((f) => f.endsWith('.js'));
+
+async function createTableIfMissing({ tableName, definition }) {
+  const existsQuery = `
+    SELECT EXISTS (
+      SELECT FROM information_schema.tables
+      WHERE table_name = $1
+    );
+  `;
+  const res = await db.query(existsQuery, [tableName]);
+
+  if (!res.rows[0].exists) {
+    const columns = Object.entries(definition)
+      .map(([col, type]) => `"${col}" ${type}`)
+      .join(',\n  ');
+
+    const createQuery = `
+      CREATE TABLE "${tableName}" (
+        id SERIAL PRIMARY KEY,
+        ${columns}
+      );
+    `;
+    await db.query(createQuery);
+    console.log(`[PATCH] Created missing table: ${tableName}`);
+  }
+}
+
+async function runPatch() {
+  for (const file of schemaFiles) {
+    const modulePath = pathToFileURL(path.join(schemaDir, file));
+    const schemaModule = await import(modulePath);
+    const schema = schemaModule.default || schemaModule;
+    await createTableIfMissing(schema);
+  }
+}
+
+runPatch()
+  .then(() => {
+    console.log('[PATCH] Schema synchronization complete.');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('[PATCH] Error:', err);
+    process.exit(1);
+  });

--- a/scripts/schemas/audit_logs.js
+++ b/scripts/schemas/audit_logs.js
@@ -1,0 +1,8 @@
+export default {
+  tableName: 'audit_logs',
+  definition: {
+    event: 'TEXT NOT NULL',
+    payload: 'JSONB NOT NULL',
+    timestamp: 'BIGINT NOT NULL'
+  }
+};

--- a/scripts/schemas/saves.js
+++ b/scripts/schemas/saves.js
@@ -1,0 +1,8 @@
+export default {
+  tableName: 'saves',
+  definition: {
+    module: 'TEXT NOT NULL',
+    data: 'TEXT NOT NULL',
+    timestamp: 'BIGINT NOT NULL'
+  }
+};

--- a/src/db.ts
+++ b/src/db.ts
@@ -170,7 +170,23 @@ async function initializeTables(): Promise<void> {
       created_at TIMESTAMPTZ DEFAULT NOW(),
       updated_at TIMESTAMPTZ DEFAULT NOW()
     )`,
-    
+
+    // Saves table for kernel failsafe writes
+    `CREATE TABLE IF NOT EXISTS saves (
+      id SERIAL PRIMARY KEY,
+      module TEXT NOT NULL,
+      data TEXT NOT NULL,
+      timestamp BIGINT NOT NULL
+    )`,
+
+    // Audit logs table for event tracking
+    `CREATE TABLE IF NOT EXISTS audit_logs (
+      id SERIAL PRIMARY KEY,
+      event TEXT NOT NULL,
+      payload JSONB NOT NULL,
+      timestamp BIGINT NOT NULL
+    )`,
+
     // Execution logs table for worker logs
     `CREATE TABLE IF NOT EXISTS execution_logs (
       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -206,6 +222,8 @@ async function initializeTables(): Promise<void> {
     
     // Indexes for performance
     `CREATE INDEX IF NOT EXISTS idx_memory_key ON memory(key)`,
+    `CREATE INDEX IF NOT EXISTS idx_saves_module ON saves(module)`,
+    `CREATE INDEX IF NOT EXISTS idx_audit_logs_event ON audit_logs(event)`,
     `CREATE INDEX IF NOT EXISTS idx_execution_logs_worker_timestamp ON execution_logs(worker_id, timestamp DESC)`,
     `CREATE INDEX IF NOT EXISTS idx_job_data_worker_status ON job_data(worker_id, status)`,
     `CREATE INDEX IF NOT EXISTS idx_reasoning_logs_timestamp ON reasoning_logs(timestamp DESC)`


### PR DESCRIPTION
## Summary
- add schema-sync script to create missing tables using definitions in scripts/schemas
- include default `saves` table schema
- expose script through new `db:patch` npm script
- ensure database initialization creates `saves` and `audit_logs` tables
- add `audit_logs` schema definition and align `saves` schema with runtime usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6b8ba716083259fee78d17ad0df0b