### PR TITLE
Initialize saves and audit log tables

### DIFF
--- a/scripts/db-init.js
+++ b/scripts/db-init.js
@@ -13,9 +13,17 @@ async function ensureSchema() {
     saves: `
       CREATE TABLE IF NOT EXISTS saves (
         id SERIAL PRIMARY KEY,
-        user_id TEXT NOT NULL,
-        content JSONB NOT NULL,
-        created_at TIMESTAMP DEFAULT NOW()
+        module TEXT NOT NULL,
+        data JSONB NOT NULL,
+        timestamp BIGINT NOT NULL
+      );
+    `,
+    audit_logs: `
+      CREATE TABLE IF NOT EXISTS audit_logs (
+        id SERIAL PRIMARY KEY,
+        event TEXT NOT NULL,
+        payload JSONB,
+        timestamp BIGINT NOT NULL
       );
     `
     // add more tables here as needed

--- a/scripts/schemas/saves.js
+++ b/scripts/schemas/saves.js
@@ -1,8 +1,8 @@
 export default {
   tableName: 'saves',
   definition: {
-    user_id: 'TEXT NOT NULL',
-    content: 'JSONB NOT NULL',
-    created_at: 'TIMESTAMP DEFAULT NOW()'
+    module: 'TEXT NOT NULL',
+    data: 'JSONB NOT NULL',
+    timestamp: 'BIGINT NOT NULL'
   }
 };

--- a/src/db.ts
+++ b/src/db.ts
@@ -162,6 +162,22 @@ async function initializeTables(): Promise<void> {
   if (!pool) return;
 
   const queries = [
+    // Saves table for persistence operations
+    `CREATE TABLE IF NOT EXISTS saves (
+      id SERIAL PRIMARY KEY,
+      module TEXT NOT NULL,
+      data JSONB NOT NULL,
+      timestamp BIGINT NOT NULL
+    )`,
+
+    // Audit logs table for persistence and rollback tracking
+    `CREATE TABLE IF NOT EXISTS audit_logs (
+      id SERIAL PRIMARY KEY,
+      event TEXT NOT NULL,
+      payload JSONB,
+      timestamp BIGINT NOT NULL
+    )`,
+
     // Memory table for persistent worker memory
     `CREATE TABLE IF NOT EXISTS memory (
       id SERIAL PRIMARY KEY,
@@ -208,7 +224,9 @@ async function initializeTables(): Promise<void> {
     `CREATE INDEX IF NOT EXISTS idx_memory_key ON memory(key)`,
     `CREATE INDEX IF NOT EXISTS idx_execution_logs_worker_timestamp ON execution_logs(worker_id, timestamp DESC)`,
     `CREATE INDEX IF NOT EXISTS idx_job_data_worker_status ON job_data(worker_id, status)`,
-    `CREATE INDEX IF NOT EXISTS idx_reasoning_logs_timestamp ON reasoning_logs(timestamp DESC)`
+    `CREATE INDEX IF NOT EXISTS idx_reasoning_logs_timestamp ON reasoning_logs(timestamp DESC)`,
+    `CREATE INDEX IF NOT EXISTS idx_saves_module_timestamp ON saves(module, timestamp)`,
+    `CREATE INDEX IF NOT EXISTS idx_audit_logs_event_timestamp ON audit_logs(event, timestamp DESC)`
   ];
 
   try {


### PR DESCRIPTION
## Summary
- ensure DB initializes `saves` and `audit_logs` tables with appropriate schema
- add indexes for new tables and align initialization script definitions

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b6bfc51dbc8325a322a9425863053d