### PR TITLE
feat: add assistant API route

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -62,6 +62,23 @@ npm run v3:test     # Run v3.0 tests
 - **Environment Support**: Reads OPENAI_API_KEY from environment variables
 - **Chat Log Persistence**: Stores chat conversations in PostgreSQL (Railway-compatible)
 
+#### Assistant API Integration
+
+The original backend now includes a minimal route for calling an OpenAI Assistant.
+
+- **Endpoint**: `POST /assistant/run`
+- **Body**:
+  ```json
+  { "prompt": "Hello", "assistantId": "asst_123" }
+  ```
+  If `assistantId` is omitted, the server uses the `OPENAI_ASSISTANT_ID` environment variable.
+- **Response**:
+  ```json
+  { "reply": "...", "threadId": "...", "runId": "..." }
+  ```
+
+This provides a starting point for integrating the Assistants API into your backend logic.
+
 ## Features Comparison
 
 | Feature | v4.0 | v3.0 | Original |

--- a/backend/index.js
+++ b/backend/index.js
@@ -6,6 +6,7 @@ import memoryRoutes from "./routes/memory.js";
 import gptRoutes from "./routes/gpt.js";
 import bookerRoutes from "./routes/booker.js";
 import chatRoutes from "./routes/chat.js";
+import assistantRoutes from "./routes/assistant.js";
 
 // Load API key from .env
 dotenv.config();
@@ -18,6 +19,7 @@ app.use("/query-finetune", queryFinetuneRouter);
 app.use("/memory", memoryRoutes);
 app.use("/api/arcanos-booker", bookerRoutes);
 app.use("/chat", chatRoutes);
+app.use("/assistant", assistantRoutes);
 app.use("/", gptRoutes);
 
 // Initialize OpenAI client

--- a/backend/routes/assistant.js
+++ b/backend/routes/assistant.js
@@ -1,0 +1,74 @@
+import express from "express";
+import OpenAI from "openai";
+
+const router = express.Router();
+
+// Initialize OpenAI client using the standard API key
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+// Optional default Assistant ID from environment
+const DEFAULT_ASSISTANT_ID = process.env.OPENAI_ASSISTANT_ID;
+
+/**
+ * Run an OpenAI Assistant and return the final response.
+ *
+ * Request body:
+ * {
+ *   "prompt": "user message",
+ *   "assistantId": "asst_123" // optional; falls back to OPENAI_ASSISTANT_ID
+ * }
+ */
+router.post("/run", async (req, res) => {
+  const { prompt, assistantId } = req.body || {};
+  const asstId = assistantId || DEFAULT_ASSISTANT_ID;
+
+  if (!prompt) {
+    return res.status(400).json({ error: "Prompt is required" });
+  }
+  if (!asstId) {
+    return res.status(400).json({ error: "Assistant ID is required" });
+  }
+
+  try {
+    // 1. Create a fresh thread for this request
+    const thread = await client.beta.threads.create();
+
+    // 2. Add the user's message
+    await client.beta.threads.messages.create(thread.id, {
+      role: "user",
+      content: prompt
+    });
+
+    // 3. Run the assistant on the thread
+    const run = await client.beta.threads.runs.create(thread.id, {
+      assistant_id: asstId
+    });
+
+    // 4. Poll until the run completes
+    let runStatus;
+    do {
+      runStatus = await client.beta.threads.runs.retrieve(thread.id, run.id);
+      if (runStatus.status === "completed") break;
+      if (["failed", "cancelled", "expired"].includes(runStatus.status)) {
+        throw new Error(runStatus.last_error?.message || `Run ${runStatus.status}`);
+      }
+      // wait for a second before checking again
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    } while (true);
+
+    // 5. Retrieve all messages and pick the assistant's reply
+    const messages = await client.beta.threads.messages.list(thread.id);
+    const assistantMessage = messages.data.find((m) => m.role === "assistant");
+    const reply = assistantMessage?.content
+      ?.map((c) => (c.text ? c.text.value : ""))
+      .join("\n") || "";
+
+    res.json({ reply, threadId: thread.id, runId: run.id });
+  } catch (error) {
+    console.error("Assistant route error:", error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+export default router;
+


### PR DESCRIPTION
## Summary
- expose `/assistant/run` endpoint to invoke OpenAI Assistants from backend
- wire assistant route into server and document usage in backend README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6c59372248325a6da2557b30c8231