### PR TITLE
feat: add retry with backoff to worker queue

### DIFF
--- a/tests/worker-task-queue.test.ts
+++ b/tests/worker-task-queue.test.ts
@@ -1,0 +1,15 @@
+import { WorkerTaskQueue } from '../src/config/workerConfig.js';
+
+test('dispatch retries failing task with exponential backoff', async () => {
+  const queue = new WorkerTaskQueue();
+  let attempts = 0;
+  queue.register(async () => {
+    attempts++;
+    if (attempts < 3) {
+      throw new Error('fail');
+    }
+  });
+
+  await queue.dispatch('test', { attempts: 3, backoffMs: 10 });
+  expect(attempts).toBe(3);
+});


### PR DESCRIPTION
## Summary
- add structured logging and retry/backoff support to worker task queue
- export worker task queue class for reuse and testing
- test retry logic with a failing task

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7d64763988325aa3887e0b0cf5411