### PR TITLE
feat: add basic openai prompt endpoint

### DIFF
--- a/docs/ai-guides/PROMPT_API_GUIDE.md
+++ b/docs/ai-guides/PROMPT_API_GUIDE.md
@@ -301,6 +301,24 @@ curl -X POST http://localhost:8080/api/memory \
 curl -X GET http://localhost:8080/api/memory
 ```
 
+### `/api/openai/prompt` - Direct Model Access
+
+**Purpose**: Send a prompt directly to a specific model.
+**Parameters**:
+- `prompt` (string) - required user prompt
+- `model` (string, optional) - fine-tuned model ID. Defaults to `AI_MODEL` when omitted
+
+```bash
+curl -X POST http://localhost:8080/api/openai/prompt \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "Hello there",
+    "model": "ft:gpt-4.1-my-custom-model"
+  }'
+```
+
+If `model` is not provided, the server uses the `AI_MODEL` environment variable.
+
 ## Configuration & Setup
 
 ### Environment Variables

--- a/src/controllers/openaiController.ts
+++ b/src/controllers/openaiController.ts
@@ -1,0 +1,39 @@
+import { Request, Response } from 'express';
+import { callOpenAI, getDefaultModel } from '../services/openai.js';
+import {
+  validateAIRequest,
+  handleAIError,
+  StandardAIRequest,
+  ErrorResponse
+} from '../utils/requestHandler.js';
+
+interface PromptRequest extends StandardAIRequest {
+  prompt: string;
+  model?: string;
+}
+
+interface PromptResponse {
+  result: string;
+  model: string;
+}
+
+export async function handlePrompt(
+  req: Request<{}, PromptResponse | ErrorResponse, PromptRequest>,
+  res: Response<PromptResponse | ErrorResponse>
+): Promise<void> {
+  const validation = validateAIRequest(req, res, 'prompt');
+  if (!validation) return; // Response already handled (mock or error)
+
+  const { input: prompt } = validation;
+  const model =
+    typeof req.body.model === 'string' && req.body.model.trim().length > 0
+      ? req.body.model
+      : getDefaultModel();
+
+  try {
+    const { output } = await callOpenAI(model, prompt, 256);
+    res.json({ result: output, model });
+  } catch (err) {
+    handleAIError(err, prompt, 'prompt', res);
+  }
+}

--- a/src/routes/openai.ts
+++ b/src/routes/openai.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import { handlePrompt } from '../controllers/openaiController.js';
+
+const router = express.Router();
+
+router.post('/prompt', handlePrompt);
+
+export default router;

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -15,6 +15,7 @@ import apiArcanosRouter from './api-arcanos.js';
 import sdkRouter from './sdk.js';
 import imageRouter from './image.js';
 import prAnalysisRouter from './pr-analysis.js';
+import openaiRouter from './openai.js';
 
 /**
  * Mounts all application routes on the provided Express app.
@@ -39,5 +40,6 @@ export function registerRoutes(app: Express): void {
   app.use('/sdk', sdkRouter);
   app.use('/api/arcanos', apiArcanosRouter);
   app.use('/api/pr-analysis', prAnalysisRouter);
+  app.use('/api/openai', openaiRouter);
   app.use('/', imageRouter);
 }

--- a/tests/openai-prompt.test.ts
+++ b/tests/openai-prompt.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+
+const callOpenAI = jest.fn();
+const getDefaultModel = jest.fn();
+const validateAIRequest = jest.fn();
+const handleAIError = jest.fn();
+
+jest.unstable_mockModule('../src/services/openai.js', () => ({
+  callOpenAI,
+  getDefaultModel
+}));
+
+jest.unstable_mockModule('../src/utils/requestHandler.js', () => ({
+  validateAIRequest,
+  handleAIError
+}));
+
+const { handlePrompt } = await import('../src/controllers/openaiController.js');
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('handlePrompt', () => {
+  it('uses provided model when specified', async () => {
+    validateAIRequest.mockReturnValue({ input: 'hi', client: {} });
+    callOpenAI.mockResolvedValue({ response: {}, output: 'ok' });
+
+    const req: any = { body: { prompt: 'hi', model: 'ft:custom-model' } };
+    const res: any = { json: jest.fn() };
+
+    await handlePrompt(req, res);
+
+    expect(callOpenAI).toHaveBeenCalledWith('ft:custom-model', 'hi', 256);
+    expect(res.json).toHaveBeenCalledWith({ result: 'ok', model: 'ft:custom-model' });
+  });
+
+  it('falls back to default model when none provided', async () => {
+    validateAIRequest.mockReturnValue({ input: 'hello', client: {} });
+    getDefaultModel.mockReturnValue('ft:default-model');
+    callOpenAI.mockResolvedValue({ response: {}, output: 'ok' });
+
+    const req: any = { body: { prompt: 'hello' } };
+    const res: any = { json: jest.fn() };
+
+    await handlePrompt(req, res);
+
+    expect(getDefaultModel).toHaveBeenCalled();
+    expect(callOpenAI).toHaveBeenCalledWith('ft:default-model', 'hello', 256);
+    expect(res.json).toHaveBeenCalledWith({ result: 'ok', model: 'ft:default-model' });
+  });
+});


### PR DESCRIPTION
## Summary
- allow specifying custom OpenAI model in `/api/openai/prompt` requests with `AI_MODEL` fallback
- document direct prompt endpoint and model override usage
- add tests covering custom and default model behavior

## Testing
- `npm run build`
- `npm test`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d265f8f08325949442bc29573d6d