### PR TITLE
Prevent cache cleanup timer from keeping Jest alive

### DIFF
--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -137,6 +137,9 @@ export class MemoryCache<T = any> {
     this.cleanupTimer = setInterval(() => {
       this.cleanup();
     }, this.options.cleanupIntervalMs);
+    if (typeof this.cleanupTimer.unref === 'function') {
+      this.cleanupTimer.unref();
+    }
   }
 
   destroy(): void {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -98,7 +98,7 @@ export const env = {
   DATABASE_URL: Environment.get('DATABASE_URL'),
   
   // Worker Configuration
-  RUN_WORKERS: Environment.getBoolean('RUN_WORKERS', true),
+  RUN_WORKERS: Environment.isTest() ? false : Environment.getBoolean('RUN_WORKERS', true),
   WORKER_API_TIMEOUT_MS: Environment.getNumber('WORKER_API_TIMEOUT_MS', 60000),
   
   // Logging Configuration


### PR DESCRIPTION
## Summary
- Skip background worker startup during tests
- Unref cache cleanup interval so it doesn't block process exit

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b90ef34d2c83258f1e13306cd8a3ad