### PR TITLE
feat: integrate web fetcher into gaming module

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -25,6 +25,7 @@
         "sqlite3": "^5.1.7"
       },
       "devDependencies": {
+        "@types/cheerio": "^0.22.35",
         "@types/cors": "^2.8.19",
         "@types/dotenv": "^6.1.1",
         "@types/express": "^5.0.3",
@@ -2186,6 +2187,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cheerio": {
+      "version": "0.22.35",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.35.tgz",
+      "integrity": "sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "@types/node": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "sqlite3": "^5.1.7"
   },
   "devDependencies": {
+    "@types/cheerio": "^0.22.35",
     "@types/cors": "^2.8.19",
     "@types/dotenv": "^6.1.1",
     "@types/express": "^5.0.3",

--- a/src/modules/arcanos-gaming.ts
+++ b/src/modules/arcanos-gaming.ts
@@ -5,7 +5,7 @@ export const ArcanosGaming = {
   description: 'Nintendo-style hotline advisor for game strategies, hints, and walkthroughs.',
   actions: {
     async query(payload: any) {
-      return runGaming(payload?.prompt || payload);
+      return runGaming(payload?.prompt || payload, payload?.url);
     },
   },
 };


### PR DESCRIPTION
## Summary
- allow gaming service to ingest optional guide URL via fetchAndClean
- pass through URL support from ArcanosGaming module
- include `@types/cheerio` for TypeScript type resolution
- handle missing OpenAI client by returning mock responses for Railway compatibility

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b93cff63688325ba2d5cd2f7fdcc71