### PR TITLE
feat: persist session memory to database

### DIFF
--- a/src/controllers/sessionMemoryController.ts
+++ b/src/controllers/sessionMemoryController.ts
@@ -1,0 +1,40 @@
+import { Request, Response } from 'express';
+import { saveMessage, getChannel } from '../services/sessionMemoryService.js';
+import { requireField } from '../utils/validation.js';
+
+export const sessionMemoryController = {
+  saveDual: async (req: Request, res: Response) => {
+    const { sessionId, message } = req.body;
+    if (!requireField(res, sessionId, 'sessionId') || !requireField(res, message, 'message')) {
+      return;
+    }
+
+    const clean = {
+      role: message.role,
+      content: (message.content || '').trim(),
+    };
+
+    const meta = {
+      tokens: message.tokens || 0,
+      audit_tag: message.tag || 'unspecified',
+      timestamp: Date.now(),
+    };
+
+    await saveMessage(sessionId, 'conversations_core', clean);
+    await saveMessage(sessionId, 'system_meta', meta);
+
+    res.status(200).json({ status: 'saved' });
+  },
+
+  getCore: async (req: Request, res: Response) => {
+    const { sessionId } = req.params;
+    const data = await getChannel(sessionId, 'conversations_core');
+    res.json(data);
+  },
+
+  getMeta: async (req: Request, res: Response) => {
+    const { sessionId } = req.params;
+    const data = await getChannel(sessionId, 'system_meta');
+    res.json(data);
+  }
+};

--- a/src/routes/memory.ts
+++ b/src/routes/memory.ts
@@ -5,6 +5,7 @@ import { saveMemory, loadMemory, deleteMemory, getStatus, query } from '../db.js
 import { asyncHandler } from '../utils/asyncHandler.js';
 import { requireField } from '../utils/validation.js';
 import { confirmGate } from '../middleware/confirmGate.js';
+import { sessionMemoryController } from '../controllers/sessionMemoryController.js';
 
 const router = express.Router();
 
@@ -109,5 +110,21 @@ router.get("/memory/view", asyncHandler(async (_: Request, res: Response) => {
     res.status(500).send("❌ Cannot read memory: " + errorMessage);
   }
 }));
+
+// Session-based conversation memory
+router.post(
+  "/memory/dual/save",
+  asyncHandler(sessionMemoryController.saveDual)
+);
+
+router.get(
+  "/memory/dual/:sessionId/core",
+  asyncHandler(sessionMemoryController.getCore)
+);
+
+router.get(
+  "/memory/dual/:sessionId/meta",
+  asyncHandler(sessionMemoryController.getMeta)
+);
 
 export default router;

--- a/src/services/sessionMemoryService.ts
+++ b/src/services/sessionMemoryService.ts
@@ -1,0 +1,33 @@
+import { saveMemory, loadMemory } from '../db.js';
+
+// Fallback in-memory store
+const memoryStore: Record<string, any[]> = {};
+
+function makeKey(sessionId: string, channel: string): string {
+  return `session:${sessionId}:${channel}`;
+}
+
+export async function saveMessage(sessionId: string, channel: string, message: any): Promise<void> {
+  const key = makeKey(sessionId, channel);
+  let messages: any[] = [];
+  try {
+    messages = (await loadMemory(key)) || [];
+  } catch {
+    messages = memoryStore[key] || [];
+  }
+  messages.push(message);
+  try {
+    await saveMemory(key, messages);
+  } catch {
+    memoryStore[key] = messages;
+  }
+}
+
+export async function getChannel(sessionId: string, channel: string): Promise<any[]> {
+  const key = makeKey(sessionId, channel);
+  try {
+    return (await loadMemory(key)) || [];
+  } catch {
+    return memoryStore[key] || [];
+  }
+}


### PR DESCRIPTION
## Summary
- add session memory service that writes and reads conversation channels from PostgreSQL with in-memory fallback
- expose controller and routes for saving and retrieving dual channel session memory

## Testing
- `npm test`
- `npm run build`
- `node validate-railway-compatibility.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9d88357208325abeb180aee68c669