### PR TITLE
feat: add session resolution service

### DIFF
--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -1,0 +1,35 @@
+import { randomUUID } from 'crypto';
+
+export interface SessionMetadata {
+  topic?: string;
+  tags?: string[];
+  summary?: string;
+}
+
+export interface SessionEntry {
+  sessionId: string;
+  conversations_core: any;
+  metadata?: SessionMetadata;
+}
+
+class MemoryStore {
+  private sessions: SessionEntry[] = [];
+
+  getAllSessions(): SessionEntry[] {
+    return this.sessions;
+  }
+
+  saveSession(entry: SessionEntry): SessionEntry {
+    const existingIndex = this.sessions.findIndex(s => s.sessionId === entry.sessionId);
+    if (existingIndex >= 0) {
+      this.sessions[existingIndex] = entry;
+      return entry;
+    }
+    const session = entry.sessionId ? entry : { ...entry, sessionId: randomUUID() };
+    this.sessions.push(session);
+    return session;
+  }
+}
+
+const memoryStore = new MemoryStore();
+export default memoryStore;

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -4,6 +4,7 @@ import arcanosRouter from './arcanos.js';
 import arcanosPipelineRouter from './openai-arcanos-pipeline.js';
 import aiEndpointsRouter from './ai-endpoints.js';
 import memoryRouter from './memory.js';
+import sessionRoutes from './sessionRoutes.js';
 import modulesRouter from './modules.js';
 import workersRouter from './workers.js';
 import heartbeatRouter from './heartbeat.js';
@@ -34,6 +35,7 @@ export function registerRoutes(app: Express): void {
   app.use('/', arcanosPipelineRouter);
   app.use('/', aiEndpointsRouter);
   app.use('/', memoryRouter);
+  app.use('/', sessionRoutes);
   app.use('/', modulesRouter);
   app.use('/', workersRouter);
   app.use('/', heartbeatRouter);

--- a/src/routes/sessionRoutes.ts
+++ b/src/routes/sessionRoutes.ts
@@ -1,0 +1,16 @@
+import express from 'express';
+import { resolveSession } from '../services/sessionResolver.js';
+
+const router = express.Router();
+
+router.post('/memory/resolve', async (req, res) => {
+  try {
+    const { query } = req.body as { query: string };
+    const result = await resolveSession(query);
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to resolve session', details: err });
+  }
+});
+
+export default router;

--- a/src/services/sessionResolver.ts
+++ b/src/services/sessionResolver.ts
@@ -1,0 +1,77 @@
+import { openai } from '../utils/openaiClient.js';
+import memoryStore from '../memory/store.js';
+
+interface ResolveResult {
+  sessionId: string;
+  conversations_core: any;
+}
+
+export async function resolveSession(nlQuery: string): Promise<ResolveResult> {
+  const sessions = memoryStore.getAllSessions();
+  if (sessions.length === 0) {
+    throw new Error('No sessions available');
+  }
+
+  // 1. Quick filter: topic or tags match
+  let candidates = sessions.filter(sess => {
+    return (
+      (sess.metadata?.topic && nlQuery.toLowerCase().includes(sess.metadata.topic.toLowerCase())) ||
+      (sess.metadata?.tags && sess.metadata.tags.some(tag => nlQuery.toLowerCase().includes(tag.toLowerCase())))
+    );
+  });
+
+  // 2. If none found, use embeddings for semantic match
+  if (candidates.length === 0 && process.env.OPENAI_API_KEY) {
+    const queryEmbedding = await openai.embeddings.create({
+      model: 'text-embedding-3-small',
+      input: nlQuery,
+    });
+
+    const queryVector = queryEmbedding.data[0].embedding;
+
+    let bestMatch: any = null;
+    let bestScore = -Infinity;
+
+    for (const sess of sessions) {
+      const metaText = `${sess.metadata?.summary || ''} ${sess.metadata?.topic || ''} ${(sess.metadata?.tags || []).join(' ')}`;
+      const metaEmbedding = await openai.embeddings.create({
+        model: 'text-embedding-3-small',
+        input: metaText,
+      });
+
+      const score = cosineSimilarity(queryVector, metaEmbedding.data[0].embedding);
+      if (score > bestScore) {
+        bestScore = score;
+        bestMatch = sess;
+      }
+    }
+
+    if (bestMatch) {
+      return {
+        sessionId: bestMatch.sessionId,
+        conversations_core: bestMatch.conversations_core,
+      };
+    }
+  }
+
+  // 3. Fallback: last active session
+  const chosen = candidates.length > 0 ? candidates[0] : sessions[sessions.length - 1];
+
+  return {
+    sessionId: chosen.sessionId,
+    conversations_core: chosen.conversations_core,
+  };
+}
+
+// Simple cosine similarity
+function cosineSimilarity(vecA: number[], vecB: number[]): number {
+  let dot = 0.0;
+  let normA = 0.0;
+  let normB = 0.0;
+  for (let i = 0; i < vecA.length; i++) {
+    dot += vecA[i] * vecB[i];
+    normA += vecA[i] * vecA[i];
+    normB += vecB[i] * vecB[i];
+  }
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}

--- a/src/utils/openaiClient.ts
+++ b/src/utils/openaiClient.ts
@@ -1,0 +1,7 @@
+import OpenAI from 'openai';
+
+export const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY || '',
+});
+
+export default openai;


### PR DESCRIPTION
## Summary
- implement session resolver that matches NL queries to existing sessions via metadata or embeddings
- add in-memory session store and OpenAI client utility
- expose /memory/resolve endpoint and register route

## Testing
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba04ea68748325aadf5ea54239a950