### PR TITLE
feat: add hallucination resistant core endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the Arcanos Backend project will be documented in this file.
 
+## [1.4.2] - 2025-03-14
+
+### Changed
+- HRCCore now uses your fine-tuned model by default and allows override via `HRC_MODEL` environment variable
+
+## [1.4.1] - 2025-03-14
+
+### Added
+- Implemented Hallucination-Resistant Core with OpenAI SDK integration
+- Exposed `/api/ask-hrc` endpoint for resilience and fidelity scoring
+
 ## [1.4.0] - 2025-01-26
 
 ### Major Documentation Overhaul

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -10,6 +10,7 @@
 | `PORT` | `8080` | Server port (Railway auto-assigns) |
 | `OPENAI_API_KEY` | `[REQUIRED]` | OpenAI API authentication key |
 | `FINE_TUNED_MODEL` | `ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH` | Primary fine-tuned model ID (supports multiple variable names) |
+| `HRC_MODEL` | `[OPTIONAL]` | Override model ID for Hallucination-Resistant Core evaluation |
 | `RUN_WORKERS` | `true` | Enable AI-controlled CRON worker processes |
 | `WORKER_LOGIC` | `arcanos` | Default logic mode for background workers |
 | `SERVER_URL` | `https://arcanos-v2-production.up.railway.app` | Production server URL for health checks |
@@ -111,7 +112,7 @@ The CRON worker system runs when `RUN_WORKERS=true` and implements **AI-controll
 - `GET /api/model/info` - Detailed model metadata
 
 #### Validation & Processing
-- `POST /api/ask-hrc` - Message validation using HRCCore overlay system with resilience and fidelity scoring
+- `POST /api/ask-hrc` - Message validation using HRCCore overlay system with resilience and fidelity scoring powered by your fine-tuned OpenAI model (configurable via `HRC_MODEL`)
 
 ### Admin Router
 - Enabled when `ADMIN_KEY` is set in the environment

--- a/src/modules/hrc.ts
+++ b/src/modules/hrc.ts
@@ -1,0 +1,61 @@
+import { openai } from '../clients/openai.js';
+import { getDefaultModel } from '../services/openai.js';
+
+export interface HRCResult {
+  fidelity: number;
+  resilience: number;
+  verdict: string;
+}
+
+/**
+ * Hallucination-Resistant Core
+ * Simple implementation that scores incoming text for fidelity and resilience
+ * using the OpenAI SDK. Falls back gracefully when the client is unavailable.
+ * Targets the project's fine-tuned model by default and can be overridden via HRC_MODEL.
+ */
+export class HRCCore {
+  async evaluate(input: string): Promise<HRCResult> {
+    // If OpenAI client isn't configured, return minimal default result
+    if (!openai) {
+      return {
+        fidelity: 0,
+        resilience: 0,
+        verdict: 'OpenAI client not configured'
+      };
+    }
+
+    try {
+      const model = process.env.HRC_MODEL || getDefaultModel();
+      const response = await openai.chat.completions.create({
+        model,
+        response_format: { type: 'json_object' },
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are the Hallucination-Resistant Core. Analyse the user message and return JSON {"fidelity":0-1,"resilience":0-1,"verdict":string}.',
+          },
+          { role: 'user', content: input }
+        ],
+        temperature: 0
+      });
+
+      const content = response.choices[0]?.message?.content || '{}';
+      const parsed = JSON.parse(content);
+
+      return {
+        fidelity: Number(parsed.fidelity) || 0,
+        resilience: Number(parsed.resilience) || 0,
+        verdict: typeof parsed.verdict === 'string' ? parsed.verdict : 'unavailable'
+      };
+    } catch (err) {
+      return {
+        fidelity: 0,
+        resilience: 0,
+        verdict: `Evaluation failed: ${err instanceof Error ? err.message : 'unknown error'}`
+      };
+    }
+  }
+}
+
+export const hrcCore = new HRCCore();

--- a/src/routes/hrc.ts
+++ b/src/routes/hrc.ts
@@ -1,0 +1,34 @@
+import express, { Request, Response } from 'express';
+import { hrcCore } from '../modules/hrc.js';
+import { createValidationMiddleware, createRateLimitMiddleware, securityHeaders } from '../utils/security.js';
+
+const router = express.Router();
+
+// Apply security middleware and basic rate limiting
+router.use(securityHeaders);
+router.use(createRateLimitMiddleware(30, 15 * 60 * 1000));
+
+const hrcSchema = {
+  message: { type: 'string' as const, required: true, minLength: 1, maxLength: 4000, sanitize: true }
+};
+
+interface HRCRequest {
+  message: string;
+}
+
+router.post('/api/ask-hrc', createValidationMiddleware(hrcSchema), async (
+  req: Request<{}, any, HRCRequest>,
+  res: Response
+) => {
+  const { message } = req.body;
+
+  try {
+    const result = await hrcCore.evaluate(message);
+    res.json({ success: true, result });
+  } catch (err: any) {
+    console.error('HRC evaluation failed:', err);
+    res.status(500).json({ success: false, error: err.message || 'HRC evaluation failed' });
+  }
+});
+
+export default router;

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -20,6 +20,7 @@ import imageRouter from './image.js';
 import prAnalysisRouter from './pr-analysis.js';
 import openaiRouter from './openai.js';
 import ragRouter from './rag.js';
+import hrcRouter from './hrc.js';
 import { createFallbackTestRoute } from '../middleware/fallbackHandler.js';
 
 /**
@@ -49,6 +50,7 @@ export function registerRoutes(app: Express): void {
   app.use('/api/memory', apiMemoryRouter);
   app.use('/api/pr-analysis', prAnalysisRouter);
   app.use('/api/openai', openaiRouter);
+  app.use('/', hrcRouter);
   app.use('/', imageRouter);
   app.use('/', ragRouter);
   


### PR DESCRIPTION
## Summary
- add Hallucination-Resistant Core module using OpenAI SDK for fidelity/resilience scoring
- expose `/api/ask-hrc` validation endpoint and wire it into route registration
- allow HRCCore to target a custom fine-tuned model via `HRC_MODEL`
- document `HRC_MODEL` env variable and note `/api/ask-hrc` uses the configured fine-tune

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba12b8ef448325a4754150aaa354e7