### PR TITLE
Improve session retrieval and semantic resolution

### DIFF
--- a/src/controllers/sessionMemoryController.ts
+++ b/src/controllers/sessionMemoryController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { saveMessage, getChannel } from '../services/sessionMemoryService.js';
 import { requireField } from '../utils/validation.js';
+import memoryStore from '../memory/store.js';
 
 export const sessionMemoryController = {
   saveDual: async (req: Request, res: Response) => {
@@ -22,6 +23,10 @@ export const sessionMemoryController = {
 
     await saveMessage(sessionId, 'conversations_core', clean);
     await saveMessage(sessionId, 'system_meta', meta);
+
+    // Keep in-memory session store in sync for semantic resolution
+    const conversations_core = await getChannel(sessionId, 'conversations_core');
+    memoryStore.saveSession({ sessionId, conversations_core });
 
     res.status(200).json({ status: 'saved' });
   },

--- a/src/services/sessionResolver.ts
+++ b/src/services/sessionResolver.ts
@@ -33,10 +33,17 @@ export async function resolveSession(nlQuery: string): Promise<ResolveResult> {
     let bestScore = -Infinity;
 
     for (const sess of sessions) {
-      const metaText = `${sess.metadata?.summary || ''} ${sess.metadata?.topic || ''} ${(sess.metadata?.tags || []).join(' ')}`;
+      const metaPieces = [
+        sess.metadata?.summary,
+        sess.metadata?.topic,
+        ...(sess.metadata?.tags || []),
+        ...(Array.isArray(sess.conversations_core)
+          ? sess.conversations_core.map((m: any) => m.content || '')
+          : [])
+      ].filter(Boolean);
       const metaEmbedding = await openai.embeddings.create({
         model: 'text-embedding-3-small',
-        input: metaText,
+        input: metaPieces.join(' '),
       });
 
       const score = cosineSimilarity(queryVector, metaEmbedding.data[0].embedding);


### PR DESCRIPTION
## Summary
- Keep session memory store in sync when saving messages
- Use conversation content for embedding-based session resolution

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba6af66cb8832598e9832e0e8541c3