### PR TITLE
feat: add lightweight runtime for memory isolation

### DIFF
--- a/RAILWAY_COMPATIBILITY_GUIDE.md
+++ b/RAILWAY_COMPATIBILITY_GUIDE.md
@@ -13,21 +13,27 @@ All AI requests now route through `createCentralizedCompletion()` which:
 - **Supports overrides**: Allow custom model via `options.model`
 - **Environment flexibility**: Supports both `FINETUNED_MODEL_ID` and `AI_MODEL`
 
-### 2. RESTful API Structure
+### 2. Lightweight Runtime Memory Isolation
+To prevent metadata from leaking into conversation context, a simple in-process
+runtime (`openaiRuntime.ts`) now stores messages and metadata in separate
+scopes. This mimics the OpenAI Runtime’s memory behaviour while remaining
+compatible with Railway deployments.
+
+### 3. RESTful API Structure
 ```
-/api/arcanos     - Core ARCANOS functionality  
+/api/arcanos     - Core ARCANOS functionality
 /api/memory      - Memory management with JSON responses
 /api/sim         - Simulation scenarios
 /api/fallback    - Fallback system testing
 ```
 
-### 3. Railway Deployment Ready
+### 4. Railway Deployment Ready
 - **Port binding**: Configured for Railway's PORT environment variable
 - **Environment support**: Added RAILWAY_ENVIRONMENT variable
 - **Structured config**: Updated railway.json with environments and services
 - **Health checks**: Built-in health monitoring for Railway observability
 
-### 4. Enhanced Security & Resilience
+### 5. Enhanced Security & Resilience
 - **Rate limiting**: 50-100 requests per 15 minutes per endpoint
 - **Input validation**: Comprehensive sanitization and validation
 - **Circuit breaker**: Exponential backoff for API calls

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -3,6 +3,7 @@ import { getTokenParameter } from '../utils/tokenParameterHelper.js';
 import { CircuitBreaker, ExponentialBackoff } from '../utils/circuitBreaker.js';
 import { responseCache } from '../utils/cache.js';
 import crypto from 'crypto';
+import { runtime } from './openaiRuntime.js';
 
 let openai: OpenAI | null = null;
 let defaultModel: string | null = null;
@@ -762,6 +763,11 @@ export async function createCentralizedCompletion(
     { role: 'system', content: 'ARCANOS routing active' },
     ...messages
   ];
+
+  // Record the conversation and model metadata in the lightweight runtime
+  const sessionId = runtime.createSession();
+  runtime.addMessages(sessionId, arcanosMessages);
+  runtime.setMetadata(sessionId, { model });
 
   console.log(`🎯 ARCANOS centralized routing - Model: ${model}`);
 

--- a/src/services/openaiRuntime.ts
+++ b/src/services/openaiRuntime.ts
@@ -1,0 +1,57 @@
+import crypto from 'crypto';
+
+/**
+ * Minimal in-process runtime to keep conversation and metadata
+ * in separate memory buckets. This mimics the behaviour of the
+ * OpenAI Runtime while remaining lightweight and compatible with
+ * Railway deployments.
+ */
+export interface RuntimeMemory {
+  messages: unknown[];
+  metadata: Record<string, unknown>;
+}
+
+class OpenAIRuntime {
+  private store = new Map<string, RuntimeMemory>();
+
+  /** Creates a new session and returns its id */
+  createSession(): string {
+    const id = crypto.randomUUID();
+    this.store.set(id, { messages: [], metadata: {} });
+    return id;
+  }
+
+  /** Adds chat messages to the conversation scope */
+  addMessages(sessionId: string, messages: unknown[]): void {
+    const entry = this.store.get(sessionId);
+    if (entry) {
+      entry.messages.push(...messages);
+    }
+  }
+
+  /** Stores metadata separate from the conversation scope */
+  setMetadata(sessionId: string, metadata: Record<string, unknown>): void {
+    const entry = this.store.get(sessionId);
+    if (entry) {
+      Object.assign(entry.metadata, metadata);
+    }
+  }
+
+  /** Retrieves messages for a session */
+  getMessages(sessionId: string): unknown[] {
+    return this.store.get(sessionId)?.messages ?? [];
+  }
+
+  /** Retrieves metadata for a session */
+  getMetadata(sessionId: string): Record<string, unknown> {
+    return this.store.get(sessionId)?.metadata ?? {};
+  }
+
+  /** Clears all stored data for a session */
+  reset(sessionId: string): void {
+    this.store.delete(sessionId);
+  }
+}
+
+export const runtime = new OpenAIRuntime();
+export default OpenAIRuntime;


### PR DESCRIPTION
## Summary
- add in-process runtime for isolating conversation messages from metadata
- integrate runtime with centralized OpenAI completion flow
- document runtime memory isolation in Railway compatibility guide

## Testing
- `npm test`
- `npm run validate:railway`


------
https://chatgpt.com/codex/tasks/task_e_68bb5be533448325b26826391e53d60f