### PR TITLE
feat(memory): simplify session storage and default retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ POST /memory/save      # Store memory entries (requires confirmation)
 GET  /memory/load      # Retrieve memory by key
 GET  /memory/health    # Memory system status
 GET  /memory/list      # List all memory entries
+POST /memory/dual/save # Store conversation + metadata
+GET  /memory/dual/:sessionId      # Retrieve conversation messages
+GET  /memory/dual/:sessionId/meta # Retrieve session metadata
+```
+
+Messages can be saved by passing either a `{ role, content }` object or a plain string (defaults to role `user`):
+
+```bash
+curl -X POST http://localhost:8080/memory/dual/save \
+  -H "Content-Type: application/json" \
+  -d '{"sessionId":"123","message":"Hello there"}'
 ```
 
 ### Chat Logs

--- a/src/controllers/sessionMemoryController.ts
+++ b/src/controllers/sessionMemoryController.ts
@@ -10,14 +10,22 @@ export const sessionMemoryController = {
       return;
     }
 
-    const clean = {
-      role: message.role,
-      content: (message.content || '').trim(),
-    };
+    const clean =
+      typeof message === 'string'
+        ? { role: 'user', content: message.trim() }
+        : {
+            role: message.role || 'user',
+            content: (message.content || '').trim(),
+          };
+
+    if (!clean.content) {
+      res.status(400).json({ error: 'message content is required' });
+      return;
+    }
 
     const meta = {
-      tokens: message.tokens || 0,
-      audit_tag: message.tag || 'unspecified',
+      tokens: typeof message === 'object' && message.tokens ? message.tokens : 0,
+      audit_tag: typeof message === 'object' && message.tag ? message.tag : 'unspecified',
       timestamp: Date.now(),
     };
 

--- a/src/routes/memory.ts
+++ b/src/routes/memory.ts
@@ -127,4 +127,10 @@ router.get(
   asyncHandler(sessionMemoryController.getMeta)
 );
 
+// Default to core conversation when no channel specified
+router.get(
+  "/memory/dual/:sessionId",
+  asyncHandler(sessionMemoryController.getCore)
+);
+
 export default router;


### PR DESCRIPTION
## Summary
- allow saving conversation messages as plain strings and validate non-empty content
- add default `/memory/dual/:sessionId` route returning conversation core
- document dual memory endpoints and string message usage

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run validate:railway`

------
https://chatgpt.com/codex/tasks/task_e_68bbb77e17e4832588d3457b050fc8a6