### PR TITLE
refactor: centralize OpenAI client and streamline Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,15 @@ WORKDIR /app
 # Copy package files for dependency installation
 COPY package*.json ./
 
-# Install dependencies with memory optimization
-RUN NODE_OPTIONS=--max_old_space_size=256 npm ci --only=production --no-audit --no-fund
+# Install all dependencies then build
+RUN npm ci --no-audit --no-fund
 
 # Copy source code and build configuration
 COPY src/ ./src/
 COPY tsconfig.json ./
 
-# Install dev dependencies and build
-RUN npm install --no-audit --no-fund && npm run build
+# Build with increased memory limit
+RUN NODE_OPTIONS=--max-old-space-size=2048 npm run build
 
 # Clean up dev dependencies after build
 RUN npm prune --production

--- a/docs/secure-reasoning-engine.md
+++ b/docs/secure-reasoning-engine.md
@@ -53,9 +53,11 @@ console.log(`Redactions: ${result.redactionsApplied.join(', ')}`);
 ### Secure Reasoning Analysis
 
 ```javascript
+import { getOpenAIClient } from './services/openai.js';
 import { executeSecureReasoning } from './services/secureReasoningEngine.js';
 
-const analysis = await executeSecureReasoning(openaiClient, {
+const openai = getOpenAIClient();
+const analysis = await executeSecureReasoning(openai, {
   userInput: 'How do I implement secure API authentication?',
   sessionId: 'user-session-123'
 });

--- a/src/services/sessionResolver.ts
+++ b/src/services/sessionResolver.ts
@@ -1,4 +1,4 @@
-import { openai } from '../utils/openaiClient.js';
+import { getOpenAIClient } from './openai.js';
 import memoryStore from '../memory/store.js';
 
 interface ResolveResult {
@@ -21,7 +21,8 @@ export async function resolveSession(nlQuery: string): Promise<ResolveResult> {
   });
 
   // 2. If none found, use embeddings for semantic match
-  if (candidates.length === 0 && process.env.OPENAI_API_KEY) {
+  const openai = getOpenAIClient();
+  if (candidates.length === 0 && openai) {
     const queryEmbedding = await openai.embeddings.create({
       model: 'text-embedding-3-small',
       input: nlQuery,

--- a/src/utils/openaiClient.ts
+++ b/src/utils/openaiClient.ts
@@ -1,7 +1,0 @@
-import OpenAI from 'openai';
-
-export const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY || '',
-});
-
-export default openai;


### PR DESCRIPTION
## Summary
- replace direct OpenAI usage in session resolver with `getOpenAIClient` to ensure all calls pass through centralized runtime
- remove unused `openaiClient` helper and update documentation for new client pattern
- streamline Dockerfile to install dependencies once and build with higher memory to avoid Railway out-of-memory errors

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run validate:railway`


------
https://chatgpt.com/codex/tasks/task_e_68bc861b471c8325b43c5dd786b0ad40