### PR TITLE
feat: add centralized openai proxy route

### DIFF
--- a/RAILWAY_COMPATIBILITY_GUIDE.md
+++ b/RAILWAY_COMPATIBILITY_GUIDE.md
@@ -25,6 +25,7 @@ compatible with Railway deployments.
 /api/memory      - Memory management with JSON responses
 /api/sim         - Simulation scenarios
 /api/fallback    - Fallback system testing
+/api/openai/prompt - Frontend proxy for centralized AI calls
 ```
 
 ### 4. Railway Deployment Ready
@@ -66,6 +67,11 @@ curl -X POST http://localhost:8080/api/sim \
 curl -X POST http://localhost:8080/api/memory/save \
   -H "Content-Type: application/json" \
   -d '{"key": "test", "value": "data"}'
+
+# Frontend proxy
+curl -X POST http://localhost:8080/api/openai/prompt \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Hello from frontend"}'
 
 # Fallback testing
 curl http://localhost:8080/api/fallback/test

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ POST /ask              # Primary AI chat endpoint (no confirmation required)
 POST /arcanos          # Main AI interface with intent routing
 ```
 
+### Frontend Proxy
+```bash
+POST /api/openai/prompt # Backend proxy for frontend chat requests
+```
+
 ### Memory Management
 ```bash
 POST /memory/save      # Store memory entries (requires confirmation)

--- a/src/controllers/openaiController.ts
+++ b/src/controllers/openaiController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { callOpenAI, getDefaultModel } from '../services/openai.js';
+import { createCentralizedCompletion, getDefaultModel } from '../services/openai.js';
 import {
   validateAIRequest,
   handleAIError,
@@ -31,8 +31,12 @@ export async function handlePrompt(
       : getDefaultModel();
 
   try {
-    const { output } = await callOpenAI(model, prompt, 256);
-    res.json({ result: output, model });
+    const completion = await createCentralizedCompletion([
+      { role: 'user', content: prompt }
+    ], { model, max_tokens: 256 });
+
+    const result = (completion as any).choices?.[0]?.message?.content || '';
+    res.json({ result, model });
   } catch (err) {
     handleAIError(err, prompt, 'prompt', res);
   }

--- a/src/routes/openai.ts
+++ b/src/routes/openai.ts
@@ -1,8 +1,14 @@
 import express from 'express';
 import { handlePrompt } from '../controllers/openaiController.js';
+import { createValidationMiddleware, createRateLimitMiddleware, commonSchemas } from '../utils/security.js';
 
 const router = express.Router();
 
-router.post('/prompt', handlePrompt);
+router.post(
+  '/prompt',
+  createRateLimitMiddleware(50, 15 * 60 * 1000),
+  createValidationMiddleware(commonSchemas.aiRequest),
+  handlePrompt
+);
 
 export default router;

--- a/tests/openai-prompt.test.ts
+++ b/tests/openai-prompt.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, jest, afterEach } from '@jest/globals';
 
-const callOpenAI = jest.fn();
+const createCentralizedCompletion = jest.fn();
 const getDefaultModel = jest.fn();
 const validateAIRequest = jest.fn();
 const handleAIError = jest.fn();
 
 jest.unstable_mockModule('../src/services/openai.js', () => ({
-  callOpenAI,
+  createCentralizedCompletion,
   getDefaultModel
 }));
 
@@ -24,21 +24,28 @@ afterEach(() => {
 describe('handlePrompt', () => {
   it('uses provided model when specified', async () => {
     validateAIRequest.mockReturnValue({ input: 'hi', client: {} });
-    callOpenAI.mockResolvedValue({ response: {}, output: 'ok' });
+    createCentralizedCompletion.mockResolvedValue({
+      choices: [{ message: { content: 'ok' } }]
+    });
 
     const req: any = { body: { prompt: 'hi', model: 'ft:custom-model' } };
     const res: any = { json: jest.fn() };
 
     await handlePrompt(req, res);
 
-    expect(callOpenAI).toHaveBeenCalledWith('ft:custom-model', 'hi', 256);
+    expect(createCentralizedCompletion).toHaveBeenCalledWith(
+      [{ role: 'user', content: 'hi' }],
+      { model: 'ft:custom-model', max_tokens: 256 }
+    );
     expect(res.json).toHaveBeenCalledWith({ result: 'ok', model: 'ft:custom-model' });
   });
 
   it('falls back to default model when none provided', async () => {
     validateAIRequest.mockReturnValue({ input: 'hello', client: {} });
     getDefaultModel.mockReturnValue('ft:default-model');
-    callOpenAI.mockResolvedValue({ response: {}, output: 'ok' });
+    createCentralizedCompletion.mockResolvedValue({
+      choices: [{ message: { content: 'ok' } }]
+    });
 
     const req: any = { body: { prompt: 'hello' } };
     const res: any = { json: jest.fn() };
@@ -46,7 +53,10 @@ describe('handlePrompt', () => {
     await handlePrompt(req, res);
 
     expect(getDefaultModel).toHaveBeenCalled();
-    expect(callOpenAI).toHaveBeenCalledWith('ft:default-model', 'hello', 256);
+    expect(createCentralizedCompletion).toHaveBeenCalledWith(
+      [{ role: 'user', content: 'hello' }],
+      { model: 'ft:default-model', max_tokens: 256 }
+    );
     expect(res.json).toHaveBeenCalledWith({ result: 'ok', model: 'ft:default-model' });
   });
 });


### PR DESCRIPTION
## Summary
- route `/api/openai/prompt` now guarded by rate limiting and input validation
- controller uses `createCentralizedCompletion` to proxy frontend prompts through the fine-tuned model
- docs updated for new proxy endpoint and Railway usage examples

## Testing
- `npm test`
- `npm run build`
- `npm run validate:railway`


------
https://chatgpt.com/codex/tasks/task_e_68bce3a859f48325ba067d6689106101