### PR TITLE
Sanitize conversation memory responses

### DIFF
--- a/src/controllers/sessionMemoryController.ts
+++ b/src/controllers/sessionMemoryController.ts
@@ -3,6 +3,17 @@ import { saveMessage, getChannel } from '../services/sessionMemoryService.js';
 import { requireField } from '../utils/validation.js';
 import memoryStore from '../memory/store.js';
 
+interface ChatMessage {
+  role: string;
+  content: string;
+}
+
+function sanitize(messages: any[]): ChatMessage[] {
+  return messages
+    .filter(m => m && typeof m.role === 'string' && typeof m.content === 'string')
+    .map(m => ({ role: m.role, content: m.content }));
+}
+
 export const sessionMemoryController = {
   saveDual: async (req: Request, res: Response) => {
     const { sessionId, message } = req.body;
@@ -42,7 +53,7 @@ export const sessionMemoryController = {
   getCore: async (req: Request, res: Response) => {
     const { sessionId } = req.params;
     const data = await getChannel(sessionId, 'conversations_core');
-    res.json(data);
+    res.json(sanitize(data));
   },
 
   getMeta: async (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary
- strip metadata from session conversation responses
- add helper to validate and format chat messages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be47a533148325b3772ecd04479cf6