### PR TITLE
Add session memory integrity retrieval

### DIFF
--- a/src/routes/memory.ts
+++ b/src/routes/memory.ts
@@ -149,6 +149,11 @@ router.get(
   asyncHandler(sessionMemoryController.getMeta)
 );
 
+router.get(
+  "/memory/dual/:sessionId/full",
+  asyncHandler(sessionMemoryController.getFull)
+);
+
 // Default to core conversation when no channel specified
 router.get(
   "/memory/dual/:sessionId",

--- a/src/services/sessionMemoryService.ts
+++ b/src/services/sessionMemoryService.ts
@@ -31,3 +31,15 @@ export async function getChannel(sessionId: string, channel: string): Promise<an
     return memoryStore[key] || [];
   }
 }
+
+export async function getConversation(sessionId: string): Promise<any[]> {
+  const [core, meta] = await Promise.all([
+    getChannel(sessionId, 'conversations_core'),
+    getChannel(sessionId, 'system_meta')
+  ]);
+
+  return core.map((msg, idx) => ({
+    ...msg,
+    meta: meta[idx] || {}
+  }));
+}

--- a/tests/session-memory-roundtrip.test.ts
+++ b/tests/session-memory-roundtrip.test.ts
@@ -1,0 +1,46 @@
+import { saveMessage, getConversation } from '../src/services/sessionMemoryService';
+
+describe('session memory round trip', () => {
+  it('stores and retrieves raw messages with metadata', async () => {
+    const sessionId = 'test-session';
+
+    await saveMessage(sessionId, 'conversations_core', {
+      role: 'user',
+      content: 'Hello',
+      timestamp: 1
+    });
+    await saveMessage(sessionId, 'system_meta', {
+      tokens: 1,
+      audit_tag: 'test',
+      timestamp: 1
+    });
+
+    await saveMessage(sessionId, 'conversations_core', {
+      role: 'assistant',
+      content: 'Hi there',
+      timestamp: 2
+    });
+    await saveMessage(sessionId, 'system_meta', {
+      tokens: 2,
+      audit_tag: 'test',
+      timestamp: 2
+    });
+
+    const convo = await getConversation(sessionId);
+    expect(convo).toEqual([
+      {
+        role: 'user',
+        content: 'Hello',
+        timestamp: 1,
+        meta: { tokens: 1, audit_tag: 'test', timestamp: 1 }
+      },
+      {
+        role: 'assistant',
+        content: 'Hi there',
+        timestamp: 2,
+        meta: { tokens: 2, audit_tag: 'test', timestamp: 2 }
+      }
+    ]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- store timestamps with saved messages and expose full conversation with metadata
- provide `getConversation` helper and `/memory/dual/:sessionId/full` route for raw history
- add round-trip test to verify memory storage

## Testing
- `npm test tests/session-memory-roundtrip.test.ts`
- `npm run lint`
- `npm run validate:railway`

------
https://chatgpt.com/codex/tasks/task_e_68be6d4a9c5c8325b83d7088add3d3c2