### PR TITLE
Add session memory integrity retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "type-check": "tsc --noEmit",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
-    "validate:railway": "node validate-railway-compatibility.js",
+    "validate:railway": "npm run build && node validate-railway-compatibility.js",
     "validate:refactoring": "node validate-refactoring.js",
     "assistants-sync": "npx ts-node scripts/assistants-sync.ts",
     "repair-migrations": "node scripts/migration-repair.js",

--- a/src/routes/memory.ts
+++ b/src/routes/memory.ts
@@ -149,6 +149,16 @@ router.get(
   asyncHandler(sessionMemoryController.getMeta)
 );
 
+router.get(
+  "/memory/dual/:sessionId/full",
+  asyncHandler(sessionMemoryController.getFull)
+);
+
+router.get(
+  "/memory/dual/:sessionId/message/:messageId",
+  asyncHandler(sessionMemoryController.getMessage)
+);
+
 // Default to core conversation when no channel specified
 router.get(
   "/memory/dual/:sessionId",

--- a/src/services/sessionMemoryService.ts
+++ b/src/services/sessionMemoryService.ts
@@ -31,3 +31,34 @@ export async function getChannel(sessionId: string, channel: string): Promise<an
     return memoryStore[key] || [];
   }
 }
+
+export async function getConversation(sessionId: string): Promise<any[]> {
+  const [core, meta] = await Promise.all([
+    getChannel(sessionId, 'conversations_core'),
+    getChannel(sessionId, 'system_meta')
+  ]);
+
+  const metaMap = new Map((meta as any[]).map((m: any) => [m.id, m]));
+
+  return (core as any[])
+    .map((msg: any) => ({
+      ...msg,
+      meta: metaMap.get(msg.id) || {}
+    }))
+    .sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
+}
+
+export async function getMessage(
+  sessionId: string,
+  messageId: string
+): Promise<any | undefined> {
+  const [core, meta] = await Promise.all([
+    getChannel(sessionId, 'conversations_core'),
+    getChannel(sessionId, 'system_meta')
+  ]);
+
+  const msg = (core as any[]).find((m: any) => m.id === messageId);
+  if (!msg) return undefined;
+  const metaEntry = (meta as any[]).find((m: any) => m.id === messageId) || {};
+  return { ...msg, meta: metaEntry };
+}

--- a/tests/session-memory-roundtrip.test.ts
+++ b/tests/session-memory-roundtrip.test.ts
@@ -1,0 +1,65 @@
+import {
+  saveMessage,
+  getConversation,
+  getMessage,
+} from '../src/services/sessionMemoryService';
+
+describe('session memory round trip', () => {
+  it('stores and retrieves raw messages with metadata', async () => {
+    const sessionId = 'test-session';
+
+    await saveMessage(sessionId, 'conversations_core', {
+      id: '1',
+      role: 'user',
+      content: 'Hello',
+      timestamp: 1,
+    });
+    await saveMessage(sessionId, 'system_meta', {
+      id: '1',
+      tokens: 1,
+      audit_tag: 'test',
+      timestamp: 1,
+    });
+
+    await saveMessage(sessionId, 'conversations_core', {
+      id: '2',
+      role: 'assistant',
+      content: 'Hi there',
+      timestamp: 2,
+    });
+    await saveMessage(sessionId, 'system_meta', {
+      id: '2',
+      tokens: 2,
+      audit_tag: 'test',
+      timestamp: 2,
+    });
+
+    const convo = await getConversation(sessionId);
+    expect(convo).toEqual([
+      {
+        id: '1',
+        role: 'user',
+        content: 'Hello',
+        timestamp: 1,
+        meta: { id: '1', tokens: 1, audit_tag: 'test', timestamp: 1 },
+      },
+      {
+        id: '2',
+        role: 'assistant',
+        content: 'Hi there',
+        timestamp: 2,
+        meta: { id: '2', tokens: 2, audit_tag: 'test', timestamp: 2 },
+      }
+    ]);
+
+    const single = await getMessage(sessionId, '1');
+    expect(single).toEqual({
+      id: '1',
+      role: 'user',
+      content: 'Hello',
+      timestamp: 1,
+      meta: { id: '1', tokens: 1, audit_tag: 'test', timestamp: 1 },
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- attach unique IDs to stored messages and metadata for precise lookup
- expose single-message endpoint and align conversations by ID and timestamp
- extend memory round-trip test to verify message retrieval by ID
- build before running Railway compatibility check so the OpenAI service is compiled

## Testing
- `npm test tests/session-memory-roundtrip.test.ts`
- `npm run lint`
- `npm run validate:railway`


------
https://chatgpt.com/codex/tasks/task_e_68be6d4a9c5c8325b83d7088add3d3c2