### PR TITLE
Use Responses API for GPT-5 operations

### DIFF
--- a/RAILWAY_COMPATIBILITY_GUIDE.md
+++ b/RAILWAY_COMPATIBILITY_GUIDE.md
@@ -135,7 +135,7 @@ All requests include:
 
 Run the comprehensive validation test:
 ```bash
-node validate-railway-compatibility.js
+npm run validate:railway
 ```
 
 This validates all requirements:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "assistants-sync": "npx ts-node scripts/assistants-sync.ts",
     "repair-migrations": "node scripts/migration-repair.js",
     "guide:generate": "node scripts/generate-tagged-guide.js",
-    "test:doc-workflow": "node scripts/test-doc-workflow.js"
+    "test:doc-workflow": "node scripts/test-doc-workflow.js",
+    "validate:railway": "node validate-railway-compatibility.js"
   },
   "keywords": [
     "ai",

--- a/railway.json
+++ b/railway.json
@@ -14,7 +14,11 @@
     "env": {
       "RUN_WORKERS": "false",
       "RAILWAY_ENVIRONMENT": "production",
-      "PORT": "${PORT}"
+      "PORT": "${PORT}",
+      "OPENAI_API_KEY": "${OPENAI_API_KEY}",
+      "OPENAI_BASE_URL": "${OPENAI_BASE_URL}",
+      "AI_MODEL": "${AI_MODEL}",
+      "GPT5_MODEL": "${GPT5_MODEL}"
     }
   },
   "environments": {
@@ -22,14 +26,22 @@
       "variables": {
         "NODE_ENV": "production",
         "RAILWAY_ENVIRONMENT": "production",
-        "RUN_WORKERS": "false"
+        "RUN_WORKERS": "false",
+        "OPENAI_API_KEY": "${OPENAI_API_KEY}",
+        "OPENAI_BASE_URL": "${OPENAI_BASE_URL}",
+        "AI_MODEL": "${AI_MODEL}",
+        "GPT5_MODEL": "${GPT5_MODEL}"
       }
     },
     "staging": {
       "variables": {
         "NODE_ENV": "staging",
         "RAILWAY_ENVIRONMENT": "staging",
-        "RUN_WORKERS": "false"
+        "RUN_WORKERS": "false",
+        "OPENAI_API_KEY": "${OPENAI_API_KEY}",
+        "OPENAI_BASE_URL": "${OPENAI_BASE_URL}",
+        "AI_MODEL": "${AI_MODEL}",
+        "GPT5_MODEL": "${GPT5_MODEL}"
       }
     }
   },

--- a/src/logic/arcanos.ts
+++ b/src/logic/arcanos.ts
@@ -391,7 +391,7 @@ export async function runARCANOS(
   // Use strict GPT-5 calls only - no fallback allowed
   const gpt5Model = getGPT5Model();
   let finalResult: string;
-  let response: OpenAI.Chat.Completions.ChatCompletion;
+  let response: any;
   
   try {
     // Use strict GPT-5 call with no fallback
@@ -408,7 +408,10 @@ export async function runARCANOS(
       ...tokenParams,
     });
 
-    finalResult = response.choices[0]?.message?.content || '';
+    finalResult =
+      response.output_text ||
+      response.output?.[0]?.content?.[0]?.text ||
+      '';
     console.log(`[🔬 ARCANOS] Diagnosis complete using strict GPT-5: ${gpt5Model}`);
     
   } catch (err) {

--- a/tests/test-gpt5-strict.js
+++ b/tests/test-gpt5-strict.js
@@ -14,20 +14,24 @@ async function testStrictGPT5Call() {
   try {
     // Test basic strict call
     const response = await call_gpt5_strict("Test prompt for GPT-5 strict validation", {
-      max_completion_tokens: 50
+      max_output_tokens: 50
     });
-    
+
     console.log('✅ [TEST] Strict GPT-5 call successful');
     console.log('Response model:', response.model);
-    console.log('Response content preview:', response.choices[0]?.message?.content?.substring(0, 100));
-    
+    const preview =
+      response.output_text ||
+      response.output?.[0]?.content?.[0]?.text ||
+      '';
+    console.log('Response content preview:', preview.substring(0, 100));
+
     // Validate response structure
     if (!response.model) {
       throw new Error('Response missing model field');
     }
-    
-    if (!response.choices || response.choices.length === 0) {
-      throw new Error('Response missing choices');
+
+    if (!response.output && !response.output_text) {
+      throw new Error('Response missing output');
     }
     
     return true;

--- a/validate-railway-compatibility.js
+++ b/validate-railway-compatibility.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * Simple Railway deployment validator for ARCANOS
+ */
+import { readFileSync } from 'fs';
+
+console.log('🚄 Railway Compatibility Validator\n');
+
+let passed = true;
+function check(desc, condition) {
+  console.log(`${condition ? '✅' : '❌'} ${desc}`);
+  if (!condition) passed = false;
+}
+
+// Environment variables
+const requiredEnv = ['OPENAI_API_KEY', 'PORT', 'RAILWAY_ENVIRONMENT'];
+for (const name of requiredEnv) {
+  check(`env.${name} set`, Boolean(process.env[name]));
+}
+
+// railway.json checks
+try {
+  const railway = JSON.parse(readFileSync('./railway.json', 'utf8'));
+  check('railway.json defines start command', Boolean(railway.deploy?.startCommand));
+  check('railway.json binds PORT', Boolean(railway.deploy?.env?.PORT));
+} catch {
+  check('railway.json present', false);
+}
+
+if (passed) {
+  console.log('\n✅ Railway compatibility validation passed');
+  process.exit(0);
+} else {
+  console.log('\n❌ Railway compatibility validation failed');
+  process.exit(1);
+}
+


### PR DESCRIPTION
## Summary
- map GPT-5 token params to `max_output_tokens`
- switch GPT-5 helper functions to `client.responses.create`
- update strict GPT-5 call and ARCANOS logic for new response format
- add Railway compatibility validator and enrich `railway.json`

## Testing
- `npm run build`
- `npm test`
- `OPENAI_API_KEY=dummy RAILWAY_ENVIRONMENT=production PORT=8080 npm run validate:railway`


------
https://chatgpt.com/codex/tasks/task_e_68c24ad3e8e883258341f16dd4b30903