### PR TITLE
feat: add shared web fetcher

### DIFF
--- a/src/controllers/healthController.ts
+++ b/src/controllers/healthController.ts
@@ -63,7 +63,7 @@ export class HealthController {
       const httpStatus = status === 'healthy' ? 200 : status === 'degraded' ? 200 : 503;
       
       res.status(httpStatus).json(healthResponse);
-    } catch (error) {
+    } catch {
       res.status(503).json({
         status: 'unhealthy',
         timestamp: new Date().toISOString(),

--- a/src/routes/sdk.ts
+++ b/src/routes/sdk.ts
@@ -312,7 +312,7 @@ router.post('/test-job', confirmGate, async (_, res) => {
     let jobRecord: any = null;
     try {
       jobRecord = await createJob('worker-1', 'test_job', jobData);
-    } catch (dbError) {
+    } catch {
       // If database not available, create mock job record
       jobRecord = {
         id: `test-job-${Date.now()}`,
@@ -355,7 +355,7 @@ router.post('/test-job', confirmGate, async (_, res) => {
     try {
       const { updateJob } = await import('../db.js');
       jobRecord = await updateJob(jobRecord.id, 'completed', result);
-    } catch (dbError) {
+    } catch {
       // Update mock record
       jobRecord.status = 'completed';
       (jobRecord as any).output = JSON.stringify(result);
@@ -530,7 +530,7 @@ router.post('/system-test', confirmGate, async (_, res) => {
     try {
       const { createJob } = await import('../db.js');
       jobRecord = await createJob('worker-1', 'test_job', testJobData);
-    } catch (dbError) {
+    } catch {
       jobRecord = {
         id: `test-job-${Date.now()}`,
         worker_id: 'worker-1',
@@ -572,7 +572,7 @@ router.post('/system-test', confirmGate, async (_, res) => {
     try {
       const { updateJob } = await import('../db.js');
       jobRecord = await updateJob(jobRecord.id, 'completed', taskResult);
-    } catch (dbError) {
+    } catch {
       jobRecord.status = 'completed';
       (jobRecord as any).output = JSON.stringify(taskResult);
       (jobRecord as any).completed_at = new Date().toISOString();

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -465,7 +465,7 @@ export const createChatCompletionWithFallback = async (
             fallbackFlag: true,
             fallbackReason: `All models failed: ${primaryModel} (primary), ${gpt5Model} (GPT-5 fallback), using final fallback`
           };
-        } catch (finalError) {
+        } catch {
           console.error(`❌ [COMPLETE FAILURE] All fallback attempts failed`);
           throw new Error(`All models failed: Primary (${primaryModel}), GPT-5 (${gpt5Model}), Final (${finalFallbackModel})`);
         }

--- a/src/services/prAssistant.ts
+++ b/src/services/prAssistant.ts
@@ -106,7 +106,7 @@ export class PRAssistant {
             issues.push(`Large file detected: ${file} (${lineCount} lines)`);
             details.push(`Consider breaking down ${file} into smaller, focused modules`);
           }
-        } catch (error) {
+        } catch {
           // File might be deleted or renamed, skip
         }
       }
@@ -294,7 +294,7 @@ export class PRAssistant {
             details.push('Update to OpenAI SDK v5.15.0 or later');
           }
         }
-      } catch (error) {
+      } catch {
         // Package.json might not be accessible, skip this check
       }
 
@@ -370,7 +370,7 @@ export class PRAssistant {
             issues.push('New environment variables not documented');
             details.push('Update .env.example with new environment variables');
           }
-        } catch (error) {
+        } catch {
           // .env.example might not exist, add it as a suggestion
           details.push('Consider creating .env.example for environment documentation');
         }
@@ -454,7 +454,7 @@ export class PRAssistant {
           timeout: 60000
         });
         details.push('Linting passed');
-      } catch (error) {
+      } catch {
         // Linting might not be available, skip
       }
 
@@ -508,7 +508,7 @@ export class PRAssistant {
           const filePath = path.join(this.workingDir, file);
           await fs.access(filePath);
           details.push(`✓ ${file} exists and accessible`);
-        } catch (error) {
+        } catch {
           return {
             status: '❌',
             message: `Critical file missing: ${file}`,
@@ -527,7 +527,7 @@ export class PRAssistant {
           hasEnvConfig = true;
           details.push(`✓ Environment configuration found: ${envFile}`);
           break;
-        } catch (error) {
+        } catch {
           // Try next file
         }
       }
@@ -547,7 +547,7 @@ export class PRAssistant {
           timeout: 60000
         });
         details.push('✓ TypeScript type checking passed');
-      } catch (error) {
+      } catch {
         try {
           await runCommand('tsc', ['--noEmit'], {
             cwd: this.workingDir,

--- a/src/services/stateManager.ts
+++ b/src/services/stateManager.ts
@@ -60,14 +60,11 @@ export function updateState(newData: Partial<SystemState>): SystemState {
  * Get current system state (for GPT sync)
  */
 import config from '../config/index.js';
+import { webFetcher } from '../utils/webFetcher.js';
 
 export async function getBackendState(port: number = config.server.port): Promise<SystemState> {
   try {
-    const response = await fetch(`http://localhost:${port}/status`);
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-    }
-    return await response.json();
+    return await webFetcher<SystemState>(`http://localhost:${port}/status`);
   } catch (error) {
     console.error('[STATE] Error fetching backend state:', error);
     // Fallback to file-based state

--- a/src/utils/dualModeAudit.ts
+++ b/src/utils/dualModeAudit.ts
@@ -64,7 +64,7 @@ export async function dualModeAudit(
       let data: any = {};
       try {
         data = await res.json();
-      } catch (jsonError) {
+      } catch {
         console.warn('Failed to parse JSON response, using empty object');
       }
       return {

--- a/src/utils/portUtils.ts
+++ b/src/utils/portUtils.ts
@@ -88,7 +88,7 @@ export async function getAvailablePort(
       isPreferred: false,
       message: `Port ${preferredPort} was in use, automatically selected port ${availablePort}`
     };
-  } catch (error) {
+  } catch {
     throw new Error(
       `Port ${preferredPort} is in use and no alternative ports are available. ` +
       `Searched ${preferredPort + 1}-${preferredPort + 50} but all were in use. ` +

--- a/src/utils/systemDiagnostics.ts
+++ b/src/utils/systemDiagnostics.ts
@@ -266,7 +266,7 @@ export async function generateSystemDiagnostics(): Promise<SystemDiagnostics> {
     try {
       const { getLatestJob } = await import('../db.js');
       latestJob = await getLatestJob();
-    } catch (error) {
+    } catch {
       // Database not connected or function not available
     }
 

--- a/src/utils/tokenParameterHelper.ts
+++ b/src/utils/tokenParameterHelper.ts
@@ -172,7 +172,7 @@ export async function testModelTokenParameter(
         console.log(`[✅ TOKEN-TEST] Model ${modelName} supports max_completion_tokens`);
         return 'max_completion_tokens';
         
-      } catch (fallbackError: any) {
+      } catch {
         console.warn(`[⚠️ TOKEN-TEST] Model ${modelName} failed both token parameters, defaulting to max_tokens`);
         modelCapabilityCache.set(modelName, 'max_tokens');
         return 'max_tokens';

--- a/src/utils/webFetcher.ts
+++ b/src/utils/webFetcher.ts
@@ -1,0 +1,24 @@
+/**
+ * Simple wrapper around the global fetch API.
+ * Throws an error for non-2xx responses and automatically
+ * parses JSON responses based on the content-type header.
+ */
+export async function webFetcher<T = unknown>(
+  url: string,
+  options?: RequestInit
+): Promise<T> {
+  const res = await fetch(url, options);
+
+  if (!res.ok) {
+    throw new Error(`Fetch failed: ${res.status} ${res.statusText}`);
+  }
+
+  const contentType = res.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    return (await res.json()) as T;
+  }
+
+  return (await res.text()) as unknown as T;
+}
+
+export default webFetcher;

--- a/src/utils/workerContext.ts
+++ b/src/utils/workerContext.ts
@@ -27,7 +27,7 @@ export function createWorkerContext(workerId: string): WorkerContext {
       console.log(`[${workerId}] ${message}`);
       try {
         await logExecution(workerId, 'info', message);
-      } catch (error) {
+      } catch {
         // Fallback logging already handled in logExecution
       }
     },
@@ -37,7 +37,7 @@ export function createWorkerContext(workerId: string): WorkerContext {
       console.error(`[${workerId}] ERROR: ${fullMessage}`);
       try {
         await logExecution(workerId, 'error', fullMessage);
-      } catch (error) {
+      } catch {
         // Fallback logging already handled in logExecution
       }
     },


### PR DESCRIPTION
## Summary
- introduce a reusable `webFetcher` wrapper around global fetch
- use shared fetcher in state manager to obtain backend status
- resolve repository lint errors by removing unused catch parameters

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5abbe617c8325aa758ced9f0a7a75