### PR TITLE
Add GPTID router mapping to modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,16 @@ docker build -t arcanos .
 docker run -p 8080:8080 -e OPENAI_API_KEY=your-key arcanos
 ```
 
+### GPT Module Routing
+
+Map custom GPT IDs to backend modules via the `GPT_MODULE_MAP` environment variable. Set it to a JSON object where each key is a GPT ID and the value provides the module route and name:
+
+```bash
+GPT_MODULE_MAP='{"gpt-backstage":{"route":"backstage-booker","module":"BACKSTAGE:BOOKER"}}'
+```
+
+This enables adding new GPT-to-module connections without requiring code changes.
+
 ## 📚 Documentation
 
 ### Core Guides

--- a/src/config/gptRouterConfig.ts
+++ b/src/config/gptRouterConfig.ts
@@ -1,0 +1,56 @@
+interface GptModuleEntry {
+  route: string;
+  module: string;
+}
+
+/**
+ * Builds a mapping of GPT IDs to module routes and names.
+ *
+ * Uses the `GPT_MODULE_MAP` environment variable when available. The variable
+ * should contain a JSON object where each key is a GPT ID and the value is an
+ * object with `route` and `module` properties. Example:
+ *
+ * ```bash
+ * GPT_MODULE_MAP='{"gpt-1":{"route":"tutor","module":"ARCANOS:TUTOR"}}'
+ * ```
+ *
+ * For backwards compatibility, legacy `GPTID_*` environment variables are also
+ * supported. These mappings can be removed once all deployments adopt the new
+ * configuration format.
+ */
+export function loadGptModuleMap(): Record<string, GptModuleEntry> {
+  const map: Record<string, GptModuleEntry> = {};
+
+  const raw = process.env.GPT_MODULE_MAP;
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as Record<string, GptModuleEntry>;
+      for (const [gptId, entry] of Object.entries(parsed)) {
+        if (entry.route && entry.module) {
+          map[gptId] = entry;
+        }
+      }
+    } catch (err) {
+      console.warn('Failed to parse GPT_MODULE_MAP', err);
+    }
+  }
+
+  // Legacy environment variables (to be deprecated)
+  const legacyEntries: Array<[string | undefined, GptModuleEntry]> = [
+    [process.env.GPTID_BACKSTAGE_BOOKER, { route: 'backstage-booker', module: 'BACKSTAGE:BOOKER' }],
+    [process.env.GPTID_ARCANOS_GAMING, { route: 'gaming', module: 'ARCANOS:GAMING' }],
+    [process.env.GPTID_ARCANOS_TUTOR, { route: 'tutor', module: 'ARCANOS:TUTOR' }],
+  ];
+
+  for (const [id, entry] of legacyEntries) {
+    if (id) {
+      map[id] = entry;
+    }
+  }
+
+  return map;
+}
+
+const gptModuleMap = loadGptModuleMap();
+
+export default gptModuleMap;

--- a/src/modules/backstage-booker.ts
+++ b/src/modules/backstage-booker.ts
@@ -1,0 +1,28 @@
+import BackstageBooker, { MatchInput, Wrestler } from './backstage/booker.js';
+
+export const BackstageBookerModule = {
+  name: 'BACKSTAGE:BOOKER',
+  description: 'Behind-the-scenes pro wrestling booker for WWE/AEW with strict canon and logic.',
+  actions: {
+    async bookEvent(payload: any) {
+      return BackstageBooker.bookEvent(payload);
+    },
+    async updateRoster(payload: Wrestler[]) {
+      return BackstageBooker.updateRoster(payload);
+    },
+    async trackStoryline(payload: any) {
+      return BackstageBooker.trackStoryline(payload);
+    },
+    async simulateMatch(payload: { match: MatchInput; rosters: Wrestler[]; winProbModifier?: number }) {
+      return BackstageBooker.simulateMatch(payload.match, payload.rosters, payload.winProbModifier ?? 0);
+    },
+    async generateBooking(payload: { prompt: string }) {
+      return BackstageBooker.generateBooking(payload.prompt);
+    },
+    async saveStoryline(payload: { key: string; storyline: string }) {
+      return BackstageBooker.saveStoryline(payload.key, payload.storyline);
+    }
+  }
+};
+
+export default BackstageBookerModule;

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -1,0 +1,24 @@
+import express from 'express';
+import modulesRouter from './modules.js';
+import gptModuleMap from '../config/gptRouterConfig.js';
+
+const router = express.Router();
+
+// Forward any request under /gpt/:gptId to the appropriate module route
+router.use('/:gptId', (req, res, next) => {
+  const entry = gptModuleMap[req.params.gptId];
+  if (!entry) {
+    return res.status(404).json({ error: 'Unknown GPTID' });
+  }
+
+  // Ensure body exists so downstream handlers can attach module metadata
+  if (!req.body) {
+    req.body = {};
+  }
+
+  req.url = `/modules/${entry.route}`;
+  req.body.module = entry.module;
+  return modulesRouter(req, res, next);
+});
+
+export default router;

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -21,6 +21,7 @@ import prAnalysisRouter from './pr-analysis.js';
 import openaiRouter from './openai.js';
 import ragRouter from './rag.js';
 import hrcRouter from './hrc.js';
+import gptRouter from './gptRouter.js';
 import { createFallbackTestRoute } from '../middleware/fallbackHandler.js';
 
 /**
@@ -43,6 +44,7 @@ export function registerRoutes(app: Express): void {
   app.use('/', orchestrationRouter);
   app.use('/', statusRouter);
   app.use('/', siriRouter);
+  app.use('/gpt', gptRouter);
   app.use('/backstage', backstageRouter);
   app.use('/sdk', sdkRouter);
   app.use('/api/arcanos', apiArcanosRouter);


### PR DESCRIPTION
## Summary
- add `gptRouter` to dispatch requests based on GPTID
- expose Backstage Booker logic as a module for router access
- configure GPTID to module mapping via environment variables and register new route
- support configurable `GPT_MODULE_MAP` for scalable GPT routing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c61eb671048325b9db7d66d0afa776