### PR TITLE
Persist Backstage Booker data and enrich GPT prompts

### DIFF
--- a/scripts/db-init.js
+++ b/scripts/db-init.js
@@ -25,6 +25,38 @@ async function ensureSchema() {
         payload JSONB,
         timestamp BIGINT NOT NULL
       );
+    `,
+    backstage_events: `
+      CREATE TABLE IF NOT EXISTS backstage_events (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        data JSONB NOT NULL,
+        created_at TIMESTAMPTZ DEFAULT NOW()
+      );
+    `,
+    backstage_wrestlers: `
+      CREATE TABLE IF NOT EXISTS backstage_wrestlers (
+        id SERIAL PRIMARY KEY,
+        name TEXT UNIQUE NOT NULL,
+        overall INTEGER NOT NULL,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        updated_at TIMESTAMPTZ DEFAULT NOW()
+      );
+    `,
+    backstage_storylines: `
+      CREATE TABLE IF NOT EXISTS backstage_storylines (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        story_key TEXT UNIQUE NOT NULL,
+        storyline TEXT NOT NULL,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        updated_at TIMESTAMPTZ DEFAULT NOW()
+      );
+    `,
+    backstage_story_beats: `
+      CREATE TABLE IF NOT EXISTS backstage_story_beats (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        data JSONB NOT NULL,
+        created_at TIMESTAMPTZ DEFAULT NOW()
+      );
     `
     // add more tables here as needed
   };

--- a/scripts/schemas/backstage_events.js
+++ b/scripts/schemas/backstage_events.js
@@ -1,0 +1,7 @@
+export default {
+  tableName: 'backstage_events',
+  definition: {
+    data: 'JSONB NOT NULL',
+    created_at: 'TIMESTAMPTZ DEFAULT NOW()'
+  }
+};

--- a/scripts/schemas/backstage_story_beats.js
+++ b/scripts/schemas/backstage_story_beats.js
@@ -1,0 +1,7 @@
+export default {
+  tableName: 'backstage_story_beats',
+  definition: {
+    data: 'JSONB NOT NULL',
+    created_at: 'TIMESTAMPTZ DEFAULT NOW()'
+  }
+};

--- a/scripts/schemas/backstage_storylines.js
+++ b/scripts/schemas/backstage_storylines.js
@@ -1,0 +1,9 @@
+export default {
+  tableName: 'backstage_storylines',
+  definition: {
+    story_key: 'TEXT UNIQUE NOT NULL',
+    storyline: 'TEXT NOT NULL',
+    created_at: 'TIMESTAMPTZ DEFAULT NOW()',
+    updated_at: 'TIMESTAMPTZ DEFAULT NOW()'
+  }
+};

--- a/scripts/schemas/backstage_wrestlers.js
+++ b/scripts/schemas/backstage_wrestlers.js
@@ -1,0 +1,9 @@
+export default {
+  tableName: 'backstage_wrestlers',
+  definition: {
+    name: 'TEXT UNIQUE NOT NULL',
+    overall: 'INTEGER NOT NULL',
+    created_at: 'TIMESTAMPTZ DEFAULT NOW()',
+    updated_at: 'TIMESTAMPTZ DEFAULT NOW()'
+  }
+};

--- a/src/config/prompts.ts
+++ b/src/config/prompts.ts
@@ -1,1 +1,14 @@
-export const BOOKING_INSTRUCTIONS_SUFFIX = "\n\nRespond with the booking storyline only. Do not include meta commentary or self reflections.";
+export const BACKSTAGE_BOOKER_PERSONA =
+  'You are Kay "Spotlight" Morales, a veteran human head booker with a warm, collaborative voice, a sharp instinct for long-term storytelling, and an ear for the locker room. You speak like a real person who loves wrestling—mixing production savvy with occasional locker-room slang—and you never refer to yourself as an AI.';
+
+export const BOOKING_RESPONSE_GUIDELINES = `
+Deliver the booking as if you are Kay pitching to the creative team.
+- Open with a quick human check-in or gut reaction (1-2 sentences).
+- Present the proposed card or segment plan as organized markdown sections.
+- Highlight consequences, momentum shifts, and any shoot-level production notes separately.
+- Keep the tone conversational, warm, and human—avoid robotic phrasing.
+- Never include meta commentary about being an AI or system.
+`;
+
+export const BOOKING_INSTRUCTIONS_SUFFIX =
+  '\n\nRespond using the structure above. Focus on immersive, human-feeling booking language. No meta commentary or self reflections outside the specified sections.';

--- a/src/db.ts
+++ b/src/db.ts
@@ -219,6 +219,35 @@ async function initializeTables(): Promise<void> {
       created_at TIMESTAMPTZ DEFAULT NOW(),
       updated_at TIMESTAMPTZ DEFAULT NOW()
     )`,
+
+    // Backstage Booker tables for persistent wrestling data
+    `CREATE TABLE IF NOT EXISTS backstage_events (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      data JSONB NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )`,
+
+    `CREATE TABLE IF NOT EXISTS backstage_wrestlers (
+      id SERIAL PRIMARY KEY,
+      name TEXT UNIQUE NOT NULL,
+      overall INTEGER NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT NOW(),
+      updated_at TIMESTAMPTZ DEFAULT NOW()
+    )`,
+
+    `CREATE TABLE IF NOT EXISTS backstage_storylines (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      story_key TEXT UNIQUE NOT NULL,
+      storyline TEXT NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT NOW(),
+      updated_at TIMESTAMPTZ DEFAULT NOW()
+    )`,
+
+    `CREATE TABLE IF NOT EXISTS backstage_story_beats (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      data JSONB NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )`,
     
     // Execution logs table for worker logs
     `CREATE TABLE IF NOT EXISTS execution_logs (
@@ -260,7 +289,10 @@ async function initializeTables(): Promise<void> {
     `CREATE INDEX IF NOT EXISTS idx_reasoning_logs_timestamp ON reasoning_logs(timestamp DESC)`,
     `CREATE INDEX IF NOT EXISTS idx_saves_module_timestamp ON saves(module, timestamp)`,
     `CREATE INDEX IF NOT EXISTS idx_audit_logs_event_timestamp ON audit_logs(event, timestamp DESC)`,
-    `CREATE INDEX IF NOT EXISTS idx_rag_docs_url ON rag_docs(url)`
+    `CREATE INDEX IF NOT EXISTS idx_rag_docs_url ON rag_docs(url)`,
+    `CREATE INDEX IF NOT EXISTS idx_backstage_wrestlers_name ON backstage_wrestlers(name)`,
+    `CREATE INDEX IF NOT EXISTS idx_backstage_events_created_at ON backstage_events(created_at DESC)`,
+    `CREATE INDEX IF NOT EXISTS idx_backstage_story_beats_created_at ON backstage_story_beats(created_at DESC)`
   ];
 
   try {

--- a/src/modules/backstage/booker.ts
+++ b/src/modules/backstage/booker.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from 'crypto';
 import { callOpenAI } from '../../services/openai.js';
 import { saveWithAuditCheck } from '../../services/persistenceManager.js';
-import { BOOKING_INSTRUCTIONS_SUFFIX } from '../../config/prompts.js';
+import {
+  BACKSTAGE_BOOKER_PERSONA,
+  BOOKING_INSTRUCTIONS_SUFFIX,
+  BOOKING_RESPONSE_GUIDELINES
+} from '../../config/prompts.js';
+import { query } from '../../db.js';
 
 export interface Wrestler {
   name: string;
@@ -37,36 +42,208 @@ const events: Array<{ id: string; data: any }> = [];
 let roster: Wrestler[] = [];
 const storylines: Array<any> = [];
 
+function formatJsonSnippet(value: unknown, maxLength = 220): string {
+  if (value === null || value === undefined) {
+    return '∅';
+  }
+
+  if (typeof value === 'string') {
+    const compact = value.replace(/\s+/g, ' ').trim();
+    return compact.length > maxLength ? `${compact.slice(0, maxLength)}…` : compact;
+  }
+
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized.length > maxLength ? `${serialized.slice(0, maxLength)}…` : serialized;
+  } catch (error) {
+    console.warn('Backstage Booker: failed to format JSON snippet', (error as Error).message);
+    const fallback = String(value);
+    return fallback.length > maxLength ? `${fallback.slice(0, maxLength)}…` : fallback;
+  }
+}
+
+function toISODate(value: unknown): string {
+  try {
+    return new Date(value as string).toISOString();
+  } catch {
+    return 'unknown-date';
+  }
+}
+
+async function buildStructuredBookingPrompt(basePrompt: string): Promise<string> {
+  try {
+    const [rosterResult, eventsResult, beatsResult, savedStoriesResult] = await Promise.all([
+      query(
+        'SELECT name, overall, updated_at FROM backstage_wrestlers ORDER BY updated_at DESC LIMIT 25',
+        [],
+        1,
+        true
+      ),
+      query(
+        'SELECT data, created_at FROM backstage_events ORDER BY created_at DESC LIMIT 5',
+        [],
+        1,
+        true
+      ),
+      query(
+        'SELECT data, created_at FROM backstage_story_beats ORDER BY created_at DESC LIMIT 5',
+        [],
+        1,
+        true
+      ),
+      query(
+        'SELECT story_key, storyline, updated_at FROM backstage_storylines ORDER BY updated_at DESC LIMIT 5',
+        [],
+        1,
+        true
+      )
+    ]);
+
+    const rosterBlock = rosterResult.rows.length
+      ? rosterResult.rows
+          .map(row => `- ${row.name} (Overall ${row.overall}) • updated ${toISODate(row.updated_at)}`)
+          .join('\n')
+      : 'No roster data recorded yet.';
+
+    const eventsBlock = eventsResult.rows.length
+      ? eventsResult.rows
+          .map(row => {
+            const payload = row.data as Record<string, unknown> | undefined;
+            const label =
+              (payload?.name as string | undefined) ||
+              (payload?.title as string | undefined) ||
+              'Unlabeled Event';
+            return `- ${label} • booked ${toISODate(row.created_at)} :: ${formatJsonSnippet(payload)}`;
+          })
+          .join('\n')
+      : 'No events booked yet.';
+
+    const beatsBlock = beatsResult.rows.length
+      ? beatsResult.rows
+          .map(row => `- ${toISODate(row.created_at)} :: ${formatJsonSnippet(row.data)}`)
+          .join('\n')
+      : 'No story beats recorded yet.';
+
+    const savedStoriesBlock = savedStoriesResult.rows.length
+      ? savedStoriesResult.rows
+          .map(row => `- ${row.story_key}: ${formatJsonSnippet(row.storyline, 260)}`)
+          .join('\n')
+      : 'No saved storylines yet.';
+
+    const sections = [
+      `<<PERSONA>>\n${BACKSTAGE_BOOKER_PERSONA}`,
+      `<<BOOKING_DIRECTIVE>>\n${basePrompt.trim()}`,
+      `<<CURRENT_ROSTER>>\n${rosterBlock}`,
+      `<<RECENT_EVENTS>>\n${eventsBlock}`,
+      `<<RECENT_STORY_BEATS>>\n${beatsBlock}`,
+      `<<SAVED_STORYLINES>>\n${savedStoriesBlock}`,
+      `<<RESPONSE_STYLE>>\n${BOOKING_RESPONSE_GUIDELINES.trim()}`
+    ];
+
+    return `${sections.join('\n\n')}${BOOKING_INSTRUCTIONS_SUFFIX}`;
+  } catch (error) {
+    console.warn('Backstage Booker: falling back to in-memory context', (error as Error).message);
+    const fallbackRoster = roster.length
+      ? roster.map(w => `- ${w.name} (Overall ${w.overall})`).join('\n')
+      : 'No roster data recorded yet.';
+    const fallbackStories = storylines.length
+      ? storylines.map((entry, idx) => `- #${idx + 1}: ${formatJsonSnippet(entry)}`).join('\n')
+      : 'No story beats recorded yet.';
+
+    const sections = [
+      `<<PERSONA>>\n${BACKSTAGE_BOOKER_PERSONA}`,
+      `<<BOOKING_DIRECTIVE>>\n${basePrompt.trim()}`,
+      `<<CURRENT_ROSTER>>\n${fallbackRoster}`,
+      `<<RECENT_STORY_BEATS>>\n${fallbackStories}`,
+      `<<RESPONSE_STYLE>>\n${BOOKING_RESPONSE_GUIDELINES.trim()}`
+    ];
+
+    return `${sections.join('\n\n')}${BOOKING_INSTRUCTIONS_SUFFIX}`;
+  }
+}
+
 /**
  * Books an event by storing the payload and returning an id.
  */
 export async function bookEvent(data: any): Promise<string> {
   const id = randomUUID();
-  events.push({ id, data });
-  return id;
+  try {
+    await query(
+      'INSERT INTO backstage_events (id, data, created_at) VALUES ($1, $2, NOW())',
+      [id, data]
+    );
+    events.push({ id, data });
+    if (events.length > 25) {
+      events.shift();
+    }
+    return id;
+  } catch (error) {
+    console.warn('Backstage Booker: falling back to in-memory events store', (error as Error).message);
+    events.push({ id, data });
+    return id;
+  }
 }
 
 /**
  * Updates the roster. Existing wrestlers are replaced, new ones added.
  */
 export async function updateRoster(wrestlers: Wrestler[]): Promise<Wrestler[]> {
-  wrestlers.forEach(w => {
-    const idx = roster.findIndex(r => r.name === w.name);
-    if (idx >= 0) {
-      roster[idx] = w;
-    } else {
-      roster.push(w);
-    }
-  });
-  return roster;
+  try {
+    await Promise.all(
+      wrestlers.map(wrestler =>
+        query(
+          `INSERT INTO backstage_wrestlers (name, overall, created_at, updated_at)
+           VALUES ($1, $2, NOW(), NOW())
+           ON CONFLICT (name)
+           DO UPDATE SET overall = EXCLUDED.overall, updated_at = NOW()`,
+          [wrestler.name, wrestler.overall]
+        )
+      )
+    );
+
+    const result = await query(
+      'SELECT name, overall FROM backstage_wrestlers ORDER BY name ASC',
+      [],
+      1,
+      true
+    );
+
+    roster = result.rows.map(row => ({ name: row.name as string, overall: Number(row.overall) }));
+    return roster;
+  } catch (error) {
+    console.warn('Backstage Booker: roster DB unavailable, using in-memory roster', (error as Error).message);
+    wrestlers.forEach(w => {
+      const idx = roster.findIndex(r => r.name === w.name);
+      if (idx >= 0) {
+        roster[idx] = w;
+      } else {
+        roster.push(w);
+      }
+    });
+    return roster;
+  }
 }
 
 /**
  * Tracks storyline information by appending to the internal array.
  */
 export async function trackStoryline(data: any): Promise<any[]> {
-  storylines.push(data);
-  return storylines;
+  try {
+    await query('INSERT INTO backstage_story_beats (data, created_at) VALUES ($1, NOW())', [data]);
+    const result = await query(
+      'SELECT data FROM backstage_story_beats ORDER BY created_at ASC',
+      [],
+      1,
+      true
+    );
+    storylines.length = 0;
+    storylines.push(...result.rows.map(row => row.data));
+    return [...storylines];
+  } catch (error) {
+    console.warn('Backstage Booker: storyline DB unavailable, using in-memory log', (error as Error).message);
+    storylines.push(data);
+    return [...storylines];
+  }
 }
 
 /**
@@ -79,7 +256,7 @@ export async function generateBooking(prompt: string): Promise<string> {
     throw new Error('USER_GPT_ID not configured');
   }
   const tokenLimit = parseInt(process.env.BOOKER_TOKEN_LIMIT ?? '512', 10);
-  const instructions = `${prompt}${BOOKING_INSTRUCTIONS_SUFFIX}`;
+  const instructions = await buildStructuredBookingPrompt(prompt);
   try {
     const { output } = await callOpenAI(model, instructions, tokenLimit, false);
     const clean = output.replace(/\b(meta|reflection)[:].*$/gi, '').trim();
@@ -95,11 +272,25 @@ export async function generateBooking(prompt: string): Promise<string> {
  */
 export async function saveStoryline(key: string, storyline: string): Promise<boolean> {
   const data = { key, storyline };
-  return await saveWithAuditCheck(
+  const result = await saveWithAuditCheck(
     'backstage_booker',
     data,
     d => typeof d.storyline === 'string' && d.storyline.trim().length > 0
   );
+  if (result) {
+    try {
+      await query(
+        `INSERT INTO backstage_storylines (story_key, storyline, created_at, updated_at)
+         VALUES ($1, $2, NOW(), NOW())
+         ON CONFLICT (story_key)
+         DO UPDATE SET storyline = EXCLUDED.storyline, updated_at = NOW()`,
+        [key, storyline]
+      );
+    } catch (error) {
+      console.warn('Backstage Booker: failed to persist storyline to DB', (error as Error).message);
+    }
+  }
+  return result;
 }
 
 /**
@@ -108,13 +299,30 @@ export async function saveStoryline(key: string, storyline: string): Promise<boo
  */
 export async function simulateMatch(
   match: MatchInput,
-  rosters: Wrestler[],
+  rosters: Wrestler[] = [],
   winProbModifier = 0
 ): Promise<KayfabeResult | RealResult> {
   const { wrestler1, wrestler2, matchType, kayfabeMode = false } = match;
 
-  const w1 = rosters.find(r => r.name === wrestler1);
-  const w2 = rosters.find(r => r.name === wrestler2);
+  let activeRoster = rosters;
+
+  if (!activeRoster || activeRoster.length === 0) {
+    try {
+      const result = await query(
+        'SELECT name, overall FROM backstage_wrestlers ORDER BY name ASC',
+        [],
+        1,
+        true
+      );
+      activeRoster = result.rows.map(row => ({ name: row.name as string, overall: Number(row.overall) }));
+    } catch (error) {
+      console.warn('Backstage Booker: match simulation falling back to in-memory roster', (error as Error).message);
+      activeRoster = roster;
+    }
+  }
+
+  const w1 = activeRoster.find(r => r.name === wrestler1);
+  const w2 = activeRoster.find(r => r.name === wrestler2);
 
   if (!w1 || !w2) {
     throw new Error('One or both wrestlers not found in roster');
@@ -127,8 +335,8 @@ export async function simulateMatch(
   w2Chance = 1 - w1Chance;
 
   let interference: string | null = null;
-  if (Math.random() < 0.1 && rosters.length > 0) {
-    interference = rosters[Math.floor(Math.random() * rosters.length)].name;
+  if (Math.random() < 0.1 && activeRoster.length > 0) {
+    interference = activeRoster[Math.floor(Math.random() * activeRoster.length)].name;
     if (Math.random() > 0.5) {
       w1Chance = Math.min(Math.max(w1Chance + 0.15, 0), 1);
     } else {

--- a/src/routes/backstage.ts
+++ b/src/routes/backstage.ts
@@ -43,8 +43,8 @@ router.post('/book-gpt', confirmGate, async (req: Request, res: Response) => {
 // Simulate Match
 router.post('/simulate-match', confirmGate, async (req: Request, res: Response) => {
   try {
-    const { match, rosters, winProbModifier }: { match: MatchInput; rosters: Wrestler[]; winProbModifier?: number } = req.body;
-    const result = await BackstageBooker.simulateMatch(match, rosters, winProbModifier || 0);
+    const { match, rosters, winProbModifier }: { match: MatchInput; rosters?: Wrestler[]; winProbModifier?: number } = req.body;
+    const result = await BackstageBooker.simulateMatch(match, rosters ?? [], winProbModifier || 0);
     res.status(200).json({ success: true, result });
   } catch (error: any) {
     res.status(500).json({ success: false, error: error.message });


### PR DESCRIPTION
## Summary
- persist Backstage Booker events, rosters, beats, and saved storylines into PostgreSQL with schema patches and fallbacks
- enrich booking prompt construction with roster/event context and a human booker persona for warmer GPT output
- allow match simulations to hydrate roster data from storage and make roster payload optional in the route

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc2a7696108325bc851816b42e0cdc