### PR TITLE
Auto-discover GPT bindings from module metadata

### DIFF
--- a/src/config/gptRouterConfig.ts
+++ b/src/config/gptRouterConfig.ts
@@ -1,14 +1,38 @@
+import { loadModuleDefinitions, LoadedModule } from '../modules/moduleLoader.js';
+
 interface GptModuleEntry {
   route: string;
   module: string;
 }
 
+function buildDefaultBindings(modules: LoadedModule[]): Record<string, GptModuleEntry> {
+  const defaults: Record<string, GptModuleEntry> = {};
+
+  for (const { route, definition } of modules) {
+    const entry: GptModuleEntry = { route, module: definition.name };
+    const ids = Array.isArray(definition.gptIds) && definition.gptIds.length > 0
+      ? definition.gptIds
+      : [route];
+
+    const normalizedIds = new Set<string>(ids.map((id) => id.trim()).filter(Boolean));
+    normalizedIds.add(route);
+
+    for (const gptId of normalizedIds) {
+      defaults[gptId] = { ...entry };
+    }
+  }
+
+  return defaults;
+}
+
 /**
  * Builds a mapping of GPT IDs to module routes and names.
  *
- * Uses the `GPT_MODULE_MAP` environment variable when available. The variable
- * should contain a JSON object where each key is a GPT ID and the value is an
- * object with `route` and `module` properties. Example:
+ * Auto-discovers module definitions from `src/modules` so that any module that
+ * declares `gptIds` is automatically routable. The `GPT_MODULE_MAP`
+ * environment variable can still override or extend the mapping by providing a
+ * JSON object where each key is a GPT ID and the value is an object with
+ * `route` and `module` properties. Example:
  *
  * ```bash
  * GPT_MODULE_MAP='{"gpt-1":{"route":"tutor","module":"ARCANOS:TUTOR"}}'
@@ -18,8 +42,11 @@ interface GptModuleEntry {
  * supported. These mappings can be removed once all deployments adopt the new
  * configuration format.
  */
-export function loadGptModuleMap(): Record<string, GptModuleEntry> {
-  const map: Record<string, GptModuleEntry> = {};
+export async function loadGptModuleMap(): Promise<Record<string, GptModuleEntry>> {
+  const loadedModules = await loadModuleDefinitions();
+  const defaults = buildDefaultBindings(loadedModules);
+
+  const map: Record<string, GptModuleEntry> = { ...defaults };
 
   const raw = process.env.GPT_MODULE_MAP;
   if (raw) {
@@ -27,7 +54,7 @@ export function loadGptModuleMap(): Record<string, GptModuleEntry> {
       const parsed = JSON.parse(raw) as Record<string, GptModuleEntry>;
       for (const [gptId, entry] of Object.entries(parsed)) {
         if (entry.route && entry.module) {
-          map[gptId] = entry;
+          map[gptId] = { ...entry };
         }
       }
     } catch (err) {
@@ -35,22 +62,27 @@ export function loadGptModuleMap(): Record<string, GptModuleEntry> {
     }
   }
 
-  // Legacy environment variables (to be deprecated)
-  const legacyEntries: Array<[string | undefined, GptModuleEntry]> = [
-    [process.env.GPTID_BACKSTAGE_BOOKER, { route: 'backstage-booker', module: 'BACKSTAGE:BOOKER' }],
-    [process.env.GPTID_ARCANOS_GAMING, { route: 'gaming', module: 'ARCANOS:GAMING' }],
-    [process.env.GPTID_ARCANOS_TUTOR, { route: 'tutor', module: 'ARCANOS:TUTOR' }],
+  const moduleRoutesByName = new Map<string, string>();
+  for (const { route, definition } of loadedModules) {
+    moduleRoutesByName.set(definition.name, route);
+  }
+
+  const legacyEntries: Array<[string | undefined, string]> = [
+    [process.env.GPTID_BACKSTAGE_BOOKER, 'BACKSTAGE:BOOKER'],
+    [process.env.GPTID_ARCANOS_GAMING, 'ARCANOS:GAMING'],
+    [process.env.GPTID_ARCANOS_TUTOR, 'ARCANOS:TUTOR'],
   ];
 
-  for (const [id, entry] of legacyEntries) {
-    if (id) {
-      map[id] = entry;
-    }
+  for (const [id, moduleName] of legacyEntries) {
+    if (!id) continue;
+    const route = moduleRoutesByName.get(moduleName);
+    if (!route) continue;
+    map[id] = { route, module: moduleName };
   }
 
   return map;
 }
 
-const gptModuleMap = loadGptModuleMap();
+const gptModuleMapPromise = loadGptModuleMap();
 
-export default gptModuleMap;
+export default gptModuleMapPromise;

--- a/src/modules/arcanos-gaming.ts
+++ b/src/modules/arcanos-gaming.ts
@@ -3,6 +3,7 @@ import { runGaming } from '../services/gaming.js';
 export const ArcanosGaming = {
   name: 'ARCANOS:GAMING',
   description: 'Nintendo-style hotline advisor for game strategies, hints, and walkthroughs.',
+  gptIds: ['arcanos-gaming', 'gaming'],
   actions: {
     async query(payload: any) {
       return runGaming(payload?.prompt || payload, payload?.url);

--- a/src/modules/arcanos-tutor.ts
+++ b/src/modules/arcanos-tutor.ts
@@ -4,6 +4,7 @@ export const ArcanosTutor = {
   name: 'ARCANOS:TUTOR',
   description:
     'Professional tutoring kernel with dynamic schema binding, modular instruction, audit traceability, and feedback loops.',
+  gptIds: ['arcanos-tutor', 'tutor'],
   actions: {
     async query(payload: any) {
       return tutorLogic.dispatch(payload);

--- a/src/modules/backstage-booker.ts
+++ b/src/modules/backstage-booker.ts
@@ -3,6 +3,7 @@ import BackstageBooker, { MatchInput, Wrestler } from './backstage/booker.js';
 export const BackstageBookerModule = {
   name: 'BACKSTAGE:BOOKER',
   description: 'Behind-the-scenes pro wrestling booker for WWE/AEW with strict canon and logic.',
+  gptIds: ['backstage-booker', 'backstage'],
   actions: {
     async bookEvent(payload: any) {
       return BackstageBooker.bookEvent(payload);

--- a/src/modules/moduleLoader.ts
+++ b/src/modules/moduleLoader.ts
@@ -1,0 +1,65 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+export interface ModuleDef {
+  name: string;
+  description?: string;
+  actions: Record<string, (payload: any) => Promise<any>>;
+  gptIds?: string[];
+}
+
+export interface LoadedModule {
+  route: string;
+  definition: ModuleDef;
+}
+
+let cachedModules: LoadedModule[] | null = null;
+
+function normalizeRouteFromFilename(fileName: string): string {
+  return fileName.replace(/\.(ts|js)$/i, '').replace(/^arcanos-/, '');
+}
+
+function shouldIncludeFile(fileName: string): boolean {
+  if (!/\.(ts|js)$/i.test(fileName)) return false;
+  if (/\.d\.ts$/i.test(fileName)) return false;
+  if (/moduleLoader\.(ts|js)$/i.test(fileName)) return false;
+  return true;
+}
+
+export async function loadModuleDefinitions(): Promise<LoadedModule[]> {
+  if (cachedModules) {
+    return cachedModules;
+  }
+
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const modulesDir = __dirname;
+  const files = await fs.readdir(modulesDir, { withFileTypes: true });
+
+  const loaded: LoadedModule[] = [];
+
+  for (const file of files) {
+    if (!file.isFile()) continue;
+    if (!shouldIncludeFile(file.name)) continue;
+
+    const route = normalizeRouteFromFilename(file.name);
+    const moduleUrl = pathToFileURL(path.join(modulesDir, file.name)).href;
+
+    try {
+      const imported = await import(moduleUrl);
+      const mod: ModuleDef | undefined = imported.default;
+      if (mod && mod.actions) {
+        loaded.push({ route, definition: mod });
+      }
+    } catch (err) {
+      console.error(`Failed to load module ${file.name}:`, err);
+    }
+  }
+
+  cachedModules = loaded;
+  return loaded;
+}
+
+export function clearModuleDefinitionCache() {
+  cachedModules = null;
+}

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -1,24 +1,29 @@
 import express from 'express';
 import modulesRouter from './modules.js';
-import gptModuleMap from '../config/gptRouterConfig.js';
+import gptModuleMapPromise from '../config/gptRouterConfig.js';
 
 const router = express.Router();
 
 // Forward any request under /gpt/:gptId to the appropriate module route
-router.use('/:gptId', (req, res, next) => {
-  const entry = gptModuleMap[req.params.gptId];
-  if (!entry) {
-    return res.status(404).json({ error: 'Unknown GPTID' });
-  }
+router.use('/:gptId', async (req, res, next) => {
+  try {
+    const gptModuleMap = await gptModuleMapPromise;
+    const entry = gptModuleMap[req.params.gptId];
+    if (!entry) {
+      return res.status(404).json({ error: 'Unknown GPTID' });
+    }
 
-  // Ensure body exists so downstream handlers can attach module metadata
-  if (!req.body) {
-    req.body = {};
-  }
+    // Ensure body exists so downstream handlers can attach module metadata
+    if (!req.body) {
+      req.body = {};
+    }
 
-  req.url = `/modules/${entry.route}`;
-  req.body.module = entry.module;
-  return modulesRouter(req, res, next);
+    req.url = `/modules/${entry.route}`;
+    req.body.module = entry.module;
+    return modulesRouter(req, res, next);
+  } catch (err) {
+    return next(err);
+  }
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- add a reusable module loader that exposes module metadata and GPT aliases
- have module definitions declare their GPT IDs so new modules auto-bind
- rebuild the GPT router config and middleware to await the generated module map

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccc62ad01883259b640bec38900ec5