### PR TITLE
Handle vector utils edge cases

### DIFF
--- a/src/services/sessionResolver.ts
+++ b/src/services/sessionResolver.ts
@@ -1,5 +1,6 @@
 import { getOpenAIClient } from './openai.js';
 import memoryStore from '../memory/store.js';
+import { cosineSimilarity } from '../utils/vectorUtils.js';
 
 interface ResolveResult {
   sessionId: string;
@@ -71,15 +72,3 @@ export async function resolveSession(nlQuery: string): Promise<ResolveResult> {
   };
 }
 
-// Simple cosine similarity
-function cosineSimilarity(vecA: number[], vecB: number[]): number {
-  let dot = 0.0;
-  let normA = 0.0;
-  let normB = 0.0;
-  for (let i = 0; i < vecA.length; i++) {
-    dot += vecA[i] * vecB[i];
-    normA += vecA[i] * vecA[i];
-    normB += vecB[i] * vecB[i];
-  }
-  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
-}

--- a/src/utils/vectorUtils.ts
+++ b/src/utils/vectorUtils.ts
@@ -1,9 +1,36 @@
 /**
- * Calculates cosine similarity between two vectors.
+ * Calculates cosine similarity between two vectors while guarding against
+ * numerical edge-cases such as zero-length or zero-magnitude vectors.
  */
 export function cosineSimilarity(a: number[], b: number[]): number {
-  const dot = a.reduce((sum, v, i) => sum + v * b[i], 0);
-  const normA = Math.sqrt(a.reduce((sum, v) => sum + v * v, 0));
-  const normB = Math.sqrt(b.reduce((sum, v) => sum + v * v, 0));
-  return dot / (normA * normB);
+  if (!Array.isArray(a) || !Array.isArray(b)) {
+    throw new TypeError('cosineSimilarity expects array inputs');
+  }
+
+  if (a.length !== b.length) {
+    throw new Error('Vectors must be the same length to compute cosine similarity');
+  }
+
+  if (a.length === 0) {
+    return 0;
+  }
+
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let i = 0; i < a.length; i++) {
+    const aVal = a[i];
+    const bVal = b[i];
+
+    dot += aVal * bVal;
+    normA += aVal * aVal;
+    normB += bVal * bVal;
+  }
+
+  if (normA === 0 || normB === 0) {
+    return 0;
+  }
+
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
 }

--- a/tests/vector-utils.test.ts
+++ b/tests/vector-utils.test.ts
@@ -1,0 +1,23 @@
+import { cosineSimilarity } from '../src/utils/vectorUtils.js';
+
+describe('cosineSimilarity', () => {
+  it('returns 0 when vectors are empty', () => {
+    expect(cosineSimilarity([], [])).toBe(0);
+  });
+
+  it('returns 0 when either vector has zero magnitude', () => {
+    expect(cosineSimilarity([0, 0, 0], [1, 2, 3])).toBe(0);
+    expect(cosineSimilarity([1, 2, 3], [0, 0, 0])).toBe(0);
+  });
+
+  it('throws when vectors have different lengths', () => {
+    expect(() => cosineSimilarity([1, 2], [1])).toThrow(
+      'Vectors must be the same length to compute cosine similarity'
+    );
+  });
+
+  it('computes cosine similarity for valid vectors', () => {
+    const result = cosineSimilarity([1, 0], [0, 1]);
+    expect(result).toBeCloseTo(0);
+  });
+});


### PR DESCRIPTION
## Summary
- guard cosine similarity calculation against mismatched lengths and zero-magnitude vectors
- reuse the shared cosine similarity helper in the session resolver
- add unit coverage for the vector utility edge cases

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0cae136ac832586b0a2b512c3af30