### PR TITLE
feat: harden startup against unknown environments

### DIFF
--- a/src/config/environmentFingerprints.ts
+++ b/src/config/environmentFingerprints.ts
@@ -1,0 +1,52 @@
+export interface EnvironmentFingerprintRecord {
+  /** Unique identifier for the known environment */
+  id: string;
+  /** Friendly label for logging and diagnostics */
+  label: string;
+  /** Expected operating system platform */
+  platform: NodeJS.Platform | string;
+  /** Expected CPU architecture */
+  arch: NodeJS.Architecture | string;
+  /** Supported major versions of Node.js */
+  nodeMajors: number[];
+  /** Optional application package versions that are considered safe */
+  packageVersions?: string[];
+  /** Optional operating system release prefixes that are considered safe */
+  releasePrefixes?: string[];
+}
+
+/**
+ * Catalog of known-good deployment environments.
+ *
+ * These fingerprints allow ARCANOS to compare the live runtime against
+ * configurations that have been formally validated. When the current
+ * environment does not match any of these fingerprints, ARCANOS will
+ * automatically fall back to safe mode safeguards.
+ */
+export const KNOWN_ENVIRONMENT_FINGERPRINTS: EnvironmentFingerprintRecord[] = [
+  {
+    id: 'arc-docker-node-22',
+    label: 'ARCANOS Docker baseline (Node 22.x, Linux x64)',
+    platform: 'linux',
+    arch: 'x64',
+    nodeMajors: [22],
+    releasePrefixes: ['5', '6'],
+    packageVersions: ['1.0.0', '1.1.0']
+  },
+  {
+    id: 'railway-node-20',
+    label: 'Railway managed deployment (Node 20.x, Linux x64)',
+    platform: 'linux',
+    arch: 'x64',
+    nodeMajors: [20],
+    releasePrefixes: ['5', '6']
+  },
+  {
+    id: 'dev-macos-node-20',
+    label: 'Local development (macOS, Node 20.x)',
+    platform: 'darwin',
+    arch: 'x64',
+    nodeMajors: [20],
+    releasePrefixes: ['22', '23']
+  }
+];

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -4,13 +4,21 @@ import { logger } from './utils/structuredLogging.js';
 import { initializeDatabase } from './db.js';
 import { validateAPIKeyAtStartup, getDefaultModel } from './services/openai.js';
 import { verifySchema } from './persistenceManagerHierarchy.js';
+import { initializeEnvironmentSecurity, getEnvironmentSecuritySummary } from './utils/environmentSecurity.js';
 
 /**
  * Runs startup checks including environment validation, database init,
  * OpenAI key validation, and schema verification.
  */
 export async function performStartup(): Promise<void> {
-  console.log(createStartupReport());
+  const securityState = await initializeEnvironmentSecurity();
+  logger.info('ARCANOS environment security', {
+    trusted: securityState.isTrusted,
+    safeMode: securityState.safeMode,
+    issues: securityState.issues,
+    policy: securityState.policyApplied
+  });
+  console.log(createStartupReport(getEnvironmentSecuritySummary()));
 
   const envValidation = validateEnvironment();
   printValidationResults(envValidation);

--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -1,11 +1,20 @@
+import { getEnvironmentSecuritySummary } from './environmentSecurity.js';
+
 export function runHealthCheck() {
   console.log('[🩺 HealthCheck] Running diagnostics');
   const mem = process.memoryUsage();
   const heapMB = (mem.heapUsed / 1024 / 1024).toFixed(2);
   const uptime = process.uptime().toFixed(1);
+  const security = getEnvironmentSecuritySummary();
   console.log(`[🩺 HealthCheck] Heap: ${heapMB}MB | Uptime: ${uptime}s`);
+
+  if (security) {
+    console.log(`[🛡️ Security] Trusted=${security.trusted} SafeMode=${security.safeMode}`);
+  }
+
   return {
     summary: `Heap: ${heapMB}MB | Uptime: ${uptime}s`,
-    raw: mem
+    raw: mem,
+    security
   };
 }

--- a/src/utils/environmentSecurity.ts
+++ b/src/utils/environmentSecurity.ts
@@ -1,0 +1,318 @@
+import os from 'os';
+import crypto from 'crypto';
+import { spawn } from 'child_process';
+import { logger } from './structuredLogging.js';
+import { KNOWN_ENVIRONMENT_FINGERPRINTS, EnvironmentFingerprintRecord } from '../config/environmentFingerprints.js';
+import { setAuditSafeMode } from '../persistenceManagerHierarchy.js';
+
+export interface EnvironmentFingerprint {
+  platform: NodeJS.Platform | string;
+  release: string;
+  arch: NodeJS.Architecture | string;
+  nodeVersion: string;
+  nodeMajor: number;
+  packageVersion: string;
+  hash: string;
+}
+
+export interface SandboxExecutionResult {
+  success: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode?: number | null;
+  timedOut: boolean;
+  errorMessage?: string;
+}
+
+export interface EnvironmentSecurityState {
+  fingerprint: EnvironmentFingerprint;
+  matchedFingerprint?: EnvironmentFingerprintRecord;
+  isTrusted: boolean;
+  issues: string[];
+  sandboxResult: SandboxExecutionResult;
+  safeMode: boolean;
+  policyApplied: 'trusted' | 'safe-mode';
+  timestamp: string;
+}
+
+export interface EnvironmentSecuritySummary {
+  trusted: boolean;
+  safeMode: boolean;
+  fingerprint: string;
+  matchedFingerprint?: string;
+  issues: string[];
+}
+
+export interface PolicyEnvelope {
+  onUnknownEnvironment: 'safe-mode' | 'allow';
+  onSandboxFailure: 'safe-mode' | 'allow';
+  safeModeEnvFlag: string;
+}
+
+const policyEnvelope: PolicyEnvelope = {
+  onUnknownEnvironment: 'safe-mode',
+  onSandboxFailure: 'safe-mode',
+  safeModeEnvFlag: 'ARC_SAFE_MODE'
+};
+
+let latestSecurityState: EnvironmentSecurityState | null = null;
+
+export function getPolicyEnvelope(): PolicyEnvelope {
+  return policyEnvelope;
+}
+
+export function collectEnvironmentFingerprint(): EnvironmentFingerprint {
+  const platform = os.platform();
+  const release = os.release();
+  const arch = os.arch();
+  const nodeVersion = process.version;
+  const nodeMajor = parseInt(nodeVersion.replace('v', '').split('.')[0] || '0', 10);
+  const packageVersion = process.env.npm_package_version || 'unknown';
+  const hash = crypto
+    .createHash('sha256')
+    .update(`${platform}|${arch}|${nodeMajor}|${packageVersion}`)
+    .digest('hex');
+
+  return {
+    platform,
+    release,
+    arch,
+    nodeVersion,
+    nodeMajor,
+    packageVersion,
+    hash
+  };
+}
+
+export function matchFingerprint(
+  fingerprint: EnvironmentFingerprint,
+  knownFingerprints: EnvironmentFingerprintRecord[] = KNOWN_ENVIRONMENT_FINGERPRINTS
+): EnvironmentFingerprintRecord | undefined {
+  return knownFingerprints.find(record => {
+    if (record.platform && record.platform !== fingerprint.platform) {
+      return false;
+    }
+
+    if (record.arch && record.arch !== fingerprint.arch) {
+      return false;
+    }
+
+    if (record.nodeMajors && !record.nodeMajors.includes(fingerprint.nodeMajor)) {
+      return false;
+    }
+
+    if (record.packageVersions && record.packageVersions.length > 0) {
+      if (!record.packageVersions.includes(fingerprint.packageVersion)) {
+        return false;
+      }
+    }
+
+    if (record.releasePrefixes && record.releasePrefixes.length > 0) {
+      const matchesPrefix = record.releasePrefixes.some(prefix => fingerprint.release.startsWith(prefix));
+      if (!matchesPrefix) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+export function summarizeFingerprint(fingerprint: EnvironmentFingerprint): string {
+  return [
+    fingerprint.platform,
+    fingerprint.arch,
+    `node${fingerprint.nodeMajor}`,
+    fingerprint.packageVersion,
+    fingerprint.hash.slice(0, 8)
+  ].join(' | ');
+}
+
+export async function executeInSandbox(
+  script: string,
+  timeoutMs = 2000
+): Promise<SandboxExecutionResult> {
+  return new Promise(resolve => {
+    const child = spawn(process.execPath, ['-e', script], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        NODE_ENV: process.env.NODE_ENV || 'production'
+      }
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let resolved = false;
+    let timedOut = false;
+
+    const finish = (result: SandboxExecutionResult) => {
+      if (!resolved) {
+        resolved = true;
+        resolve(result);
+      }
+    };
+
+    const timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+      finish({
+        success: false,
+        stdout,
+        stderr,
+        timedOut,
+        errorMessage: 'Sandbox execution timed out'
+      });
+    }, timeoutMs);
+
+    child.stdout.on('data', data => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on('data', data => {
+      stderr += data.toString();
+    });
+
+    child.on('error', err => {
+      clearTimeout(timeoutHandle);
+      finish({
+        success: false,
+        stdout,
+        stderr: stderr + (err.message || ''),
+        exitCode: null,
+        timedOut,
+        errorMessage: err.message
+      });
+    });
+
+    child.on('close', code => {
+      clearTimeout(timeoutHandle);
+      const success = !timedOut && code === 0;
+      finish({
+        success,
+        stdout,
+        stderr,
+        exitCode: code ?? undefined,
+        timedOut,
+        errorMessage: success ? undefined : stderr.trim() || `Sandbox exited with code ${code}`
+      });
+    });
+  });
+}
+
+async function probeRuntimeApis(): Promise<{ issues: string[]; sandbox: SandboxExecutionResult }> {
+  const sandbox = await executeInSandbox(
+    "const summary = { nodeVersion: process.version, hasFetch: typeof fetch === 'function', hasIntl: typeof Intl !== 'undefined' }; console.log(JSON.stringify(summary));"
+  );
+
+  const issues: string[] = [];
+
+  if (!sandbox.success) {
+    issues.push('Sandboxed runtime probe failed');
+    return { issues, sandbox };
+  }
+
+  try {
+    const parsed = JSON.parse(sandbox.stdout.trim() || '{}');
+    if (!parsed.hasFetch) {
+      issues.push('Fetch API not available in runtime');
+    }
+    if (!parsed.hasIntl) {
+      issues.push('Intl API not available in runtime');
+    }
+  } catch (error: any) {
+    issues.push(`Failed to parse sandbox response: ${error?.message || 'unknown error'}`);
+  }
+
+  return { issues, sandbox };
+}
+
+async function enforceSafeMode(): Promise<void> {
+  process.env[policyEnvelope.safeModeEnvFlag] = 'true';
+
+  if (!process.env.DATABASE_URL) {
+    return;
+  }
+
+  try {
+    await setAuditSafeMode('true');
+  } catch (error: any) {
+    logger.warn('Failed to persist audit-safe mode while enforcing policy', {
+      error: error?.message || error
+    });
+  }
+}
+
+function disableSafeModeFlag(): void {
+  process.env[policyEnvelope.safeModeEnvFlag] = 'false';
+}
+
+export function getEnvironmentSecurityState(): EnvironmentSecurityState | null {
+  return latestSecurityState;
+}
+
+export async function initializeEnvironmentSecurity(): Promise<EnvironmentSecurityState> {
+  const fingerprint = collectEnvironmentFingerprint();
+  const matchedFingerprint = matchFingerprint(fingerprint);
+  const { issues: probeIssues, sandbox } = await probeRuntimeApis();
+
+  const issues: string[] = [];
+  if (!matchedFingerprint) {
+    issues.push('Unknown environment fingerprint detected');
+  }
+  issues.push(...probeIssues);
+
+  let safeMode = false;
+  let policyApplied: 'trusted' | 'safe-mode' = 'trusted';
+
+  if (!matchedFingerprint && policyEnvelope.onUnknownEnvironment === 'safe-mode') {
+    safeMode = true;
+    policyApplied = 'safe-mode';
+  }
+
+  if (probeIssues.length > 0 && policyEnvelope.onSandboxFailure === 'safe-mode') {
+    safeMode = true;
+    policyApplied = 'safe-mode';
+  }
+
+  if (safeMode) {
+    await enforceSafeMode();
+    logger.warn('Environment security policy applied: safe mode enabled', {
+      fingerprint: summarizeFingerprint(fingerprint),
+      issues
+    });
+  } else {
+    disableSafeModeFlag();
+    logger.info('Trusted environment fingerprint confirmed', {
+      fingerprint: summarizeFingerprint(fingerprint),
+      matchedFingerprint: matchedFingerprint?.id
+    });
+  }
+
+  const state: EnvironmentSecurityState = {
+    fingerprint,
+    matchedFingerprint,
+    isTrusted: !safeMode,
+    issues,
+    sandboxResult: sandbox,
+    safeMode,
+    policyApplied,
+    timestamp: new Date().toISOString()
+  };
+
+  latestSecurityState = state;
+  return state;
+}
+
+export function getEnvironmentSecuritySummary(): EnvironmentSecuritySummary | null {
+  if (!latestSecurityState) {
+    return null;
+  }
+
+  return {
+    trusted: latestSecurityState.isTrusted,
+    safeMode: latestSecurityState.safeMode,
+    fingerprint: summarizeFingerprint(latestSecurityState.fingerprint),
+    matchedFingerprint: latestSecurityState.matchedFingerprint?.id,
+    issues: latestSecurityState.issues
+  };
+}

--- a/src/utils/environmentValidation.ts
+++ b/src/utils/environmentValidation.ts
@@ -4,6 +4,7 @@
  */
 
 import { logger } from './structuredLogging.js';
+import type { EnvironmentSecuritySummary } from './environmentSecurity.js';
 
 export interface EnvironmentCheck {
   name: string;
@@ -286,10 +287,27 @@ export function validateRailwayEnvironment(): ValidationResult {
 /**
  * Creates a startup report with all environment information
  */
-export function createStartupReport(): string {
+export function createStartupReport(securitySummary?: EnvironmentSecuritySummary | null): string {
   const envResult = validateEnvironment();
   const _railwayResult = validateRailwayEnvironment();
   const envInfo = getEnvironmentInfo();
+
+  const securityLines = securitySummary
+    ? [
+        '🛡️ Environment Security:',
+        `├─ Trusted: ${securitySummary.trusted ? '✅' : '❌'}`,
+        `├─ Safe Mode: ${securitySummary.safeMode ? 'ENABLED' : 'DISABLED'}`,
+        `├─ Fingerprint: ${securitySummary.fingerprint}`,
+        securitySummary.matchedFingerprint
+          ? `└─ Matched: ${securitySummary.matchedFingerprint}`
+          : securitySummary.issues.length > 0
+            ? `└─ Issues: ${securitySummary.issues.join('; ')}`
+            : '└─ Issues: none'
+      ]
+    : [
+        '🛡️ Environment Security:',
+        '└─ Probe pending'
+      ];
 
   const report = [
     '🚀 ARCANOS Startup Report',
@@ -314,6 +332,8 @@ export function createStartupReport(): string {
     process.env.DATABASE_URL?.includes('railway.app') ? 
       '└─ Database: Railway PostgreSQL ✅' : 
       '└─ Database: External/Local',
+    '',
+    ...securityLines,
     '',
     '========================'
   ].join('\n');

--- a/tests/environment-security.test.ts
+++ b/tests/environment-security.test.ts
@@ -1,0 +1,96 @@
+import {
+  collectEnvironmentFingerprint,
+  matchFingerprint,
+  executeInSandbox,
+  summarizeFingerprint,
+  EnvironmentFingerprint
+} from '../src/utils/environmentSecurity.js';
+import type { EnvironmentFingerprintRecord } from '../src/config/environmentFingerprints.js';
+
+describe('environment security utilities', () => {
+  test('collectEnvironmentFingerprint provides stable structure', () => {
+    const fingerprint = collectEnvironmentFingerprint();
+    expect(typeof fingerprint.platform).toBe('string');
+    expect(typeof fingerprint.nodeVersion).toBe('string');
+    expect(typeof fingerprint.nodeMajor).toBe('number');
+    expect(typeof fingerprint.hash).toBe('string');
+    expect(fingerprint.hash.length).toBeGreaterThan(10);
+  });
+
+  test('matchFingerprint matches compatible record', () => {
+    const fingerprint: EnvironmentFingerprint = {
+      platform: 'linux',
+      release: '6.0.0-test',
+      arch: 'x64',
+      nodeVersion: 'v20.10.0',
+      nodeMajor: 20,
+      packageVersion: '1.0.0',
+      hash: 'hash'
+    };
+
+    const records: EnvironmentFingerprintRecord[] = [
+      {
+        id: 'test',
+        label: 'Test',
+        platform: 'linux',
+        arch: 'x64',
+        nodeMajors: [20],
+        packageVersions: ['1.0.0'],
+        releasePrefixes: ['6']
+      }
+    ];
+
+    const match = matchFingerprint(fingerprint, records);
+    expect(match).toBeDefined();
+    expect(match?.id).toBe('test');
+  });
+
+  test('matchFingerprint rejects incompatible record', () => {
+    const fingerprint: EnvironmentFingerprint = {
+      platform: 'linux',
+      release: '6.0.0-test',
+      arch: 'arm64',
+      nodeVersion: 'v20.10.0',
+      nodeMajor: 20,
+      packageVersion: '1.0.0',
+      hash: 'hash'
+    };
+
+    const records: EnvironmentFingerprintRecord[] = [
+      {
+        id: 'test',
+        label: 'Test',
+        platform: 'linux',
+        arch: 'x64',
+        nodeMajors: [20]
+      }
+    ];
+
+    const match = matchFingerprint(fingerprint, records);
+    expect(match).toBeUndefined();
+  });
+
+  test('executeInSandbox runs isolated scripts', async () => {
+    const result = await executeInSandbox("console.log('sandbox-ok')");
+    expect(result.success).toBe(true);
+    expect(result.stdout.trim()).toBe('sandbox-ok');
+    expect(result.timedOut).toBe(false);
+  });
+
+  test('summarizeFingerprint produces compact summary', () => {
+    const fingerprint: EnvironmentFingerprint = {
+      platform: 'linux',
+      release: '6.0.0-test',
+      arch: 'x64',
+      nodeVersion: 'v20.10.0',
+      nodeMajor: 20,
+      packageVersion: '1.0.0',
+      hash: '1234567890abcdef'
+    };
+
+    const summary = summarizeFingerprint(fingerprint);
+    expect(summary).toContain('linux');
+    expect(summary).toContain('node20');
+    expect(summary).toContain('12345678');
+  });
+});


### PR DESCRIPTION
## Summary
- add an environment security layer that fingerprints the runtime, probes APIs in a sandboxed child process, and enforces safe mode when untrusted
- surface security status in startup logs, startup report, and diagnostics while cataloging trusted deployment fingerprints
- cover fingerprint matching and sandbox execution with unit tests

## Testing
- npm test -- environment-security

------
https://chatgpt.com/codex/tasks/task_e_68d631e22abc832580a87acac6d229b0