### PR TITLE
Refactor session memory into repository with cache

### DIFF
--- a/src/controllers/sessionMemoryController.ts
+++ b/src/controllers/sessionMemoryController.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from 'express';
 import { saveMessage, getChannel, getConversation } from '../services/sessionMemoryService.js';
 import { requireField } from '../utils/validation.js';
-import memoryStore from '../memory/store.js';
 
 export const sessionMemoryController = {
   saveDual: async (req: Request, res: Response) => {
@@ -32,10 +31,6 @@ export const sessionMemoryController = {
 
     await saveMessage(sessionId, 'conversations_core', { ...clean, timestamp });
     await saveMessage(sessionId, 'system_meta', meta);
-
-    // Keep in-memory session store in sync for semantic resolution
-    const conversations_core = await getChannel(sessionId, 'conversations_core');
-    memoryStore.saveSession({ sessionId, conversations_core });
 
     res.status(200).json({ status: 'saved' });
   },

--- a/src/services/sessionMemoryRepository.ts
+++ b/src/services/sessionMemoryRepository.ts
@@ -1,0 +1,178 @@
+import type { SessionEntry, SessionMetadata } from '../memory/store.js';
+import memoryStore from '../memory/store.js';
+import { loadMemory, saveMemory } from '../db.js';
+
+type ChannelName = string;
+
+interface FallbackEntry {
+  messages: any[];
+  expiresAt: number;
+}
+
+interface SessionMemoryRepositoryOptions {
+  fallbackTtlMs?: number;
+}
+
+const DEFAULT_FALLBACK_TTL_MS = parseInt(process.env.SESSION_CACHE_TTL_MS || '300000', 10);
+
+function cloneMessage<T>(message: T): T {
+  if (Array.isArray(message)) {
+    return [...message] as T;
+  }
+
+  if (message && typeof message === 'object') {
+    return { ...(message as Record<string, unknown>) } as T;
+  }
+
+  return message;
+}
+
+function cloneMessages<T>(messages: T[]): T[] {
+  return messages.map(item => cloneMessage(item));
+}
+
+function deriveMetadataFromMessage(message: any): SessionMetadata | undefined {
+  if (!message || typeof message !== 'object') {
+    return undefined;
+  }
+
+  const { topic, tags, summary, metadata } = message as Record<string, unknown>;
+  const derived: SessionMetadata = {};
+
+  if (typeof topic === 'string' && topic.trim()) {
+    derived.topic = topic.trim();
+  }
+
+  if (Array.isArray(tags)) {
+    derived.tags = tags.filter(tag => typeof tag === 'string' && tag.trim()).map(tag => tag.trim());
+  }
+
+  if (typeof summary === 'string' && summary.trim()) {
+    derived.summary = summary.trim();
+  }
+
+  if (metadata && typeof metadata === 'object') {
+    return { ...derived, ...metadata as Record<string, unknown> };
+  }
+
+  return Object.keys(derived).length > 0 ? derived : undefined;
+}
+
+class SessionMemoryRepository {
+  private readonly fallback = new Map<string, FallbackEntry>();
+  private readonly fallbackTtlMs: number;
+
+  constructor(options: SessionMemoryRepositoryOptions = {}) {
+    const ttl = options.fallbackTtlMs ?? DEFAULT_FALLBACK_TTL_MS;
+    this.fallbackTtlMs = Number.isFinite(ttl) && ttl > 0 ? ttl : DEFAULT_FALLBACK_TTL_MS;
+  }
+
+  async appendMessage(sessionId: string, channel: ChannelName, message: any): Promise<void> {
+    const key = this.makeKey(sessionId, channel);
+    const history = await this.getChannel(sessionId, channel);
+    const nextHistory = [...history, cloneMessage(message)];
+
+    try {
+      await saveMemory(key, nextHistory);
+      this.fallback.delete(key);
+    } catch (error) {
+      this.setFallback(key, nextHistory);
+      console.warn('[memory] Falling back to in-process cache for session channel', {
+        sessionId,
+        channel,
+        error: (error as Error).message
+      });
+    }
+
+    this.updateProcessCache(sessionId, channel, nextHistory, message);
+  }
+
+  async getChannel(sessionId: string, channel: ChannelName): Promise<any[]> {
+    const key = this.makeKey(sessionId, channel);
+
+    try {
+      const stored = await loadMemory(key);
+      if (Array.isArray(stored)) {
+        this.fallback.delete(key);
+        return cloneMessages(stored);
+      }
+      if (stored == null) {
+        this.fallback.delete(key);
+        return [];
+      }
+      if (typeof stored === 'object' && 'length' in (stored as any)) {
+        const arrayLike = Array.from(stored as any);
+        this.fallback.delete(key);
+        return cloneMessages(arrayLike);
+      }
+    } catch (error) {
+      const cached = this.getFallback(key);
+      if (cached) {
+        console.warn('[memory] Using fallback cache for session channel', {
+          sessionId,
+          channel,
+          error: (error as Error).message
+        });
+        return cloneMessages(cached);
+      }
+    }
+
+    return [];
+  }
+
+  async getConversation(sessionId: string): Promise<any[]> {
+    const [core, meta] = await Promise.all([
+      this.getChannel(sessionId, 'conversations_core'),
+      this.getChannel(sessionId, 'system_meta')
+    ]);
+
+    return core.map((message, index) => ({
+      ...message,
+      meta: meta[index] || {}
+    }));
+  }
+
+  getCachedSessions(): SessionEntry[] {
+    return memoryStore.getAllSessions();
+  }
+
+  private makeKey(sessionId: string, channel: ChannelName): string {
+    return `session:${sessionId}:${channel}`;
+  }
+
+  private getFallback(key: string): any[] | null {
+    const cached = this.fallback.get(key);
+    if (!cached) {
+      return null;
+    }
+
+    if (cached.expiresAt <= Date.now()) {
+      this.fallback.delete(key);
+      return null;
+    }
+
+    return cloneMessages(cached.messages);
+  }
+
+  private setFallback(key: string, messages: any[]): void {
+    this.fallback.set(key, {
+      messages: cloneMessages(messages),
+      expiresAt: Date.now() + this.fallbackTtlMs
+    });
+  }
+
+  private updateProcessCache(sessionId: string, channel: ChannelName, history: any[], message: any): void {
+    const metadata = channel === 'system_meta' ? deriveMetadataFromMessage(message) : undefined;
+
+    memoryStore.saveSession({
+      sessionId,
+      conversations_core: channel === 'conversations_core' ? history : undefined,
+      metadata
+    });
+  }
+}
+
+const sessionMemoryRepository = new SessionMemoryRepository();
+
+export { SessionMemoryRepository };
+export default sessionMemoryRepository;

--- a/src/services/sessionResolver.ts
+++ b/src/services/sessionResolver.ts
@@ -1,5 +1,5 @@
 import { getOpenAIClient } from './openai.js';
-import memoryStore from '../memory/store.js';
+import { getCachedSessions } from './sessionMemoryService.js';
 import { cosineSimilarity } from '../utils/vectorUtils.js';
 
 interface ResolveResult {
@@ -8,7 +8,7 @@ interface ResolveResult {
 }
 
 export async function resolveSession(nlQuery: string): Promise<ResolveResult> {
-  const sessions = memoryStore.getAllSessions();
+  const sessions = getCachedSessions();
   if (sessions.length === 0) {
     throw new Error('No sessions available');
   }


### PR DESCRIPTION
## Summary
- replace controller-managed session synchronization with a repository that centralizes persistence and in-process caching
- upgrade the process memory store to a bounded map that safely merges metadata for resolver usage
- expose cached session access through services to keep downstream consumers OpenAI SDK compatible and Railway ready

## Testing
- npm run lint
- npm run validate:railway *(fails locally without OPENAI_API_KEY/PORT/RAILWAY_ENVIRONMENT)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e85aebf4832589613b094f9400e8