### PR TITLE
Restore backend manifest and add Railway healthcheck

### DIFF
--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -32,6 +32,10 @@ export function registerRoutes(app: Express): void {
     res.send('ARCANOS is live');
   });
 
+  app.get('/railway/healthcheck', (_: Request, res: Response) => {
+    res.status(200).send('OK');
+  });
+
   app.use('/', askRouter);
   app.use('/', arcanosRouter);
   app.use('/', arcanosPipelineRouter);


### PR DESCRIPTION
## Summary
- restore the original backend package.json with its scripts, dependencies, and metadata so the lockfile and install commands stay in sync
- remove the standalone server shim and wire a Railway-compatible healthcheck route into the main Express router

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fc18942b748325bf2aa679f8a383b9