### PR TITLE
Mirror session memory messages into RAG store

### DIFF
--- a/src/routes/rag.ts
+++ b/src/routes/rag.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { ingestUrl, answerQuestion } from '../services/webRag.js';
+import { ingestUrl, ingestContent, answerQuestion } from '../services/webRag.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 
 const router = Router();
@@ -10,7 +10,30 @@ router.post('/rag/fetch', asyncHandler(async (req, res) => {
     return res.status(400).json({ error: 'url required' });
   }
   const doc = await ingestUrl(url);
-  res.json({ id: doc.id, url: doc.url, contentLength: doc.content.length });
+  res.json({ id: doc.id, url: doc.url, contentLength: doc.content.length, metadata: doc.metadata ?? {} });
+}));
+
+router.post('/rag/save', asyncHandler(async (req, res) => {
+  const { id, content, source, metadata } = req.body ?? {};
+  if (typeof content !== 'string' || !content.trim()) {
+    return res.status(400).json({ error: 'content required' });
+  }
+  if (id !== undefined && typeof id !== 'string') {
+    return res.status(400).json({ error: 'id must be a string when provided' });
+  }
+  if (source !== undefined && typeof source !== 'string') {
+    return res.status(400).json({ error: 'source must be a string when provided' });
+  }
+  let metadataObject: Record<string, unknown> | undefined;
+  if (metadata !== undefined) {
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+      return res.status(400).json({ error: 'metadata must be an object when provided' });
+    }
+    metadataObject = metadata as Record<string, unknown>;
+  }
+
+  const doc = await ingestContent({ id, content, source, metadata: metadataObject });
+  res.json({ id: doc.id, source: doc.url, contentLength: doc.content.length, metadata: doc.metadata ?? {} });
 }));
 
 router.post('/rag/query', asyncHandler(async (req, res) => {

--- a/src/services/sessionMemoryService.ts
+++ b/src/services/sessionMemoryService.ts
@@ -1,7 +1,54 @@
 import sessionMemoryRepository from './sessionMemoryRepository.js';
+import { recordConversationSnippet } from './webRag.js';
+import { logger } from '../utils/structuredLogging.js';
+
+const sessionMemoryLogger = logger.child({ module: 'sessionMemory' });
 
 export async function saveMessage(sessionId: string, channel: string, message: any): Promise<void> {
   await sessionMemoryRepository.appendMessage(sessionId, channel, message);
+
+  if (channel === 'conversations_core') {
+    const content = typeof message === 'string' ? message : message?.content;
+    if (typeof content !== 'string' || !content.trim()) {
+      return;
+    }
+
+    const role = typeof message === 'object' && typeof message.role === 'string' ? message.role : 'user';
+    const timestamp = typeof message === 'object' && typeof message.timestamp === 'number'
+      ? message.timestamp
+      : Date.now();
+
+    const snippetMetadata: Record<string, unknown> = { channel };
+    if (typeof message === 'object' && message) {
+      if (typeof message.tokens === 'number' && Number.isFinite(message.tokens)) {
+        snippetMetadata.tokens = message.tokens;
+      }
+      const auditTag = message.audit_tag || message.tag;
+      if (typeof auditTag === 'string' && auditTag.trim()) {
+        snippetMetadata.audit_tag = auditTag.trim();
+      }
+      if (typeof message.id === 'string' && message.id.trim()) {
+        snippetMetadata.messageId = message.id.trim();
+      }
+    }
+
+    try {
+      await recordConversationSnippet({
+        sessionId,
+        role,
+        content,
+        timestamp,
+        channel,
+        metadata: snippetMetadata,
+      });
+    } catch (error) {
+      sessionMemoryLogger.warn('Failed to mirror conversation message into RAG', {
+        operation: 'saveMessage',
+        sessionId,
+        channel,
+      }, undefined, error instanceof Error ? error : undefined);
+    }
+  }
 }
 
 export async function getChannel(sessionId: string, channel: string): Promise<any[]> {

--- a/src/services/webRag.ts
+++ b/src/services/webRag.ts
@@ -1,16 +1,52 @@
-import { getOpenAIClient, getDefaultModel } from './openai.js';
+import { randomUUID } from 'crypto';
+import { getOpenAIClient, getDefaultModel, hasValidAPIKey } from './openai.js';
 import { fetchAndClean } from './webFetcher.js';
 import { cosineSimilarity } from '../utils/vectorUtils.js';
 import { saveRagDoc, loadAllRagDocs, initializeDatabase, getStatus } from '../db.js';
+import { logger } from '../utils/structuredLogging.js';
 
 interface Doc {
   id: string;
   url: string;
   content: string;
   embedding: number[];
+  metadata?: Record<string, unknown>;
 }
 
 let vectorStore: Doc[] | null = null;
+const ragLogger = logger.child({ module: 'webRag' });
+
+function upsertDoc(doc: Doc): void {
+  if (!vectorStore) {
+    vectorStore = [];
+  }
+  const existingIndex = vectorStore.findIndex((existing) => existing.id === doc.id);
+  if (existingIndex >= 0) {
+    vectorStore[existingIndex] = doc;
+  } else {
+    vectorStore.push(doc);
+  }
+}
+
+function sanitizeMetadataInput(metadata?: Record<string, unknown>): Record<string, unknown> {
+  if (!metadata) {
+    return {};
+  }
+  if (typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return {};
+  }
+  try {
+    return JSON.parse(JSON.stringify(metadata));
+  } catch {
+    return {};
+  }
+}
+
+interface SourceDetail {
+  id: string;
+  url: string;
+  metadata?: Record<string, unknown>;
+}
 
 async function ensureStore(): Promise<void> {
   if (vectorStore !== null) {
@@ -57,20 +93,125 @@ export async function ingestUrl(url: string): Promise<Doc> {
     url,
     content,
     embedding: embeddingRes.data[0].embedding,
+    metadata: {
+      sourceType: 'url',
+      fetchedAt: new Date().toISOString(),
+    },
   };
   try {
     await saveRagDoc(doc);
   } catch (error) {
     console.warn('[🧠 RAG] Failed to persist document to database - retaining in-memory copy', error);
   }
-  if (!vectorStore) {
-    vectorStore = [];
-  }
-  vectorStore.push(doc);
+  upsertDoc(doc);
   return doc;
 }
 
-export async function answerQuestion(question: string): Promise<{ answer: string; sources: string[]; verification: string }> {
+interface IngestContentOptions {
+  id?: string;
+  content: string;
+  source?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export async function ingestContent(options: IngestContentOptions): Promise<Doc> {
+  const { id, content, source, metadata } = options;
+  await ensureStore();
+  const client = getOpenAIClient();
+  if (!client) {
+    throw new Error('OpenAI client not initialized');
+  }
+
+  const docId = (id && id.trim()) || randomUUID();
+  const sourceLabel = (source && source.trim()) || docId;
+  const sanitizedMetadata = sanitizeMetadataInput(metadata);
+  if (!('sourceType' in sanitizedMetadata)) {
+    sanitizedMetadata.sourceType = 'direct';
+  }
+  sanitizedMetadata.savedAt = new Date().toISOString();
+  if (sourceLabel) {
+    sanitizedMetadata.source = sourceLabel;
+  }
+
+  const embeddingRes = await client.embeddings.create({
+    model: 'text-embedding-3-small',
+    input: content,
+  });
+
+  const doc: Doc = {
+    id: docId,
+    url: sourceLabel,
+    content,
+    embedding: embeddingRes.data[0].embedding,
+    metadata: sanitizedMetadata,
+  };
+
+  try {
+    await saveRagDoc(doc);
+  } catch (error) {
+    console.warn('[🧠 RAG] Failed to persist document to database - retaining in-memory copy', error);
+  }
+
+  upsertDoc(doc);
+  return doc;
+}
+
+interface ConversationSnippetOptions {
+  sessionId: string;
+  role: string;
+  content: string;
+  timestamp?: number;
+  channel?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export async function recordConversationSnippet(options: ConversationSnippetOptions): Promise<boolean> {
+  const { sessionId, role, content, timestamp, channel = 'conversations_core', metadata } = options;
+  const trimmed = typeof content === 'string' ? content.trim() : '';
+
+  if (!trimmed) {
+    return false;
+  }
+
+  if (!hasValidAPIKey()) {
+    ragLogger.debug('Skipping conversation ingestion - OpenAI key missing', {
+      operation: 'recordConversationSnippet',
+      sessionId,
+      channel,
+    });
+    return false;
+  }
+
+  const snippetMetadata = sanitizeMetadataInput(metadata);
+  if (!('sourceType' in snippetMetadata)) {
+    snippetMetadata.sourceType = 'conversation';
+  }
+  snippetMetadata.sessionId = sessionId;
+  snippetMetadata.role = role;
+  snippetMetadata.channel = channel;
+  if (timestamp !== undefined) {
+    snippetMetadata.timestamp = new Date(timestamp).toISOString();
+    snippetMetadata.timestampMs = timestamp;
+  }
+
+  try {
+    await ingestContent({
+      content: trimmed,
+      source: `session:${sessionId}`,
+      metadata: snippetMetadata,
+    });
+    return true;
+  } catch (error) {
+    ragLogger.warn('Failed to ingest conversation snippet', {
+      operation: 'recordConversationSnippet',
+      sessionId,
+      channel,
+    }, undefined, error instanceof Error ? error : undefined);
+    return false;
+  }
+}
+
+export async function answerQuestion(question: string): Promise<{ answer: string; sources: string[]; verification: string; sourceDetails: SourceDetail[] }> {
   await ensureStore();
   const client = getOpenAIClient();
   if (!client) {
@@ -88,7 +229,12 @@ export async function answerQuestion(question: string): Promise<{ answer: string
   scored.sort((a, b) => b.score - a.score);
   const topDocs = scored.slice(0, 3).map((s) => s.doc);
 
-  const context = topDocs.map((d) => d.content).join('\n---\n');
+  const context = topDocs.map((d) => {
+    const metadataText = d.metadata && Object.keys(d.metadata).length
+      ? `Metadata: ${JSON.stringify(d.metadata)}\n`
+      : '';
+    return `${metadataText}${d.content}`;
+  }).join('\n---\n');
   const answerRes = await client.chat.completions.create({
     model: getDefaultModel(),
     messages: [
@@ -107,5 +253,10 @@ export async function answerQuestion(question: string): Promise<{ answer: string
   });
   const verification = verifyRes.choices[0]?.message?.content || '';
 
-  return { answer, sources: topDocs.map((d) => d.url), verification };
+  return {
+    answer,
+    sources: topDocs.map((d) => d.url),
+    verification,
+    sourceDetails: topDocs.map((d) => ({ id: d.id, url: d.url, metadata: d.metadata })),
+  };
 }


### PR DESCRIPTION
## Summary
- stream sessionMemory conversation saves into the RAG pipeline with metadata so front-end chats are indexed automatically
- add a webRag helper that sanitizes conversation snippets, skips ingestion without an OpenAI key, and reuses ingestContent for persistence

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690000890b10832585ad91c6b0a8811f