### PR TITLE
Allow trusted GPT IDs to bypass confirmation gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,15 @@ The system performs comprehensive environment validation on startup:
 - `POST /api/workers/*` - Worker system management
 
 ### Confirmation Gate Pattern
-Protected endpoints require the `X-Confirmation` header:
+Protected endpoints require the `x-confirmed: yes` header unless the request comes from a trusted GPT ID:
 ```bash
 curl -X POST http://localhost:8080/api/memory/create \
   -H "Content-Type: application/json" \
-  -H "X-Confirmation: confirmed" \
+  -H "x-confirmed: yes" \
   -d '{"key": "example", "value": "data"}'
 ```
+
+To allow pre-approved GPT integrations to bypass the manual confirmation header, configure the `TRUSTED_GPT_IDS` environment variable with a comma-separated list of GPT IDs. Requests that provide a matching `x-gpt-id` header (or `gptId` field in the body) are treated as already reviewed and pass through the confirmation gate automatically.
 
 **📖 Complete API reference:** [docs/api/README.md](docs/api/README.md)
 

--- a/README_ORIGINAL.md
+++ b/README_ORIGINAL.md
@@ -263,6 +263,8 @@ curl http://localhost:8080/health
 ### Confirmation Requirements
 Most sensitive operations require explicit user confirmation via the `x-confirmed: yes` header to ensure compliance with OpenAI's Terms of Service and prevent unauthorized actions.
 
+If you're routing traffic through Custom GPTs that you personally supervise, populate the `TRUSTED_GPT_IDS` environment variable with a comma-separated list of approved GPT IDs. When a request supplies a matching `x-gpt-id` header (or `gptId` in the payload), the confirmation gate recognizes the human review already performed in the GPT interface and allows the request without the manual confirmation header.
+
 **Protected Endpoints** (require confirmation):
 - Data modification operations (`/memory/save`, `/memory/delete`)
 - AI processing with side effects (`/arcanos`, `/brain`, `/write`, `/guide`, `/audit`, `/sim`)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -68,7 +68,7 @@ curl -X POST http://localhost:8080/ask \
 ```bash
 curl -X POST http://localhost:8080/api/memory/store \
   -H "Content-Type: application/json" \
-  -H "X-Confirm-Action: yes" \
+  -H "x-confirmed: yes" \
   -d '{"session": "user123", "data": {"context": "conversation state"}}'
 ```
 
@@ -80,16 +80,18 @@ curl http://localhost:8080/health
 ## 🛡️ Security & Compliance
 
 ### Confirmation Requirements
-Certain operations require explicit confirmation via the `X-Confirm-Action: yes` header:
+Certain operations require explicit confirmation via the `x-confirmed: yes` header (or a trusted GPT ID):
 - Memory storage operations (`/api/memory/store`, `/api/memory/clear`)
 - Administrative functions (`/admin/*`)
 - Worker control operations (`/workers/*`)
+
+To pre-authorize requests coming from Custom GPTs that you personally supervise, set the `TRUSTED_GPT_IDS` environment variable to a comma-separated list of GPT IDs. When a request includes a matching `x-gpt-id` header (or `gptId` in the body), the confirmation gate treats it as already reviewed and does not require the manual header.
 
 ### Example Usage with Confirmation
 ```bash
 # Protected operation - requires confirmation header
 curl -X POST http://localhost:8080/api/memory/clear \
-  -H "X-Confirm-Action: yes" \
+  -H "x-confirmed: yes" \
   -H "Content-Type: application/json"
 
 # Safe operation - no confirmation needed  
@@ -101,7 +103,7 @@ curl -X POST http://localhost:8080/ask \
 ## Authentication
 
 - **Admin endpoints**: Require `ADMIN_KEY` environment variable
-- **Protected operations**: Require `X-Confirm-Action: yes` header
+- **Protected operations**: Require `x-confirmed: yes` header (unless the request supplies a trusted GPT ID)
 - **OpenAI integration**: Requires valid `OPENAI_API_KEY`
 
 ## Rate Limiting


### PR DESCRIPTION
## Summary
- allow the confirmation middleware to accept trusted GPT IDs configured via the TRUSTED_GPT_IDS environment variable
- log GPT ID context during confirmation checks and return it when rejecting requests
- refresh the README and API documentation to describe the trusted GPT ID workflow and align the header names

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69003c4e86bc832590835da27a4fc36d