### PR TITLE
Add dedicated docs for Gaming and Tutor custom GPT modules

### DIFF
--- a/docs/ai-guides/CUSTOM_GPT_INTEGRATION.md
+++ b/docs/ai-guides/CUSTOM_GPT_INTEGRATION.md
@@ -2,6 +2,8 @@
 
 This guide has been refactored into focused modules. Jump to the section that fits your workflow:
 
+- [`arcanos-gaming.md`](custom-gpt/arcanos-gaming.md) – hotline playbook for the Gaming persona and audit trace outputs.
+- [`arcanos-tutor.md`](custom-gpt/arcanos-tutor.md) – tutoring kernel patterns, payload schema, and pipeline reference.
 - [`overview.md`](custom-gpt/overview.md) – requirements and the integration checklist.
 - [`endpoint-architecture.md`](custom-gpt/endpoint-architecture.md) – documenting routes and confirmation headers.
 - [`builder-instructions.md`](custom-gpt/builder-instructions.md) – copy-ready GPT Builder instruction block.

--- a/docs/ai-guides/custom-gpt/arcanos-gaming.md
+++ b/docs/ai-guides/custom-gpt/arcanos-gaming.md
@@ -1,0 +1,43 @@
+# ARCANOS Gaming Module
+
+**Profile:** Nintendo-style hotline advisor that delivers actionable game strategies, hints, and walkthrough summaries.
+
+## When to Route Here
+- Player needs help with a puzzle, boss fight, or progression blocker.
+- Caller is requesting a walkthrough summary or strategy breakdown.
+- User provides an optional guide URL that should be ingested before answering.
+
+## Request Payload
+```json
+{
+  "prompt": "How do I beat the Guardian Ape in Sekiro?",
+  "url": "https://example.com/sekiro/guardian-ape-guide"
+}
+```
+- `prompt` (string) – Required user question or context. A raw string is also accepted when the calling workflow does not wrap the payload.
+- `url` (string, optional) – Remote guide to hydrate the prompt. The service attempts to fetch and clean this URL before intake.
+
+## Pipeline
+1. **Intake (Fine-tuned model).** Normalizes the user prompt and routes to the Gaming persona. System message: `ARCANOS Intake: Route to Gaming module.`
+2. **Reasoning (GPT-5).** Generates hotline-quality strategy guidance with a friendly, professional tone.
+3. **Audit (Fine-tuned model).** Validates clarity, safety, and alignment before releasing the answer. System message: `ARCANOS Audit: Validate Gaming module response for clarity, safety, and alignment.`
+
+If OpenAI access is unavailable, the module emits deterministic mock text plus a trace indicating that intake and reasoning were skipped.
+
+## Response Shape
+```json
+{
+  "gaming_response": "Final audited answer...",
+  "audit_trace": {
+    "intake": "Refined prompt...",
+    "reasoning": "Raw GPT-5 output...",
+    "finalized": "Audited answer"
+  }
+}
+```
+The `audit_trace` fields mirror the three pipeline stages, enabling downstream logging or escalation flows.
+
+## Implementation Notes
+- Module name: `ARCANOS:GAMING` (`src/modules/arcanos-gaming.ts`).
+- Delegates to `runGaming` (`src/services/gaming.ts`) for all orchestration, including optional guide hydration via `fetchAndClean`.
+- Temperature is set to `0.6` during reasoning for energetic yet reliable hints.

--- a/docs/ai-guides/custom-gpt/arcanos-tutor.md
+++ b/docs/ai-guides/custom-gpt/arcanos-tutor.md
@@ -1,0 +1,84 @@
+# ARCANOS Tutor Module
+
+**Profile:** Professional tutoring kernel with dynamic schema binding, modular instruction patterns, and full audit traceability.
+
+## When to Route Here
+- Learner asks for structured explanations, study plans, or concept breakdowns.
+- Memory, research, or logic workflows require pedagogical validation.
+- Follow-up tutoring is needed after Backstage or Gaming escalations.
+
+## Request Payload
+```json
+{
+  "intent": "research",
+  "domain": "research",
+  "module": "findSources",
+  "payload": {
+    "topic": "Neural architecture search"
+  }
+}
+```
+Fields:
+- `intent` (string, optional) – Free-form description recorded in the audit trace.
+- `domain` (string) – Selects a pattern (`memory`, `research`, `logic`). Defaults to `default` if unspecified or unknown.
+- `module` (string) – Chooses the instruction module within the selected domain (for example `findSources`).
+- `payload` (object) – Module-specific arguments consumed by downstream helpers.
+
+## Pipeline
+1. **Intake (Default fine-tuned model).** Routes to the tutor persona (`ARCANOS Intake: Route to Tutor module.`) and normalizes the prompt.
+2. **Reasoning (GPT-5).** Produces structured, learner-friendly guidance. Temperature defaults to `0.3` but can be overridden by modules.
+3. **Audit (Default fine-tuned model).** Validates accuracy, tone, and clarity (`ARCANOS Audit: Validate the tutoring response...`).
+
+Mock responses are generated when the OpenAI client is unavailable or the environment is configured for testing.
+
+## Domain Modules
+| Domain | Module | Description |
+| --- | --- | --- |
+| `memory` | `explain` | Explains stored memory logic for a given topic. |
+| `memory` | `audit` | Audits an individual memory entry for correctness. |
+| `research` | `findSources` | Calls `searchScholarly` to gather academic references and synthesizes a learning brief. |
+| `logic` | `clarify` | Clarifies an application logic flow based on structured payload input. |
+| `default` | `generic` | Fallback tutor instructions for any payload. |
+
+Each module can override token limits, temperature, and custom prompts when invoking the shared pipeline.
+
+## Response Shape
+```json
+{
+  "arcanos_tutor": "Finalized tutoring answer...",
+  "audit_trace": {
+    "received_at": "2024-04-01T00:00:00.000Z",
+    "intent_clarified": "research",
+    "domain_bound": "research",
+    "instruction_module": "findSources",
+    "pattern_ref": "pattern_1756454042135",
+    "fallback_invoked": false,
+    "pipeline": {
+      "intake": "Refined prompt...",
+      "reasoning": "Structured outline...",
+      "finalized": "Audited guidance"
+    },
+    "model": {
+      "intake": "gpt-4.1-mini",
+      "reasoning": "gpt-5.0",
+      "audit": "gpt-4.1-mini"
+    }
+  },
+  "metadata": {
+    "sources": [
+      {
+        "title": "Sample Source",
+        "year": 2023,
+        "journal": "Journal of AI"
+      }
+    ]
+  }
+}
+```
+Audit metadata exposes routing decisions alongside the pipeline trace for observability.
+
+## Implementation Notes
+- Module name: `ARCANOS:TUTOR` (`src/modules/arcanos-tutor.ts`).
+- Core orchestration lives in `src/logic/tutor-logic.ts`.
+- Uses `searchScholarly` to hydrate research flows with academic citations when available.
+- Automatically falls back to a mock response if any stage throws, flagging `fallback_invoked` and noting the redirected module.


### PR DESCRIPTION
## Summary
- add dedicated module reference pages for the ARCANOS Gaming and Tutor GPT integrations
- highlight the new module references at the top of the custom GPT integration index

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_6900612663b48325abf99eb37c5da7c2