### PR TITLE
Add command execution API for front-end orchestration

### DIFF
--- a/src/routes/api-commands.ts
+++ b/src/routes/api-commands.ts
@@ -1,0 +1,65 @@
+import express, { Request, Response } from 'express';
+import { confirmGate } from '../middleware/confirmGate.js';
+import { createRateLimitMiddleware, createValidationMiddleware, securityHeaders } from '../utils/security.js';
+import { asyncHandler } from '../utils/asyncHandler.js';
+import { executeCommand, listAvailableCommands } from '../services/commandCenter.js';
+import type { CommandName } from '../services/commandCenter.js';
+
+const router = express.Router();
+
+router.use(securityHeaders);
+router.use(createRateLimitMiddleware(50, 15 * 60 * 1000));
+
+const commandExecutionSchema = {
+  command: {
+    required: true,
+    type: 'string' as const,
+    minLength: 3,
+    maxLength: 100,
+    sanitize: true
+  },
+  payload: {
+    required: false,
+    type: 'object' as const
+  }
+};
+
+router.get(
+  '/',
+  (_: Request, res: Response) => {
+    res.json({
+      success: true,
+      commands: listAvailableCommands(),
+      metadata: {
+        count: listAvailableCommands().length,
+        timestamp: new Date().toISOString()
+      }
+    });
+  }
+);
+
+router.get(
+  '/health',
+  (_: Request, res: Response) => {
+    res.json({
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      availableCommands: listAvailableCommands().length
+    });
+  }
+);
+
+router.post(
+  '/execute',
+  confirmGate,
+  createValidationMiddleware(commandExecutionSchema),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { command, payload } = req.body as { command: CommandName; payload?: Record<string, any> };
+
+    const result = await executeCommand(command, payload);
+
+    res.status(result.success ? 200 : 400).json(result);
+  })
+);
+
+export default router;

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -14,6 +14,7 @@ import backstageRouter from './backstage.js';
 import apiArcanosRouter from './api-arcanos.js';
 import apiSimRouter from './api-sim.js';
 import apiMemoryRouter from './api-memory.js';
+import apiCommandsRouter from './api-commands.js';
 import sdkRouter from './sdk.js';
 import imageRouter from './image.js';
 import prAnalysisRouter from './pr-analysis.js';
@@ -55,6 +56,7 @@ export function registerRoutes(app: Express): void {
   app.use('/api/arcanos', apiArcanosRouter);
   app.use('/api/sim', apiSimRouter);
   app.use('/api/memory', apiMemoryRouter);
+  app.use('/api/commands', apiCommandsRouter);
   app.use('/api/pr-analysis', prAnalysisRouter);
   app.use('/api/openai', openaiRouter);
   app.use('/', hrcRouter);

--- a/src/services/commandCenter.ts
+++ b/src/services/commandCenter.ts
@@ -1,0 +1,159 @@
+import { sanitizeInput } from '../utils/security.js';
+import { createCentralizedCompletion, generateMockResponse, hasValidAPIKey } from './openai.js';
+import { getAuditSafeMode, interpretCommand, setAuditSafeMode } from './auditSafeToggle.js';
+
+export type CommandName = 'audit-safe:set-mode' | 'audit-safe:interpret' | 'ai:prompt';
+
+type CommandHandler = (payload?: Record<string, any>) => Promise<CommandExecutionResult>;
+
+export interface CommandDefinition {
+  name: CommandName;
+  description: string;
+  requiresConfirmation: boolean;
+  payloadExample?: Record<string, unknown>;
+}
+
+export interface CommandExecutionResult {
+  success: boolean;
+  command: CommandName;
+  message: string;
+  output?: Record<string, unknown>;
+  metadata: {
+    executedAt: string;
+    auditSafeMode: string;
+  };
+}
+
+const AVAILABLE_COMMANDS: Record<CommandName, CommandDefinition> = {
+  'audit-safe:set-mode': {
+    name: 'audit-safe:set-mode',
+    description: 'Directly set the Audit-Safe enforcement mode.',
+    requiresConfirmation: true,
+    payloadExample: { mode: 'true' }
+  },
+  'audit-safe:interpret': {
+    name: 'audit-safe:interpret',
+    description: 'Interpret a natural-language instruction to adjust Audit-Safe mode.',
+    requiresConfirmation: true,
+    payloadExample: { instruction: 'Enable strict audit safe mode' }
+  },
+  'ai:prompt': {
+    name: 'ai:prompt',
+    description: 'Execute an AI command through the centralized OpenAI routing pipeline.',
+    requiresConfirmation: true,
+    payloadExample: { prompt: 'Summarize current system status' }
+  }
+};
+
+const VALID_AUDIT_MODES: Array<'true' | 'false' | 'passive' | 'log-only'> = ['true', 'false', 'passive', 'log-only'];
+
+const commandHandlers: Record<CommandName, CommandHandler> = {
+  'audit-safe:set-mode': async (payload) => {
+    const mode = typeof payload?.mode === 'string' ? (payload.mode as typeof VALID_AUDIT_MODES[number]) : undefined;
+
+    if (!mode || !VALID_AUDIT_MODES.includes(mode)) {
+      return buildResult('audit-safe:set-mode', false, "Invalid mode. Use 'true', 'false', 'passive', or 'log-only'.");
+    }
+
+    setAuditSafeMode(mode);
+
+    return buildResult('audit-safe:set-mode', true, `Audit-Safe mode set to ${mode}.`, {
+      mode
+    });
+  },
+  'audit-safe:interpret': async (payload) => {
+    const instruction = typeof payload?.instruction === 'string' ? sanitizeInput(payload.instruction) : '';
+
+    if (!instruction) {
+      return buildResult('audit-safe:interpret', false, 'Instruction text is required.');
+    }
+
+    await interpretCommand(instruction);
+
+    return buildResult('audit-safe:interpret', true, 'Instruction processed. Audit-Safe mode updated if recognized.', {
+      instruction,
+      mode: getAuditSafeMode()
+    });
+  },
+  'ai:prompt': async (payload) => {
+    const prompt = typeof payload?.prompt === 'string' ? payload.prompt.trim() : '';
+
+    if (!prompt) {
+      return buildResult('ai:prompt', false, 'Prompt text is required.');
+    }
+
+    const sanitizedPrompt = sanitizeInput(prompt);
+
+    if (!hasValidAPIKey()) {
+      const mock = generateMockResponse(sanitizedPrompt, 'ask');
+      return buildResult('ai:prompt', true, 'OpenAI API key not configured - returning mock response.', {
+        result: mock.result,
+        meta: mock.meta,
+        fallback: true
+      });
+    }
+
+    try {
+      const response = await createCentralizedCompletion([
+        { role: 'user', content: sanitizedPrompt }
+      ]);
+
+      if ('choices' in response) {
+        const firstChoice = response.choices[0];
+        const content = firstChoice?.message?.content ?? '';
+        return buildResult('ai:prompt', true, 'AI command executed successfully.', {
+          result: content,
+          usage: response.usage ?? null,
+          model: response.model
+        });
+      }
+
+      return buildResult('ai:prompt', true, 'Streaming response started.', {
+        result: null,
+        streaming: true
+      });
+    } catch (error: any) {
+      return buildResult('ai:prompt', false, error?.message || 'Failed to execute AI command.');
+    }
+  }
+};
+
+function buildResult(
+  command: CommandName,
+  success: boolean,
+  message: string,
+  output: Record<string, unknown> | undefined = undefined
+): CommandExecutionResult {
+  return {
+    success,
+    command,
+    message,
+    output,
+    metadata: {
+      executedAt: new Date().toISOString(),
+      auditSafeMode: getAuditSafeMode()
+    }
+  };
+}
+
+export async function executeCommand(
+  command: CommandName,
+  payload: Record<string, any> = {}
+): Promise<CommandExecutionResult> {
+  const handler = commandHandlers[command];
+
+  if (!handler) {
+    return buildResult(command, false, 'Unsupported command.');
+  }
+
+  return handler(payload);
+}
+
+export function listAvailableCommands(): CommandDefinition[] {
+  return Object.values(AVAILABLE_COMMANDS);
+}
+
+export default {
+  executeCommand,
+  listAvailableCommands
+};


### PR DESCRIPTION
## Summary
- add a command center service that executes whitelisted commands through the centralized OpenAI routing stack
- expose `/api/commands` endpoints with validation, rate limiting, and confirmation guard for safe front-end control
- register the router so Railway deployments automatically support the command execution surface

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6902b810909c8325968a2bcbebac6e06