### PR TITLE
Add streaming command tunnel for front-end control

### DIFF
--- a/src/routes/api-command-tunnel.ts
+++ b/src/routes/api-command-tunnel.ts
@@ -1,0 +1,253 @@
+import express, { Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+import { confirmGate } from '../middleware/confirmGate.js';
+import { asyncHandler } from '../utils/asyncHandler.js';
+import {
+  createRateLimitMiddleware,
+  createValidationMiddleware,
+  securityHeaders
+} from '../utils/security.js';
+import {
+  buildTunnelContext,
+  closeSession,
+  createTunnelSession,
+  getActiveSessionCount,
+  getSessionSnapshot,
+  heartbeatSession,
+  publishAck,
+  publishResult,
+  subscribeToSession
+} from '../services/commandTunnel.js';
+import { executeCommand, listAvailableCommands } from '../services/commandCenter.js';
+
+const router = express.Router();
+
+router.use(securityHeaders);
+router.use(createRateLimitMiddleware(100, 15 * 60 * 1000));
+
+const sessionSchema = {
+  clientId: {
+    required: false,
+    type: 'string' as const,
+    maxLength: 120,
+    sanitize: true
+  },
+  requestedTtlMs: {
+    required: false,
+    type: 'number' as const
+  }
+};
+
+const executeSchema = {
+  clientId: {
+    required: true,
+    type: 'string' as const,
+    maxLength: 200,
+    sanitize: true
+  },
+  token: {
+    required: true,
+    type: 'string' as const,
+    maxLength: 256,
+    sanitize: true
+  },
+  command: {
+    required: true,
+    type: 'string' as const,
+    minLength: 3,
+    maxLength: 100,
+    sanitize: true
+  },
+  payload: {
+    required: false,
+    type: 'object' as const
+  }
+};
+
+const heartbeatSchema = {
+  clientId: {
+    required: true,
+    type: 'string' as const,
+    sanitize: true
+  },
+  token: {
+    required: true,
+    type: 'string' as const,
+    sanitize: true
+  }
+};
+
+router.post(
+  '/session',
+  confirmGate,
+  createValidationMiddleware(sessionSchema),
+  (req: Request, res: Response) => {
+    const summary = createTunnelSession(req.body);
+
+    res.json({
+      success: true,
+      session: summary,
+      metadata: {
+        availableCommands: listAvailableCommands(),
+        activeSessions: getActiveSessionCount(),
+        createdAt: new Date().toISOString()
+      }
+    });
+  }
+);
+
+router.get(
+  '/stream/:clientId',
+  createRateLimitMiddleware(200, 15 * 60 * 1000),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { clientId } = req.params;
+    const token = (req.query.token as string) || '';
+    const subscription = subscribeToSession(clientId, token, (event) => {
+      res.write(`event: ${event.type}\n`);
+      res.write(`data: ${JSON.stringify(event.data)}\n\n`);
+    });
+
+    if (!subscription) {
+      res.status(401).json({
+        success: false,
+        error: 'Invalid or expired session token',
+        code: 'INVALID_SESSION'
+      });
+      return;
+    }
+
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('Connection', 'keep-alive');
+
+    const snapshot = getSessionSnapshot(clientId, token);
+    const readyEvent = {
+      type: 'ready' as const,
+      data: {
+        clientId,
+        streamId: randomUUID(),
+        connectedAt: new Date().toISOString(),
+        expiresAt: snapshot?.expiresAt,
+        availableCommands: listAvailableCommands()
+      }
+    };
+
+    res.write(`event: ${readyEvent.type}\n`);
+    res.write(`data: ${JSON.stringify(readyEvent.data)}\n\n`);
+
+    const keepAlive = setInterval(() => {
+      res.write(`event: heartbeat\n`);
+      res.write(`data: ${JSON.stringify({ timestamp: new Date().toISOString() })}\n\n`);
+    }, 25_000);
+
+    req.on('close', () => {
+      clearInterval(keepAlive);
+      subscription.unsubscribe();
+    });
+  })
+);
+
+router.post(
+  '/execute',
+  confirmGate,
+  createValidationMiddleware(executeSchema),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { clientId, token, command, payload } = req.body as {
+      clientId: string;
+      token: string;
+      command: string;
+      payload?: Record<string, unknown>;
+    };
+
+    const context = buildTunnelContext(clientId, token);
+
+    if (!context) {
+      res.status(401).json({
+        success: false,
+        error: 'Invalid or expired session token',
+        code: 'INVALID_SESSION'
+      });
+      return;
+    }
+
+    const commandId = randomUUID();
+    publishAck(clientId, token, {
+      clientId,
+      commandId,
+      command,
+      receivedAt: new Date().toISOString()
+    });
+
+    const result = await executeCommand(command, payload as Record<string, any>, {
+      ...context,
+      commandId
+    });
+
+    const delivered = publishResult(clientId, token, result);
+
+    res.status(result.success ? 202 : 400).json({
+      success: result.success,
+      commandId,
+      queued: true,
+      message: result.message,
+      metadata: result.metadata,
+      delivered
+    });
+  })
+);
+
+router.post(
+  '/heartbeat',
+  createValidationMiddleware(heartbeatSchema),
+  (req: Request, res: Response) => {
+    const { clientId, token } = req.body as { clientId: string; token: string };
+    const summary = heartbeatSession(clientId, token);
+
+    if (!summary) {
+      res.status(401).json({
+        success: false,
+        error: 'Invalid or expired session token',
+        code: 'INVALID_SESSION'
+      });
+      return;
+    }
+
+    res.json({
+      success: true,
+      session: summary
+    });
+  }
+);
+
+router.delete(
+  '/session',
+  createValidationMiddleware(heartbeatSchema),
+  (req: Request, res: Response) => {
+    const { clientId, token } = req.body as { clientId: string; token: string };
+    const success = closeSession(clientId, token);
+
+    if (!success) {
+      res.status(401).json({
+        success: false,
+        error: 'Invalid or expired session token',
+        code: 'INVALID_SESSION'
+      });
+      return;
+    }
+
+    res.json({
+      success: true,
+      message: 'Session closed'
+    });
+  }
+);
+
+router.use((_: Request, res: Response) => {
+  res.status(404).json({
+    success: false,
+    error: 'Not found',
+    code: 'NOT_FOUND'
+  });
+});
+
+export default router;

--- a/src/routes/api-commands.ts
+++ b/src/routes/api-commands.ts
@@ -1,0 +1,65 @@
+import express, { Request, Response } from 'express';
+import { confirmGate } from '../middleware/confirmGate.js';
+import { createRateLimitMiddleware, createValidationMiddleware, securityHeaders } from '../utils/security.js';
+import { asyncHandler } from '../utils/asyncHandler.js';
+import { executeCommand, listAvailableCommands } from '../services/commandCenter.js';
+import type { CommandName } from '../services/commandCenter.js';
+
+const router = express.Router();
+
+router.use(securityHeaders);
+router.use(createRateLimitMiddleware(50, 15 * 60 * 1000));
+
+const commandExecutionSchema = {
+  command: {
+    required: true,
+    type: 'string' as const,
+    minLength: 3,
+    maxLength: 100,
+    sanitize: true
+  },
+  payload: {
+    required: false,
+    type: 'object' as const
+  }
+};
+
+router.get(
+  '/',
+  (_: Request, res: Response) => {
+    res.json({
+      success: true,
+      commands: listAvailableCommands(),
+      metadata: {
+        count: listAvailableCommands().length,
+        timestamp: new Date().toISOString()
+      }
+    });
+  }
+);
+
+router.get(
+  '/health',
+  (_: Request, res: Response) => {
+    res.json({
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      availableCommands: listAvailableCommands().length
+    });
+  }
+);
+
+router.post(
+  '/execute',
+  confirmGate,
+  createValidationMiddleware(commandExecutionSchema),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { command, payload } = req.body as { command: CommandName; payload?: Record<string, any> };
+
+    const result = await executeCommand(command, payload);
+
+    res.status(result.success ? 200 : 400).json(result);
+  })
+);
+
+export default router;

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -14,6 +14,8 @@ import backstageRouter from './backstage.js';
 import apiArcanosRouter from './api-arcanos.js';
 import apiSimRouter from './api-sim.js';
 import apiMemoryRouter from './api-memory.js';
+import apiCommandsRouter from './api-commands.js';
+import apiCommandTunnelRouter from './api-command-tunnel.js';
 import sdkRouter from './sdk.js';
 import imageRouter from './image.js';
 import prAnalysisRouter from './pr-analysis.js';
@@ -55,6 +57,8 @@ export function registerRoutes(app: Express): void {
   app.use('/api/arcanos', apiArcanosRouter);
   app.use('/api/sim', apiSimRouter);
   app.use('/api/memory', apiMemoryRouter);
+  app.use('/api/commands', apiCommandsRouter);
+  app.use('/api/commands/tunnel', apiCommandTunnelRouter);
   app.use('/api/pr-analysis', prAnalysisRouter);
   app.use('/api/openai', openaiRouter);
   app.use('/', hrcRouter);

--- a/src/services/commandCenter.ts
+++ b/src/services/commandCenter.ts
@@ -1,0 +1,200 @@
+import { sanitizeInput } from '../utils/security.js';
+import { createCentralizedCompletion, generateMockResponse, hasValidAPIKey } from './openai.js';
+import { getAuditSafeMode, interpretCommand, setAuditSafeMode } from './auditSafeToggle.js';
+
+export type CommandName = 'audit-safe:set-mode' | 'audit-safe:interpret' | 'ai:prompt';
+
+export interface CommandExecutionContext {
+  commandId?: string;
+  clientId?: string;
+}
+
+type CommandHandler = (
+  payload?: Record<string, any>,
+  context?: CommandExecutionContext
+) => Promise<CommandExecutionResult>;
+
+export interface CommandDefinition {
+  name: CommandName;
+  description: string;
+  requiresConfirmation: boolean;
+  payloadExample?: Record<string, unknown>;
+}
+
+export interface CommandExecutionResult {
+  success: boolean;
+  command: CommandName;
+  message: string;
+  output?: Record<string, unknown>;
+  metadata: {
+    executedAt: string;
+    auditSafeMode: string;
+    commandId?: string;
+    clientId?: string;
+  };
+}
+
+const AVAILABLE_COMMANDS: Record<CommandName, CommandDefinition> = {
+  'audit-safe:set-mode': {
+    name: 'audit-safe:set-mode',
+    description: 'Directly set the Audit-Safe enforcement mode.',
+    requiresConfirmation: true,
+    payloadExample: { mode: 'true' }
+  },
+  'audit-safe:interpret': {
+    name: 'audit-safe:interpret',
+    description: 'Interpret a natural-language instruction to adjust Audit-Safe mode.',
+    requiresConfirmation: true,
+    payloadExample: { instruction: 'Enable strict audit safe mode' }
+  },
+  'ai:prompt': {
+    name: 'ai:prompt',
+    description: 'Execute an AI command through the centralized OpenAI routing pipeline.',
+    requiresConfirmation: true,
+    payloadExample: { prompt: 'Summarize current system status' }
+  }
+};
+
+const VALID_AUDIT_MODES: Array<'true' | 'false' | 'passive' | 'log-only'> = ['true', 'false', 'passive', 'log-only'];
+
+const commandHandlers: Record<CommandName, CommandHandler> = {
+  'audit-safe:set-mode': async (payload, context) => {
+    const mode = typeof payload?.mode === 'string' ? (payload.mode as typeof VALID_AUDIT_MODES[number]) : undefined;
+
+    if (!mode || !VALID_AUDIT_MODES.includes(mode)) {
+      return buildResult('audit-safe:set-mode', false, "Invalid mode. Use 'true', 'false', 'passive', or 'log-only'.", undefined, context);
+    }
+
+    setAuditSafeMode(mode);
+
+    return buildResult('audit-safe:set-mode', true, `Audit-Safe mode set to ${mode}.`,
+      {
+        mode
+      },
+      context
+    );
+  },
+  'audit-safe:interpret': async (payload, context) => {
+    const instruction = typeof payload?.instruction === 'string' ? sanitizeInput(payload.instruction) : '';
+
+    if (!instruction) {
+      return buildResult('audit-safe:interpret', false, 'Instruction text is required.', undefined, context);
+    }
+
+    await interpretCommand(instruction);
+
+    return buildResult(
+      'audit-safe:interpret',
+      true,
+      'Instruction processed. Audit-Safe mode updated if recognized.',
+      {
+        instruction,
+        mode: getAuditSafeMode()
+      },
+      context
+    );
+  },
+  'ai:prompt': async (payload, context) => {
+    const prompt = typeof payload?.prompt === 'string' ? payload.prompt.trim() : '';
+
+    if (!prompt) {
+      return buildResult('ai:prompt', false, 'Prompt text is required.', undefined, context);
+    }
+
+    const sanitizedPrompt = sanitizeInput(prompt);
+
+    if (!hasValidAPIKey()) {
+      const mock = generateMockResponse(sanitizedPrompt, 'ask');
+      return buildResult(
+        'ai:prompt',
+        true,
+        'OpenAI API key not configured - returning mock response.',
+        {
+          result: mock.result,
+          meta: mock.meta,
+          fallback: true
+        },
+        context
+      );
+    }
+
+    try {
+      const response = await createCentralizedCompletion([
+        { role: 'user', content: sanitizedPrompt }
+      ]);
+
+      if ('choices' in response) {
+        const firstChoice = response.choices[0];
+        const content = firstChoice?.message?.content ?? '';
+        return buildResult(
+          'ai:prompt',
+          true,
+          'AI command executed successfully.',
+          {
+            result: content,
+            usage: response.usage ?? null,
+            model: response.model
+          },
+          context
+        );
+      }
+
+      return buildResult(
+        'ai:prompt',
+        true,
+        'Streaming response started.',
+        {
+          result: null,
+          streaming: true
+        },
+        context
+      );
+    } catch (error: any) {
+      return buildResult('ai:prompt', false, error?.message || 'Failed to execute AI command.', undefined, context);
+    }
+  }
+};
+
+function buildResult(
+  command: CommandName,
+  success: boolean,
+  message: string,
+  output: Record<string, unknown> | undefined = undefined,
+  context: CommandExecutionContext | undefined = undefined
+): CommandExecutionResult {
+  return {
+    success,
+    command,
+    message,
+    output,
+    metadata: {
+      executedAt: new Date().toISOString(),
+      auditSafeMode: getAuditSafeMode(),
+      ...(context?.commandId ? { commandId: context.commandId } : {}),
+      ...(context?.clientId ? { clientId: context.clientId } : {})
+    }
+  };
+}
+
+export async function executeCommand(
+  command: CommandName,
+  payload: Record<string, any> = {},
+  context: CommandExecutionContext = {}
+): Promise<CommandExecutionResult> {
+  const handler = commandHandlers[command];
+
+  if (!handler) {
+    return buildResult(command, false, 'Unsupported command.', undefined, context);
+  }
+
+  return handler(payload, context);
+}
+
+export function listAvailableCommands(): CommandDefinition[] {
+  return Object.values(AVAILABLE_COMMANDS);
+}
+
+export default {
+  executeCommand,
+  listAvailableCommands
+};

--- a/src/services/commandTunnel.ts
+++ b/src/services/commandTunnel.ts
@@ -1,0 +1,290 @@
+import { EventEmitter } from 'events';
+import { randomUUID } from 'crypto';
+import { sanitizeInput } from '../utils/security.js';
+import type { CommandExecutionResult, CommandExecutionContext } from './commandCenter.js';
+
+const DEFAULT_SESSION_TTL_MS = 15 * 60 * 1000; // 15 minutes
+const MIN_SESSION_TTL_MS = 60 * 1000; // 1 minute
+const MAX_SESSION_TTL_MS = 60 * 60 * 1000; // 1 hour
+const CLEANUP_INTERVAL_MS = 60 * 1000; // 1 minute
+
+type TunnelEventType = 'ready' | 'ack' | 'result' | 'error' | 'heartbeat' | 'info';
+
+export interface CommandTunnelEvent {
+  type: TunnelEventType;
+  data: Record<string, unknown>;
+}
+
+interface CommandTunnelSession {
+  id: string;
+  token: string;
+  emitter: EventEmitter;
+  createdAt: number;
+  lastActivity: number;
+  expiresAt: number;
+  isStreaming: boolean;
+}
+
+export interface TunnelSessionSummary {
+  clientId: string;
+  token: string;
+  createdAt: string;
+  expiresAt: string;
+  streamPath: string;
+}
+
+export interface TunnelSessionOptions {
+  clientId?: string;
+  requestedTtlMs?: number;
+}
+
+const sessions = new Map<string, CommandTunnelSession>();
+
+function clampTtl(requestedTtl?: number): number {
+  if (!requestedTtl) {
+    return DEFAULT_SESSION_TTL_MS;
+  }
+
+  return Math.min(Math.max(requestedTtl, MIN_SESSION_TTL_MS), MAX_SESSION_TTL_MS);
+}
+
+function createToken(): string {
+  return randomUUID().replace(/-/g, '');
+}
+
+function now(): number {
+  return Date.now();
+}
+
+function sanitizeClientId(candidate?: string): string | undefined {
+  if (!candidate) return undefined;
+  const sanitized = sanitizeInput(candidate);
+  return sanitized.length > 0 ? sanitized : undefined;
+}
+
+function buildSession(id: string, ttlMs: number): CommandTunnelSession {
+  const createdAt = now();
+  return {
+    id,
+    token: createToken(),
+    emitter: new EventEmitter(),
+    createdAt,
+    lastActivity: createdAt,
+    expiresAt: createdAt + ttlMs,
+    isStreaming: false
+  };
+}
+
+function cleanupSession(sessionId: string): void {
+  const session = sessions.get(sessionId);
+  if (session) {
+    session.emitter.removeAllListeners();
+  }
+  sessions.delete(sessionId);
+}
+
+function getSession(sessionId: string): CommandTunnelSession | undefined {
+  const session = sessions.get(sessionId);
+  if (!session) {
+    return undefined;
+  }
+
+  if (session.expiresAt <= now()) {
+    cleanupSession(sessionId);
+    return undefined;
+  }
+
+  return session;
+}
+
+function verifySession(sessionId: string, token: string | undefined): CommandTunnelSession | undefined {
+  if (!token) return undefined;
+  const session = getSession(sessionId);
+  if (!session) return undefined;
+  if (session.token !== token) return undefined;
+  return session;
+}
+
+function touchSession(session: CommandTunnelSession, extend: boolean = false): void {
+  session.lastActivity = now();
+  if (extend) {
+    const ttl = clampTtl(DEFAULT_SESSION_TTL_MS);
+    session.expiresAt = Math.min(session.lastActivity + ttl, session.createdAt + MAX_SESSION_TTL_MS);
+  }
+}
+
+export function createTunnelSession(options: TunnelSessionOptions = {}): TunnelSessionSummary {
+  const sanitizedId = sanitizeClientId(options.clientId);
+  const ttlMs = clampTtl(options.requestedTtlMs);
+  const clientId = sanitizedId && !sessions.has(sanitizedId) ? sanitizedId : randomUUID();
+
+  const existing = sessions.get(clientId);
+  if (existing) {
+    existing.token = createToken();
+    existing.expiresAt = Math.min(now() + ttlMs, existing.createdAt + MAX_SESSION_TTL_MS);
+    touchSession(existing);
+    return {
+      clientId: existing.id,
+      token: existing.token,
+      createdAt: new Date(existing.createdAt).toISOString(),
+      expiresAt: new Date(existing.expiresAt).toISOString(),
+      streamPath: `/api/commands/tunnel/stream/${existing.id}`
+    };
+  }
+
+  const session = buildSession(clientId, ttlMs);
+  sessions.set(clientId, session);
+
+  return {
+    clientId: session.id,
+    token: session.token,
+    createdAt: new Date(session.createdAt).toISOString(),
+    expiresAt: new Date(session.expiresAt).toISOString(),
+    streamPath: `/api/commands/tunnel/stream/${session.id}`
+  };
+}
+
+export function subscribeToSession(
+  clientId: string,
+  token: string,
+  listener: (event: CommandTunnelEvent) => void
+): { unsubscribe: () => void } | undefined {
+  const session = verifySession(clientId, token);
+  if (!session) {
+    return undefined;
+  }
+
+  session.isStreaming = true;
+  const handler = (event: CommandTunnelEvent) => listener(event);
+  session.emitter.on('event', handler);
+  touchSession(session);
+
+  return {
+    unsubscribe: () => {
+      const current = sessions.get(clientId);
+      if (!current) return;
+      current.emitter.off('event', handler);
+      current.isStreaming = false;
+      touchSession(current);
+    }
+  };
+}
+
+export function publishToSession(
+  clientId: string,
+  token: string,
+  event: CommandTunnelEvent
+): boolean {
+  const session = verifySession(clientId, token);
+  if (!session) {
+    return false;
+  }
+
+  session.emitter.emit('event', event);
+  touchSession(session);
+  return true;
+}
+
+export function heartbeatSession(clientId: string, token: string): TunnelSessionSummary | undefined {
+  const session = verifySession(clientId, token);
+  if (!session) {
+    return undefined;
+  }
+
+  touchSession(session, true);
+
+  return {
+    clientId: session.id,
+    token: session.token,
+    createdAt: new Date(session.createdAt).toISOString(),
+    expiresAt: new Date(session.expiresAt).toISOString(),
+    streamPath: `/api/commands/tunnel/stream/${session.id}`
+  };
+}
+
+export function closeSession(clientId: string, token: string): boolean {
+  const session = verifySession(clientId, token);
+  if (!session) {
+    return false;
+  }
+
+  cleanupSession(clientId);
+  return true;
+}
+
+export function buildTunnelContext(clientId: string, token: string): CommandExecutionContext | undefined {
+  const session = verifySession(clientId, token);
+  if (!session) {
+    return undefined;
+  }
+
+  touchSession(session);
+  return {
+    clientId
+  };
+}
+
+export function publishResult(
+  clientId: string,
+  token: string,
+  result: CommandExecutionResult
+): boolean {
+  return publishToSession(clientId, token, {
+    type: 'result',
+    data: result as unknown as Record<string, unknown>
+  });
+}
+
+export function publishAck(
+  clientId: string,
+  token: string,
+  data: Record<string, unknown>
+): boolean {
+  return publishToSession(clientId, token, {
+    type: 'ack',
+    data
+  });
+}
+
+export function publishError(
+  clientId: string,
+  token: string,
+  error: string,
+  context: Record<string, unknown> = {}
+): boolean {
+  return publishToSession(clientId, token, {
+    type: 'error',
+    data: {
+      error,
+      ...context
+    }
+  });
+}
+
+setInterval(() => {
+  const expirationCutoff = now();
+  for (const [id, session] of sessions.entries()) {
+    if (session.expiresAt <= expirationCutoff) {
+      cleanupSession(id);
+    }
+  }
+}, CLEANUP_INTERVAL_MS);
+
+export function getActiveSessionCount(): number {
+  return sessions.size;
+}
+
+export function getSessionSnapshot(clientId: string, token: string): TunnelSessionSummary | undefined {
+  const session = verifySession(clientId, token);
+  if (!session) {
+    return undefined;
+  }
+
+  return {
+    clientId: session.id,
+    token: session.token,
+    createdAt: new Date(session.createdAt).toISOString(),
+    expiresAt: new Date(session.expiresAt).toISOString(),
+    streamPath: `/api/commands/tunnel/stream/${session.id}`
+  };
+}


### PR DESCRIPTION
## Summary
- introduce a command tunnel service that manages authenticated command sessions with TTL-aware bookkeeping
- add `/api/commands/tunnel` endpoints that provide SSE streaming, heartbeats, and command execution delivery for clients that cannot rely on standard HTTP flows
- enrich command execution metadata so tunnel deliveries include command and client identifiers for downstream tracking

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6902b810909c8325968a2bcbebac6e06