### PR TITLE
Add documentation explaining ChatGPT front-end rationale

### DIFF
--- a/docs/ai-guides/CHATGPT_FRONTEND_JUSTIFICATION.md
+++ b/docs/ai-guides/CHATGPT_FRONTEND_JUSTIFICATION.md
@@ -1,0 +1,37 @@
+# ChatGPT Front-End Justification
+
+## Overview
+ChatGPT serves as the interactive front-end for Arcanos, connecting users to orchestration services, domain-specific tooling, and managed automations. Choosing ChatGPT was an intentional decision that balances user familiarity with tight integration into our AI platform. This document outlines the key factors that led to that decision, the operational impact of the choice, and the trade-offs we evaluated.
+
+## Decision Drivers
+- **User familiarity and trust**: Millions of users already interact with ChatGPT daily. Leveraging the same interface removes onboarding friction, increases confidence in AI responses, and reduces the need for bespoke UI/UX investment.
+- **Production-grade conversation engine**: ChatGPT provides out-of-the-box capabilities for turn-taking, context retention, and tool invocation. Building an equivalent conversational stack would require significant engineering and maintenance effort.
+- **Deep integration with OpenAI platform**: Arcanos already depends on OpenAI for model hosting, moderation, and logging. Using ChatGPT allows us to reuse authentication, session management, and analytics without duplicating functionality elsewhere.
+- **Extensible agent framework**: ChatGPT’s function-calling and tool-usage APIs map cleanly onto our orchestration services. This makes it straightforward to expose new capabilities, route tasks to specialized models, or capture structured outputs.
+- **Accessibility and compliance**: ChatGPT ships with accessibility features, security hardening, and compliance assurances (SOC 2, GDPR, HIPAA-eligible tiers) that would otherwise require dedicated compliance programs on our side.
+
+## Operational Benefits
+1. **Accelerated product velocity**: Teams can prototype new automations directly inside the ChatGPT UI using schema-defined tools, eliminating the need to maintain separate front-end deployments.
+2. **Observability and auditing**: Centralized conversation logs, tool traces, and cost reports flow through the OpenAI platform. This gives the governance team a single place to enforce retention policies and monitor incidents.
+3. **Scalability**: ChatGPT’s managed infrastructure handles spiky traffic, model upgrades, and fallbacks. Our infrastructure footprint remains focused on domain services and data pipelines instead of front-end hosting.
+4. **Localization and accessibility support**: Built-in localization coverage and accessibility affordances (screen-reader compatibility, keyboard navigation) expand our user base without bespoke engineering.
+5. **Safety systems**: Moderation pipelines, rate-limiting, and red-team mitigations provided by ChatGPT reduce the surface area for prompt injection and misuse.
+
+## Trade-offs Considered
+- **Customization constraints**: ChatGPT’s UI is opinionated. We mitigate this by exposing high-leverage workflows via custom actions, conversation starters, and system messages. For edge cases requiring bespoke UX, we maintain a thin fallback web client.
+- **Dependency risk**: Relying on a third-party interface introduces vendor risk. To offset this, we maintain API-level parity in our orchestration layer and regularly export conversation logs for portability.
+- **Cost visibility**: ChatGPT usage is billed differently from direct API calls. Finance dashboards incorporate both sources so that unit economics stay transparent.
+
+## Alignment with Arcanos Architecture
+Our orchestration layer centers on AI workers, policy enforcement, and memory subsystems. ChatGPT acts as a secure shell into that ecosystem:
+- Function calls trigger workflows described in `ORCHESTRATION_API.md` and `AI_DISPATCHER_REFACTOR_GUIDE.md`.
+- Conversation state is synchronized with the Universal Memory service documented in `UNIVERSAL_MEMORY_GUIDE.md`.
+- Guardrails use the same policy hooks as the backend sync described in `BACKEND_SYNC_IMPLEMENTATION.md`.
+
+By design, the front-end choice reinforces our focus on orchestration logic rather than interface maintenance. As our automation catalog expands, ChatGPT scales with us—providing a familiar canvas for users and a flexible API surface for engineers.
+
+## Future Considerations
+- Evaluate the upcoming ChatGPT UI extensibility features (custom components, embedded dashboards) for richer domain-specific interfaces.
+- Continue monitoring usage telemetry to determine when dedicated front-end experiences are warranted for niche user journeys.
+- Maintain export tooling so that we can re-host critical workflows if vendor terms change.
+


### PR DESCRIPTION
## Summary
- add documentation outlining the reasons for selecting ChatGPT as the user-facing front-end
- describe operational benefits, trade-offs, and alignment with existing orchestration architecture

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905153a871483259a30ccbf98394f7f