### PR TITLE
docs: add rationale for railway hosting

### DIFF
--- a/docs/why-we-chose-railway.md
+++ b/docs/why-we-chose-railway.md
@@ -1,0 +1,66 @@
+# Why We Chose Railway for Cloud Hosting
+
+## Executive Summary
+Railway is the deployment platform for the ARCANOS backend because it gives us a production-ready runtime with minimal operational overhead. The platform aligns with our priorities—fast iteration, predictable scaling, and built-in observability—without requiring us to run our own infrastructure or maintain heavyweight DevOps tooling. Railway lets us focus on product development while still meeting enterprise expectations around reliability, security, and cost control.
+
+## Selection Criteria
+We assessed hosting options against six core requirements:
+
+1. **Developer Velocity** – Simple workflows for spinning up environments, running previews, and promoting changes to production.
+2. **Operational Reliability** – Managed health checks, restarts, and runtime monitoring so the service stays available without manual babysitting.
+3. **Scalability and Performance** – Automatic resource sizing, container restarts, and support for the 8GB memory profile we optimized for ARCANOS.
+4. **Platform Compatibility** – First-class support for Node.js, Docker images, and the OpenAI-compatible API surface our application exposes.
+5. **Security and Compliance** – Isolated deployments, environment variable management, and secrets handling that align with our security baseline.
+6. **Cost Efficiency** – Transparent pricing, sensible defaults, and the ability to tune resource usage without surprise overages.
+
+Railway was the only provider that delivered strongly across all six, while keeping the day-to-day developer experience approachable for a small team.
+
+## Key Advantages of Railway
+
+### 1. Streamlined Developer Experience
+- **Git-native deployments:** Our main branch can deploy directly through Railway, eliminating hand-built CI scripts for the majority of changes.
+- **Ephemeral environments:** Preview deployments mirror production settings, so we can validate changes (including OpenAI SDK integrations) before merging.
+- **One-click rollbacks:** Railway snapshots give us an immediate escape hatch if a release regresses.
+
+### 2. Operational Reliability Out of the Box
+- **Managed health checks and restarts:** Railway continuously probes our `/api/test` endpoint and restarts the service automatically if it becomes unhealthy.
+- **Structured logs and metrics:** Centralized logging plus CPU/memory dashboards make it easy to trace issues without bolting on external observability.
+- **Autoscaling-ready runtime:** Our container footprint can be resized in the dashboard, aligning with the 8GB memory plan we already tune for.
+
+### 3. First-Class Support for the ARCANOS Stack
+- **Docker & Node.js support:** Railway runs the same Dockerfile we use locally, guaranteeing parity between development and production.
+- **Environment variable management:** Built-in secret storage covers OpenAI keys, PostgreSQL credentials, and feature flags.
+- **OpenAI-compatible networking:** The platform’s outbound networking rules are permissive enough for our fine-tuned model relay while still enforcing sensible rate limits.
+
+### 4. Built-In Database and Queue Integrations
+- **Managed PostgreSQL:** Provisioned from the same dashboard, giving us low-latency connectivity without separate cloud accounts.
+- **Connection pooling:** Railway integrates with PgBouncer-style pooling, which matches our Prisma ORM usage patterns.
+- **Service discovery:** Environment variables like `DATABASE_URL` are injected automatically, reducing manual configuration drift.
+
+### 5. Cost and Resource Transparency
+- **Predictable pricing tiers:** The Hobby 8GB plan maps directly to our Node.js memory optimizations, ensuring we pay only for resources we can actually consume.
+- **Usage insights:** Per-service metrics highlight when we should scale up or down, avoiding guesswork.
+- **No surprise networking bills:** Railway includes egress within the plan, which keeps our OpenAI proxy traffic affordable.
+
+### 6. Operational Guardrails Without Heavy Process
+- **Access control:** Role-based permissions let us invite collaborators with scoped access.
+- **Auditability:** Deployment history, logs, and CLI commands create a traceable record for compliance reviews.
+- **Disaster recovery:** Automatic backups for managed databases and quick redeploys from container images keep recovery time objectives low.
+
+## Comparison to Alternatives Considered
+
+| Platform | Strengths | Gaps for ARCANOS |
+| --- | --- | --- |
+| **Render** | Simple UI, supports Docker, built-in managed PostgreSQL | Slower build times, fewer observability hooks, weaker preview environment story |
+| **Fly.io** | Global edge deployments, flexible networking | More manual configuration, requires deeper SRE expertise, PostgreSQL clusters demand extra operational work |
+| **Heroku** | Mature ecosystem, polished CLI | Higher cost for comparable resources, limited RAM per dyno, add-ons required for modern observability |
+
+While each provider has attractive features, Railway struck the best balance between modern tooling and low-friction operations. It delivers Heroku-like simplicity with the performance profile and price point we need.
+
+## Impact on the Team
+- **Faster onboarding:** New engineers can deploy within minutes using the shared Railway project.
+- **Reduced maintenance:** No one has to maintain Terraform, Kubernetes, or bespoke CI pipelines for production releases.
+- **Confidence in releases:** Health checks, observability, and rollbacks give the team confidence to ship frequently.
+
+## Looking Ahead
+Railway remains the default deployment target for ARCANOS. We continuously monitor the platform roadmap—particularly around autoscaling, secrets rotation, and service mesh features—to ensure it continues meeting our needs. If our workload grows beyond Railway’s sweet spot, this document will guide a structured re-evaluation, but today Railway provides the best mix of speed, reliability, and cost-effectiveness for our application.


### PR DESCRIPTION
## Summary
- add documentation detailing why Railway is our preferred hosting platform and how it meets our operational criteria

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69052f62bf908325b94fef416b087169