### PR TITLE
Add documentation for audits and model resiliency plans

### DIFF
--- a/docs/audits-and-resiliency.md
+++ b/docs/audits-and-resiliency.md
@@ -1,0 +1,73 @@
+# Audit and Fine-Tuned Model Resiliency Strategy
+
+## Purpose
+This document outlines how Arcanos employs audits to ensure compliance and operational excellence, and explains our resiliency backup plans for fine-tuned models. It includes clear, repeatable methods for conducting audits and activating model backups so that teams can respond effectively to incidents.
+
+## Audit Program Overview
+- **Scope**: Audits cover data pipelines, model training processes, deployment environments, and user-facing integrations.
+- **Frequency**: Routine audits are scheduled quarterly, with additional ad-hoc reviews triggered by major releases or policy changes.
+- **Governance**: The Compliance & Safety Guild owns the audit calendar, while domain leads provide evidence and remediation plans.
+
+## Audit Method
+1. **Preparation**
+   - Review the quarterly risk register for prioritized systems.
+   - Confirm audit objectives, success criteria, and required evidence.
+   - Notify responsible teams and share the audit checklist at least two weeks in advance.
+2. **Evidence Collection**
+   - Pull configuration snapshots from infrastructure-as-code repositories.
+   - Export relevant model training logs, data lineage reports, and evaluation dashboards.
+   - Interview system owners to capture undocumented controls or recent changes.
+3. **Validation**
+   - Cross-check evidence against policy requirements (security, privacy, and fairness standards).
+   - Reproduce a sample of deployment steps in the staging environment to validate procedural accuracy.
+   - Run automated compliance scripts (see `arcanos_audit_config.json`) and record all findings.
+4. **Reporting**
+   - Compile findings into the standardized audit template.
+   - Categorize issues by severity and map each to an owner and remediation deadline.
+   - Present results at the weekly governance review and archive the report in the compliance drive.
+5. **Follow-Up**
+   - Track remediation tasks in the compliance dashboard.
+   - Schedule verification checks to confirm fixes before closure.
+   - Document lessons learned to refine the next audit cycle.
+
+## Fine-Tuned Model Resiliency
+We maintain resiliency measures to ensure fine-tuned models remain available and performant even during incidents.
+
+### Backup Plan Components
+- **Model Versioning**: All fine-tuned models are versioned with semantic tags and stored in the secure model registry.
+- **Shadow Deployments**: A shadow instance of the previous stable model runs alongside the primary deployment for instant fallback.
+- **Automated Health Checks**: Real-time metrics monitor latency, accuracy drift, and safety trigger rates. Alerts escalate to the on-call ML engineer.
+- **Disaster Recovery Storage**: Encrypted backups of training data, fine-tuning configurations, and weights are replicated across regions.
+
+### Backup Activation Method
+1. **Incident Detection**
+   - Receive automated alert or manual incident report indicating degraded model performance or availability.
+   - Confirm the issue by reviewing monitoring dashboards and recent deployment changes.
+2. **Triage and Decision**
+   - Convene the incident response bridge.
+   - Decide whether to roll back to the shadow model or trigger full redeployment based on severity and blast radius.
+3. **Fallback Execution**
+   - Use the deployment pipeline to promote the shadow model to primary traffic.
+   - Update routing rules and clear caches to ensure consistent responses.
+4. **Root Cause Analysis**
+   - Collect logs, compare recent training artifacts, and inspect feature store updates.
+   - Document the timeline and contributing factors in the incident report.
+5. **Recovery and Validation**
+   - Once fixes are implemented, deploy the corrected fine-tuned model into a canary environment.
+   - Run regression, fairness, and safety evaluations prior to full rollout.
+   - Update the disaster recovery records with new artifacts and lessons learned.
+
+## Clear Communication Method
+To keep stakeholders aligned during audits and resiliency events:
+1. **Notification Matrix**: Maintain a contact list for compliance leads, ML engineers, product owners, and executive sponsors.
+2. **Status Updates**: Provide written updates every four hours during active incidents and within 24 hours of audit completion.
+3. **Documentation**: Store all communications, decisions, and approvals in the compliance collaboration space for traceability.
+4. **Post-Event Review**: Conduct a retrospective meeting within one week to confirm actions and update playbooks.
+
+## Responsibilities Summary
+- **Compliance & Safety Guild**: Owns audit framework, tracks remediation, and coordinates communication.
+- **ML Engineering Team**: Maintains model registry, shadow deployments, and health monitoring.
+- **SRE Team**: Ensures infrastructure resilience and disaster recovery replication.
+- **Product & Policy Leads**: Validate user-facing impacts and ensure policy adherence.
+
+By following these methods, Arcanos can consistently verify compliance, respond swiftly to incidents, and safeguard the reliability of our fine-tuned models.


### PR DESCRIPTION
## Summary
- add a documentation page describing the audit program and backup strategy for fine-tuned models
- outline clear methods for executing audits, activating backups, and communicating during incidents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905404204bc8325a11ae6da397ae95e