### PR TITLE
Add documentation for resiliency patches and CLEAR auditing

### DIFF
--- a/docs/resiliency-patches-and-clear.md
+++ b/docs/resiliency-patches-and-clear.md
@@ -1,0 +1,319 @@
+# ARCANOS Resiliency Patches and CLEAR Auditing
+
+ARCANOS pairs runtime safeguards with rigorous auditing so that orchestration logic stays transparent, recoverable, and aligned with intent. This guide covers how resiliency patches operate, how the CLEAR (Clarity, Leverage, Efficiency, Alignment, Resilience) method evaluates implementation health, and how both systems reinforce one another at runtime.
+
+## Component Responsibilities
+
+| Component | Responsibility | Key Interfaces |
+|-----------|----------------|----------------|
+| Resiliency Patch Manager | Registers, versions, and applies patches against live orchestration graphs. | `patch.registry.yaml`, `/orchestration/patches`, `/diagnostic full` |
+| Hallucination-Resistant Core (HRC) | Executes vetted reasoning chains and enforces guard-rails defined by active patches. | `/workers/status`, `/orchestration/status` |
+| ARCANOS Orchestration Layer | Routes intents through skills, workers, and fallback trees while honoring patch contracts. | `orchestration.manifest.json`, patch-specific lifecycle hooks |
+| CLEAR Audit Service | Scores workflows, functions, and decision trees for CLEAR 2.0 compliance, emitting reports and remediation hints. | `/audits/clear`, `clear_audit.log` |
+| Observability Stack | Streams logs, metrics, and traces associated with patch lifecycles and CLEAR events. | `logs/resiliency.log`, `metrics/clear.prom` |
+
+## 1. Resiliency Patches
+
+### 1.1 Definition
+
+A **resiliency patch** encapsulates fault-isolation policies, fallback logic, and recovery guarantees that can be activated without redeploying the entire orchestration graph. Patches are authored declaratively, versioned atomically, and instrumented for auditability. Each patch declares:
+
+- **Target scopes** (workflows, worker pools, decision edges, or HRC reasoning steps).
+- **Isolation rules** that constrain blast radius when anomalies are detected.
+- **Fallback plans** describing failover workers or alternative skill chains.
+- **Rollback protections** specifying safe-state checkpoints and reversal logic.
+
+### 1.2 Declaration and Activation Workflow
+
+1. Author the patch manifest and register it with the patch manager.
+2. Run a dry-run audit to validate compatibility and CLEAR alignment.
+3. Activate the patch via the orchestration API; the HRC and workers apply scoped guards.
+4. Monitor lifecycle hooks and revert or iterate based on telemetry.
+
+```yaml
+# patch-manifests/semantic-guardrail.yaml
+apiVersion: resiliency.arcanos/v1
+kind: Patch
+metadata:
+  name: semantic-guardrail
+  version: 3.2.0
+spec:
+  target:
+    workflow: narrative-response
+    stage: "post_reasoning"
+  isolation:
+    circuitBreaker:
+      threshold: 5
+      cooldownSeconds: 60
+  fallback:
+    strategy: failover-worker
+    workerRef: workers/hallucination-reviewer
+    confidenceFloor: 0.82
+  rollback:
+    safePoint: checkpoints/narrative-response@2024-02-18
+    revertAction: promote_shadow_revision
+  activation:
+    auto: true
+    conditions:
+      - metric: hrc.output_hallucination_rate
+        op: ">"
+        value: 0.07
+```
+
+Activate the patch:
+
+```bash
+curl -X POST https://orchestration.internal/patches \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "semantic-guardrail",
+    "version": "3.2.0",
+    "mode": "activate",
+    "dryRun": false
+  }'
+```
+
+### 1.3 Fault Isolation, Fallback Handling, and Rollback Protection
+
+**Fault Isolation**
+
+- The orchestration layer injects circuit breakers and throttles on the targeted workflow stage.
+- The HRC suspends speculative reasoning branches that violate the patch’s anomaly metrics.
+- Worker pools receive quarantined traffic until health probes recover.
+
+**Fallback Handling**
+
+- Alternate workers defined in the patch manifest are promoted via the orchestration router.
+- In-flight requests are re-queued with CLEAR-aligned metadata, preserving audit trails.
+- Fallback success/failure emits structured events to `logs/resiliency.log`:
+
+```text
+2024-03-22T14:06:12.118Z [resiliency] PATCH semantic-guardrail v3.2.0 triggered fallback
+  request_id=7f92f434-f98a-4f2f-8f25-c2f776ae4b41
+  original_worker=workers/narrative-synthesizer
+  failover_worker=workers/hallucination-reviewer
+  confidence=0.79
+  clear_alignment=8.6/10
+```
+
+**Rollback Protection**
+
+- Safe-state checkpoints are created prior to activation; the patch manager stores state hashes.
+- Rollback commands reverse activation and restore previous routing and HRC guardrails.
+- Protection routines prevent downgrade if dependent patches require current semantics.
+
+```bash
+curl -X POST https://orchestration.internal/patches \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "semantic-guardrail",
+    "version": "3.2.0",
+    "mode": "deactivate",
+    "rollback": {
+      "restoreCheckpoint": "checkpoints/narrative-response@2024-02-18"
+    }
+  }'
+```
+
+### 1.4 Versioning and Audit Trail
+
+- Every patch increment requires semantic versioning (MAJOR.MINOR.PATCH) with immutable manifests.
+- Activation and deactivation events emit audit entries:
+
+```json
+{
+  "timestamp": "2024-03-22T14:05:58.447Z",
+  "event": "patch.lifecycle",
+  "name": "semantic-guardrail",
+  "version": "3.2.0",
+  "action": "activated",
+  "actor": "svc-orchestrator",
+  "clearScore": 8.9,
+  "hooks": ["/diagnostic full", "/workers/status"],
+  "signature": "0x97af..."
+}
+```
+
+- Deactivation requires an attested signature plus evidence of restored CLEAR alignment.
+- YAML manifests are stored in Git; production activations reference Git commit SHAs for traceability.
+
+### 1.5 Integration Points
+
+- **With HRC**: active patches adjust reasoning budgets, clamp hallucination-prone tokens, and feed anomaly metrics into the HRC’s adaptive decoder.
+- **With Orchestration Layer**: patches inject runtime middleware, override routing weights, and trigger lifecycle hooks (`onActivate`, `onFallback`, `onRollback`).
+- **Lifecycle Hooks**: `/diagnostic full` and `/workers/status` auto-fire during activation; `/orchestration/status` emits post-activation validation summaries.
+
+## 2. The CLEAR Method (CLEAR 2.0)
+
+CLEAR provides a weighted rubric for evaluating orchestration assets. Each principle is scored 0–10, with composite thresholds enforcing go/no-go decisions for deployments and patch activations.
+
+### 2.1 Principles
+
+- **Clarity** — Expose reasoning steps, inputs, and outputs with human-readable descriptors and machine-verifiable metadata.
+- **Leverage** — Encourage modular reuse of skills, prompts, and workers; penalize duplicated logic.
+- **Efficiency** — Optimize runtime, cost, and resource utilization without compromising safeguards.
+- **Alignment** — Ensure system goals, policy constraints, and user intents remain consistent across branches.
+- **Resilience** — Validate fault tolerance, fallback coverage, and recovery automation.
+
+### 2.2 CLEAR 2.0 Scoring Mechanics
+
+- Each audited asset receives sub-metrics per principle (e.g., `clarity.traces`, `leverage.sharedModules`).
+- Scores are normalized to 0–10 and weighted: Clarity 25%, Leverage 15%, Efficiency 20%, Alignment 20%, Resilience 20%.
+- Scores ≥ 8 trigger green status; 6–7.9 require remediation backlog; < 6 blocks deployment or patch activation.
+- The audit service persists results to `clear_audit.log` and publishes JSON payloads for automation.
+
+```json
+{
+  "asset": "workflow:narrative-response",
+  "revision": "1.18.4",
+  "auditedAt": "2024-03-22T14:00:05.731Z",
+  "scores": {
+    "clarity": { "total": 8.5, "traces": 9.0, "docs": 8.0 },
+    "leverage": { "total": 7.2, "moduleReuse": 7.0, "promptLibrary": 7.4 },
+    "efficiency": { "total": 8.1, "latency": 8.3, "cost": 7.9 },
+    "alignment": { "total": 9.0, "policy": 9.2, "intentMatch": 8.8 },
+    "resilience": { "total": 8.9, "fallbackCoverage": 9.1, "rollbackTests": 8.6 }
+  },
+  "composite": 8.42,
+  "status": "green",
+  "recommendations": [
+    "Refactor duplicate summarization logic to boost leverage score",
+    "Add latency probes to newly introduced worker"
+  ]
+}
+```
+
+### 2.3 CLEAR Audit Reports
+
+**Markdown Summary**
+
+```markdown
+# CLEAR 2.0 Report — workflow:narrative-response (rev 1.18.4)
+
+- **Composite Score**: 8.42 _(Green)_
+- **Highlights**:
+  - Clarity: Rich trace exports available in observability stack.
+  - Alignment: Policy hooks verified against latest governance ruleset.
+  - Resilience: Patch coverage meets "double-fallback" target.
+- **Risks**:
+  - Leverage: Two custom summarizers duplicate prompt logic.
+- **Actions**:
+  1. Consolidate summarizer workers into `workers/summary-hub` by 2024-03-29.
+  2. Attach latency budget SLOs to the failover worker.
+```
+
+**JSON Payload** — typically pushed to compliance automation (see example above).
+
+### 2.4 Applying CLEAR in Practice
+
+#### Workflow Example
+
+A `content-curation` workflow is evaluated before a patch activation:
+
+```yaml
+workflows:
+  content-curation:
+    revision: 2.4.1
+    clear:
+      clarity:
+        traces: true
+        documentation: "docs/workflows/content-curation.md"
+      leverage:
+        sharedModules:
+          - skills/entity-extract
+          - skills/policy-guard
+      efficiency:
+        latencyBudgetMs: 850
+        parallelism: 4
+      alignment:
+        policyPack: governance/2024-Q1
+      resilience:
+        patches:
+          - semantic-guardrail@3.2.0
+          - fallback-summarizer@1.1.0
+```
+
+#### Logic Function Example
+
+```typescript
+// src/orchestration/hooks/fallback.ts
+export async function selectFallbackWorker(context: FallbackContext) {
+  context.clear.auditTag("Resilience", "fallback-path");
+  if (context.signal.healthScore < 0.8) {
+    context.metrics.increment("fallback.invocations");
+    return context.registry.use("workers/hallucination-reviewer");
+  }
+  return context.registry.use("workers/narrative-synthesizer");
+}
+```
+
+- The `auditTag` call feeds Clarity and Alignment metrics into CLEAR scoring.
+- Metric increments provide Efficiency telemetry for subsequent audits.
+
+#### Decision Tree Example
+
+```json
+{
+  "decisionTree": "orchestration://narrative-response",
+  "nodes": [
+    { "id": "ingest", "type": "input", "clear": { "clarity": 9.1 } },
+    { "id": "reason", "type": "hrc", "clear": { "alignment": 9.4, "resilience": 8.8 } },
+    { "id": "fallback", "type": "router", "clear": { "leverage": 7.8, "resilience": 9.2 } }
+  ],
+  "edges": [
+    { "from": "reason", "to": "fallback", "condition": "confidence < 0.8" }
+  ]
+}
+```
+
+## 3. Integration Context
+
+Resiliency patches and CLEAR audits operate as a closed feedback loop:
+
+- CLEAR scoring determines whether a patch may be promoted beyond dry-run.
+- Active patches emit telemetry that feeds back into CLEAR 2.0 to verify sustained compliance.
+- HRC leverages patch metadata to enforce Clarity (via trace annotations) and Alignment (via policy bindings).
+- The orchestration layer enforces patch-derived fallbacks, improving Resilience and Efficiency scores.
+
+**Lifecycle Hooks and Auto-Triggers**
+
+- `/diagnostic full`: runs immediately after patch activation to snapshot CLEAR metrics and dependency health.
+- `/workers/status`: polls worker pools and updates Efficiency/Resilience gauges; triggers if fallback thresholds are crossed.
+- `/orchestration/status`: summarizes routing changes, CLEAR score deltas, and outstanding remediation items.
+
+**Runtime Enforcement Example**
+
+```text
+2024-03-22T14:06:13.004Z [diag] /diagnostic full completed — composite CLEAR delta +0.12
+2024-03-22T14:06:13.071Z [workers] /workers/status warning — worker narrative-synthesizer latency p95 920ms (threshold 850ms)
+2024-03-22T14:06:13.089Z [orchestration] /orchestration/status applied routing override to workers/hallucination-reviewer
+```
+
+## API Payload Example: Patch Audit Request
+
+```http
+POST /audits/clear HTTP/1.1
+Host: orchestration.internal
+Content-Type: application/json
+
+{
+  "asset": "patch:semantic-guardrail@3.2.0",
+  "context": {
+    "trigger": "activation",
+    "hooks": ["/diagnostic full", "/workers/status"],
+    "requestedBy": "svc-orchestrator"
+  }
+}
+```
+
+The audit service responds with the JSON structure shown earlier, enabling automated go/no-go checks prior to activation.
+
+## Best Practices for Implementers
+
+1. **Design for Observability First** — instrument clarity and alignment hooks before enabling automatic activation.
+2. **Version Relentlessly** — treat every patch as immutable once activated; introduce new versions for even minor logic tweaks.
+3. **Automate CLEAR Gates** — block activation if composite scores drop below thresholds, and surface remediation steps in CI/CD.
+4. **Stage Fallbacks** — test fallback workers under load in staging; include them in CLEAR audit scope to prevent degraded experiences.
+5. **Leverage Lifecycle Hooks** — subscribe to `/diagnostic full`, `/workers/status`, and `/orchestration/status` to automate rollback decisions.
+6. **Document Rollbacks** — ensure every patch manifest references a checkpoint and includes operator runbooks for manual intervention.
+7. **Continuously Refine Metrics** — review CLEAR sub-metrics quarterly to align with evolving governance and resilience priorities.


### PR DESCRIPTION
## Summary
- add a developer guide explaining resiliency patch lifecycles, isolation mechanics, and orchestration/HRC hooks
- document CLEAR 2.0 scoring, examples, and audit report formats for workflows, logic functions, and decision trees
- describe the shared runtime context between resiliency patches and CLEAR along with implementation best practices

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_69054a3e938c8325b05651ac48d1c1b2