### PR TITLE
Surface worker diagnostics in Railway health check

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -17,21 +17,25 @@ export function setupDiagnostics(app: Express): void {
   app.get('/health', async (_: Request, res: Response) => {
     const healthReport = await runHealthCheck();
     const defaultModel = getDefaultModel();
+    const statusCode = healthReport.status === 'ok' ? 200 : 503;
 
-    res.status(200).json({
-      status: 'OK',
+    res.status(statusCode).json({
+      status: healthReport.status,
       timestamp: new Date().toISOString(),
       service: 'ARCANOS',
       version: process.env.npm_package_version || '1.0.0',
+      summary: healthReport.summary,
+      components: healthReport.components,
       ai: {
         defaultModel: defaultModel,
         fallbackModel: config.ai.fallbackModel
       },
       system: {
-        memory: healthReport.summary,
+        memory: healthReport.components.memory,
         uptime: `${process.uptime().toFixed(1)}s`,
         nodeVersion: process.version,
-        environment: config.server.environment
+        environment: config.server.environment,
+        security: healthReport.security
       }
     });
   });

--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -1,20 +1,128 @@
+import fs from 'fs';
+import path from 'path';
 import { getEnvironmentSecuritySummary } from './environmentSecurity.js';
 
-export function runHealthCheck() {
+interface WorkerHealth {
+  expected: boolean;
+  directoryExists: boolean;
+  healthy: boolean;
+  files: string[];
+  reason?: string;
+}
+
+export interface HealthCheckReport {
+  status: 'ok' | 'degraded';
+  summary: string;
+  raw: NodeJS.MemoryUsage;
+  security: ReturnType<typeof getEnvironmentSecuritySummary>;
+  components: {
+    workers: WorkerHealth;
+    memory: {
+      heapMB: string;
+      rssMB: string;
+      externalMB: string;
+    };
+  };
+}
+
+function evaluateWorkerHealth(): WorkerHealth {
+  const workersDir = path.resolve(process.cwd(), 'workers');
+  const runWorkersEnv = process.env.RUN_WORKERS;
+  const workersEnabled = runWorkersEnv === 'true' || runWorkersEnv === '1';
+  const directoryExists = fs.existsSync(workersDir);
+
+  if (!workersEnabled) {
+    return {
+      expected: false,
+      directoryExists,
+      healthy: true,
+      files: [],
+      reason: 'Workers disabled via RUN_WORKERS'
+    };
+  }
+
+  if (!directoryExists) {
+    return {
+      expected: true,
+      directoryExists: false,
+      healthy: false,
+      files: [],
+      reason: 'Workers directory not found'
+    };
+  }
+
+  let workerFiles: string[] = [];
+  try {
+    workerFiles = fs
+      .readdirSync(workersDir)
+      .filter(file => file.endsWith('.js') && !file.includes('shared'));
+  } catch (error) {
+    return {
+      expected: true,
+      directoryExists: true,
+      healthy: false,
+      files: [],
+      reason: error instanceof Error ? error.message : 'Failed to read workers directory'
+    };
+  }
+
+  if (workerFiles.length === 0) {
+    return {
+      expected: true,
+      directoryExists: true,
+      healthy: false,
+      files: workerFiles,
+      reason: 'No worker modules found'
+    };
+  }
+
+  return {
+    expected: true,
+    directoryExists: true,
+    healthy: true,
+    files: workerFiles
+  };
+}
+
+export function runHealthCheck(): HealthCheckReport {
   console.log('[🩺 HealthCheck] Running diagnostics');
   const mem = process.memoryUsage();
   const heapMB = (mem.heapUsed / 1024 / 1024).toFixed(2);
+  const rssMB = (mem.rss / 1024 / 1024).toFixed(2);
+  const externalMB = (mem.external / 1024 / 1024).toFixed(2);
   const uptime = process.uptime().toFixed(1);
   const security = getEnvironmentSecuritySummary();
-  console.log(`[🩺 HealthCheck] Heap: ${heapMB}MB | Uptime: ${uptime}s`);
+  const workers = evaluateWorkerHealth();
+
+  console.log(`[🩺 HealthCheck] Heap: ${heapMB}MB | RSS: ${rssMB}MB | Uptime: ${uptime}s`);
 
   if (security) {
     console.log(`[🛡️ Security] Trusted=${security.trusted} SafeMode=${security.safeMode}`);
   }
 
+  if (!workers.healthy) {
+    console.warn('[🧵 Workers] Worker subsystem reported an unhealthy status', workers.reason);
+  }
+
+  const status: HealthCheckReport['status'] = workers.healthy ? 'ok' : 'degraded';
+  const summaryParts = [`Heap: ${heapMB}MB`, `Uptime: ${uptime}s`];
+
+  if (!workers.healthy && workers.reason) {
+    summaryParts.push(`Workers: ${workers.reason}`);
+  }
+
   return {
-    summary: `Heap: ${heapMB}MB | Uptime: ${uptime}s`,
+    status,
+    summary: summaryParts.join(' | '),
     raw: mem,
-    security
+    security,
+    components: {
+      workers,
+      memory: {
+        heapMB,
+        rssMB,
+        externalMB
+      }
+    }
   };
 }


### PR DESCRIPTION
## Summary
- extend the health diagnostics helper with worker directory checks and detailed memory metrics
- return the diagnostic report from the `/railway/healthcheck` endpoint so Railway restarts when workers are missing
- update `/health` to surface the richer diagnostics payload and status code

## Testing
- npm run build
- npx eslint src/utils/diagnostics.ts src/routes/register.ts src/diagnostics.ts

------
https://chatgpt.com/codex/tasks/task_e_69059519986c83259f224e8c231e2d38