### PR TITLE
Handle optional worker directory in health diagnostics

### DIFF
--- a/src/utils/diagnostics.ts
+++ b/src/utils/diagnostics.ts
@@ -43,11 +43,11 @@ function evaluateWorkerHealth(): WorkerHealth {
 
   if (!directoryExists) {
     return {
-      expected: true,
+      expected: false,
       directoryExists: false,
-      healthy: false,
+      healthy: true,
       files: [],
-      reason: 'Workers directory not found'
+      reason: 'Workers directory not found (worker modules optional)'
     };
   }
 
@@ -70,9 +70,9 @@ function evaluateWorkerHealth(): WorkerHealth {
     return {
       expected: true,
       directoryExists: true,
-      healthy: false,
+      healthy: true,
       files: workerFiles,
-      reason: 'No worker modules found'
+      reason: 'No worker modules registered'
     };
   }
 


### PR DESCRIPTION
## Summary
- treat the workers directory as optional when evaluating health checks
- report an idle worker subsystem instead of degraded when no worker modules are registered

## Testing
- npm run lint -- src/utils/diagnostics.ts

------
https://chatgpt.com/codex/tasks/task_e_69062ace5efc832583d866c8aadaabe6