### PR TITLE
feat: make reflection ai configurable

### DIFF
--- a/src/services/ai-reflections.ts
+++ b/src/services/ai-reflections.ts
@@ -3,13 +3,46 @@
  * Provides stateless reflection generation without memory dependencies
  */
 
-import { callOpenAI } from './openai.js';
+import { callOpenAI, getDefaultModel } from './openai.js';
+
+const DEFAULT_REFLECTION_SYSTEM_PROMPT =
+  process.env.AI_REFLECTION_SYSTEM_PROMPT ||
+  'You are the ARCANOS self-reflection engine. Provide concise, actionable improvement notes that help engineers iterate on the system.';
+
+const parseEnvInt = (value: string | undefined, fallback: number): number => {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) ? fallback : parsed;
+};
+
+const parseEnvFloat = (value: string | undefined, fallback: number): number => {
+  if (!value) return fallback;
+  const parsed = Number.parseFloat(value);
+  return Number.isNaN(parsed) ? fallback : parsed;
+};
+
+const shouldUseCache = (value: string | undefined, fallback: boolean): boolean => {
+  if (value === undefined) return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (['false', '0', 'off', 'no'].includes(normalized)) return false;
+  if (['true', '1', 'on', 'yes'].includes(normalized)) return true;
+  return fallback;
+};
 
 export interface PatchSetOptions {
   useMemory?: boolean;
   priority?: 'low' | 'medium' | 'high';
   category?: string;
   systemAnalysis?: boolean;
+  model?: string;
+  tokenLimit?: number;
+  temperature?: number;
+  topP?: number;
+  frequencyPenalty?: number;
+  presencePenalty?: number;
+  systemPrompt?: string;
+  useCache?: boolean;
+  aiMetadata?: Record<string, unknown>;
 }
 
 export interface PatchSet {
@@ -21,6 +54,18 @@ export interface PatchSet {
     generated: string;
     useMemory: boolean;
     systemState?: any;
+    modelUsed?: string;
+    cached?: boolean;
+    configuration?: {
+      model: string;
+      tokenLimit: number;
+      temperature: number;
+      topP: number;
+      frequencyPenalty: number;
+      presencePenalty: number;
+      cache: boolean;
+      systemPrompt: string;
+    };
   };
 }
 
@@ -34,6 +79,17 @@ export async function buildPatchSet(options: PatchSetOptions = {}): Promise<Patc
     category = 'general',
     systemAnalysis = true
   } = options;
+
+  const reflectionModel = options.model || process.env.AI_REFLECTION_MODEL || getDefaultModel();
+  const tokenLimit = options.tokenLimit ?? parseEnvInt(process.env.AI_REFLECTION_TOKEN_LIMIT, 200);
+  const temperature = options.temperature ?? parseEnvFloat(process.env.AI_REFLECTION_TEMPERATURE, 0.2);
+  const topP = options.topP ?? parseEnvFloat(process.env.AI_REFLECTION_TOP_P, 1);
+  const frequencyPenalty =
+    options.frequencyPenalty ?? parseEnvFloat(process.env.AI_REFLECTION_FREQUENCY_PENALTY, 0);
+  const presencePenalty =
+    options.presencePenalty ?? parseEnvFloat(process.env.AI_REFLECTION_PRESENCE_PENALTY, 0);
+  const systemPrompt = options.systemPrompt || DEFAULT_REFLECTION_SYSTEM_PROMPT;
+  const useCache = options.useCache ?? shouldUseCache(process.env.AI_REFLECTION_CACHE, true);
 
   // If useMemory is false, bypass memory orchestration
   if (!useMemory) {
@@ -57,32 +113,44 @@ export async function buildPatchSet(options: PatchSetOptions = {}): Promise<Patc
     
     Keep the response concise and actionable.`;
 
-    const aiResponse = await callOpenAI(
-      'gpt-4',
-      reflectionPrompt,
-      200
-    );
+    const aiResponse = await callOpenAI(reflectionModel, reflectionPrompt, tokenLimit, useCache, {
+      systemPrompt,
+      temperature,
+      top_p: topP,
+      frequency_penalty: frequencyPenalty,
+      presence_penalty: presencePenalty,
+      metadata: {
+        feature: 'ai-reflections',
+        category,
+        priority,
+        useMemory,
+        ...(options.aiMetadata || {})
+      }
+    });
 
     if (aiResponse.output) {
       improvements.push('AI-generated system analysis completed');
-      improvements.push('Reflection content generated successfully');
-      
+      improvements.push(
+        aiResponse.cached ? 'Reflection content retrieved from cache' : 'Reflection content generated successfully'
+      );
+
       // Extract system state analysis if requested
       if (systemAnalysis) {
         systemState = {
           memoryMode: useMemory ? 'enabled' : 'stateless',
           timestamp: new Date().toISOString(),
-          aiModelUsed: 'gpt-4',
+          aiModelUsed: aiResponse.model,
           category,
           priority
         };
         improvements.push('System state analysis performed');
       }
+      improvements.push(`Reflection engine used model ${aiResponse.model}`);
     }
 
     // Build the patch content
-    const patchContent = aiResponse.output 
-      ? aiResponse.output 
+    const patchContent = aiResponse.output
+      ? aiResponse.output
       : `Automated system improvement patch (${priority} priority)
         
 Category: ${category}
@@ -100,17 +168,29 @@ The changes are designed to enhance system performance and reliability.`;
       metadata: {
         generated: new Date().toISOString(),
         useMemory,
-        systemState
+        systemState,
+        modelUsed: aiResponse.model,
+        cached: aiResponse.cached ?? false,
+        configuration: {
+          model: reflectionModel,
+          tokenLimit,
+          temperature,
+          topP,
+          frequencyPenalty,
+          presencePenalty,
+          cache: useCache,
+          systemPrompt
+        }
       }
     };
 
   } catch (error: any) {
     console.error('❌ Error generating patch set:', error.message);
-    
+
     // Fallback patch set
     return {
       content: `Fallback system improvement patch
-      
+
 Generated due to AI service unavailability.
 Priority: ${priority}
 Category: ${category}
@@ -127,7 +207,20 @@ while providing basic enhancement capabilities.`,
         useMemory,
         systemState: systemState || {
           error: error.message,
-          fallbackMode: true
+          fallbackMode: true,
+          aiModelUsed: reflectionModel
+        },
+        modelUsed: reflectionModel,
+        cached: false,
+        configuration: {
+          model: reflectionModel,
+          tokenLimit,
+          temperature,
+          topP,
+          frequencyPenalty,
+          presencePenalty,
+          cache: useCache,
+          systemPrompt
         }
       }
     };

--- a/tests/openai-integration.test.ts
+++ b/tests/openai-integration.test.ts
@@ -231,11 +231,13 @@ describe('OpenAI SDK Integration Tests', () => {
       
       try {
         const result = await callOpenAI('gpt-4', 'Test prompt', 100, false);
-        
+
         // Should return a result even without API key (fallback)
         expect(result).toHaveProperty('response');
         expect(result).toHaveProperty('output');
         expect(typeof result.output).toBe('string');
+        expect(result).toHaveProperty('model');
+        expect(result).toHaveProperty('cached');
       } finally {
         if (originalApiKey) {
           process.env.OPENAI_API_KEY = originalApiKey;

--- a/tests/openai-prompt.test.ts
+++ b/tests/openai-prompt.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
 describe('handlePrompt', () => {
   it('uses provided model when specified', async () => {
     validateAIRequest.mockReturnValue({ input: 'hi', client: {} });
-    callOpenAI.mockResolvedValue({ response: {}, output: 'ok' });
+    callOpenAI.mockResolvedValue({ response: {}, output: 'ok', model: 'ft:custom-model', cached: false });
 
     const req: any = { body: { prompt: 'hi', model: 'ft:custom-model' } };
     const res: any = { json: jest.fn() };
@@ -52,7 +52,7 @@ describe('handlePrompt', () => {
   it('falls back to default model when none provided', async () => {
     validateAIRequest.mockReturnValue({ input: 'hello', client: {} });
     getDefaultModel.mockReturnValue('ft:default-model');
-    callOpenAI.mockResolvedValue({ response: {}, output: 'ok' });
+    callOpenAI.mockResolvedValue({ response: {}, output: 'ok', model: 'ft:default-model', cached: false });
 
     const req: any = { body: { prompt: 'hello' } };
     const res: any = { json: jest.fn() };


### PR DESCRIPTION
## Summary
- extend the OpenAI helper to accept configurable prompts, sampling controls, and return the active model metadata
- allow the reflections service to read environment-driven model, token, and sampling overrides while surfacing those details in metadata
- update unit tests to reflect the richer OpenAI helper response shape

## Testing
- npm test -- openai

------
https://chatgpt.com/codex/tasks/task_e_6906e38a26988325a8886e90a1135ed1