### PR TITLE
Enable AI-controlled ARCANOS worker runtime

### DIFF
--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -252,7 +252,28 @@ Lists worker files and the runtime configuration.
     "enabled": true,
     "count": 4,
     "model": "gpt-4o",
-    "status": "Active"
+    "status": "Active",
+    "runtime": {
+      "enabled": true,
+      "model": "gpt-4o",
+      "configuredCount": 4,
+      "started": true,
+      "startedAt": "2024-10-30T11:59:00.000Z",
+      "activeListeners": 4,
+      "workerIds": [
+        "arcanos-worker-1",
+        "arcanos-worker-2",
+        "arcanos-worker-3",
+        "arcanos-worker-4"
+      ],
+      "totalDispatched": 12,
+      "lastDispatchAt": "2024-10-30T12:14:55.000Z",
+      "lastInputPreview": "Run diagnostics for subsystem alpha",
+      "lastResult": {
+        "result": "Diagnostics completed.",
+        "workerId": "arcanos-worker-3"
+      }
+    }
   },
   "system": {
     "model": "gpt-4o",
@@ -271,16 +292,25 @@ curl -X POST http://localhost:8080/workers/run/demoWorker \
   -d '{"payload":"value"}'
 ```
 
-**Response**
+**ARCANOS Worker Response**
 ```json
 {
   "success": true,
-  "workerId": "demoWorker",
-  "result": { "output": "Worker result" },
-  "executionTime": "185ms",
+  "workerId": "arcanos-worker-1",
+  "name": "ARCANOS Core Worker",
+  "description": "ARCANOS core logic with GPT-5 reasoning",
+  "pattern": "arcanos-core",
+  "result": {
+    "result": "Diagnostics complete.",
+    "requiresReasoning": false,
+    "workerId": "arcanos-worker-1"
+  },
+  "executionTime": "312ms",
   "timestamp": "2024-10-30T12:16:05.000Z"
 }
 ```
+
+> Tip: Send `POST /workers/run/arcanos` with a JSON payload containing `input`, `prompt`, or `text` to let the ARCANOS AI brain process work without requiring a physical worker file.
 
 ### `POST /heartbeat`
 Confirmation required. Writes to `logs/heartbeat.log`.

--- a/src/config/workerConfig.ts
+++ b/src/config/workerConfig.ts
@@ -15,35 +15,77 @@ export const workerSettings = {
   model: process.env.WORKER_MODEL || process.env.AI_MODEL || 'gpt-4-turbo'
 };
 
+// Worker runtime bookkeeping
+interface WorkerRuntimeState {
+  started: boolean;
+  startedAt?: string;
+  workerIds: string[];
+  totalDispatched: number;
+  lastDispatchAt?: string;
+  lastInputPreview?: string;
+  lastResult?: WorkerResult | null;
+  lastError?: string | null;
+}
+
+export interface WorkerRuntimeStatus {
+  enabled: boolean;
+  model: string;
+  configuredCount: number;
+  started: boolean;
+  startedAt?: string;
+  activeListeners: number;
+  workerIds: string[];
+  totalDispatched: number;
+  lastDispatchAt?: string;
+  lastInputPreview?: string;
+  lastResult?: WorkerResult | null;
+  lastError?: string;
+}
+
+const runtimeState: WorkerRuntimeState = {
+  started: false,
+  workerIds: [],
+  totalDispatched: 0,
+  lastResult: null,
+  lastError: null
+};
+
 // Simple task queue based on EventEmitter with retry & backoff
 export class WorkerTaskQueue extends EventEmitter {
   register(task: (input: string) => Promise<WorkerResult>): void {
     this.on('task', task);
   }
 
-  async dispatch(input: string, options: { attempts?: number; backoffMs?: number } = {}): Promise<void> {
+  async dispatch(
+    input: string,
+    options: { attempts?: number; backoffMs?: number } = {}
+  ): Promise<WorkerResult[]> {
     const listeners = this.listeners('task');
     const { attempts = 3, backoffMs = 1000 } = options;
+    const results: WorkerResult[] = [];
 
     for (const listener of listeners) {
       let attempt = 0;
       let delay = backoffMs;
       while (attempt < attempts) {
         try {
-          await (listener as (input: string) => Promise<WorkerResult>)(input);
-          logger.info('[WORKER] Task completed', { input });
+          const result = await (listener as (input: string) => Promise<WorkerResult>)(input);
+          results.push(result);
+          logger.info('[WORKER] Task completed', { inputPreview: input.slice(0, 120) });
           break;
         } catch (err) {
           attempt++;
           if (attempt >= attempts) {
+            const errorMessage = err instanceof Error ? err.message : String(err);
             logger.error('[WORKER] Task failed after max retries', {
-              input,
-              error: err instanceof Error ? err.message : err
+              inputPreview: input.slice(0, 120),
+              error: errorMessage
             });
+            results.push({ error: errorMessage });
           } else {
             logger.warn(`[WORKER] Task failed - retrying in ${delay}ms`, {
               attempt,
-              input,
+              inputPreview: input.slice(0, 120),
               error: err instanceof Error ? err.message : err
             });
             await new Promise(res => {
@@ -56,6 +98,8 @@ export class WorkerTaskQueue extends EventEmitter {
         }
       }
     }
+
+    return results;
   }
 }
 
@@ -72,7 +116,13 @@ export async function gpt5Reasoning(prompt: string): Promise<string> {
 
 // Use the return type of runARCANOS to keep compatibility
 type ArcanosResult = Awaited<ReturnType<typeof runARCANOS>>;
-export type WorkerResult = Partial<ArcanosResult> & { reasoning?: string; error?: string; requiresReasoning?: boolean; reasoningPrompt?: string };
+export type WorkerResult = Partial<ArcanosResult> & {
+  reasoning?: string;
+  error?: string;
+  requiresReasoning?: boolean;
+  reasoningPrompt?: string;
+  workerId?: string;
+};
 
 // ✅ ARCANOS core logic alias for compatibility with problem statement
 export async function arcanosCoreLogic(input: string): Promise<WorkerResult> {
@@ -108,11 +158,139 @@ export async function workerTask(input: string): Promise<WorkerResult> {
 }
 
 // ✅ Worker startup
-export function startWorkers(): void {
-  for (let i = 0; i < workerSettings.count; i++) {
-    console.log(`[WORKER] Starting worker #${i + 1} with ARCANOS logic + GPT-5 reasoning...`);
-    workerTaskQueue.register(workerTask);
+export interface WorkerBootstrapSummary {
+  started: boolean;
+  alreadyRunning: boolean;
+  runWorkers: boolean;
+  workerCount: number;
+  workerIds: string[];
+  model: string;
+  startedAt?: string;
+  message: string;
+}
+
+function createWorkerHandler(workerId: string) {
+  return async (input: string): Promise<WorkerResult> => {
+    logger.info('[WORKER] Dispatching task', {
+      workerId,
+      inputPreview: input.slice(0, 120)
+    });
+
+    const result = await workerTask(input);
+
+    logger.info('[WORKER] Task processed', {
+      workerId,
+      requiresReasoning: result.requiresReasoning,
+      error: result.error
+    });
+
+    return { ...result, workerId };
+  };
+}
+
+export function startWorkers(force = false): WorkerBootstrapSummary {
+  if (!workerSettings.runWorkers && !force) {
+    return {
+      started: false,
+      alreadyRunning: false,
+      runWorkers: false,
+      workerCount: 0,
+      workerIds: [],
+      model: workerSettings.model,
+      message: 'RUN_WORKERS disabled; workers not started.'
+    };
   }
+
+  if (runtimeState.started && !force) {
+    return {
+      started: false,
+      alreadyRunning: true,
+      runWorkers: workerSettings.runWorkers,
+      workerCount: runtimeState.workerIds.length,
+      workerIds: runtimeState.workerIds,
+      model: workerSettings.model,
+      startedAt: runtimeState.startedAt,
+      message: 'Workers already running.'
+    };
+  }
+
+  // Reset existing listeners when forcing a restart
+  if (force && runtimeState.started) {
+    workerTaskQueue.removeAllListeners('task');
+    runtimeState.workerIds = [];
+  }
+
+  for (let i = 0; i < workerSettings.count; i++) {
+    const workerId = `arcanos-worker-${i + 1}`;
+    logger.info('[WORKER] Starting worker', { workerId, model: workerSettings.model });
+    workerTaskQueue.register(createWorkerHandler(workerId));
+    runtimeState.workerIds.push(workerId);
+  }
+
+  runtimeState.started = true;
+  runtimeState.startedAt = new Date().toISOString();
+
+  return {
+    started: true,
+    alreadyRunning: false,
+    runWorkers: true,
+    workerCount: runtimeState.workerIds.length,
+    workerIds: runtimeState.workerIds,
+    model: workerSettings.model,
+    startedAt: runtimeState.startedAt,
+    message: 'Workers started successfully.'
+  };
+}
+
+export async function dispatchArcanosTask(
+  input: string,
+  options: { attempts?: number; backoffMs?: number } = {}
+): Promise<WorkerResult[]> {
+  const inputPreview = input.slice(0, 120);
+  logger.info('[WORKER] Incoming dispatch', { inputPreview });
+
+  const bootstrap = startWorkers();
+
+  let results: WorkerResult[];
+
+  if (!bootstrap.runWorkers) {
+    // RUN_WORKERS disabled; execute synchronously via core logic
+    const directResult = await workerTask(input);
+    results = [{ ...directResult, workerId: 'arcanos-core-direct' }];
+  } else {
+    results = await workerTaskQueue.dispatch(input, options);
+    if (results.length === 0) {
+      const fallbackResult = await workerTask(input);
+      results = [{ ...fallbackResult, workerId: 'arcanos-core-direct' }];
+    }
+  }
+
+  runtimeState.totalDispatched += results.length;
+  runtimeState.lastDispatchAt = new Date().toISOString();
+  runtimeState.lastInputPreview = inputPreview;
+
+  const primaryResult = results[0];
+  runtimeState.lastResult = primaryResult ?? null;
+  runtimeState.lastError = primaryResult?.error ?? null;
+
+  return results;
+}
+
+export function getWorkerRuntimeStatus(): WorkerRuntimeStatus {
+  return {
+    enabled: workerSettings.runWorkers,
+    model: workerSettings.model,
+    configuredCount: workerSettings.count,
+    started: runtimeState.started,
+    startedAt: runtimeState.startedAt,
+    activeListeners: workerTaskQueue.listenerCount('task'),
+    workerIds: runtimeState.workerIds,
+    totalDispatched: runtimeState.totalDispatched,
+    lastDispatchAt: runtimeState.lastDispatchAt,
+    lastInputPreview: runtimeState.lastInputPreview,
+    lastResult: runtimeState.lastResult ?? undefined,
+    lastError: runtimeState.lastError ?? undefined
+  };
 }
 
 if (workerSettings.runWorkers) {

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -80,6 +80,21 @@ export const workerInfoSchema = z.object({
 
 export type WorkerInfoDTO = z.infer<typeof workerInfoSchema>;
 
+const arcanosRuntimeSchema = z.object({
+  enabled: z.boolean(),
+  model: z.string(),
+  configuredCount: z.number(),
+  started: z.boolean(),
+  startedAt: z.string().optional(),
+  activeListeners: z.number(),
+  workerIds: z.array(z.string()),
+  totalDispatched: z.number(),
+  lastDispatchAt: z.string().optional(),
+  lastInputPreview: z.string().optional(),
+  lastResult: z.unknown().optional(),
+  lastError: z.string().optional()
+});
+
 export const workerStatusResponseSchema = z.object({
   timestamp: z.string(),
   workersDirectory: z.string(),
@@ -90,7 +105,8 @@ export const workerStatusResponseSchema = z.object({
     enabled: z.boolean(),
     count: z.number(),
     model: z.string(),
-    status: z.string()
+    status: z.string(),
+    runtime: arcanosRuntimeSchema
   }),
   system: z.object({
     model: z.string(),
@@ -105,7 +121,7 @@ export const workerRunResponseSchema = z.object({
   workerId: z.string(),
   name: z.string().optional(),
   description: z.string().optional(),
-  pattern: z.enum(['context-based', 'legacy']).optional(),
+  pattern: z.enum(['context-based', 'legacy', 'arcanos-core']).optional(),
   result: z.unknown().optional(),
   executionTime: z.string(),
   timestamp: z.string(),

--- a/src/utils/systemDiagnostics.ts
+++ b/src/utils/systemDiagnostics.ts
@@ -5,6 +5,7 @@
  */
 
 import { getStatus, query } from '../db.js';
+import { getWorkerRuntimeStatus, type WorkerRuntimeStatus } from '../config/workerConfig.js';
 
 interface WorkerDiagnostics {
   count: number;
@@ -13,6 +14,7 @@ interface WorkerDiagnostics {
   details?: any[];
   expected?: number;
   error?: string;
+  runtime?: WorkerRuntimeStatus;
 }
 
 interface ScheduledJob {
@@ -61,7 +63,8 @@ async function getWorkerDiagnostics(): Promise<WorkerDiagnostics> {
     return {
       count: 0,
       healthy: false,
-      reason: 'Database not connected - cannot check worker status'
+      reason: 'Database not connected - cannot check worker status',
+      runtime: getWorkerRuntimeStatus()
     };
   }
 
@@ -83,13 +86,15 @@ async function getWorkerDiagnostics(): Promise<WorkerDiagnostics> {
       count: activeWorkers,
       healthy: activeWorkers >= expectedWorkers,
       details: workerActivity.rows,
-      expected: expectedWorkers
+      expected: expectedWorkers,
+      runtime: getWorkerRuntimeStatus()
     };
   } catch (error) {
     return {
       count: 0,
       healthy: false,
-      error: error instanceof Error ? error.message : 'Unknown error'
+      error: error instanceof Error ? error.message : 'Unknown error',
+      runtime: getWorkerRuntimeStatus()
     };
   }
 }


### PR DESCRIPTION
## Summary
- expose ARCANOS worker bootstrap/dispatch helpers that keep runtime statistics and allow AI-driven execution
- update SDK and worker routes to dispatch jobs through the ARCANOS queue and surface richer runtime diagnostics
- extend DTO schemas and documentation to describe the new runtime metadata returned by worker status endpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690804f5c0dc83259acb9b92c7a26751