### PR TITLE
Fix Railway start command to use start-server entrypoint

### DIFF
--- a/OPTIMIZATION_REPORT.md
+++ b/OPTIMIZATION_REPORT.md
@@ -104,7 +104,7 @@ Created an automated audit-refactor system that recursively scans and validates 
 
 | Component | Status | Details |
 |-----------|--------|---------|
-| Procfile | ✅ VALID | Correctly configured with `node dist/server.js` |
+| Procfile | ✅ VALID | Correctly configured with `node dist/start-server.js` |
 | railway.json | ✅ VALID | Complete configuration with build and deploy commands |
 | Health Endpoint | ✅ EXISTS | `/health` endpoint implemented |
 | Environment Variables | ✅ DOCUMENTED | All required vars in `.env.example` |

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node --max-old-space-size=7168 dist/server.js
+web: node --max-old-space-size=7168 dist/start-server.js

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -76,7 +76,7 @@ Comprehensive codebase audit and refactor completed on 2025-08-09. This major re
 ### Architecture Consolidation:
 1. **Unified Start Script**
    - **BEFORE**: `npm start` → `railway/workers.js` (process manager)
-   - **AFTER**: `npm start` → `dist/server.js` (TypeScript server)
+   - **AFTER**: `npm start` → `dist/start-server.js` (TypeScript server)
 
 2. **Worker Management Modernization**  
    - **REMOVED**: Separate process-based worker system

--- a/railway.json
+++ b/railway.json
@@ -10,7 +10,7 @@
     }
   },
   "deploy": {
-    "startCommand": "node --max-old-space-size=7168 dist/server.js",
+    "startCommand": "node --max-old-space-size=7168 dist/start-server.js",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",

--- a/railway/config.example.json
+++ b/railway/config.example.json
@@ -9,7 +9,7 @@
     }
   },
   "deploy": {
-    "startCommand": "node --max-old-space-size=7168 dist/server.js",
+    "startCommand": "node --max-old-space-size=7168 dist/start-server.js",
     "healthcheckPath": "/health",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",

--- a/scripts/probe.js
+++ b/scripts/probe.js
@@ -70,7 +70,7 @@ function runProbe() {
   const requiredFiles = [
     { path: 'index.js', description: 'Main entry point' },
     { path: 'tests/test-arcanos-api.js', description: 'API test file' },
-    { path: 'dist/server.js', description: 'Compiled server file' },
+    { path: 'dist/start-server.js', description: 'Runtime entry point' },
     { path: 'package.json', description: 'Package configuration' }
   ];
 

--- a/scripts/sdk-compliance-audit.js
+++ b/scripts/sdk-compliance-audit.js
@@ -240,7 +240,7 @@ async function auditDeploymentReadiness(result) {
     // Check Procfile
     try {
         const procfile = await fs.readFile(path.join(projectRoot, 'Procfile'), 'utf8');
-        if (procfile.includes('dist/server.js')) {
+        if (procfile.includes('dist/start-server.js')) {
             result.deploymentChecks.procfileValid = true;
             console.log('   ✅ Procfile is valid');
         }

--- a/scripts/sdk-compliance-audit.ts
+++ b/scripts/sdk-compliance-audit.ts
@@ -311,7 +311,7 @@ async function auditDeploymentReadiness(result: AuditResult): Promise<void> {
   // Check Procfile
   try {
     const procfile = await fs.readFile(path.join(projectRoot, 'Procfile'), 'utf8');
-    if (procfile.includes('dist/server.js')) {
+    if (procfile.includes('dist/start-server.js')) {
       result.deploymentChecks.procfileValid = true;
       console.log('   ✅ Procfile is valid');
     } else {

--- a/scripts/self-check-validation.js
+++ b/scripts/self-check-validation.js
@@ -51,7 +51,7 @@ check('Modern ES modules', packageJson.type === 'module');
 
 // 4. Railway Compatibility Checks
 console.log('\n🚄 Railway Compatibility Validation:');
-check('Start script defined', packageJson.scripts?.start === 'node dist/server.js');
+check('Start script defined', packageJson.scripts?.start === 'node dist/start-server.js');
 check('Main entry point correct', packageJson.main === 'dist/server.js');
 check('PostgreSQL client present', packageJson.dependencies?.pg !== undefined);
 check('Port 8080 configuration', openaiService.includes('8080') || readFileSync('./src/config/index.ts', 'utf8').includes('8080'));


### PR DESCRIPTION
## Summary
- point the Railway Procfile and deployment config at the compiled `dist/start-server.js` entrypoint so the server actually boots in production
- refresh audit/validation scripts and docs to expect the new start script location and keep probe checks accurate

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69082461bc9c8325a6118a775119b1c7