### PR TITLE
Ensure GPT-5 reasoning validates response model

### DIFF
--- a/src/config/workerConfig.ts
+++ b/src/config/workerConfig.ts
@@ -110,7 +110,22 @@ export async function gpt5Reasoning(prompt: string): Promise<string> {
   const client = getOpenAIClient();
   if (!client) return '[Fallback: GPT-5 unavailable]';
 
-  const result = await createGPT5Reasoning(client, prompt, 'ARCANOS: Use GPT-5 for deep reasoning on every request. Return structured analysis only.');
+  const result = await createGPT5Reasoning(
+    client,
+    prompt,
+    'ARCANOS: Use GPT-5 for deep reasoning on every request. Return structured analysis only.'
+  );
+
+  if (result.error) {
+    logger.warn('[WORKER] GPT-5 reasoning fallback triggered', {
+      error: result.error
+    });
+  } else if (result.model) {
+    logger.info('[WORKER] GPT-5 reasoning confirmed', {
+      model: result.model
+    });
+  }
+
   return result.content;
 }
 


### PR DESCRIPTION
## Summary
- add model-verification helpers to enforce GPT-5 response identifiers
- expose GPT-5 model metadata and logging in the trinity pipeline and worker reasoning helper
- propagate verified model usage into audit logs for transparency

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6908f8bbbb94832580b8d6df8e399eac