### PR TITLE
Improve worker directory resolution

### DIFF
--- a/src/routes/workers.ts
+++ b/src/routes/workers.ts
@@ -3,9 +3,9 @@
  * Provides endpoints for running and monitoring workers
  */
 
-import { Router, Request, Response } from 'express';
 import fs from 'fs';
 import path from 'path';
+import { Router, Request, Response } from 'express';
 import { createWorkerContext } from '../utils/workerContext.js';
 import { confirmGate } from '../middleware/confirmGate.js';
 import { dispatchArcanosTask, getWorkerRuntimeStatus } from '../config/workerConfig.js';
@@ -14,11 +14,12 @@ import type {
   WorkerRunResponseDTO,
   WorkerStatusResponseDTO
 } from '../types/dto.js';
+import { resolveWorkersDirectory } from '../utils/workerPaths.js';
 
 const router = Router();
 
 // Get path to workers directory (from dist, it's one level up from the root)
-const workersDir = path.resolve(process.cwd(), 'workers');
+const { path: workersDir } = resolveWorkersDirectory();
 
 /**
  * GET /workers/status - Get available workers

--- a/src/utils/workerBoot.ts
+++ b/src/utils/workerBoot.ts
@@ -9,6 +9,7 @@ import path from 'path';
 import cron from 'node-cron';
 import { initializeDatabase, getStatus } from '../db.js';
 import { createWorkerContext } from './workerContext.js';
+import { resolveWorkersDirectory } from './workerPaths.js';
 
 interface WorkerInitResult {
   initialized: string[];
@@ -59,7 +60,7 @@ async function initializeWorkers(): Promise<WorkerInitResult> {
 
   console.log('[🔧 WORKER-BOOT] Starting worker initialization...');
   
-  const workersDir = path.resolve(process.cwd(), 'workers');
+  const { path: workersDir, exists: workersDirExists } = resolveWorkersDirectory();
   const results: WorkerInitResult = {
     initialized: [],
     failed: [],
@@ -71,7 +72,7 @@ async function initializeWorkers(): Promise<WorkerInitResult> {
   };
 
   try {
-    if (!fs.existsSync(workersDir)) {
+    if (!workersDirExists || !fs.existsSync(workersDir)) {
       console.log(`[🔧 WORKER-BOOT] Workers directory not found: ${workersDir}`);
       console.log('[🔧 WORKER-BOOT] Skipping worker initialization');
       return results;

--- a/src/utils/workerPaths.ts
+++ b/src/utils/workerPaths.ts
@@ -1,0 +1,68 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+interface WorkersDirectoryResolution {
+  /**
+   * Absolute path to the workers directory (even if it does not exist).
+   */
+  path: string;
+  /**
+   * Whether any of the candidate directories currently exists on disk.
+   */
+  exists: boolean;
+  /**
+   * Ordered list of the locations that were inspected while resolving the
+   * directory. Useful for diagnostics when no candidate exists.
+   */
+  checked: string[];
+}
+
+/**
+ * Resolve the most appropriate workers directory for the current runtime.
+ *
+ * The application can be executed from several entry points (the repository
+ * root during development, the compiled `dist` folder in production, or inside
+ * tests that modify `process.cwd()`).  Relying exclusively on `process.cwd()`
+ * therefore causes false negatives when the runtime is rooted somewhere other
+ * than the repository root.  To make the resolution robust we build a set of
+ * candidate directories and return the first one that exists.
+ */
+export function resolveWorkersDirectory(): WorkersDirectoryResolution {
+  const checked: string[] = [];
+  const candidates: string[] = [];
+
+  const envOverride = process.env.WORKERS_DIRECTORY;
+  if (envOverride) {
+    candidates.push(
+      path.isAbsolute(envOverride)
+        ? envOverride
+        : path.resolve(process.cwd(), envOverride)
+    );
+  }
+
+  candidates.push(path.resolve(process.cwd(), 'workers'));
+
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  candidates.push(path.resolve(moduleDir, '../../workers'));
+  candidates.push(path.resolve(moduleDir, '../../../workers'));
+
+  for (const candidate of candidates) {
+    if (checked.includes(candidate)) {
+      continue;
+    }
+
+    checked.push(candidate);
+
+    if (fs.existsSync(candidate)) {
+      return { path: candidate, exists: true, checked };
+    }
+  }
+
+  const fallback = candidates[0] ?? path.resolve(process.cwd(), 'workers');
+  if (!checked.includes(fallback)) {
+    checked.push(fallback);
+  }
+
+  return { path: fallback, exists: false, checked };
+}


### PR DESCRIPTION
## Summary
- add a shared utility that resolves the workers directory across different runtime roots
- update worker boot, diagnostics, and worker routes to rely on the new resolver and report accurate health status

## Testing
- npm run test -- worker-task-queue.test.ts

------
https://chatgpt.com/codex/tasks/task_e_6909165ca9148325a167709d1af3b558