### PR TITLE
Add AFOL adaptive fallback orchestration module

### DIFF
--- a/src/afol/engine.ts
+++ b/src/afol/engine.ts
@@ -1,0 +1,60 @@
+import { evaluate } from './policies.js';
+import { getStatus } from './health.js';
+import { logDecision } from './logger.js';
+import { DecideInput, DecisionRecord, PolicyEvaluation, RouteExecutionResult, RouteSelection } from './types.js';
+
+export async function decide(input: DecideInput): Promise<DecisionRecord> {
+  const started = Date.now();
+  const snapshot = getStatus();
+  const intent = typeof input.intent === 'string' ? input.intent : 'default';
+  const policy = evaluate(snapshot, intent);
+  const route = selectRoute(policy);
+  const response = await executeRoute(route, input);
+
+  const decision: DecisionRecord = {
+    ok: route.name !== 'reject',
+    policy,
+    route,
+    response,
+    meta: {
+      latencyMs: Date.now() - started,
+      timestamp: new Date().toISOString()
+    }
+  };
+
+  logDecision(input, decision);
+  return decision;
+}
+
+function selectRoute(policy: PolicyEvaluation): RouteSelection {
+  if (policy.allow && policy.primaryAvailable) {
+    return { name: 'primary', reason: 'Primary healthy' };
+  }
+  if (policy.allow && policy.backupAvailable) {
+    return { name: 'backup', reason: 'Fallback engaged' };
+  }
+  return { name: 'reject', reason: 'No viable route' };
+}
+
+async function executeRoute(route: RouteSelection, input: DecideInput): Promise<RouteExecutionResult> {
+  if (route.name === 'reject') {
+    return { route: route.name, input: input.intent ?? 'default' };
+  }
+
+  // Placeholder for actual route execution logic
+  return {
+    route: route.name,
+    input: input.intent ?? 'default'
+  };
+}
+
+export function __selectRouteForTest(policy: PolicyEvaluation): RouteSelection {
+  return selectRoute(policy);
+}
+
+export async function __executeRouteForTest(
+  route: RouteSelection,
+  input: DecideInput
+): Promise<RouteExecutionResult> {
+  return executeRoute(route, input);
+}

--- a/src/afol/health.ts
+++ b/src/afol/health.ts
@@ -1,0 +1,54 @@
+import { HealthSnapshot, ServiceHealth } from './types.js';
+
+const baseState: HealthSnapshot = {
+  redis: { ok: true, latency: 14 },
+  postgres: { ok: true, latency: 28 },
+  api: { ok: true, latency: 53 }
+};
+
+let healthState: HealthSnapshot = cloneState(baseState);
+
+function cloneState(state: HealthSnapshot): HealthSnapshot {
+  return JSON.parse(JSON.stringify(state));
+}
+
+export function getStatus(): HealthSnapshot {
+  return cloneState(healthState);
+}
+
+export function simulateFailure(service: keyof HealthSnapshot): void {
+  const current = healthState[service];
+  if (current) {
+    healthState = {
+      ...healthState,
+      [service]: { ...current, ok: false }
+    };
+  }
+}
+
+export function simulateRecovery(service: keyof HealthSnapshot): void {
+  const current = healthState[service];
+  if (current) {
+    healthState = {
+      ...healthState,
+      [service]: { ...current, ok: true }
+    };
+  }
+}
+
+export function setServiceHealth(service: string, status: ServiceHealth): void {
+  healthState = {
+    ...healthState,
+    [service]: { ...status }
+  };
+}
+
+export function resetHealth(): void {
+  healthState = cloneState(baseState);
+}
+
+export function setHealthSnapshot(snapshot: HealthSnapshot): void {
+  healthState = cloneState(snapshot);
+}
+
+export const defaultHealthSnapshot: HealthSnapshot = cloneState(baseState);

--- a/src/afol/logger.ts
+++ b/src/afol/logger.ts
@@ -1,0 +1,76 @@
+import fs from 'fs';
+import path from 'path';
+import { DecisionRecord, LogEntry } from './types.js';
+
+const defaultLogPath = path.resolve(process.cwd(), 'logs', 'afol-decisions.log');
+
+let logFilePath = defaultLogPath;
+
+function ensureLogDestination(): void {
+  const directory = path.dirname(logFilePath);
+  if (!fs.existsSync(directory)) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+  if (!fs.existsSync(logFilePath)) {
+    fs.writeFileSync(logFilePath, '', { encoding: 'utf8' });
+  }
+}
+
+export function configureLogger(options: { filePath?: string } = {}): void {
+  if (options.filePath) {
+    logFilePath = options.filePath;
+  } else {
+    logFilePath = defaultLogPath;
+  }
+}
+
+export function getLogFilePath(): string {
+  return logFilePath;
+}
+
+export function logDecision(input: unknown, decision: DecisionRecord): void {
+  ensureLogDestination();
+  const entry: LogEntry = {
+    timestamp: new Date().toISOString(),
+    input,
+    decision
+  };
+  fs.appendFileSync(logFilePath, `${JSON.stringify(entry)}\n`, { encoding: 'utf8' });
+}
+
+export function logError(context: string, error: unknown): void {
+  ensureLogDestination();
+  const entry: LogEntry = {
+    timestamp: new Date().toISOString(),
+    context,
+    error: error instanceof Error ? error.message : String(error)
+  };
+  fs.appendFileSync(logFilePath, `${JSON.stringify(entry)}\n`, { encoding: 'utf8' });
+}
+
+export function getRecent(limit = 10): LogEntry[] {
+  try {
+    if (!fs.existsSync(logFilePath)) {
+      return [];
+    }
+    const raw = fs.readFileSync(logFilePath, { encoding: 'utf8' });
+    const lines = raw
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    const slice = lines.slice(-Math.max(limit, 0));
+    return slice.map((line) => JSON.parse(line) as LogEntry);
+  } catch {
+    return [];
+  }
+}
+
+export function clearLogs(): void {
+  if (fs.existsSync(logFilePath)) {
+    fs.writeFileSync(logFilePath, '', { encoding: 'utf8' });
+  }
+}
+
+export function resetLogger(): void {
+  logFilePath = defaultLogPath;
+}

--- a/src/afol/policies.ts
+++ b/src/afol/policies.ts
@@ -1,0 +1,25 @@
+import { HealthSnapshot, PolicyEvaluation } from './types.js';
+
+function isServiceHealthy(service?: { ok?: boolean }): boolean {
+  return service?.ok === true;
+}
+
+export function evaluate(health: HealthSnapshot, intent: string = 'default'): PolicyEvaluation {
+  const redisOk = isServiceHealthy(health.redis);
+  const apiOk = isServiceHealthy(health.api);
+  const primaryAvailable = redisOk && apiOk;
+  const backupAvailable = isServiceHealthy(health.postgres);
+
+  const rationale = primaryAvailable
+    ? 'Primary path stable'
+    : backupAvailable
+      ? 'Switching to fallback route'
+      : 'No healthy routes available';
+
+  return {
+    allow: true,
+    primaryAvailable,
+    backupAvailable,
+    rationale
+  };
+}

--- a/src/afol/types.ts
+++ b/src/afol/types.ts
@@ -1,0 +1,54 @@
+export interface ServiceHealth {
+  ok: boolean;
+  latency: number;
+}
+
+export interface HealthSnapshot {
+  [service: string]: ServiceHealth | undefined;
+  redis?: ServiceHealth;
+  postgres?: ServiceHealth;
+  api?: ServiceHealth;
+}
+
+export interface PolicyEvaluation {
+  allow: boolean;
+  primaryAvailable: boolean;
+  backupAvailable: boolean;
+  rationale: string;
+}
+
+export type RouteName = 'primary' | 'backup' | 'reject';
+
+export interface RouteSelection {
+  name: RouteName;
+  reason: string;
+}
+
+export interface DecideInput {
+  intent?: string;
+  [key: string]: unknown;
+}
+
+export interface RouteExecutionResult {
+  route: RouteName;
+  input: string;
+}
+
+export interface DecisionRecord {
+  ok: boolean;
+  policy: PolicyEvaluation;
+  route: RouteSelection;
+  response: RouteExecutionResult;
+  meta: {
+    latencyMs: number;
+    timestamp: string;
+  };
+}
+
+export interface LogEntry {
+  timestamp: string;
+  input?: unknown;
+  decision?: DecisionRecord;
+  context?: string;
+  error?: string;
+}

--- a/src/routes/afol.ts
+++ b/src/routes/afol.ts
@@ -1,0 +1,26 @@
+import { Router } from 'express';
+import { decide } from '../afol/engine.js';
+import { getStatus } from '../afol/health.js';
+import { getRecent, logError } from '../afol/logger.js';
+
+const router = Router();
+
+router.post('/decide', async (req, res) => {
+  try {
+    const result = await decide(req.body ?? {});
+    res.json(result);
+  } catch (error) {
+    logError('decide', error);
+    res.status(500).json({ ok: false, error: error instanceof Error ? error.message : 'Unknown error' });
+  }
+});
+
+router.get('/health', (_req, res) => {
+  res.json(getStatus());
+});
+
+router.get('/logs', (_req, res) => {
+  res.json(getRecent());
+});
+
+export default router;

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -24,6 +24,7 @@ import hrcRouter from './hrc.js';
 import gptRouter from './gptRouter.js';
 import researchRouter from './research.js';
 import healthRouter from './health.js';
+import afolRouter from './afol.js';
 import { createFallbackTestRoute } from '../middleware/fallbackHandler.js';
 import { runHealthCheck } from '../utils/diagnostics.js';
 
@@ -77,6 +78,7 @@ export function registerRoutes(app: Express): void {
   app.use('/api/commands', apiCommandsRouter);
   app.use('/api/pr-analysis', prAnalysisRouter);
   app.use('/api/openai', openaiRouter);
+  app.use('/api/afol', afolRouter);
   app.use('/', hrcRouter);
   app.use('/', imageRouter);
   app.use('/', ragRouter);

--- a/tests/afol.test.ts
+++ b/tests/afol.test.ts
@@ -1,0 +1,89 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import { decide } from '../src/afol/engine.js';
+import { evaluate } from '../src/afol/policies.js';
+import { getStatus, resetHealth, simulateFailure } from '../src/afol/health.js';
+import { clearLogs, configureLogger, getRecent, logError, resetLogger } from '../src/afol/logger.js';
+
+function createTempLogPath(): string {
+  const uniqueId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return path.join(os.tmpdir(), `afol-${uniqueId}.log`);
+}
+
+describe('AFOL engine orchestration', () => {
+  let tempLogPath: string;
+
+  beforeEach(() => {
+    resetHealth();
+    tempLogPath = createTempLogPath();
+    configureLogger({ filePath: tempLogPath });
+    clearLogs();
+  });
+
+  afterEach(() => {
+    clearLogs();
+    resetLogger();
+    if (tempLogPath && fs.existsSync(tempLogPath)) {
+      fs.unlinkSync(tempLogPath);
+    }
+  });
+
+  test('decide uses primary route when services are healthy', async () => {
+    const decision = await decide({ intent: 'ingest' });
+
+    expect(decision.ok).toBe(true);
+    expect(decision.route.name).toBe('primary');
+    expect(decision.policy.primaryAvailable).toBe(true);
+    expect(decision.policy.backupAvailable).toBe(true);
+  });
+
+  test('decide falls back to backup when primary services fail', async () => {
+    simulateFailure('redis');
+    const decision = await decide({ intent: 'ingest' });
+
+    expect(decision.ok).toBe(true);
+    expect(decision.route.name).toBe('backup');
+    expect(decision.policy.primaryAvailable).toBe(false);
+    expect(decision.policy.backupAvailable).toBe(true);
+  });
+
+  test('decide rejects when no services are available', async () => {
+    simulateFailure('redis');
+    simulateFailure('api');
+    simulateFailure('postgres');
+
+    const decision = await decide({ intent: 'ingest' });
+
+    expect(decision.ok).toBe(false);
+    expect(decision.route.name).toBe('reject');
+    expect(decision.policy.backupAvailable).toBe(false);
+  });
+
+  test('logs decisions and exposes recent entries', async () => {
+    await decide({ intent: 'sync' });
+    const logs = getRecent();
+
+    expect(logs.length).toBeGreaterThan(0);
+    expect(logs[logs.length - 1]?.decision?.route.name).toBeDefined();
+  });
+
+  test('policies evaluate snapshot consistently', () => {
+    const healthySnapshot = getStatus();
+    const policy = evaluate(healthySnapshot, 'ingest');
+
+    expect(policy.allow).toBe(true);
+    expect(policy.primaryAvailable).toBe(true);
+    expect(policy.rationale).toBe('Primary path stable');
+  });
+
+  test('error logging captures context', () => {
+    logError('test-context', new Error('failure'));
+    const logs = getRecent();
+    const lastEntry = logs[logs.length - 1];
+
+    expect(lastEntry?.context).toBe('test-context');
+    expect(lastEntry?.error).toBe('failure');
+  });
+});


### PR DESCRIPTION
## Summary
- implement AFOL health, policy evaluation, decision engine, and logging utilities
- add Express routes for AFOL decisioning, health snapshots, and recent audit logs
- cover the AFOL orchestration flow with dedicated Jest tests

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_6909b8559260832595a0127726c2084c