### PR TITLE
Add module registry endpoints to backend

### DIFF
--- a/src/routes/modules.ts
+++ b/src/routes/modules.ts
@@ -1,8 +1,11 @@
 import express, { Request, Response } from 'express';
 import { loadModuleDefinitions, ModuleDef } from '../modules/moduleLoader.js';
 
-const registry: Record<string, ModuleDef> = {};
 const router = express.Router();
+
+const registryByRoute = new Map<string, ModuleDef>();
+const registryByName = new Map<string, ModuleDef>();
+const moduleRoutes = new Map<string, string>();
 
 function createHandler(mod: ModuleDef) {
   return async (req: Request, res: Response) => {
@@ -20,8 +23,9 @@ function createHandler(mod: ModuleDef) {
 }
 
 export function registerModule(route: string, mod: ModuleDef) {
-  registry[route] = mod;
-  registry[mod.name] = mod;
+  registryByRoute.set(route, mod);
+  registryByName.set(mod.name, mod);
+  moduleRoutes.set(mod.name, route);
   router.post(`/modules/${route}`, createHandler(mod));
 }
 
@@ -30,9 +34,52 @@ for (const { route, definition } of loadedModules) {
   registerModule(route, definition);
 }
 
+router.get('/registry', (_req: Request, res: Response) => {
+  const modules = Array.from(registryByName.values()).map((mod) => ({
+    name: mod.name,
+    description: mod.description ?? null,
+    route: moduleRoutes.get(mod.name) ?? null,
+    actions: Object.keys(mod.actions),
+    gptIds: mod.gptIds ?? []
+  }));
+
+  res.json({
+    count: modules.length,
+    modules
+  });
+});
+
+router.get('/registry/:moduleName', (req: Request, res: Response) => {
+  const identifier = req.params.moduleName;
+  let mod = registryByName.get(identifier);
+  let route = moduleRoutes.get(identifier) ?? null;
+
+  if (!mod) {
+    mod = registryByRoute.get(identifier);
+    if (mod) {
+      route = moduleRoutes.get(mod.name) ?? identifier;
+    }
+  }
+
+  if (!mod) {
+    return res.json({ exists: false, module: null });
+  }
+
+  return res.json({
+    exists: true,
+    module: {
+      name: mod.name,
+      description: mod.description ?? null,
+      route,
+      actions: Object.keys(mod.actions),
+      gptIds: mod.gptIds ?? []
+    }
+  });
+});
+
 router.post('/queryroute', async (req: Request, res: Response) => {
   const { module: moduleName, action, payload } = req.body;
-  const mod = registry[moduleName];
+  const mod = registryByName.get(moduleName) ?? registryByRoute.get(moduleName);
   if (!mod) {
     return res.status(404).json({ error: 'Module not found' });
   }


### PR DESCRIPTION
## Summary
- add dedicated registry indexes for module names and routes
- expose `/registry` and `/registry/:moduleName` endpoints for module verification
- retain `/queryroute` support for route identifiers while using the new indexes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_690ae80cc6588325be6b7739d9aee4fd