### PR TITLE
Improve OpenAI integration and confirm gate flexibility

### DIFF
--- a/src/routes/openai.ts
+++ b/src/routes/openai.ts
@@ -1,8 +1,9 @@
 import express from 'express';
-import { handlePrompt } from '../controllers/openaiController.js';
+import { handlePrompt, getOpenAIStatus } from '../controllers/openaiController.js';
 
 const router = express.Router();
 
+router.get('/status', getOpenAIStatus);
 router.post('/prompt', handlePrompt);
 
 export default router;


### PR DESCRIPTION
## Summary
- resolve the OpenAI API key using Railway-compatible environment variables and surface key source details through a new status endpoint
- expose `/api/openai/status` so front ends and custom GPTs can verify backend configuration and handshake requirements
- support wildcard or allow-all GPT confirmation flow while reporting confirmation settings for client orchestration

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_690bd9989e5c8325a2e92e41d280e144