### PR TITLE
Add /api/ask bridge for ChatGPT integrations

### DIFF
--- a/src/routes/api-ask.ts
+++ b/src/routes/api-ask.ts
@@ -1,0 +1,94 @@
+import express, { Request, Response } from 'express';
+import { handleAIRequest, type AskRequest, type AskResponse } from './ask.js';
+import { createRateLimitMiddleware, createValidationMiddleware, securityHeaders } from '../utils/security.js';
+import type { ErrorResponseDTO } from '../types/dto.js';
+
+const router = express.Router();
+
+router.use(securityHeaders);
+router.use(createRateLimitMiddleware(120, 10 * 60 * 1000));
+
+const actionSchema = {
+  message: { type: 'string' as const, required: false, minLength: 1, maxLength: 6000, sanitize: true },
+  prompt: { type: 'string' as const, required: false, minLength: 1, maxLength: 6000, sanitize: true },
+  userInput: { type: 'string' as const, required: false, minLength: 1, maxLength: 6000, sanitize: true },
+  content: { type: 'string' as const, required: false, minLength: 1, maxLength: 6000, sanitize: true },
+  text: { type: 'string' as const, required: false, minLength: 1, maxLength: 6000, sanitize: true },
+  query: { type: 'string' as const, required: false, minLength: 1, maxLength: 6000, sanitize: true },
+  domain: { type: 'string' as const, required: false, maxLength: 120, sanitize: true },
+  useRAG: { type: 'boolean' as const, required: false },
+  useHRC: { type: 'boolean' as const, required: false },
+  sessionId: { type: 'string' as const, required: false, maxLength: 100, sanitize: true },
+  overrideAuditSafe: { type: 'string' as const, required: false, maxLength: 50, sanitize: true },
+  metadata: { type: 'object' as const, required: false }
+};
+
+const apiAskValidation = createValidationMiddleware(actionSchema);
+
+interface ChatGPTActionBody {
+  message?: string;
+  prompt?: string;
+  userInput?: string;
+  content?: string;
+  text?: string;
+  query?: string;
+  domain?: string;
+  useRAG?: boolean;
+  useHRC?: boolean;
+  sessionId?: string;
+  overrideAuditSafe?: string;
+  metadata?: Record<string, unknown>;
+}
+
+router.post('/api/ask', apiAskValidation, (req: Request<{}, AskResponse | ErrorResponseDTO, ChatGPTActionBody>, res: Response<AskResponse | ErrorResponseDTO>) => {
+  const { domain, useRAG, useHRC, sessionId, overrideAuditSafe, metadata } = req.body;
+
+  const basePrompt =
+    req.body.message ||
+    req.body.prompt ||
+    req.body.userInput ||
+    req.body.content ||
+    req.body.text ||
+    req.body.query;
+
+  if (!basePrompt) {
+    return res.status(400).json({
+      error: 'Validation failed',
+      details: ['Request must include one of message, prompt, userInput, content, text, or query fields']
+    });
+  }
+
+  const contextDirectives: string[] = [];
+
+  if (domain) {
+    contextDirectives.push(`Domain routing hint: ${domain}`);
+  }
+  if (typeof useRAG === 'boolean') {
+    contextDirectives.push(`RAG requested: ${useRAG ? 'ENABLED' : 'DISABLED'}`);
+  }
+  if (typeof useHRC === 'boolean') {
+    contextDirectives.push(`HRC requested: ${useHRC ? 'ENABLED' : 'DISABLED'}`);
+  }
+  if (metadata && Object.keys(metadata).length > 0) {
+    const keys = Object.keys(metadata).slice(0, 10);
+    contextDirectives.push(`Metadata keys: ${keys.join(', ')}`);
+  }
+
+  const normalizedPrompt = contextDirectives.length
+    ? `${basePrompt}\n\n[ARCANOS CONTEXT]\n${contextDirectives.join('\n')}`
+    : basePrompt;
+
+  const normalizedRequest: AskRequest = {
+    prompt: normalizedPrompt,
+    sessionId,
+    overrideAuditSafe
+  };
+
+  const typedRequest = req as unknown as Request<{}, AskResponse | ErrorResponseDTO, AskRequest>;
+  typedRequest.body = normalizedRequest;
+
+  return handleAIRequest(typedRequest, res, 'ask');
+});
+
+export default router;
+

--- a/src/routes/ask.ts
+++ b/src/routes/ask.ts
@@ -18,15 +18,15 @@ const askValidationSchema = {
   overrideAuditSafe: { type: 'string' as const, maxLength: 50, sanitize: true }
 };
 
-const askValidationMiddleware = createValidationMiddleware(askValidationSchema);
+export const askValidationMiddleware = createValidationMiddleware(askValidationSchema);
 
-type AskRequest = AIRequestDTO & {
+export type AskRequest = AIRequestDTO & {
   prompt: string;
   sessionId?: string;
   overrideAuditSafe?: string;
 };
 
-interface AskResponse extends AIResponseDTO {
+export interface AskResponse extends AIResponseDTO {
   routingStages?: string[];
   gpt5Used?: boolean;
   auditSafe?: {
@@ -51,7 +51,7 @@ interface AskResponse extends AIResponseDTO {
  * Shared handler for both ask and brain endpoints
  * Handles AI request processing with standardized error handling and validation
  */
-const handleAIRequest = async (
+export const handleAIRequest = async (
   req: Request<{}, AskResponse | ErrorResponseDTO, AskRequest>,
   res: Response<AskResponse | ErrorResponseDTO>,
   endpointName: string

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -1,5 +1,6 @@
 import { Express, Request, Response } from 'express';
 import askRouter from './ask.js';
+import apiAskRouter from './api-ask.js';
 import arcanosRouter from './arcanos.js';
 import arcanosPipelineRouter from './openai-arcanos-pipeline.js';
 import aiEndpointsRouter from './ai-endpoints.js';
@@ -60,6 +61,7 @@ export function registerRoutes(app: Express): void {
 
   app.use('/', healthRouter);
   app.use('/', askRouter);
+  app.use('/', apiAskRouter);
   app.use('/', arcanosRouter);
   app.use('/', arcanosPipelineRouter);
   app.use('/', aiEndpointsRouter);

--- a/tests/placeholder.test.ts
+++ b/tests/placeholder.test.ts
@@ -50,6 +50,24 @@ describe('AI endpoints in mock mode', () => {
     expect(payload.auditSafe).toBeDefined();
   });
 
+  it('normalizes ChatGPT action payload through /api/ask', async () => {
+    const response = await fetch(`${baseUrl}/api/ask`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        message: 'How does the system behave?',
+        domain: 'diagnostics',
+        useRAG: true,
+        useHRC: false
+      })
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.result).toContain('[MOCK AI RESPONSE]');
+    expect(payload.routingStages).toContain('ARCANOS-INTAKE:MOCK');
+  });
+
   it('provides deterministic mock diagnostics for /arcanos', async () => {
     const response = await fetch(`${baseUrl}/arcanos`, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- expose the shared Trinity ask handler for reuse by other routes
- add a new /api/ask route that normalizes ChatGPT action payloads before routing to /ask
- register the new router and expand tests to cover the bridge

## Testing
- npm test -- --runTestsByPath tests/placeholder.test.ts
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690bf5400e74832593a053b6eb66df01