### PR TITLE
Add standalone ARCANOS memory service Express scaffold

### DIFF
--- a/memory-service/.env.example
+++ b/memory-service/.env.example
@@ -1,0 +1,6 @@
+PORT=8080
+NODE_ENV=production
+AUTH_TOKEN=your-secure-token
+OPENAI_API_KEY=sk-xxxx
+AUDIT_LOG_LEVEL=info
+STORAGE_PROVIDER=in-memory

--- a/memory-service/package.json
+++ b/memory-service/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "arcanos-memory-service",
+  "version": "2.1.0",
+  "type": "module",
+  "main": "src/server.js",
+  "scripts": {
+    "dev": "NODE_ENV=development node src/server.js",
+    "start": "node src/server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "helmet": "^7.1.0",
+    "morgan": "^1.10.0",
+    "openai": "^5.0.0",
+    "uuid": "^9.0.1",
+    "zod": "^3.23.8"
+  }
+}

--- a/memory-service/railway.json
+++ b/memory-service/railway.json
@@ -1,0 +1,8 @@
+{
+  "build": { "builder": "NIXPACKS" },
+  "deploy": {
+    "startCommand": "npm start",
+    "healthcheckPath": "/health",
+    "restartPolicyType": "ON_FAILURE"
+  }
+}

--- a/memory-service/src/app.js
+++ b/memory-service/src/app.js
@@ -1,0 +1,18 @@
+import express from "express";
+import cors from "cors";
+import helmet from "helmet";
+import morgan from "morgan";
+import memoryRoutes from "./routes/memoryRoutes.js";
+
+const app = express();
+
+app.use(helmet());
+app.use(cors());
+app.use(express.json());
+app.use(morgan("combined"));
+
+app.use("/api/memory", memoryRoutes);
+
+app.get("/health", (_req, res) => res.json({ status: "ok" }));
+
+export default app;

--- a/memory-service/src/config/env.js
+++ b/memory-service/src/config/env.js
@@ -1,0 +1,14 @@
+import dotenv from "dotenv";
+
+dotenv.config();
+
+export const config = {
+  port: process.env.PORT || 8080,
+  env: process.env.NODE_ENV || "development",
+  authToken: process.env.AUTH_TOKEN,
+  openaiKey: process.env.OPENAI_API_KEY,
+  audit: {
+    level: process.env.AUDIT_LOG_LEVEL || "info"
+  },
+  storageProvider: process.env.STORAGE_PROVIDER || "in-memory"
+};

--- a/memory-service/src/config/openai.js
+++ b/memory-service/src/config/openai.js
@@ -1,0 +1,4 @@
+import OpenAI from "openai";
+import { config } from "./env.js";
+
+export const openai = new OpenAI({ apiKey: config.openaiKey });

--- a/memory-service/src/controllers/memoryController.js
+++ b/memory-service/src/controllers/memoryController.js
@@ -1,0 +1,23 @@
+import { memoryService } from "../services/memoryService.js";
+
+export async function commitMemory(req, res) {
+  try {
+    const result = await memoryService.commit(req.body);
+    res.status(200).json(result);
+  } catch (err) {
+    console.error("Memory commit failed", err);
+    res.status(500).json({ error: "Commit failed" });
+  }
+}
+
+export async function retrieveMemory(req, res) {
+  try {
+    const { traceId } = req.params;
+    const result = await memoryService.retrieve(traceId);
+    const status = result.error ? 404 : 200;
+    res.status(status).json(result);
+  } catch (err) {
+    console.error("Memory retrieve failed", err);
+    res.status(500).json({ error: "Retrieve failed" });
+  }
+}

--- a/memory-service/src/middleware/audit.js
+++ b/memory-service/src/middleware/audit.js
@@ -1,0 +1,16 @@
+import { auditService } from "../services/auditService.js";
+
+export default function audit(req, res, next) {
+  const start = Date.now();
+
+  res.on("finish", () => {
+    auditService.record({
+      method: req.method,
+      path: req.originalUrl,
+      status: res.statusCode,
+      durationMs: Date.now() - start
+    });
+  });
+
+  next();
+}

--- a/memory-service/src/middleware/auth.js
+++ b/memory-service/src/middleware/auth.js
@@ -1,0 +1,9 @@
+import { config } from "../config/env.js";
+
+export default function auth(req, res, next) {
+  const token = req.headers.authorization?.split(" ")[1];
+  if (!config.authToken || token !== config.authToken) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+  return next();
+}

--- a/memory-service/src/middleware/resilience.js
+++ b/memory-service/src/middleware/resilience.js
@@ -1,0 +1,14 @@
+const REQUEST_TIMEOUT_MS = 15000;
+
+export default function resilience(req, res, next) {
+  const timeout = setTimeout(() => {
+    if (!res.headersSent) {
+      res.status(503).json({ error: "Request timeout" });
+    }
+  }, REQUEST_TIMEOUT_MS);
+
+  res.on("finish", () => clearTimeout(timeout));
+  res.on("close", () => clearTimeout(timeout));
+
+  next();
+}

--- a/memory-service/src/routes/memoryRoutes.js
+++ b/memory-service/src/routes/memoryRoutes.js
@@ -1,0 +1,12 @@
+import express from "express";
+import auth from "../middleware/auth.js";
+import audit from "../middleware/audit.js";
+import resilience from "../middleware/resilience.js";
+import { commitMemory, retrieveMemory } from "../controllers/memoryController.js";
+
+const router = express.Router();
+
+router.post("/commit", auth, resilience, audit, commitMemory);
+router.get("/retrieve/:traceId", auth, resilience, audit, retrieveMemory);
+
+export default router;

--- a/memory-service/src/server.js
+++ b/memory-service/src/server.js
@@ -1,0 +1,6 @@
+import { config } from "./config/env.js";
+import app from "./app.js";
+
+app.listen(config.port, () => {
+  console.log(`ARCANOS Memory Service running on port ${config.port}`);
+});

--- a/memory-service/src/services/auditService.js
+++ b/memory-service/src/services/auditService.js
@@ -1,0 +1,29 @@
+import { config } from "../config/env.js";
+
+const levels = ["error", "warn", "info", "debug"];
+const activeLevelIndex = levels.indexOf(config.audit.level);
+
+function shouldLog(level) {
+  const index = levels.indexOf(level);
+  if (index === -1) {
+    return false;
+  }
+  if (activeLevelIndex === -1) {
+    return level === "info";
+  }
+  return index <= activeLevelIndex;
+}
+
+export const auditService = {
+  record(event) {
+    if (!shouldLog("info")) {
+      return;
+    }
+    const entry = {
+      ...event,
+      timestamp: new Date().toISOString(),
+      env: config.env
+    };
+    console.log(`[AUDIT] ${entry.timestamp} ${entry.method} ${entry.path} ${entry.status} ${entry.durationMs}ms`);
+  }
+};

--- a/memory-service/src/services/memoryService.js
+++ b/memory-service/src/services/memoryService.js
@@ -1,0 +1,44 @@
+import { v4 as uuidv4 } from "uuid";
+import { z } from "zod";
+import { config } from "../config/env.js";
+
+const MemoryPayloadSchema = z
+  .object({
+    trace_id: z.string().uuid().optional(),
+    content: z.any(),
+    metadata: z.record(z.any()).optional(),
+    tags: z.array(z.string()).optional()
+  })
+  .passthrough();
+
+const memoryStore = new Map();
+
+function persist(id, payload) {
+  if (config.storageProvider !== "in-memory") {
+    console.warn(
+      `Storage provider "${config.storageProvider}" is not implemented. Falling back to in-memory storage.`
+    );
+  }
+  memoryStore.set(id, payload);
+}
+
+export const memoryService = {
+  async commit(rawPayload) {
+    const payload = MemoryPayloadSchema.parse(rawPayload);
+    const id = payload.trace_id || uuidv4();
+    const record = {
+      ...payload,
+      id,
+      saved_at: new Date().toISOString()
+    };
+    persist(id, record);
+    return { status: "success", id };
+  },
+
+  async retrieve(id) {
+    if (!id) {
+      return { error: "Trace ID required" };
+    }
+    return memoryStore.get(id) || { error: "Not found" };
+  }
+};


### PR DESCRIPTION
## Summary
- add a standalone Express-based memory microservice with authentication, auditing, and resilience middleware
- implement in-memory storage with zod validation and OpenAI client configuration
- provide environment template and Railway deployment configuration for the memory service

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912c237bcb483259f3df006ca25b1fe)