### PR TITLE
Persist self-reflections in database

### DIFF
--- a/scripts/db-init.js
+++ b/scripts/db-init.js
@@ -57,6 +57,17 @@ async function ensureSchema() {
         data JSONB NOT NULL,
         created_at TIMESTAMPTZ DEFAULT NOW()
       );
+    `,
+    self_reflections: `
+      CREATE TABLE IF NOT EXISTS self_reflections (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        priority TEXT NOT NULL,
+        category TEXT NOT NULL,
+        content TEXT NOT NULL,
+        improvements JSONB NOT NULL DEFAULT '[]'::jsonb,
+        metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+        created_at TIMESTAMPTZ DEFAULT NOW()
+      );
     `
     // add more tables here as needed
   };

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -71,6 +71,10 @@ export {
   logReasoning
 } from './repositories/reasoningLogRepository.js';
 
+export {
+  saveSelfReflection
+} from './repositories/selfReflectionRepository.js';
+
 /**
  * Initialize database with full schema setup
  * This is the main entry point for database initialization

--- a/src/db/repositories/selfReflectionRepository.ts
+++ b/src/db/repositories/selfReflectionRepository.ts
@@ -1,0 +1,47 @@
+/**
+ * Self-Reflection Repository for ARCANOS
+ *
+ * Persists AI reflection outputs for historical analysis and tooling reuse.
+ */
+
+import { isDatabaseConnected } from '../client.js';
+import { query } from '../query.js';
+
+export interface SelfReflectionInsert {
+  priority: string;
+  category: string;
+  content: string;
+  improvements: string[];
+  metadata: unknown;
+}
+
+/**
+ * Store a generated self-reflection in the database when connectivity is available.
+ */
+export async function saveSelfReflection({
+  priority,
+  category,
+  content,
+  improvements,
+  metadata
+}: SelfReflectionInsert): Promise<void> {
+  if (!isDatabaseConnected()) {
+    console.warn('[🧠 Reflections] Database not connected; skipping persistence for self-reflection');
+    return;
+  }
+
+  const sanitizedImprovements = Array.isArray(improvements) ? improvements : [];
+  const serializedMetadata = metadata ?? {};
+
+  await query(
+    `INSERT INTO self_reflections (priority, category, content, improvements, metadata)
+     VALUES ($1, $2, $3, $4::jsonb, $5::jsonb)`,
+    [
+      priority,
+      category,
+      content,
+      JSON.stringify(sanitizedImprovements),
+      JSON.stringify(serializedMetadata)
+    ]
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -204,6 +204,17 @@ export async function initializeTables(): Promise<void> {
       data JSONB NOT NULL,
       created_at TIMESTAMPTZ DEFAULT NOW()
     )`,
+
+    // Self-reflection storage for AI analysis history
+    `CREATE TABLE IF NOT EXISTS self_reflections (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      priority TEXT NOT NULL,
+      category TEXT NOT NULL,
+      content TEXT NOT NULL,
+      improvements JSONB NOT NULL DEFAULT '[]'::jsonb,
+      metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    )`,
     
     // Execution logs table for worker logs
     `CREATE TABLE IF NOT EXISTS execution_logs (
@@ -248,7 +259,9 @@ export async function initializeTables(): Promise<void> {
     `CREATE INDEX IF NOT EXISTS idx_rag_docs_url ON rag_docs(url)`,
     `CREATE INDEX IF NOT EXISTS idx_backstage_wrestlers_name ON backstage_wrestlers(name)`,
     `CREATE INDEX IF NOT EXISTS idx_backstage_events_created_at ON backstage_events(created_at DESC)`,
-    `CREATE INDEX IF NOT EXISTS idx_backstage_story_beats_created_at ON backstage_story_beats(created_at DESC)`
+    `CREATE INDEX IF NOT EXISTS idx_backstage_story_beats_created_at ON backstage_story_beats(created_at DESC)`,
+    `CREATE INDEX IF NOT EXISTS idx_self_reflections_created_at ON self_reflections(created_at DESC)`,
+    `CREATE INDEX IF NOT EXISTS idx_self_reflections_category_priority ON self_reflections(category, priority)`
   ];
 
   try {


### PR DESCRIPTION
## Summary
- add a dedicated `self_reflections` table and supporting indexes during schema setup
- expose a repository helper for saving reflection outputs and reuse it from the AI reflections service
- ensure the database init script provisions the new table for existing environments

## Testing
- npm test -- --passWithNoTests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138acd2da483259ab6978529c2057a)