### PR TITLE
Add Railway management API client and validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,6 +122,10 @@ RAILWAY_PROJECT=arcanos-core
 # Values: production | development | pr-* (for preview deployments)
 RAILWAY_ENVIRONMENT=production
 
+# Railway Management API Token (enables deploy/rollback automation)
+# Generate from: https://railway.app/account/tokens
+RAILWAY_API_TOKEN=
+
 # Public API URL (set by Railway, can be overridden)
 API_URL=https://arcanos-v2-production.up.railway.app
 

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -44,6 +44,11 @@ PORT=8080                    # Auto-set by Railway
 RAILWAY_ENVIRONMENT=production  # Auto-set by Railway
 ```
 
+#### Railway Management (optional but recommended):
+```bash
+RAILWAY_API_TOKEN=your-railway-api-token   # Enables deploy/rollback automation via GraphQL API
+```
+
 #### Fine-Tuned Model (Railway Compatible):
 ```bash
 FINETUNED_MODEL_ID=ft:gpt-4.1-2025-04-14:personal:arcanos:C8Msdote

--- a/RAILWAY_COMPATIBILITY_GUIDE.md
+++ b/RAILWAY_COMPATIBILITY_GUIDE.md
@@ -97,6 +97,11 @@ RAILWAY_ENVIRONMENT=production
 PORT=8080
 ```
 
+### Management API (optional)
+```bash
+RAILWAY_API_TOKEN=your-railway-api-token
+```
+
 ### Railway Deployment
 The application automatically:
 - Binds to Railway's provided PORT

--- a/src/services/railwayClient.ts
+++ b/src/services/railwayClient.ts
@@ -1,0 +1,288 @@
+import { logger } from '../utils/structuredLogging.js';
+
+const DEFAULT_GRAPHQL_ENDPOINT = 'https://backboard.railway.app/graphql';
+const GRAPHQL_ENDPOINT = process.env.RAILWAY_GRAPHQL_ENDPOINT || DEFAULT_GRAPHQL_ENDPOINT;
+
+interface GraphQLErrorPayload {
+  message: string;
+}
+
+interface GraphQLResponse<T> {
+  data?: T;
+  errors?: GraphQLErrorPayload[];
+}
+
+export interface RailwayProjectSummary {
+  id: string;
+  name: string;
+  environments: Array<{
+    id: string;
+    name: string;
+    services: Array<{
+      id: string;
+      name: string;
+      latestDeployment?: {
+        id: string;
+        status: string;
+        createdAt: string;
+      } | null;
+    }>;
+  }>;
+}
+
+export interface DeployServiceOptions {
+  serviceId: string;
+  branch?: string;
+  commitId?: string;
+}
+
+export interface RedeployEnvironmentOptions {
+  environmentId: string;
+}
+
+export interface PromoteDeploymentOptions {
+  deploymentId: string;
+}
+
+export interface RailwayApiProbeResult {
+  ok: boolean;
+  projectCount?: number;
+  environmentCount?: number;
+  serviceCount?: number;
+}
+
+class RailwayApiError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RailwayApiError';
+  }
+}
+
+function getToken(): string | null {
+  const token = process.env.RAILWAY_API_TOKEN?.trim();
+  return token ? token : null;
+}
+
+export function isRailwayApiConfigured(): boolean {
+  return Boolean(getToken());
+}
+
+async function executeGraphQL<T>(query: string, variables?: Record<string, unknown>): Promise<T> {
+  const token = getToken();
+  if (!token) {
+    throw new RailwayApiError('Railway API token is not configured. Set RAILWAY_API_TOKEN to enable management APIs.');
+  }
+
+  const response = await fetch(GRAPHQL_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({ query, variables })
+  });
+
+  const raw = await response.text();
+  let parsed: GraphQLResponse<T>;
+
+  try {
+    parsed = JSON.parse(raw) as GraphQLResponse<T>;
+  } catch (error) {
+    throw new RailwayApiError(`Failed to parse Railway API response: ${(error as Error).message}`);
+  }
+
+  if (!response.ok) {
+    const detail = parsed.errors?.map((err) => err.message).join('; ') || raw || response.statusText;
+    throw new RailwayApiError(`Railway API request failed (${response.status}): ${detail}`);
+  }
+
+  if (parsed.errors?.length) {
+    const messages = parsed.errors.map((err) => err.message).join('; ');
+    throw new RailwayApiError(messages);
+  }
+
+  if (!parsed.data) {
+    throw new RailwayApiError('Railway API returned no data payload');
+  }
+
+  return parsed.data;
+}
+
+export async function listProjects(): Promise<RailwayProjectSummary[]> {
+  const query = `
+    query ViewerProjects {
+      viewer {
+        projects {
+          edges {
+            node {
+              id
+              name
+              environments {
+                id
+                name
+                services {
+                  id
+                  name
+                  latestDeployment {
+                    id
+                    status
+                    createdAt
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const data = await executeGraphQL<{
+    viewer: {
+      projects: {
+        edges: Array<{
+          node: RailwayProjectSummary;
+        }>;
+      };
+    };
+  }>(query);
+
+  return data.viewer.projects.edges.map((edge) => edge.node);
+}
+
+export async function deployService(options: DeployServiceOptions): Promise<{ deploymentId: string; status: string; }> {
+  const mutation = `
+    mutation DeployService($input: DeployServiceInput!) {
+      deployService(input: $input) {
+        id
+        status
+      }
+    }
+  `;
+
+  const variables = {
+    input: {
+      serviceId: options.serviceId,
+      branch: options.branch,
+      commitId: options.commitId
+    }
+  };
+
+  const data = await executeGraphQL<{
+    deployService: {
+      id: string;
+      status: string;
+    };
+  }>(mutation, variables);
+
+  return {
+    deploymentId: data.deployService.id,
+    status: data.deployService.status
+  };
+}
+
+export async function redeployEnvironment(options: RedeployEnvironmentOptions): Promise<{ deploymentId: string; status: string; }> {
+  const mutation = `
+    mutation RedeployEnvironment($input: RedeployEnvironmentInput!) {
+      redeployEnvironment(input: $input) {
+        id
+        status
+      }
+    }
+  `;
+
+  const variables = {
+    input: {
+      environmentId: options.environmentId
+    }
+  };
+
+  const data = await executeGraphQL<{
+    redeployEnvironment: {
+      id: string;
+      status: string;
+    };
+  }>(mutation, variables);
+
+  return {
+    deploymentId: data.redeployEnvironment.id,
+    status: data.redeployEnvironment.status
+  };
+}
+
+export async function promoteDeployment(options: PromoteDeploymentOptions): Promise<{ deploymentId: string; status: string; environmentId?: string; }> {
+  const mutation = `
+    mutation PromoteDeployment($input: PromoteDeploymentInput!) {
+      promoteDeployment(input: $input) {
+        id
+        status
+        environmentId
+      }
+    }
+  `;
+
+  const variables = {
+    input: {
+      deploymentId: options.deploymentId
+    }
+  };
+
+  const data = await executeGraphQL<{
+    promoteDeployment: {
+      id: string;
+      status: string;
+      environmentId?: string;
+    };
+  }>(mutation, variables);
+
+  return {
+    deploymentId: data.promoteDeployment.id,
+    status: data.promoteDeployment.status,
+    environmentId: data.promoteDeployment.environmentId
+  };
+}
+
+export async function probeRailwayApi(): Promise<RailwayApiProbeResult> {
+  if (!isRailwayApiConfigured()) {
+    return { ok: false };
+  }
+
+  try {
+    const projects = await listProjects();
+    const projectCount = projects.length;
+    const environmentCount = projects.reduce((acc, project) => acc + project.environments.length, 0);
+    const serviceCount = projects.reduce((acc, project) => (
+      acc + project.environments.reduce((serviceTotal, environment) => serviceTotal + environment.services.length, 0)
+    ), 0);
+
+    logger.info('Railway API probe succeeded', {
+      projects: projectCount,
+      environments: environmentCount,
+      services: serviceCount
+    });
+
+    return {
+      ok: true,
+      projectCount,
+      environmentCount,
+      serviceCount
+    };
+  } catch (error) {
+    logger.warn('Railway API probe failed', {
+      error: (error as Error).message
+    });
+
+    return {
+      ok: false
+    };
+  }
+}
+
+export default {
+  isRailwayApiConfigured,
+  listProjects,
+  deployService,
+  redeployEnvironment,
+  promoteDeployment,
+  probeRailwayApi
+};

--- a/src/utils/envValidation.ts
+++ b/src/utils/envValidation.ts
@@ -17,6 +17,7 @@ export interface EnvValidationResult {
     logLevel?: string;
     crepidPurge?: string;
     nodeEnv?: string;
+    railwayApiToken?: string;
   };
 }
 
@@ -41,7 +42,12 @@ export function validateEnvironment(): EnvValidationResult {
   if (!openaiApiKey || openaiApiKey === 'your-openai-api-key-here') {
     warnings.push('OPENAI_API_KEY not configured - AI endpoints will return mock responses');
   }
-  
+
+  const railwayApiToken = process.env.RAILWAY_API_TOKEN;
+  if (!railwayApiToken) {
+    warnings.push('RAILWAY_API_TOKEN not configured - Railway management API features are disabled');
+  }
+
   // Important but non-critical variables
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) {
@@ -86,7 +92,8 @@ export function validateEnvironment(): EnvValidationResult {
       port,
       logLevel,
       crepidPurge,
-      nodeEnv
+      nodeEnv,
+      railwayApiToken: railwayApiToken ? '***configured***' : undefined
     }
   };
 }
@@ -119,6 +126,7 @@ export function logEnvironmentValidation(result: EnvValidationResult): void {
   console.log(`   LOG_LEVEL: ${result.config.logLevel}`);
   console.log(`   OPENAI_API_KEY: ${result.config.openaiApiKey || 'not configured'}`);
   console.log(`   OPENAI_MODEL: ${result.config.openaiModel}`);
+  console.log(`   RAILWAY_API_TOKEN: ${result.config.railwayApiToken || 'not configured'}`);
   console.log(`   DATABASE_URL: ${result.config.databaseUrl ? 'configured' : 'not configured'}`);
   console.log(`   CREPID_PURGE: ${result.config.crepidPurge}`);
   console.log('================================\n');

--- a/src/utils/environmentValidation.ts
+++ b/src/utils/environmentValidation.ts
@@ -89,6 +89,17 @@ const environmentChecks: EnvironmentCheck[] = [
     }
   },
   {
+    name: 'RAILWAY_API_TOKEN',
+    required: false,
+    description: 'Railway management API token for GraphQL access',
+    validator: (value) => value.length >= 32,
+    suggestions: [
+      'Generate a Railway API token from https://railway.app/account/tokens',
+      'Store the token as RAILWAY_API_TOKEN to enable deployment automation',
+      'Keep this token secret – it grants management access to your Railway project'
+    ]
+  },
+  {
     name: 'DATABASE_URL',
     required: false, // Optional for in-memory fallback
     description: 'PostgreSQL connection string',
@@ -270,6 +281,12 @@ export function validateRailwayEnvironment(): ValidationResult {
     }
   }
 
+  if (!process.env.RAILWAY_API_TOKEN) {
+    result.warnings.push('⚠️  Railway API token (RAILWAY_API_TOKEN) not set - management API features disabled');
+  } else {
+    logger.info('✅ Railway management API token detected');
+  }
+
   // Check for Railway PostgreSQL
   if (process.env.DATABASE_URL && process.env.DATABASE_URL.includes('railway.app')) {
     logger.info('✅ Railway PostgreSQL detected');
@@ -326,11 +343,12 @@ export function createStartupReport(securitySummary?: EnvironmentSecuritySummary
     `└─ Configured Variables: ${envInfo.configuredVariables.length}`,
     '',
     '🚄 Railway Status:',
-    process.env.RAILWAY_ENVIRONMENT ? 
-      `├─ Project: ${process.env.RAILWAY_PROJECT_ID}` : 
+    process.env.RAILWAY_ENVIRONMENT ?
+      `├─ Project: ${process.env.RAILWAY_PROJECT_ID}` :
       '├─ Platform: Local/Other',
-    process.env.DATABASE_URL?.includes('railway.app') ? 
-      '└─ Database: Railway PostgreSQL ✅' : 
+    `├─ Management API: ${process.env.RAILWAY_API_TOKEN ? 'configured' : 'disabled'}`,
+    process.env.DATABASE_URL?.includes('railway.app') ?
+      '└─ Database: Railway PostgreSQL ✅' :
       '└─ Database: External/Local',
     '',
     ...securityLines,

--- a/tests/railway-client.test.ts
+++ b/tests/railway-client.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, jest } from '@jest/globals';
+import { deployService, isRailwayApiConfigured } from '../src/services/railwayClient.js';
+
+const ORIGINAL_TOKEN = process.env.RAILWAY_API_TOKEN;
+let originalFetch: typeof fetch | undefined;
+
+describe('railwayClient', () => {
+  beforeAll(() => {
+    originalFetch = global.fetch;
+  });
+
+  beforeEach(() => {
+    delete process.env.RAILWAY_API_TOKEN;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (ORIGINAL_TOKEN) {
+      process.env.RAILWAY_API_TOKEN = ORIGINAL_TOKEN;
+    } else {
+      delete process.env.RAILWAY_API_TOKEN;
+    }
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      // @ts-expect-error - allow cleanup when fetch was not originally defined
+      delete global.fetch;
+    }
+  });
+
+  it('detects when the management token is not configured', () => {
+    expect(isRailwayApiConfigured()).toBe(false);
+  });
+
+  it('throws a helpful error when attempting to deploy without a token', async () => {
+    await expect(deployService({ serviceId: 'service-123' })).rejects.toThrow(/token/i);
+  });
+
+  it('sends authorized GraphQL request when token is present', async () => {
+    process.env.RAILWAY_API_TOKEN = 'test-token-1234567890-railway-access';
+
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({
+        data: {
+          deployService: {
+            id: 'deployment-abc',
+            status: 'DEPLOYING'
+          }
+        }
+      })
+    } as any;
+
+    const fetchSpy = jest.fn().mockResolvedValue(mockResponse);
+    global.fetch = fetchSpy;
+
+    const result = await deployService({ serviceId: 'service-123', branch: 'main' });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, requestInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(requestInit.headers).toMatchObject({ Authorization: 'Bearer test-token-1234567890-railway-access' });
+
+    expect(result).toEqual({ deploymentId: 'deployment-abc', status: 'DEPLOYING' });
+  });
+});

--- a/validate-railway-compatibility.js
+++ b/validate-railway-compatibility.js
@@ -14,7 +14,7 @@ function check(desc, condition) {
 }
 
 // Environment variables sourced from configuration files
-const requiredEnv = ['OPENAI_API_KEY', 'PORT', 'RAILWAY_ENVIRONMENT'];
+const requiredEnv = ['OPENAI_API_KEY', 'PORT', 'RAILWAY_ENVIRONMENT', 'RAILWAY_API_TOKEN'];
 const documentedEnv = new Set();
 
 const envExamplePath = path.join(process.cwd(), '.env.example');


### PR DESCRIPTION
## Summary
- add a Railway GraphQL management client with deployment helpers and a startup connectivity probe
- surface the RAILWAY_API_TOKEN across environment validation, compatibility checks, and documentation
- add targeted unit tests covering the new client utilities

## Testing
- npm run test -- --testPathPattern=railway-client
- npm run validate:railway

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914156ce6f883258150a7b3f2d807f5)