### PR TITLE
Improve Railway GraphQL resiliency

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -47,6 +47,7 @@ RAILWAY_ENVIRONMENT=production  # Auto-set by Railway
 #### Railway Management (optional but recommended):
 ```bash
 RAILWAY_API_TOKEN=your-railway-api-token   # Enables deploy/rollback automation via GraphQL API
+RAILWAY_GRAPHQL_TIMEOUT_MS=20000           # Optional - override default 15s GraphQL timeout
 ```
 
 #### Fine-Tuned Model (Railway Compatible):

--- a/RAILWAY_COMPATIBILITY_GUIDE.md
+++ b/RAILWAY_COMPATIBILITY_GUIDE.md
@@ -100,6 +100,7 @@ PORT=8080
 ### Management API (optional)
 ```bash
 RAILWAY_API_TOKEN=your-railway-api-token
+RAILWAY_GRAPHQL_TIMEOUT_MS=20000
 ```
 
 ### Railway Deployment

--- a/src/utils/envValidation.ts
+++ b/src/utils/envValidation.ts
@@ -18,6 +18,7 @@ export interface EnvValidationResult {
     crepidPurge?: string;
     nodeEnv?: string;
     railwayApiToken?: string;
+    railwayGraphqlTimeoutMs?: number;
   };
 }
 
@@ -46,6 +47,17 @@ export function validateEnvironment(): EnvValidationResult {
   const railwayApiToken = process.env.RAILWAY_API_TOKEN;
   if (!railwayApiToken) {
     warnings.push('RAILWAY_API_TOKEN not configured - Railway management API features are disabled');
+  }
+
+  const rawRailwayTimeout = process.env.RAILWAY_GRAPHQL_TIMEOUT_MS?.trim();
+  let railwayGraphqlTimeoutMs: number | undefined;
+  if (rawRailwayTimeout) {
+    const parsedTimeout = Number.parseInt(rawRailwayTimeout, 10);
+    if (!Number.isFinite(parsedTimeout) || parsedTimeout <= 0) {
+      warnings.push(`Invalid RAILWAY_GRAPHQL_TIMEOUT_MS value: ${rawRailwayTimeout}. Using default 15000ms`);
+    } else {
+      railwayGraphqlTimeoutMs = parsedTimeout;
+    }
   }
 
   // Important but non-critical variables
@@ -93,7 +105,8 @@ export function validateEnvironment(): EnvValidationResult {
       logLevel,
       crepidPurge,
       nodeEnv,
-      railwayApiToken: railwayApiToken ? '***configured***' : undefined
+      railwayApiToken: railwayApiToken ? '***configured***' : undefined,
+      railwayGraphqlTimeoutMs
     }
   };
 }
@@ -127,6 +140,7 @@ export function logEnvironmentValidation(result: EnvValidationResult): void {
   console.log(`   OPENAI_API_KEY: ${result.config.openaiApiKey || 'not configured'}`);
   console.log(`   OPENAI_MODEL: ${result.config.openaiModel}`);
   console.log(`   RAILWAY_API_TOKEN: ${result.config.railwayApiToken || 'not configured'}`);
+  console.log(`   RAILWAY_GRAPHQL_TIMEOUT_MS: ${result.config.railwayGraphqlTimeoutMs ?? 'default (15000)'}`);
   console.log(`   DATABASE_URL: ${result.config.databaseUrl ? 'configured' : 'not configured'}`);
   console.log(`   CREPID_PURGE: ${result.config.crepidPurge}`);
   console.log('================================\n');


### PR DESCRIPTION
## Summary
- add configurable GraphQL timeout handling to the Railway client with richer error diagnostics
- surface the new timeout option in environment validation plus deployment docs
- extend the Railway client unit tests to cover timeout and transport failure handling

## Testing
- `npm test -- --testPathPattern=railway-client.test.ts`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691422f942748325837d4487ae7061c2)