### PR TITLE
Add read-only codebase access API layer

### DIFF
--- a/src/routes/api-codebase.ts
+++ b/src/routes/api-codebase.ts
@@ -1,0 +1,66 @@
+import express, { Request, Response } from 'express';
+import { asyncHandler } from '../utils/asyncHandler.js';
+import { createRateLimitMiddleware } from '../utils/security.js';
+import { listDirectory, readRepositoryFile } from '../services/codebaseAccess.js';
+
+const router = express.Router();
+
+router.use(createRateLimitMiddleware(60, 5 * 60 * 1000));
+
+router.get('/tree', asyncHandler(async (req: Request, res: Response) => {
+  const relativePath = typeof req.query.path === 'string' ? req.query.path : '';
+
+  try {
+    const result = await listDirectory(relativePath);
+    res.json({
+      status: 'success',
+      message: 'Directory contents retrieved',
+      data: result,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    res.status(400).json({
+      status: 'error',
+      message: error instanceof Error ? error.message : 'Unable to list directory',
+      timestamp: new Date().toISOString(),
+    });
+  }
+}));
+
+router.get('/file', asyncHandler(async (req: Request, res: Response) => {
+  const relativePath = typeof req.query.path === 'string' ? req.query.path : undefined;
+  if (!relativePath) {
+    return res.status(400).json({
+      status: 'error',
+      message: 'Query parameter "path" is required',
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  const startLineRaw = typeof req.query.startLine === 'string' ? Number(req.query.startLine) : undefined;
+  const endLineRaw = typeof req.query.endLine === 'string' ? Number(req.query.endLine) : undefined;
+
+  const startLine = Number.isFinite(startLineRaw) ? startLineRaw : undefined;
+  const endLine = Number.isFinite(endLineRaw) ? endLineRaw : undefined;
+
+  const maxBytesRaw = typeof req.query.maxBytes === 'string' ? Number(req.query.maxBytes) : undefined;
+  const maxBytes = Number.isFinite(maxBytesRaw) ? maxBytesRaw : undefined;
+
+  try {
+    const result = await readRepositoryFile(relativePath, { startLine, endLine, maxBytes });
+    res.json({
+      status: 'success',
+      message: 'File content retrieved',
+      data: result,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    res.status(400).json({
+      status: 'error',
+      message: error instanceof Error ? error.message : 'Unable to read file',
+      timestamp: new Date().toISOString(),
+    });
+  }
+}));
+
+export default router;

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -15,6 +15,7 @@ import backstageRouter from './backstage.js';
 import apiArcanosRouter from './api-arcanos.js';
 import apiSimRouter from './api-sim.js';
 import apiMemoryRouter from './api-memory.js';
+import apiCodebaseRouter from './api-codebase.js';
 import apiCommandsRouter from './api-commands.js';
 import sdkRouter from './sdk.js';
 import imageRouter from './image.js';
@@ -79,6 +80,7 @@ export function registerRoutes(app: Express): void {
   app.use('/api/arcanos', apiArcanosRouter);
   app.use('/api/sim', apiSimRouter);
   app.use('/api/memory', apiMemoryRouter);
+  app.use('/api/codebase', apiCodebaseRouter);
   app.use('/api/commands', apiCommandsRouter);
   app.use('/api/pr-analysis', prAnalysisRouter);
   app.use('/api/openai', openaiRouter);

--- a/src/services/codebaseAccess.ts
+++ b/src/services/codebaseAccess.ts
@@ -1,0 +1,208 @@
+import fs from 'fs';
+import { promises as fsp } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const { readdir, readFile, stat } = fsp;
+
+export interface DirectoryEntry {
+  name: string;
+  path: string;
+  type: 'file' | 'directory';
+  size: number;
+  modifiedAt: string;
+}
+
+export interface ReadFileOptions {
+  startLine?: number;
+  endLine?: number;
+  maxBytes?: number;
+}
+
+export interface FileReadResult {
+  path: string;
+  size: number;
+  modifiedAt: string;
+  content?: string;
+  binary: boolean;
+  truncated: boolean;
+  totalLines?: number;
+  startLine?: number;
+  endLine?: number;
+}
+
+const DEFAULT_MAX_BYTES = 250 * 1024;
+let cachedRoot: string | null = null;
+
+function candidateRepositoryRoots(): string[] {
+  const candidates: string[] = [];
+  const envRoot = process.env.CODEBASE_ROOT;
+  if (envRoot) {
+    candidates.push(path.isAbsolute(envRoot) ? envRoot : path.resolve(process.cwd(), envRoot));
+  }
+
+  candidates.push(process.cwd());
+
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  candidates.push(path.resolve(moduleDir, '../../'));
+  candidates.push(path.resolve(moduleDir, '../../../'));
+
+  return [...new Set(candidates)];
+}
+
+function hasRepositoryMarker(directory: string): boolean {
+  try {
+    return fs.existsSync(path.join(directory, 'package.json'));
+  } catch {
+    return false;
+  }
+}
+
+export function resolveRepositoryRoot(): string {
+  if (cachedRoot) {
+    return cachedRoot;
+  }
+
+  for (const candidate of candidateRepositoryRoots()) {
+    const resolved = path.resolve(candidate);
+    if (hasRepositoryMarker(resolved)) {
+      cachedRoot = resolved;
+      return cachedRoot;
+    }
+  }
+
+  cachedRoot = path.resolve(process.cwd());
+  return cachedRoot;
+}
+
+function ensureWithinRepository(resolvedPath: string, root: string): void {
+  const normalizedRoot = root.endsWith(path.sep) ? root : root + path.sep;
+  if (resolvedPath === root) {
+    return;
+  }
+  if (!resolvedPath.startsWith(normalizedRoot)) {
+    throw new Error('Path is outside of repository root');
+  }
+}
+
+function normalizeRelativePath(relativePath = ''): string {
+  if (!relativePath) {
+    return '';
+  }
+  const cleaned = relativePath.replace(/\\/g, '/');
+  const stripped = cleaned.startsWith('/') ? cleaned.slice(1) : cleaned;
+  return stripped;
+}
+
+export function resolveSafePath(relativePath = ''): { absolutePath: string; relativePath: string; root: string } {
+  const root = resolveRepositoryRoot();
+  const normalizedRelative = normalizeRelativePath(relativePath);
+  const absolutePath = path.resolve(root, normalizedRelative);
+  ensureWithinRepository(absolutePath, root);
+  return { absolutePath, relativePath: normalizedRelative, root };
+}
+
+export async function listDirectory(relativePath = ''): Promise<{ entries: DirectoryEntry[]; path: string }> {
+  const { absolutePath, relativePath: normalizedRelative, root } = resolveSafePath(relativePath);
+  const stats = await stat(absolutePath);
+  if (!stats.isDirectory()) {
+    throw new Error('Requested path is not a directory');
+  }
+
+  const dirEntries = await readdir(absolutePath, { withFileTypes: true });
+  const entries: DirectoryEntry[] = [];
+
+  for (const entry of dirEntries) {
+    const entryPath = path.join(absolutePath, entry.name);
+    const entryStats = await stat(entryPath);
+    const relative = path.relative(root, entryPath) || entry.name;
+    entries.push({
+      name: entry.name,
+      path: relative.replace(/\\/g, '/'),
+      type: entry.isDirectory() ? 'directory' : 'file',
+      size: entryStats.size,
+      modifiedAt: entryStats.mtime.toISOString(),
+    });
+  }
+
+  entries.sort((a, b) => {
+    if (a.type === b.type) {
+      return a.name.localeCompare(b.name);
+    }
+    return a.type === 'directory' ? -1 : 1;
+  });
+
+  return { entries, path: normalizedRelative };
+}
+
+function detectBinary(buffer: Buffer): boolean {
+  if (!buffer.length) {
+    return false;
+  }
+  const sample = buffer.slice(0, Math.min(buffer.length, 1024));
+  for (const byte of sample) {
+    if (byte === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function readRepositoryFile(relativePath: string, options: ReadFileOptions = {}): Promise<FileReadResult> {
+  const { absolutePath, relativePath: normalizedRelative } = resolveSafePath(relativePath);
+  const fileStats = await stat(absolutePath);
+  if (!fileStats.isFile()) {
+    throw new Error('Requested path is not a file');
+  }
+
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+  const raw = await readFile(absolutePath);
+  const binary = detectBinary(raw);
+
+  if (binary) {
+    return {
+      path: normalizedRelative,
+      size: fileStats.size,
+      modifiedAt: fileStats.mtime.toISOString(),
+      binary: true,
+      truncated: fileStats.size > maxBytes,
+    };
+  }
+
+  let content = raw.toString('utf8');
+  let truncated = false;
+  if (Buffer.byteLength(content, 'utf8') > maxBytes) {
+    const limitedBuffer = raw.slice(0, maxBytes);
+    content = limitedBuffer.toString('utf8');
+    truncated = true;
+  }
+
+  const lines = content.split(/\r?\n/);
+  const totalLines = lines.length;
+
+  let startLine = options.startLine && options.startLine > 0 ? options.startLine : 1;
+  let endLine = options.endLine && options.endLine >= startLine ? options.endLine : totalLines;
+
+  startLine = Math.max(1, Math.min(startLine, totalLines));
+  endLine = Math.max(startLine, Math.min(endLine, totalLines));
+
+  if (startLine !== 1 || endLine !== totalLines) {
+    content = lines.slice(startLine - 1, endLine).join('\n');
+  }
+
+  return {
+    path: normalizedRelative,
+    size: fileStats.size,
+    modifiedAt: fileStats.mtime.toISOString(),
+    content,
+    binary: false,
+    truncated,
+    totalLines,
+    startLine,
+    endLine,
+  };
+}
+
+export function resetRepositoryRootCache(): void {
+  cachedRoot = null;
+}

--- a/tests/codebase-api.test.ts
+++ b/tests/codebase-api.test.ts
@@ -1,0 +1,63 @@
+import { describe, beforeAll, afterAll, it, expect } from '@jest/globals';
+import type { Server } from 'http';
+import type { AddressInfo } from 'net';
+import { createApp } from '../src/app.js';
+
+describe('Codebase access API', () => {
+  let server: Server;
+  let baseUrl: string;
+  const originalOpenAIKey = process.env.OPENAI_API_KEY;
+
+  beforeAll(async () => {
+    process.env.OPENAI_API_KEY = '';
+    const app = createApp();
+    server = await new Promise<Server>((resolve, reject) => {
+      const listener = app.listen(0, '127.0.0.1', () => resolve(listener));
+      listener.on('error', reject);
+    });
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    process.env.OPENAI_API_KEY = originalOpenAIKey;
+    if (!server) {
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      server.close(err => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it('lists repository root contents', async () => {
+    const response = await fetch(`${baseUrl}/api/codebase/tree`);
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.status).toBe('success');
+    expect(Array.isArray(payload.data.entries)).toBe(true);
+    const names = payload.data.entries.map((entry: { name: string }) => entry.name);
+    expect(names).toContain('src');
+    expect(names).toContain('package.json');
+  });
+
+  it('reads a repository file', async () => {
+    const response = await fetch(`${baseUrl}/api/codebase/file?path=README.md&startLine=1&endLine=5`);
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.status).toBe('success');
+    expect(payload.data.path).toBe('README.md');
+    expect(payload.data.binary).toBe(false);
+    expect(typeof payload.data.content).toBe('string');
+    expect(payload.data.content).toContain('# Arcanos Backend');
+    expect(payload.data.startLine).toBe(1);
+    expect(payload.data.endLine).toBeGreaterThanOrEqual(1);
+  });
+
+  it('prevents path traversal outside repository', async () => {
+    const response = await fetch(`${baseUrl}/api/codebase/file?path=../package.json`);
+    expect(response.status).toBe(400);
+    const payload = await response.json();
+    expect(payload.status).toBe('error');
+    expect(payload.message).toContain('outside');
+  });
+});


### PR DESCRIPTION
## Summary
- add a codebase access service to resolve repository paths safely and stream directory or file data without writes
- expose `/api/codebase/tree` and `/api/codebase/file` routes so ChatGPT can inspect the live codebase read-only with rate limiting
- cover the new endpoints with Jest tests including path traversal protection

## Testing
- npm test -- codebase-api.test.ts
- npm run type-check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914642262988325a8c57993a9209cde)