### PR TITLE
Add AFOL analytics and telemetry resiliency improvements

### DIFF
--- a/src/afol/analytics.ts
+++ b/src/afol/analytics.ts
@@ -1,0 +1,130 @@
+import fs from 'fs';
+import path from 'path';
+import { DecisionRecord } from './types.js';
+import { recordTraceEvent } from '../utils/telemetry.js';
+
+interface AnalyticsState {
+  totals: {
+    decisions: number;
+    successful: number;
+    rejected: number;
+  };
+  perRoute: Record<string, number>;
+  latency: {
+    averageMs: number;
+    lastMs: number;
+  };
+  recent: DecisionRecord[];
+  lastUpdated: string | null;
+}
+
+const RECENT_LIMIT = parseInt(process.env.AFOL_ANALYTICS_RECENT_LIMIT || '50', 10);
+
+const defaultAnalyticsPath = process.env.AFOL_ANALYTICS_PATH
+  ? path.resolve(process.env.AFOL_ANALYTICS_PATH)
+  : path.resolve(process.cwd(), 'logs', 'afol-analytics.json');
+
+let analyticsFilePath = defaultAnalyticsPath;
+
+const state: AnalyticsState = {
+  totals: {
+    decisions: 0,
+    successful: 0,
+    rejected: 0
+  },
+  perRoute: {
+    primary: 0,
+    backup: 0,
+    reject: 0
+  },
+  latency: {
+    averageMs: 0,
+    lastMs: 0
+  },
+  recent: [],
+  lastUpdated: null
+};
+
+function ensureDestination(): void {
+  const directory = path.dirname(analyticsFilePath);
+  if (!fs.existsSync(directory)) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+}
+
+function updateLatency(latencyMs: number): void {
+  state.latency.lastMs = latencyMs;
+  const previousAverage = state.latency.averageMs;
+  const count = state.totals.decisions;
+  state.latency.averageMs = count === 1 ? latencyMs : Math.round(((previousAverage * (count - 1)) + latencyMs) / count);
+}
+
+export function configureAnalytics(options: { filePath?: string } = {}): void {
+  if (options.filePath) {
+    analyticsFilePath = path.resolve(options.filePath);
+  } else {
+    analyticsFilePath = defaultAnalyticsPath;
+  }
+}
+
+export async function persistDecision(decision: DecisionRecord): Promise<void> {
+  state.totals.decisions += 1;
+  if (decision.ok) {
+    state.totals.successful += 1;
+  } else {
+    state.totals.rejected += 1;
+  }
+
+  state.perRoute[decision.route.name] = (state.perRoute[decision.route.name] || 0) + 1;
+  updateLatency(decision.meta.latencyMs);
+
+  state.recent.push(decision);
+  if (state.recent.length > Math.max(5, RECENT_LIMIT)) {
+    state.recent.splice(0, state.recent.length - RECENT_LIMIT);
+  }
+
+  state.lastUpdated = new Date().toISOString();
+
+  ensureDestination();
+
+  const payload = {
+    ...state,
+    recent: state.recent
+  };
+
+  try {
+    await fs.promises.writeFile(analyticsFilePath, JSON.stringify(payload, null, 2), { encoding: 'utf8' });
+  } catch (error) {
+    console.warn('[afol-analytics] Failed to persist analytics snapshot', error);
+  }
+
+  recordTraceEvent('afol.analytics.persisted', {
+    decisionId: decision.id,
+    route: decision.route.name,
+    ok: decision.ok
+  });
+}
+
+export function getAnalyticsSnapshot() {
+  return {
+    ...state,
+    recent: [...state.recent]
+  };
+}
+
+export function resetAnalytics(): void {
+  state.totals = { decisions: 0, successful: 0, rejected: 0 };
+  state.perRoute = { primary: 0, backup: 0, reject: 0 };
+  state.latency = { averageMs: 0, lastMs: 0 };
+  state.recent = [];
+  state.lastUpdated = null;
+
+  if (fs.existsSync(analyticsFilePath)) {
+    try {
+      fs.unlinkSync(analyticsFilePath);
+    } catch (error) {
+      console.warn('[afol-analytics] Failed to reset analytics file', error);
+    }
+  }
+}
+

--- a/src/afol/engine.ts
+++ b/src/afol/engine.ts
@@ -1,6 +1,10 @@
+import { generateRequestId } from '../utils/idGenerator.js';
+import { recordTraceEvent } from '../utils/telemetry.js';
 import { evaluate } from './policies.js';
 import { getStatus } from './health.js';
 import { logDecision } from './logger.js';
+import { executeRoute as executeSelectedRoute } from './routes.js';
+import { persistDecision } from './analytics.js';
 import { DecideInput, DecisionRecord, PolicyEvaluation, RouteExecutionResult, RouteSelection } from './types.js';
 
 export async function decide(input: DecideInput): Promise<DecisionRecord> {
@@ -9,10 +13,19 @@ export async function decide(input: DecideInput): Promise<DecisionRecord> {
   const intent = typeof input.intent === 'string' ? input.intent : 'default';
   const policy = evaluate(snapshot, intent);
   const route = selectRoute(policy);
-  const response = await executeRoute(route, input);
+  recordTraceEvent('afol.decision.route', {
+    intent,
+    route: route.name,
+    reason: route.reason
+  });
+  const response = await executeSelectedRoute(route, input);
+
+  const ok = route.name !== 'reject' && !response.error;
+  const decisionId = generateRequestId('afol');
 
   const decision: DecisionRecord = {
-    ok: route.name !== 'reject',
+    id: decisionId,
+    ok,
     policy,
     route,
     response,
@@ -22,7 +35,14 @@ export async function decide(input: DecideInput): Promise<DecisionRecord> {
     }
   };
 
+  await persistDecision(decision);
   logDecision(input, decision);
+  recordTraceEvent('afol.decision.completed', {
+    decisionId,
+    ok,
+    route: route.name,
+    latencyMs: decision.meta.latencyMs
+  });
   return decision;
 }
 
@@ -36,18 +56,6 @@ function selectRoute(policy: PolicyEvaluation): RouteSelection {
   return { name: 'reject', reason: 'No viable route' };
 }
 
-async function executeRoute(route: RouteSelection, input: DecideInput): Promise<RouteExecutionResult> {
-  if (route.name === 'reject') {
-    return { route: route.name, input: input.intent ?? 'default' };
-  }
-
-  // Placeholder for actual route execution logic
-  return {
-    route: route.name,
-    input: input.intent ?? 'default'
-  };
-}
-
 export function __selectRouteForTest(policy: PolicyEvaluation): RouteSelection {
   return selectRoute(policy);
 }
@@ -56,5 +64,5 @@ export async function __executeRouteForTest(
   route: RouteSelection,
   input: DecideInput
 ): Promise<RouteExecutionResult> {
-  return executeRoute(route, input);
+  return executeSelectedRoute(route, input);
 }

--- a/src/afol/routes.ts
+++ b/src/afol/routes.ts
@@ -1,0 +1,118 @@
+import { callOpenAI, getDefaultModel, getFallbackModel, generateMockResponse } from '../services/openai.js';
+import { recordTraceEvent } from '../utils/telemetry.js';
+import { DecideInput, RouteExecutionResult, RouteSelection } from './types.js';
+
+const PRIMARY_TOKEN_LIMIT = parseInt(process.env.AFOL_PRIMARY_TOKEN_LIMIT || '1024', 10);
+const BACKUP_TOKEN_LIMIT = parseInt(process.env.AFOL_BACKUP_TOKEN_LIMIT || '1024', 10);
+
+function extractPrompt(input: DecideInput): string {
+  if (typeof input.prompt === 'string') return input.prompt;
+  if (typeof input.query === 'string') return input.query;
+  if (typeof input.intent === 'string') return input.intent;
+  if (typeof input.input === 'string') return input.input;
+  if (typeof input.message === 'string') return input.message;
+  const messages = (input as Record<string, unknown>).messages as unknown;
+  if (Array.isArray(messages)) {
+    const last = messages[messages.length - 1];
+    if (last && typeof last === 'object' && typeof (last as any).content === 'string') {
+      return (last as any).content;
+    }
+  }
+
+  try {
+    return JSON.stringify(input);
+  } catch {
+    return '[unavailable prompt]';
+  }
+}
+
+async function executeModelRoute(
+  route: RouteSelection,
+  intent: string | undefined,
+  prompt: string,
+  model: string,
+  tokenLimit: number
+): Promise<RouteExecutionResult> {
+  recordTraceEvent('afol.route.execute', {
+    route: route.name,
+    reason: route.reason,
+    model,
+    intent
+  });
+
+  try {
+    const result = await callOpenAI(model, prompt, tokenLimit, true, {
+      metadata: {
+        route: route.name,
+        reason: route.reason,
+        intent
+      }
+    });
+
+    recordTraceEvent('afol.route.success', {
+      route: route.name,
+      model: result.model,
+      cached: result.cached
+    });
+
+    return {
+      route: route.name,
+      input: prompt,
+      output: result.output,
+      model: result.model,
+      cached: result.cached,
+      metadata: {
+        routeReason: route.reason,
+        intent
+      }
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown error';
+    recordTraceEvent('afol.route.error', {
+      route: route.name,
+      error: message
+    });
+
+    const mock = generateMockResponse(prompt, 'ask');
+    return {
+      route: route.name,
+      input: prompt,
+      output: mock.result,
+      model: mock.activeModel || 'mock',
+      cached: false,
+      error: message,
+      metadata: {
+        routeReason: route.reason,
+        intent,
+        degraded: true
+      }
+    };
+  }
+}
+
+export async function executeRoute(route: RouteSelection, input: DecideInput): Promise<RouteExecutionResult> {
+  const prompt = extractPrompt(input);
+  const intent = typeof input.intent === 'string' ? input.intent : undefined;
+
+  switch (route.name) {
+    case 'primary':
+      return executeModelRoute(route, intent, prompt, getDefaultModel(), PRIMARY_TOKEN_LIMIT);
+    case 'backup':
+      return executeModelRoute(route, intent, prompt, getFallbackModel(), BACKUP_TOKEN_LIMIT);
+    default:
+      recordTraceEvent('afol.route.reject', {
+        intent,
+        reason: route.reason
+      });
+      return {
+        route: 'reject',
+        input: prompt,
+        error: route.reason,
+        metadata: {
+          intent,
+          routeReason: route.reason
+        }
+      };
+  }
+}
+

--- a/src/afol/types.ts
+++ b/src/afol/types.ts
@@ -32,9 +32,15 @@ export interface DecideInput {
 export interface RouteExecutionResult {
   route: RouteName;
   input: string;
+  output?: string;
+  model?: string;
+  cached?: boolean;
+  error?: string;
+  metadata?: Record<string, unknown>;
 }
 
 export interface DecisionRecord {
+  id: string;
   ok: boolean;
   policy: PolicyEvaluation;
   route: RouteSelection;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -27,6 +27,10 @@ const reinforcementMode = (process.env.ARCANOS_CONTEXT_MODE || 'reinforcement') 
 const reinforcementWindow = parseNumber(process.env.ARCANOS_CONTEXT_WINDOW, 50, 1);
 const reinforcementDigestSize = parseNumber(process.env.ARCANOS_MEMORY_DIGEST_SIZE, 8, 1);
 const reinforcementMinimumClearScore = parseNumber(process.env.ARCANOS_CLEAR_MIN_SCORE, 0.85);
+const fallbackStrictEnvironments = (process.env.FALLBACK_STRICT_ENVIRONMENTS || 'production,staging')
+  .split(',')
+  .map(value => value.trim())
+  .filter(Boolean);
 
 export const config = {
   // Server configuration
@@ -59,10 +63,20 @@ export const config = {
     requestTimeout: Number(process.env.REQUEST_TIMEOUT) || 30000
   },
 
+  fallback: {
+    strictEnvironments: fallbackStrictEnvironments,
+    preemptive: process.env.ENABLE_PREEMPTIVE_FALLBACK === 'true'
+  },
+
   // Logging configuration
   logging: {
     level: process.env.LOG_LEVEL || 'info',
     sessionLogPath: process.env.ARC_LOG_PATH || './memory/session.log'
+  },
+
+  telemetry: {
+    recentLogLimit: parseNumber(process.env.TELEMETRY_RECENT_LOGS_LIMIT, 100, 10),
+    traceEventLimit: parseNumber(process.env.TELEMETRY_TRACE_EVENT_LIMIT, 200, 25)
   },
 
   // External integrations

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -26,7 +26,9 @@ export function setupDiagnostics(app: Express): void {
           memory: report.components.memory,
           workers: report.components.workers,
           security: report.security,
-          metrics: report.metrics
+          metrics: report.metrics,
+          telemetry: report.telemetry.metrics,
+          resilience: report.resilience.circuitBreaker
         }
       );
     });
@@ -52,7 +54,8 @@ export function setupDiagnostics(app: Express): void {
       components: healthReport.components,
       ai: {
         defaultModel: defaultModel,
-        fallbackModel: config.ai.fallbackModel
+        fallbackModel: config.ai.fallbackModel,
+        resilience: healthReport.resilience.circuitBreaker
       },
       system: {
         memory: healthReport.components.memory,
@@ -62,7 +65,8 @@ export function setupDiagnostics(app: Express): void {
         environment: config.server.environment,
         security: healthReport.security,
         workers: healthReport.components.workers
-      }
+      },
+      observability: healthReport.telemetry
     });
   });
 }

--- a/src/routes/afol.ts
+++ b/src/routes/afol.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { decide } from '../afol/engine.js';
 import { getStatus } from '../afol/health.js';
 import { getRecent, logError } from '../afol/logger.js';
+import { getAnalyticsSnapshot } from '../afol/analytics.js';
 
 const router = Router();
 
@@ -21,6 +22,10 @@ router.get('/health', (_req, res) => {
 
 router.get('/logs', (_req, res) => {
   res.json(getRecent());
+});
+
+router.get('/analytics', (_req, res) => {
+  res.json(getAnalyticsSnapshot());
 });
 
 export default router;

--- a/src/services/openai/credentialProvider.ts
+++ b/src/services/openai/credentialProvider.ts
@@ -1,0 +1,103 @@
+const OPENAI_KEY_ENV_PRIORITY = [
+  'OPENAI_API_KEY',
+  'RAILWAY_OPENAI_API_KEY',
+  'API_KEY',
+  'OPENAI_KEY'
+] as const;
+
+const OPENAI_KEY_PLACEHOLDERS = new Set([
+  '',
+  'your-openai-api-key-here',
+  'your-openai-key-here'
+]);
+
+let resolvedApiKey: string | null | undefined;
+let resolvedApiKeySource: string | null = null;
+let cachedDefaultModel: string | null = null;
+
+const baseUrlCandidates = [
+  process.env.OPENAI_BASE_URL,
+  process.env.OPENAI_API_BASE_URL,
+  process.env.OPENAI_API_BASE
+].filter((value): value is string => Boolean(value && value.trim().length > 0));
+
+function computeDefaultModelFromEnv(): string {
+  return (
+    process.env.OPENAI_MODEL ||
+    process.env.RAILWAY_OPENAI_MODEL ||
+    process.env.FINETUNED_MODEL_ID ||
+    process.env.FINE_TUNED_MODEL_ID ||
+    process.env.AI_MODEL ||
+    'gpt-4o'
+  );
+}
+
+export function resolveOpenAIBaseURL(): string | undefined {
+  return baseUrlCandidates[0]?.trim();
+}
+
+export function resolveOpenAIKey(): string | null {
+  if (resolvedApiKey !== undefined) {
+    return resolvedApiKey;
+  }
+
+  for (const envName of OPENAI_KEY_ENV_PRIORITY) {
+    const rawValue = process.env[envName];
+    if (!rawValue) continue;
+
+    const trimmed = rawValue.trim();
+    if (OPENAI_KEY_PLACEHOLDERS.has(trimmed)) {
+      continue;
+    }
+
+    resolvedApiKey = trimmed;
+    resolvedApiKeySource = envName;
+    return resolvedApiKey;
+  }
+
+  resolvedApiKey = null;
+  resolvedApiKeySource = null;
+  return null;
+}
+
+export function getOpenAIKeySource(): string | null {
+  return resolvedApiKeySource;
+}
+
+export function resetCredentialCache(): void {
+  resolvedApiKey = undefined;
+  resolvedApiKeySource = null;
+  cachedDefaultModel = null;
+}
+
+export function hasValidAPIKey(): boolean {
+  return resolveOpenAIKey() !== null;
+}
+
+export function setDefaultModel(model: string): void {
+  cachedDefaultModel = model;
+}
+
+export function getDefaultModel(): string {
+  if (!cachedDefaultModel) {
+    cachedDefaultModel = computeDefaultModelFromEnv();
+  }
+  return cachedDefaultModel;
+}
+
+export function getFallbackModel(): string {
+  return (
+    process.env.FALLBACK_MODEL ||
+    process.env.AI_FALLBACK_MODEL ||
+    process.env.RAILWAY_OPENAI_FALLBACK_MODEL ||
+    process.env.FINETUNED_MODEL_ID ||
+    process.env.FINE_TUNED_MODEL_ID ||
+    process.env.AI_MODEL ||
+    'gpt-4'
+  );
+}
+
+export function getGPT5Model(): string {
+  return process.env.GPT5_MODEL || 'gpt-5';
+}
+

--- a/src/services/openai/mock.ts
+++ b/src/services/openai/mock.ts
@@ -1,0 +1,101 @@
+import { generateRequestId } from '../../utils/idGenerator.js';
+import { MOCK_RESPONSE_CONSTANTS, MOCK_RESPONSE_MESSAGES, truncateInput } from '../../config/mockResponseConfig.js';
+
+export const generateMockResponse = (input: string, endpoint: string = 'ask'): any => {
+  const mockId = generateRequestId('mock');
+  const timestamp = Math.floor(Date.now() / 1000);
+  const inputPreview = truncateInput(input);
+
+  const baseMockResponse = {
+    meta: {
+      id: mockId,
+      created: timestamp,
+      tokens: {
+        prompt_tokens: MOCK_RESPONSE_CONSTANTS.PROMPT_TOKENS,
+        completion_tokens: MOCK_RESPONSE_CONSTANTS.COMPLETION_TOKENS,
+        total_tokens: MOCK_RESPONSE_CONSTANTS.TOTAL_TOKENS
+      }
+    },
+    activeModel: MOCK_RESPONSE_CONSTANTS.MODEL_NAME,
+    fallbackFlag: false,
+    gpt5Used: true,
+    routingStages: MOCK_RESPONSE_CONSTANTS.ROUTING_STAGES,
+    auditSafe: {
+      mode: true,
+      overrideUsed: input.toLowerCase().includes('override'),
+      overrideReason: input.toLowerCase().includes('override')
+        ? MOCK_RESPONSE_MESSAGES.OVERRIDE_DETECTED
+        : undefined,
+      auditFlags: MOCK_RESPONSE_CONSTANTS.AUDIT_FLAGS,
+      processedSafely: true
+    },
+    memoryContext: {
+      entriesAccessed: Math.floor(Math.random() * MOCK_RESPONSE_CONSTANTS.MAX_MEMORY_ENTRIES),
+      contextSummary: MOCK_RESPONSE_MESSAGES.MEMORY_CONTEXT,
+      memoryEnhanced: Math.random() > MOCK_RESPONSE_CONSTANTS.MEMORY_ENHANCEMENT_PROBABILITY
+    },
+    taskLineage: {
+      requestId: mockId,
+      logged: true
+    },
+    error: MOCK_RESPONSE_MESSAGES.NO_API_KEY
+  };
+
+  switch (endpoint) {
+    case 'arcanos':
+      return {
+        ...baseMockResponse,
+        result: `[MOCK ARCANOS RESPONSE] System analysis for: "${inputPreview}"`,
+        componentStatus: MOCK_RESPONSE_MESSAGES.ALL_SYSTEMS_OPERATIONAL,
+        suggestedFixes: MOCK_RESPONSE_MESSAGES.CONFIGURE_API_KEY,
+        coreLogicTrace: MOCK_RESPONSE_MESSAGES.CORE_LOGIC_TRACE,
+        gpt5Delegation: {
+          used: true,
+          reason: MOCK_RESPONSE_MESSAGES.GPT5_ROUTING,
+          delegatedQuery: input
+        }
+      };
+    case 'ask':
+    case 'brain':
+      return {
+        ...baseMockResponse,
+        result: `[MOCK AI RESPONSE] Processed request: "${inputPreview}"`,
+        module: 'MockBrain'
+      };
+    case 'write':
+      return {
+        ...baseMockResponse,
+        result: `[MOCK WRITE RESPONSE] Generated content for: "${inputPreview}"`,
+        module: 'MockWriter',
+        endpoint: 'write'
+      };
+    case 'guide':
+      return {
+        ...baseMockResponse,
+        result: `[MOCK GUIDE RESPONSE] Step-by-step guidance for: "${inputPreview}"`,
+        module: 'MockGuide',
+        endpoint: 'guide'
+      };
+    case 'audit':
+      return {
+        ...baseMockResponse,
+        result: `[MOCK AUDIT RESPONSE] Analysis and evaluation of: "${inputPreview}"`,
+        module: 'MockAuditor',
+        endpoint: 'audit'
+      };
+    case 'sim':
+      return {
+        ...baseMockResponse,
+        result: `[MOCK SIMULATION RESPONSE] Scenario modeling for: "${inputPreview}"`,
+        module: 'MockSimulator',
+        endpoint: 'sim'
+      };
+    default:
+      return {
+        ...baseMockResponse,
+        result: `[MOCK RESPONSE] Processed request: "${inputPreview}"`,
+        module: 'MockProcessor'
+      };
+  }
+};
+

--- a/src/services/openai/resilience.ts
+++ b/src/services/openai/resilience.ts
@@ -1,0 +1,74 @@
+import { CircuitBreaker, ExponentialBackoff } from '../../utils/circuitBreaker.js';
+import { recordTraceEvent, markOperation } from '../../utils/telemetry.js';
+
+export const RESILIENCE_CONSTANTS = {
+  DEFAULT_MAX_TOKENS: 1024,
+  RATE_LIMIT_JITTER_MAX_MS: 2000,
+  CIRCUIT_BREAKER_FAILURE_THRESHOLD: 5,
+  CIRCUIT_BREAKER_RESET_TIMEOUT_MS: 30000,
+  CIRCUIT_BREAKER_MONITORING_PERIOD_MS: 60000,
+  BACKOFF_BASE_DELAY_MS: 1000,
+  BACKOFF_MAX_DELAY_MS: 30000,
+  BACKOFF_MULTIPLIER: 2,
+  BACKOFF_JITTER_MAX_MS: 500
+} as const;
+
+const circuitBreaker = new CircuitBreaker({
+  failureThreshold: RESILIENCE_CONSTANTS.CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+  resetTimeoutMs: RESILIENCE_CONSTANTS.CIRCUIT_BREAKER_RESET_TIMEOUT_MS,
+  monitoringPeriodMs: RESILIENCE_CONSTANTS.CIRCUIT_BREAKER_MONITORING_PERIOD_MS
+});
+
+const backoffStrategy = new ExponentialBackoff(
+  RESILIENCE_CONSTANTS.BACKOFF_BASE_DELAY_MS,
+  RESILIENCE_CONSTANTS.BACKOFF_MAX_DELAY_MS,
+  RESILIENCE_CONSTANTS.BACKOFF_MULTIPLIER,
+  RESILIENCE_CONSTANTS.BACKOFF_JITTER_MAX_MS
+);
+
+export async function executeWithResilience<T>(operation: () => Promise<T>): Promise<T> {
+  recordTraceEvent('openai.resilience.execute', {
+    state: circuitBreaker.getState()
+  });
+
+  return circuitBreaker.execute(async () => {
+    try {
+      const result = await operation();
+      markOperation('openai.success');
+      recordTraceEvent('openai.resilience.success', {
+        state: circuitBreaker.getState()
+      });
+      return result;
+    } catch (error) {
+      markOperation('openai.failure');
+      recordTraceEvent('openai.resilience.failure', {
+        state: circuitBreaker.getState(),
+        error: error instanceof Error ? error.message : 'unknown'
+      });
+      throw error;
+    }
+  });
+}
+
+export function calculateRetryDelay(attempt: number, error: any): number {
+  const delay = backoffStrategy.calculateDelay(attempt);
+  if (error?.status === 429) {
+    const jitter = Math.random() * RESILIENCE_CONSTANTS.RATE_LIMIT_JITTER_MAX_MS;
+    return delay + jitter;
+  }
+  return delay;
+}
+
+export function getCircuitBreakerSnapshot() {
+  const metrics = circuitBreaker.getMetrics();
+  return {
+    ...metrics,
+    state: circuitBreaker.getState(),
+    constants: RESILIENCE_CONSTANTS
+  };
+}
+
+export function getCircuitBreakerState() {
+  return circuitBreaker.getState();
+}
+

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -1,0 +1,125 @@
+import { EventEmitter } from 'events';
+import { generateRequestId } from './idGenerator.js';
+
+type TelemetryLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface TelemetryLogEvent {
+  id: string;
+  timestamp: string;
+  level: TelemetryLevel;
+  message: string;
+  context?: Record<string, unknown>;
+  metadata?: Record<string, unknown> | undefined;
+  duration?: number;
+}
+
+export interface TelemetryTraceEvent {
+  id: string;
+  timestamp: string;
+  name: string;
+  attributes?: Record<string, unknown>;
+}
+
+interface TelemetryMetrics {
+  totalLogs: number;
+  logsByLevel: Record<TelemetryLevel, number>;
+  operations: Record<string, { count: number; lastTimestamp: string }>; 
+}
+
+interface TelemetryState {
+  metrics: TelemetryMetrics;
+  recentLogs: TelemetryLogEvent[];
+  traceEvents: TelemetryTraceEvent[];
+}
+
+const MAX_RECENT_LOGS = parseInt(process.env.TELEMETRY_RECENT_LOGS_LIMIT || '100', 10);
+const MAX_TRACE_EVENTS = parseInt(process.env.TELEMETRY_TRACE_EVENT_LIMIT || '200', 10);
+
+const telemetryEmitter = new EventEmitter();
+
+const telemetryState: TelemetryState = {
+  metrics: {
+    totalLogs: 0,
+    logsByLevel: {
+      debug: 0,
+      info: 0,
+      warn: 0,
+      error: 0
+    },
+    operations: {}
+  },
+  recentLogs: [],
+  traceEvents: []
+};
+
+function clampBuffer<T>(buffer: T[], maxSize: number): void {
+  while (buffer.length > maxSize) {
+    buffer.shift();
+  }
+}
+
+export function recordLogEvent(entry: Omit<TelemetryLogEvent, 'id'>): TelemetryLogEvent {
+  const event: TelemetryLogEvent = {
+    ...entry,
+    id: generateRequestId('log')
+  };
+
+  telemetryState.metrics.totalLogs += 1;
+  if (telemetryState.metrics.logsByLevel[event.level] !== undefined) {
+    telemetryState.metrics.logsByLevel[event.level] += 1;
+  }
+
+  telemetryState.recentLogs.push(event);
+  clampBuffer(telemetryState.recentLogs, Math.max(10, MAX_RECENT_LOGS));
+
+  telemetryEmitter.emit('log', event);
+  return event;
+}
+
+export function recordTraceEvent(name: string, attributes: Record<string, unknown> = {}): TelemetryTraceEvent {
+  const event: TelemetryTraceEvent = {
+    id: generateRequestId('trace'),
+    timestamp: new Date().toISOString(),
+    name,
+    attributes
+  };
+
+  telemetryState.traceEvents.push(event);
+  clampBuffer(telemetryState.traceEvents, Math.max(25, MAX_TRACE_EVENTS));
+  telemetryEmitter.emit('trace', event);
+  return event;
+}
+
+export function markOperation(name: string): void {
+  const now = new Date().toISOString();
+  const existing = telemetryState.metrics.operations[name];
+  telemetryState.metrics.operations[name] = {
+    count: existing ? existing.count + 1 : 1,
+    lastTimestamp: now
+  };
+  recordTraceEvent(`operation.${name}`, { count: telemetryState.metrics.operations[name].count });
+}
+
+export function getTelemetrySnapshot() {
+  return {
+    generatedAt: new Date().toISOString(),
+    metrics: telemetryState.metrics,
+    traces: {
+      recentLogs: [...telemetryState.recentLogs],
+      recentEvents: [...telemetryState.traceEvents]
+    }
+  };
+}
+
+export function onTelemetry(event: 'log' | 'trace', listener: (payload: TelemetryLogEvent | TelemetryTraceEvent) => void) {
+  telemetryEmitter.on(event, listener as any);
+}
+
+export function resetTelemetry(): void {
+  telemetryState.metrics.totalLogs = 0;
+  telemetryState.metrics.logsByLevel = { debug: 0, info: 0, warn: 0, error: 0 };
+  telemetryState.metrics.operations = {};
+  telemetryState.recentLogs.length = 0;
+  telemetryState.traceEvents.length = 0;
+}
+

--- a/tests/afol.test.ts
+++ b/tests/afol.test.ts
@@ -6,6 +6,7 @@ import { decide } from '../src/afol/engine.js';
 import { evaluate } from '../src/afol/policies.js';
 import { getStatus, resetHealth, simulateFailure } from '../src/afol/health.js';
 import { clearLogs, configureLogger, getRecent, logError, resetLogger } from '../src/afol/logger.js';
+import { configureAnalytics, resetAnalytics } from '../src/afol/analytics.js';
 
 function createTempLogPath(): string {
   const uniqueId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
@@ -14,19 +15,27 @@ function createTempLogPath(): string {
 
 describe('AFOL engine orchestration', () => {
   let tempLogPath: string;
+  let tempAnalyticsPath: string;
 
   beforeEach(() => {
     resetHealth();
     tempLogPath = createTempLogPath();
+    tempAnalyticsPath = createTempLogPath();
     configureLogger({ filePath: tempLogPath });
+    configureAnalytics({ filePath: tempAnalyticsPath });
+    resetAnalytics();
     clearLogs();
   });
 
   afterEach(() => {
     clearLogs();
     resetLogger();
+    resetAnalytics();
     if (tempLogPath && fs.existsSync(tempLogPath)) {
       fs.unlinkSync(tempLogPath);
+    }
+    if (tempAnalyticsPath && fs.existsSync(tempAnalyticsPath)) {
+      fs.unlinkSync(tempAnalyticsPath);
     }
   });
 


### PR DESCRIPTION
## Summary
- implement real AFOL route execution backed by OpenAI calls, persistence analytics storage, and a new /api/afol/analytics endpoint
- refactor the OpenAI service into dedicated credential, resilience, and mock providers while instrumenting telemetry and surfacing circuit-breaker state in diagnostics
- capture structured log telemetry, expose resilience metrics in health responses, and allow configurable fallback enforcement beyond production

## Testing
- npm test -- afol
- npm run type-check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914eb82002483258fc09d77b4e37486)