### PR TITLE
Refresh backend and API documentation

### DIFF
--- a/docs/DATABASE_INTEGRATION.md
+++ b/docs/DATABASE_INTEGRATION.md
@@ -1,131 +1,132 @@
 # ARCANOS Database Integration
 
-This document describes the database integration implemented for ARCANOS workers.
+The database layer powers durable memory, retrieval, and worker telemetry for the
+backend. The implementation lives under `src/db/` and is designed to fall back to
+console/in-memory flows whenever PostgreSQL is unavailable so that local
+development and CI continue to run.
 
-## Overview
+---
 
-The ARCANOS backend now supports PostgreSQL database integration for persistent storage of worker data, execution logs, and GPT-5 reasoning results. The implementation provides graceful fallback to in-memory/console logging when a database is not available.
+## Architecture overview
 
-## Database Module (`src/db.ts`)
+The monolithic `db.ts` file has been refactored into a modular structure and now
+re-exports stable helpers for backward compatibility:
 
-### Features
-- **Connection Pool Management**: Uses `pg` (node-postgres) library with connection pooling
-- **Graceful Fallback**: Works without DATABASE_URL by logging to console and using in-memory storage
-- **Type Safety**: Full TypeScript support with proper type definitions
-- **Error Handling**: Comprehensive error handling with detailed logging
+| Module | Responsibility |
+| --- | --- |
+| `client.ts` | Connection pooling, SSL enforcement, connection status helpers, graceful shutdown (`initializeDatabase`, `getPool`, `getStatus`). |
+| `schema.ts` | Zod schemas plus the SQL migrations executed during boot (`initializeTables`, `refreshDatabaseCollation`). |
+| `query.ts` | Centralized query helper with caching, retry, and transaction utilities. |
+| `repositories/` | Entity-specific helpers (`memoryRepository`, `ragRepository`, `executionLogRepository`, `jobRepository`, `reasoningLogRepository`, `selfReflectionRepository`). |
+| `index.ts` | Public surface that wires the client, schema, and repositories, and exposes `initializeDatabaseWithSchema()` for worker/server boot. |
 
-### Database Tables
-- `memory`: Persistent worker memory storage (key-value with JSONB)
-- `execution_logs`: Worker execution logs with metadata
-- `job_data`: Worker job tracking and status
-- `reasoning_logs`: GPT-5 reasoning results with input/output/metadata
+`src/db.ts` re-exports everything from `src/db/index.ts` so existing imports continue to work while the modular layout remains organized.
 
-### Core Functions
-- `initializeDatabase()`: Initializes connection pool and creates tables
-- `saveMemory()`, `loadMemory()`, `deleteMemory()`: Memory management
-- `logExecution()`: Worker execution logging
-- `createJob()`, `updateJob()`: Job management
-- `logReasoning()`: GPT-5 reasoning logging
-- `getStatus()`: Connection status check
+---
 
-## Workers (`workers/` directory)
+## Schema & entities
 
-### Worker Types
-1. **worker-logger.js**: Centralized logging with database storage
-2. **worker-memory.js**: Persistent memory management
-3. **worker-gpt5-reasoning.js**: GPT-5 reasoning with result logging
-4. **worker-planner-engine.js**: Job scheduling and management
+`schema.ts` provisions the tables listed below during startup:
 
-### Worker Features
-- **Database Integration**: All workers use the centralized db module
-- **Fallback Behavior**: Continue operating without database
-- **Logging**: Comprehensive logging of operations and status
-- **Error Handling**: Graceful error handling with console fallbacks
+- **Core persistence** – `memory`, `saves`, and `audit_logs` hold key/value
+  state plus legacy persistence snapshots.
+- **Retrieval** – `rag_docs` stores fetched documents and embeddings.
+- **Backstage tooling** – `backstage_events`, `backstage_wrestlers`,
+  `backstage_storylines`, and `backstage_story_beats` retain simulation data.
+- **Self-reflection** – `self_reflections` captures AI retrospection payloads.
+- **Worker telemetry** – `execution_logs`, `job_data`, and `reasoning_logs`
+  store worker heartbeats, queued work, and GPT‑5 oversight summaries.
 
-## API Endpoints
+Every schema export also ships with a matching Zod type so higher-level modules
+can validate payloads before writing to the database.
 
-### Memory Management
-- `GET /memory/health`: Database connection status
-- `POST /memory/save`: Store key-value data
-- `GET /memory/load?key=<key>`: Retrieve stored data
-- `GET /memory/list`: List recent memory entries
-- `DELETE /memory/delete`: Remove stored data
+---
 
-### Response Examples
+## Repository helpers in practice
 
-**Health Check (No Database)**:
-```json
-{
-  "database": false,
-  "error": null,
-  "timestamp": "2025-08-09T13:55:34.067Z"
-}
-```
+- `saveMemory`, `loadMemory`, `deleteMemory` back the `/api/memory/*` routes and
+  enforce UPSERT semantics with optimistic caching for reads.
+- `saveRagDoc` and `loadAllRagDocs` support the `/rag/fetch`, `/rag/save`, and
+  `/rag/query` ingestion pipeline.
+- `logExecution` and `logExecutionBatch` are called by worker contexts and
+  `utils/workerContext.ts` so every worker run is mirrored into
+  `execution_logs` even when the automation runs outside the main server.
+- `createJob`, `updateJob`, and `getLatestJob` are used by
+  `worker-planner-engine` to reason about queue depth and liveness.
+- `logReasoning` and `saveSelfReflection` persist GPT‑5 reasoning summaries and
+  CLEAR/self-reflection payloads for later audit.
 
-**Save Memory (No Database)**:
-```json
-{
-  "error": "Failed to save memory",
-  "details": "Database not configured"
-}
-```
+These helpers guard against missing connections by checking
+`isDatabaseConnected()` before running a query. When the pool is offline they
+log to stdout and return fallback data so callers do not crash.
+
+---
+
+## API touchpoints
+
+The following HTTP routes rely on the shared database module:
+
+| Route | Usage |
+| --- | --- |
+| `/api/memory/save`, `/api/memory/load`, `/api/memory/delete`, `/api/memory/list`, `/api/memory/view`, `/api/memory/bulk`, `/api/memory/health` | CRUD operations and status reporting. Errors bubble up when no database is configured so operators know persistence is disabled. |
+| `/rag/*` | Fetch, store, and query documents with embeddings before answering retrieval-augmented prompts. |
+| `/api/memory/health` & `/workers/status` | Surface the connection status returned by `getStatus()` so dashboards can show degraded persistence. |
+| `/workers/run/:workerId` | Workers executed via the HTTP API inherit the same `createWorkerContext()` used during `initializeWorkers()`, which injects the database `query` helper. |
+| `/commands/research`, `/sdk/research`, `/api/ask-hrc` | Persist generated insights, diagnostics, and audit trails through the repositories described above. |
+
+Because `initializeWorkers()` calls `initializeDatabase('worker-boot')` during
+server startup, the worker status payload always includes the latest connection
+state even if automation is disabled via `RUN_WORKERS`.
+
+---
 
 ## Configuration
 
-### Environment Variables
-- `DATABASE_URL`: PostgreSQL connection string (optional)
-- `RUN_WORKERS`: Enable/disable worker initialization (default: true)
+The connection helper automatically reads either `DATABASE_URL` or assembles a
+connection string from `PGUSER`, `PGPASSWORD`, `PGHOST`, `PGPORT`, and
+`PGDATABASE`. When the host is not `localhost` it appends `sslmode=require`
+unless one is already provided, ensuring managed deployments negotiate SSL.
+Additional variables such as `DATABASE_PUBLIC_URL`, `PGDATA`, and
+`POSTGRES_USER/PASSWORD` are loaded so Railway-provisioned environments that only
+set a subset of credentials still boot correctly.
 
-### Database URL Format
-```
-postgresql://username:password@hostname:port/database
-```
+Useful scripts:
+- `npm run db:init` – ensures the pool and schema can be created.
+- `npm run db:patch` – reruns the table sync logic (`schema.ts`).
 
-Example:
-```
-DATABASE_URL=postgresql://arcanos:password@localhost:5432/arcanos
-```
+---
 
-## Boot Sequence
+## Boot sequence
 
-1. **Database Initialization**: Attempts to connect to PostgreSQL if DATABASE_URL is set
-2. **Table Creation**: Creates required tables if they don't exist
-3. **Worker Initialization**: Starts all workers with database awareness
-4. **Fallback Setup**: Configures console/memory fallbacks for workers without database
-5. **Status Logging**: Reports database and worker status during boot
+1. `performStartup()` (`src/startup.ts`) calls `initializeDatabase('server')`.
+   Failures log a warning and the service continues in in-memory mode while the
+   health endpoints show the degraded status.
+2. `initializeWorkers()` repeats the initialization with the worker identifier
+   so that worker heartbeats can be written even when they start before the
+   server. If `RUN_WORKERS` is not `true`/`1`, the helper still records the
+   connection state for `/workers/status`.
+3. The `/api/memory/health` route reads the latest status via `getStatus()` to
+   display `connected`, `hasPool`, and `error` fields.
 
-## Graceful Fallback Behavior
+---
 
-When `DATABASE_URL` is not set or connection fails:
-- Workers continue to operate normally
-- Memory operations fall back to in-memory Map storage
-- Execution logs go to console output
-- Reasoning logs go to console output
-- Job scheduling is disabled (requires database)
-- No errors or crashes occur
+## Fallback & observability
 
-## Testing
+- `logExecution`/`logExecutionBatch` print to stdout whenever the pool is
+  offline so worker telemetry is never lost.
+- `query()` throws a descriptive `Database not configured` error when a helper
+  is called without a connection; the HTTP handlers wrap these errors with JSON
+  responses that explain persistence is disabled.
+- The worker context exposes `context.db.query` so every custom worker benefits
+  from the same retry/caching logic without re-implementing pool management.
+- `/api/memory/health` is the quickest way to confirm the current status from an
+  operator dashboard.
 
-The implementation includes comprehensive testing:
-- Database connection logic validation
-- Graceful fallback behavior verification
-- Memory API endpoint testing
-- Worker initialization testing
-- Error handling validation
+---
 
-## Production Deployment
+## Testing expectations
 
-For production use:
-1. Set up PostgreSQL database
-2. Configure DATABASE_URL environment variable
-3. Ensure database connectivity from ARCANOS instance
-4. Monitor worker initialization logs for database status
-5. Workers will automatically use database features when available
-
-## OpenAI SDK Compatibility
-
-All OpenAI API calls follow OpenAI SDK v5+ standards:
-- Uses official `openai` package (v5.16.0+)
-- Proper error handling and response parsing
-- Compatible with GPT-5 model when available
-- Fallback to GPT-4o for reasoning tasks
+Jest suites call `initializeDatabase()` against ephemeral instances and verify
+that missing credentials trigger the fallback pathways described above. When a
+real database is available, the tests assert that memory CRUD helpers, RAG
+repositories, and worker logging all function end-to-end.

--- a/docs/ai-guides/PROMPT_API_EXAMPLES.md
+++ b/docs/ai-guides/PROMPT_API_EXAMPLES.md
@@ -1,509 +1,235 @@
 # Arcanos API Practical Examples
 
-This file contains ready-to-use examples for testing and implementing Arcanos API endpoints.
+Ready-to-use cURL snippets and client templates for exercising the current API
+surface.
 
 ## Setup Test Environment
 
-First, create your environment file:
 ```bash
 cp .env.example .env
-# Edit .env with your actual OpenAI credentials
+# Edit .env with your OPENAI_API_KEY and OPENAI_MODEL
+npm install
+npm run build
+npm start
 ```
+
+---
 
 ## Basic Connectivity Tests
 
-### 1. Health Check
 ```bash
+# Health + readiness
 curl http://localhost:8080/health
-# Expected: ✅ OK
+curl http://localhost:8080/readyz
+
+# Smoke probe
+curl http://localhost:8080/api/test
+
+# Worker inventory
+curl http://localhost:8080/workers/status
 ```
 
-### 2. API Welcome
-```bash
-curl http://localhost:8080/api
-# Expected: JSON with welcome message and model status
-```
-
-### 3. Echo Test
-```bash
-curl -X POST http://localhost:8080/api/echo \
-  -H "Content-Type: application/json" \
-  -d '{"message": "Hello Arcanos!", "test": true}'
-# Expected: Echo of your input data
-```
-
-### 4. Model Status
-```bash
-curl http://localhost:8080/api/model-status
-# Expected: Model configuration status
-```
+---
 
 ## AI Interaction Examples
 
-### Basic AI Chat (No Fallback)
+### Primary chat (`/ask`)
+```bash
+curl -X POST http://localhost:8080/ask \
+  -H "Content-Type: application/json" \
+  -d '{
+        "prompt": "Compare REST and GraphQL architectures",
+        "sessionId": "doc-demo"
+      }'
+```
+
+### Flexible JSON (`/api/ask`)
 ```bash
 curl -X POST http://localhost:8080/api/ask \
   -H "Content-Type: application/json" \
   -d '{
-    "message": "What is the difference between REST and GraphQL?"
-  }'
+        "message": "Summarize the current sprint goals",
+        "domain": "product",
+        "useRAG": true
+      }'
 ```
 
-### AI Chat with Fallback Support
+### Diagnostic orchestration (`/arcanos`)
 ```bash
-curl -X POST http://localhost:8080/api/ask-with-fallback \
+curl -X POST http://localhost:8080/arcanos \
   -H "Content-Type: application/json" \
+  -H "x-confirmed: yes" \
   -d '{
-    "message": "Explain microservices architecture and its benefits"
-  }'
+        "userInput": "Audit the staging environment and report degraded services",
+        "sessionId": "ops-shift"
+      }'
 ```
 
-### Multi-turn Conversation
+### Programmatic JSON (`/api/arcanos/ask`)
 ```bash
-curl -X POST http://localhost:8080/api/ask-with-fallback \
+curl -X POST http://localhost:8080/api/arcanos/ask \
   -H "Content-Type: application/json" \
-  -d '{
-    "messages": [
-      {"role": "user", "content": "I need help with Python"},
-      {"role": "assistant", "content": "I'd be happy to help with Python! What specific topic would you like assistance with?"},
-      {"role": "user", "content": "How do I handle exceptions properly?"}
-    ]
-  }'
+  -H "x-confirmed: yes" \
+  -d '{"prompt":"Ping"}'
 ```
 
-## Programming Examples
-
-### Code Generation
-```bash
-curl -X POST http://localhost:8080/api/arcanos \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Create a Python function that validates email addresses using regex",
-    "domain": "programming"
-  }'
-```
-
-### Code Review/Audit
-```bash
-curl -X POST http://localhost:8080/api/arcanos \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Review this code for security issues: function login(user, pass) { return user === admin && pass === 123; }",
-    "domain": "security"
-  }'
-```
-
-### API Design
-```bash
-curl -X POST http://localhost:8080/api/ask-v1-safe \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Design a RESTful API for a blog platform with users, posts, and comments",
-    "domain": "programming",
-    "useRAG": true,
-    "useHRC": false
-  }'
-```
-
-### Database Design
-```bash
-curl -X POST http://localhost:8080/api/ask-v1-safe \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Create a database schema for an e-commerce platform with products, users, orders, and inventory",
-    "domain": "database",
-    "useRAG": true,
-    "useHRC": true
-  }'
-```
-
-## Security Analysis Examples
-
-### Vulnerability Assessment
-```bash
-curl -X POST http://localhost:8080/api/arcanos \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Analyze this SQL query for injection vulnerabilities: SELECT * FROM users WHERE id = " + userId,
-    "domain": "security"
-  }'
-```
-
-### Authentication Review
-```bash
-curl -X POST http://localhost:8080/api/ask-v1-safe \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Review this authentication implementation for security best practices: const auth = (req, res, next) => { if (req.headers.token === process.env.SECRET) next(); else res.status(401).send(); }",
-    "domain": "security",
-    "useRAG": true,
-    "useHRC": true
-  }'
-```
-
-## Memory and Context Examples
-
-### Store Context
-```bash
-# Store user preferences
-curl -X POST http://localhost:8080/api/memory \
-  -H "Content-Type: application/json" \
-  -d '{
-    "value": "User prefers TypeScript over JavaScript for new projects"
-  }'
-
-# Store project context
-curl -X POST http://localhost:8080/api/memory \
-  -H "Content-Type: application/json" \
-  -d '{
-    "value": "Current project: Building a real-time chat application using Socket.io and Node.js"
-  }'
-
-# Store technical requirements
-curl -X POST http://localhost:8080/api/memory \
-  -H "Content-Type: application/json" \
-  -d '{
-    "value": "System requirements: Must support 10k concurrent users, Redis for caching, PostgreSQL database"
-  }'
-```
-
-### Retrieve Context
-```bash
-curl http://localhost:8080/api/memory
-```
-
-### Context-Aware Query
-```bash
-# After storing context, ask a related question
-curl -X POST http://localhost:8080/api/ask-v1-safe \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "What technology stack would you recommend for my new project?",
-    "domain": "programming",
-    "useRAG": true,
-    "useHRC": false
-  }'
-```
-
-## Validation Examples
-
-### HRC Message Validation
+### Safety scoring (`/api/ask-hrc`)
 ```bash
 curl -X POST http://localhost:8080/api/ask-hrc \
   -H "Content-Type: application/json" \
+  -H "x-confirmed: yes" \
+  -d '{"message": "Ship unreviewed code now"}'
+```
+
+---
+
+## Memory and Context Examples
+
+```bash
+# Save
+curl -X POST http://localhost:8080/api/memory/save \
+  -H "Content-Type: application/json" \
+  -H "x-confirmed: yes" \
+  -d '{"key":"user:pref","value":{"lang":"TypeScript"}}'
+
+# Load
+curl "http://localhost:8080/api/memory/load?key=user:pref"
+
+# Bulk
+curl -X POST http://localhost:8080/api/memory/bulk \
+  -H "Content-Type: application/json" \
+  -H "x-confirmed: yes" \
   -d '{
-    "message": "Please analyze this code: console.log(userPassword);"
-  }'
+        "operations": [
+          {"type":"save","key":"project:focus","value":{"name":"Atlas"}},
+          {"type":"delete","key":"project:legacy"}
+        ]
+      }'
 ```
 
-### Safe Interface with All Features
-```bash
-curl -X POST http://localhost:8080/api/ask-v1-safe \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Help me optimize this database query for better performance: SELECT * FROM orders o JOIN users u ON o.user_id = u.id WHERE o.created_at > 2023-01-01",
-    "domain": "database",
-    "useRAG": true,
-    "useHRC": true
-  }'
-```
+---
 
-## Intent-Based Routing Examples
-
-### Content Creation (Should Route to WRITE)
-```bash
-curl -X POST http://localhost:8080/api/arcanos \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Write a React component for user login form",
-    "domain": "programming"
-  }'
-```
-
-### Analysis/Review (Should Route to AUDIT)
-```bash
-curl -X POST http://localhost:8080/api/arcanos \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Audit this Docker configuration for security best practices",
-    "domain": "security"
-  }'
-```
-
-### Documentation Creation
-```bash
-curl -X POST http://localhost:8080/api/arcanos \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Generate API documentation for a user management service",
-    "domain": "general"
-  }'
-```
-
-## Testing Different Domains
-
-### General Domain
-```bash
-curl -X POST http://localhost:8080/api/ask-v1-safe \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Explain the benefits and drawbacks of cloud computing",
-    "domain": "general",
-    "useRAG": false,
-    "useHRC": false
-  }'
-```
-
-### Programming Domain
-```bash
-curl -X POST http://localhost:8080/api/ask-v1-safe \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "What are the SOLID principles in software design?",
-    "domain": "programming",
-    "useRAG": true,
-    "useHRC": false
-  }'
-```
-
-### Security Domain
-```bash
-curl -X POST http://localhost:8080/api/ask-v1-safe \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Explain OWASP Top 10 security vulnerabilities",
-    "domain": "security",
-    "useRAG": true,
-    "useHRC": true
-  }'
-```
-
-### Database Domain
-```bash
-curl -X POST http://localhost:8080/api/ask-v1-safe \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Compare SQL vs NoSQL databases for a social media application",
-    "domain": "database",
-    "useRAG": true,
-    "useHRC": false
-  }'
-```
-
-## Error Handling Examples
-
-### Missing Message
-```bash
-curl -X POST http://localhost:8080/api/ask \
-  -H "Content-Type: application/json" \
-  -d '{}'
-# Expected: Error about missing message
-```
-
-### Invalid Endpoint
-```bash
-curl -X POST http://localhost:8080/api/nonexistent \
-  -H "Content-Type: application/json" \
-  -d '{"message": "test"}'
-# Expected: 404 error
-```
-
-### Test Without API Key
-```bash
-# With empty/invalid API key, you should see configuration errors
-curl http://localhost:8080/api/model-status
-```
-
-## Batch Testing Script
-
-Create a test script to validate all endpoints:
+## RAG & Research
 
 ```bash
-#!/bin/bash
-
-echo "=== Testing Arcanos API ==="
-
-echo "1. Health Check:"
-curl -s http://localhost:8080/health
-echo -e "\n"
-
-echo "2. API Welcome:"
-curl -s http://localhost:8080/api | jq .
-echo -e "\n"
-
-echo "3. Echo Test:"
-curl -s -X POST http://localhost:8080/api/echo \
+# Fetch document by URL
+curl -X POST http://localhost:8080/rag/fetch \
   -H "Content-Type: application/json" \
-  -d '{"test": "hello"}' | jq .
-echo -e "\n"
+  -d '{"url":"https://example.com/postmortem"}'
 
-echo "4. Model Status:"
-curl -s http://localhost:8080/api/model-status | jq .
-echo -e "\n"
-
-echo "5. Memory Test:"
-curl -s -X POST http://localhost:8080/api/memory \
+# Query stored corpus
+curl -X POST http://localhost:8080/rag/query \
   -H "Content-Type: application/json" \
-  -d '{"value": "test memory"}' | jq .
-echo -e "\n"
+  -d '{"query":"List remediation items"}'
 
-echo "6. HRC Validation:"
-curl -s -X POST http://localhost:8080/api/ask-hrc \
+# Research module
+curl -X POST http://localhost:8080/commands/research \
   -H "Content-Type: application/json" \
-  -d '{"message": "test validation"}' | jq .
-echo -e "\n"
-
-echo "=== Test Complete ==="
+  -H "x-confirmed: yes" \
+  -d '{"topic":"LLM guardrails"}'
 ```
 
-Save as `test-api.sh`, make executable with `chmod +x test-api.sh`, and run with `./test-api.sh`.
+---
 
-## JavaScript/Node.js Integration Examples
+## Worker Automation
 
-### Simple Client
+```bash
+# Dispatch ARCANOS queue
+curl -X POST http://localhost:8080/workers/run/arcanos \
+  -H "Content-Type: application/json" \
+  -H "x-confirmed: yes" \
+  -d '{"input":"Summarize pending incidents"}'
+
+# Run the memory synchronizer manually
+curl -X POST http://localhost:8080/workers/run/worker-memory \
+  -H "Content-Type: application/json" \
+  -H "x-confirmed: yes"
+```
+
+---
+
+## Assistant Registry & Codebase APIs
+
+```bash
+# Inspect assistants
+curl http://localhost:8080/api/assistants
+
+# Force sync
+curl -X POST http://localhost:8080/api/assistants/sync -H "Content-Type: application/json"
+
+# Browse repository tree
+curl "http://localhost:8080/api/codebase/tree?path=src"
+
+# Fetch file snippet
+curl "http://localhost:8080/api/codebase/file?path=src/server.ts&startLine=1&endLine=60"
+```
+
+---
+
+## JavaScript Client Skeleton
+
 ```javascript
-const axios = require('axios');
+import axios from 'axios';
 
 class ArcanosClient {
   constructor(baseURL = 'http://localhost:8080') {
-    this.baseURL = baseURL;
+    this.http = axios.create({ baseURL });
   }
 
-  async ask(message, options = {}) {
-    try {
-      const response = await axios.post(`${this.baseURL}/api/ask`, {
-        message,
-        ...options
-      });
-      return response.data;
-    } catch (error) {
-      if (error.response?.data?.error?.includes('Fine-tuned model')) {
-        // Try fallback
-        return await this.askWithFallback(message, options);
-      }
-      throw error;
-    }
+  async ask(prompt, sessionId) {
+    const { data } = await this.http.post('/ask', { prompt, sessionId });
+    return data;
   }
 
-  async askWithFallback(message, options = {}) {
-    const response = await axios.post(`${this.baseURL}/api/ask-with-fallback`, {
-      message,
-      ...options
+  async arcanos(userInput, sessionId, confirmed = false) {
+    const headers = confirmed ? { 'x-confirmed': 'yes' } : {};
+    const { data } = await this.http.post('/arcanos', { userInput, sessionId }, { headers });
+    return data;
+  }
+
+  async saveMemory(key, value) {
+    const { data } = await this.http.post('/api/memory/save', { key, value }, {
+      headers: { 'x-confirmed': 'yes' }
     });
-    return response.data;
-  }
-
-  async askSafe(message, domain = 'general', useRAG = true, useHRC = true) {
-    const response = await axios.post(`${this.baseURL}/api/ask-v1-safe`, {
-      message,
-      domain,
-      useRAG,
-      useHRC
-    });
-    return response.data;
-  }
-
-  async arcanos(message, domain = 'general') {
-    const response = await axios.post(`${this.baseURL}/api/arcanos`, {
-      message,
-      domain
-    });
-    return response.data;
-  }
-
-  async storeMemory(value) {
-    const response = await axios.post(`${this.baseURL}/api/memory`, { value });
-    return response.data;
-  }
-
-  async getMemories() {
-    const response = await axios.get(`${this.baseURL}/api/memory`);
-    return response.data;
-  }
-}
-
-// Usage example
-async function example() {
-  const client = new ArcanosClient();
-  
-  try {
-    // Store some context
-    await client.storeMemory('User is working on a Node.js project');
-    
-    // Ask a question with context
-    const result = await client.askSafe(
-      'What testing framework would you recommend?',
-      'programming',
-      true,
-      false
-    );
-    
-    console.log('Response:', result.response);
-  } catch (error) {
-    console.error('Error:', error.message);
+    return data;
   }
 }
 ```
 
-### Python Integration Example
+---
+
+## Python Client Skeleton
+
 ```python
 import requests
-import json
 
 class ArcanosClient:
-    def __init__(self, base_url="http://localhost:8080"):
+    def __init__(self, base_url: str = "http://localhost:8080"):
         self.base_url = base_url
-    
-    def ask(self, message, **options):
-        try:
-            response = requests.post(
-                f"{self.base_url}/api/ask",
-                json={"message": message, **options}
-            )
-            return response.json()
-        except requests.exceptions.RequestException as e:
-            # Try fallback
-            return self.ask_with_fallback(message, **options)
-    
-    def ask_with_fallback(self, message, **options):
-        response = requests.post(
-            f"{self.base_url}/api/ask-with-fallback",
-            json={"message": message, **options}
-        )
-        return response.json()
-    
-    def ask_safe(self, message, domain="general", use_rag=True, use_hrc=True):
-        response = requests.post(
-            f"{self.base_url}/api/ask-v1-safe",
-            json={
-                "message": message,
-                "domain": domain,
-                "useRAG": use_rag,
-                "useHRC": use_hrc
-            }
-        )
-        return response.json()
-    
-    def arcanos(self, message, domain="general"):
-        response = requests.post(
-            f"{self.base_url}/api/arcanos",
-            json={"message": message, "domain": domain}
-        )
-        return response.json()
 
-# Usage
-client = ArcanosClient()
-result = client.ask_safe("Explain Python decorators", "programming")
-print(result["response"])
+    def ask(self, prompt: str, session_id: str | None = None):
+        resp = requests.post(f"{self.base_url}/ask", json={"prompt": prompt, "sessionId": session_id})
+        resp.raise_for_status()
+        return resp.json()
+
+    def arcanos(self, user_input: str, session_id: str | None = None):
+        resp = requests.post(
+            f"{self.base_url}/arcanos",
+            json={"userInput": user_input, "sessionId": session_id},
+            headers={"x-confirmed": "yes"}
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def save_memory(self, key: str, value: dict):
+        resp = requests.post(
+            f"{self.base_url}/api/memory/save",
+            json={"key": key, "value": value},
+            headers={"x-confirmed": "yes"}
+        )
+        resp.raise_for_status()
+        return resp.json()
 ```
 
-### Code Interpreter Example
-```python
-response = requests.post(
-    f"{client.base_url}/api/code-interpreter",
-    json={"prompt": "Calculate the mean of [1,2,3,4]"}
-)
-print(response.json()["data"]["content"])
-```
-
-These examples provide a comprehensive set of ready-to-use implementations for testing and integrating with the Arcanos API.
+These snippets align with the current TypeScript routes and validate that the
+backend responds with the latest payload formats.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,6 +1,6 @@
 # ARCANOS API Reference
 
-> **Last Updated:** 2024-10-30 | **Version:** 1.0.0 | **OpenAI SDK:** v5.16.0
+> **Last Updated:** 2024-11-24 | **Version:** 1.0.0 | **OpenAI SDK:** v5.16.0
 
 This guide summarises the HTTP API exposed by the Arcanos backend. All routes
 are registered in [`src/routes/register.ts`](../../src/routes/register.ts).
@@ -17,27 +17,29 @@ automations should wait for the confirmation challenge response and retry with
 | --- | --- | --- |
 | `POST /ask` | No | Primary chat endpoint routed through the Trinity brain. |
 | `POST /brain` | Yes | Confirmation-gated alias for `/ask`. |
+| `POST /api/ask` | No | ChatGPT-style JSON API that normalizes payloads before forwarding to `/ask`. |
 | `POST /arcanos` | Yes | Diagnostic orchestration entry point backed by `runARCANOS`. |
 | `POST /siri` | Yes | Siri-style interface that reuses the Trinity pipeline. |
-| `POST /arcanos-pipeline` | Yes | Multi-stage pipeline that combines ARCANOS, GPT‑3.5, and GPT‑5 reasoning. |
+| `POST /arcanos-pipeline` | Yes | Multi-stage pipeline that combines ARCANOS, a GPT‑3.5 sub-agent, and GPT‑5 reasoning. |
 | `POST /api/arcanos/ask` | Yes | Minimal JSON API that returns or streams ARCANOS completions. |
+| `POST /api/ask-hrc` | Yes | Hallucination Resistant Core validation endpoint. |
 
 ### AI Utilities
 - `POST /write`, `POST /guide`, `POST /audit`, `POST /sim`
   – Content generation, guidance, auditing, and simulation helpers (all require
   confirmation).
-- `POST /image`
-  – Image generation via OpenAI Images API (honours optional `size`).
-- `POST /api/sim`
-  – Simulation API with supporting routes `GET /api/sim/health` and
-  `GET /api/sim/examples`.
-- `POST /gpt/:gptId/*`
-  – Dynamic router that forwards GPT-specific traffic to modules defined in
-  `config/gptRouterConfig.ts`.
+- `POST /api/sim` – Simulation API with supporting routes `GET /api/sim/health`
+  and `GET /api/sim/examples`.
+- `POST /image` – Image generation via the OpenAI Images API (honours optional
+  `size`).
+- `POST /gpt/:gptId/*` – Dynamic router that forwards GPT-specific traffic to
+  modules defined in `config/gptRouterConfig.ts`.
+- `GET /api/openai/status`, `POST /api/openai/prompt` – Lightweight compatibility
+  shim for invoking the configured OpenAI model or verifying key health.
 
 ---
 
-## 🗂️ Memory & State APIs
+## 🗂️ Memory, Assistants & Codebase APIs
 
 | Endpoint | Notes |
 | --- | --- |
@@ -48,9 +50,13 @@ automations should wait for the confirmation challenge response and retry with
 | `GET /api/memory/list` | List recent memory entries ordered by update time. |
 | `GET /api/memory/view` | Return the legacy filesystem log snapshot. |
 | `POST /api/memory/bulk` | Execute a sequence of memory operations (requires confirmation). |
+| `GET /api/assistants` | Inspect the cached assistant registry loaded by `logic/assistantSyncCron.ts`. |
+| `POST /api/assistants/sync` | Force an on-demand assistant registry sync. |
+| `GET /api/assistants/:name` | Return a single assistant definition by name. |
+| `GET /api/codebase/tree` | List repository contents relative to the provided `path` query parameter. |
+| `GET /api/codebase/file` | Read a repository file with optional `startLine`, `endLine`, or `maxBytes` filters. |
 | `POST /heartbeat` | Append heartbeat telemetry to `logs/heartbeat.log` (requires confirmation). |
-| `GET /status` | Return the contents of `systemState.json`. |
-| `POST /status` | Update the backend state document (requires confirmation). |
+| `GET /status` / `POST /status` | Read or update the shared state document (writes require confirmation). |
 
 ---
 
@@ -72,8 +78,8 @@ See [`docs/api/CONTEXTUAL_REINFORCEMENT.md`](CONTEXTUAL_REINFORCEMENT.md) for co
 
 | Endpoint | Confirmation | Description |
 | --- | --- | --- |
-| `GET /workers/status` | No | Lists worker files in the `workers/` directory and reports runtime configuration. |
-| `POST /workers/run/:workerId` | Yes | Executes a worker module by filename using the worker context helper. |
+| `GET /workers/status` | No | Lists worker files in the `workers/` directory, reports runtime configuration, and shows database health. |
+| `POST /workers/run/:workerId` | Yes | Executes a worker module by filename using the worker context helper. Passing `arcanos` dispatches work through the built-in task queue. |
 
 ---
 
@@ -82,16 +88,15 @@ See [`docs/api/CONTEXTUAL_REINFORCEMENT.md`](CONTEXTUAL_REINFORCEMENT.md) for co
 | Endpoint | Confirmation | Description |
 | --- | --- | --- |
 | `POST /commands/research` | Yes | Invokes the research module to aggregate external sources. |
+| `POST /sdk/research` | Yes | Mirrors the research pipeline for SDK consumers while applying the same validation stack. |
 | `POST /rag/fetch` | No | Fetch and ingest a document by URL. |
 | `POST /rag/save` | No | Persist custom text content for later retrieval. |
 | `POST /rag/query` | No | Run a retrieval-augmented query across stored documents. |
-| `POST /api/ask-hrc` | Yes | Hallucination Resistant Core evaluation. |
-| `POST /api/pr-analysis/*` | Yes | Pull-request analysis helpers (see module documentation). |
 | `POST /api/commands/execute` | Yes | Execute a registered command via `services/commandCenter.ts`. |
 | `GET /api/commands/` | No | Enumerate available commands. |
 | `GET /api/commands/health` | No | Command service health probe. |
-| `POST /api/openai/*` | Mixed | OpenAI compatibility shims (see route for details). |
-| `POST /api/sim` | No | Run a simulation scenario with optional streaming. |
+| `POST /api/pr-analysis/*` | Yes | Pull-request analysis helpers (see module documentation). |
+| `POST /api/openai/prompt` | Yes | Direct access to the configured OpenAI client (confirmation recommended for parity with other mutating routes). |
 
 ---
 
@@ -100,11 +105,12 @@ See [`docs/api/CONTEXTUAL_REINFORCEMENT.md`](CONTEXTUAL_REINFORCEMENT.md) for co
 | Endpoint | Description |
 | --- | --- |
 | `GET /` | Plain-text "ARCANOS is live" banner. |
-| `GET /railway/healthcheck` | Railway-friendly health check. |
+| `GET /railway/healthcheck` | Railway-friendly health check driven by `runHealthCheck()`. |
 | `GET /health` | Aggregated health report including OpenAI and database status. |
 | `GET /healthz` | Liveness probe. |
 | `GET /readyz` | Readiness probe (ensures required dependencies are available). |
 | `GET /api/test` | Lightweight JSON probe used for smoke tests. |
+| `GET /api/fallback/test` | Exercises the fallback middleware pipeline. |
 
 ---
 


### PR DESCRIPTION
## Summary
- sync `docs/backend.md`, the database guide, and worker documentation with the current startup pipeline and worker boot behavior
- update API references (core README plus detailed reference) to describe the active routes, assistant registry endpoints, and codebase utilities
- overhaul the AI prompt guides with accurate examples that target the maintained `/ask`, `/arcanos`, memory, RAG, and worker routes

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69157ad409d08325a1e0ed19bd4e6f01)