### PR TITLE
Add self-test pipeline and auto-heal workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,14 @@ See [`docs/TRINITY_PIPELINE.md`](docs/TRINITY_PIPELINE.md) for a detailed walkth
   configuration.
 - `POST /workers/run/:workerId` – Executes a worker by filename (requires
   confirmation).
+- `POST /workers/heal` – Generates a GPT-backed recovery plan and optionally
+  restarts the worker pool (requires confirmation header).
 - `POST /heartbeat` – Records operator heartbeats to `logs/heartbeat.log`
   (requires confirmation).
+- `POST /devops/self-test` – Runs the automated `/ask` self-test suite and
+  stores results in `logs/healthcheck.json`.
+- `POST /devops/daily-summary` – Forces the daily GPT-4(fine-tuned) summary log
+  to regenerate and save to `memory/summary-*.json`.
 
 ### Research, RAG, and Integrations
 
@@ -196,7 +202,13 @@ context for downstream analysis.
 npm test                     # Jest test suites
 npm run lint                 # ESLint (via @typescript-eslint)
 npm run build && npm start   # Ensure the compiled server boots
+npm run self-test            # Execute the self-test pipeline (requires dist/)
+npm run daily-summary        # Generate a daily GPT-4 summary snapshot
 ```
+
+Railway deployments pick up these jobs automatically through
+[`railway/cron.yaml`](railway/cron.yaml), which schedules the self-test every 30
+minutes and the daily summary at 23:00 UTC.
 
 For additional diagnostics, `src/services/gptSync.ts` executes a post-boot system
 diagnostic and `/api/test` returns a lightweight readiness payload for Railway.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "repair-migrations": "node scripts/migration-repair.js",
     "guide:generate": "node scripts/generate-tagged-guide.js",
     "test:doc-workflow": "node scripts/test-doc-workflow.js",
+    "self-test": "node dist/commands/runSelfTest.js",
+    "daily-summary": "node dist/commands/runDailySummary.js",
     "validate:railway": "node validate-railway-compatibility.js",
     "audit:continuous": "node scripts/continuous-audit.js",
     "audit:sdk-compliance": "node scripts/sdk-compliance-audit.js",

--- a/railway/cron.yaml
+++ b/railway/cron.yaml
@@ -1,0 +1,8 @@
+version: "1"
+cron:
+  - name: self-test-pipeline
+    schedule: "*/30 * * * *"
+    command: "npm run self-test"
+  - name: daily-gpt4-summary
+    schedule: "0 23 * * *"
+    command: "npm run daily-summary"

--- a/src/commands/runDailySummary.ts
+++ b/src/commands/runDailySummary.ts
@@ -1,0 +1,14 @@
+import { generateDailySummary } from '../services/dailySummaryService.js';
+
+async function main() {
+  try {
+    const summary = await generateDailySummary('cli');
+    console.log('[DAILY-SUMMARY] Complete');
+    console.log(JSON.stringify(summary, null, 2));
+  } catch (error) {
+    console.error('[DAILY-SUMMARY] Failed to generate summary', error);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/src/commands/runSelfTest.ts
+++ b/src/commands/runSelfTest.ts
@@ -1,0 +1,22 @@
+import { runSelfTestPipeline } from '../services/selfTestPipeline.js';
+
+async function main() {
+  try {
+    const summary = await runSelfTestPipeline({
+      baseUrl: process.env.SELF_TEST_BASE_URL,
+      triggeredBy: 'cli'
+    });
+
+    console.log('[SELF-TEST] Completed');
+    console.log(JSON.stringify(summary, null, 2));
+
+    if (summary.failCount > 0) {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    console.error('[SELF-TEST] Failed to execute pipeline', error);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/src/routes/devops.ts
+++ b/src/routes/devops.ts
@@ -1,0 +1,36 @@
+import { Router, Request, Response } from 'express';
+import { runSelfTestPipeline } from '../services/selfTestPipeline.js';
+import { generateDailySummary } from '../services/dailySummaryService.js';
+
+const router = Router();
+
+router.post('/devops/self-test', async (req: Request, res: Response) => {
+  try {
+    const summary = await runSelfTestPipeline({
+      baseUrl: req.body?.baseUrl,
+      triggeredBy: req.body?.triggeredBy || 'api'
+    });
+    res.json(summary);
+  } catch (error) {
+    console.error('[DEVOPS] Self-test execution failed', error);
+    res.status(500).json({
+      error: 'Self-test failed',
+      message: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+});
+
+router.post('/devops/daily-summary', async (_: Request, res: Response) => {
+  try {
+    const summary = await generateDailySummary('api');
+    res.json(summary);
+  } catch (error) {
+    console.error('[DEVOPS] Daily summary failed', error);
+    res.status(500).json({
+      error: 'Daily summary failed',
+      message: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+});
+
+export default router;

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -31,6 +31,7 @@ import apiAssistantsRouter from './api-assistants.js';
 import reinforcementRouter from './reinforcement.js';
 import { createFallbackTestRoute } from '../middleware/fallbackHandler.js';
 import { runHealthCheck } from '../utils/diagnostics.js';
+import devopsRouter from './devops.js';
 
 /**
  * Mounts all application routes on the provided Express app.
@@ -91,6 +92,7 @@ export function registerRoutes(app: Express): void {
   app.use('/', ragRouter);
   app.use('/', researchRouter);
   app.use('/', reinforcementRouter);
+  app.use('/', devopsRouter);
   
   // Add test endpoints for Railway health checks
   app.get('/api/test', (_: Request, res: Response) => {

--- a/src/routes/workers.ts
+++ b/src/routes/workers.ts
@@ -8,18 +8,84 @@ import path from 'path';
 import { Router, Request, Response } from 'express';
 import { createWorkerContext } from '../utils/workerContext.js';
 import { confirmGate } from '../middleware/confirmGate.js';
-import { dispatchArcanosTask, getWorkerRuntimeStatus } from '../config/workerConfig.js';
+import { dispatchArcanosTask, getWorkerRuntimeStatus, startWorkers } from '../config/workerConfig.js';
 import type {
   WorkerInfoDTO,
   WorkerRunResponseDTO,
   WorkerStatusResponseDTO
 } from '../types/dto.js';
 import { resolveWorkersDirectory } from '../utils/workerPaths.js';
+import { buildAutoHealPlan, summarizeAutoHeal } from '../services/autoHealService.js';
+import { loadState, updateState } from '../services/stateManager.js';
 
 const router = Router();
 
 // Get path to workers directory (from dist, it's one level up from the root)
 const { path: workersDir } = resolveWorkersDirectory();
+
+async function loadWorkerInventory(): Promise<WorkerInfoDTO[]> {
+  const workers: WorkerInfoDTO[] = [];
+
+  if (!fs.existsSync(workersDir)) {
+    return workers;
+  }
+
+  const files = fs.readdirSync(workersDir);
+  const workerFiles = files.filter(file => file.endsWith('.js') && !file.includes('shared'));
+
+  for (const file of workerFiles) {
+    try {
+      const workerPath = path.join(workersDir, file);
+      const worker = await import(workerPath);
+
+      workers.push({
+        id: worker.id || file.replace('.js', ''),
+        description: worker.description || 'No description available',
+        file: file,
+        available: true
+      });
+    } catch (error) {
+      workers.push({
+        id: file.replace('.js', ''),
+        description: 'Failed to load worker',
+        file: file,
+        available: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      });
+    }
+  }
+
+  return workers;
+}
+
+async function buildStatusPayload(): Promise<WorkerStatusResponseDTO> {
+  const workers = await loadWorkerInventory();
+  const runtimeStatus = getWorkerRuntimeStatus();
+  const arcanosWorkers = {
+    enabled: runtimeStatus.enabled,
+    count: runtimeStatus.configuredCount,
+    model: runtimeStatus.model,
+    status: runtimeStatus.started ? 'Active' : runtimeStatus.enabled ? 'Pending' : 'Disabled',
+    runtime: runtimeStatus
+  };
+
+  const payload: WorkerStatusResponseDTO = {
+    timestamp: new Date().toISOString(),
+    workersDirectory: workersDir,
+    totalWorkers: workers.length,
+    availableWorkers: workers.filter(w => w.available).length,
+    workers,
+    arcanosWorkers,
+    system: {
+      model: process.env.AI_MODEL || 'gpt-4-turbo',
+      environment: process.env.NODE_ENV || 'development'
+    }
+  };
+
+  payload.autoHeal = summarizeAutoHeal(payload);
+
+  return payload;
+}
 
 /**
  * GET /workers/status - Get available workers
@@ -28,58 +94,7 @@ router.get(
   '/workers/status',
   async (_: Request, res: Response<WorkerStatusResponseDTO | { error: string; message: string }>) => {
   try {
-    const workers: WorkerInfoDTO[] = [];
-    
-    if (fs.existsSync(workersDir)) {
-      const files = fs.readdirSync(workersDir);
-      const workerFiles = files.filter(file => file.endsWith('.js') && !file.includes('shared'));
-      
-      for (const file of workerFiles) {
-        try {
-          const workerPath = path.join(workersDir, file);
-          const worker = await import(workerPath);
-
-          workers.push({
-            id: worker.id || file.replace('.js', ''),
-            description: worker.description || 'No description available',
-            file: file,
-            available: true
-          });
-        } catch (error) {
-          workers.push({
-            id: file.replace('.js', ''),
-            description: 'Failed to load worker',
-            file: file,
-            available: false,
-            error: error instanceof Error ? error.message : 'Unknown error'
-          });
-        }
-      }
-    }
-    
-    // Include ARCANOS worker configuration status
-    const runtimeStatus = getWorkerRuntimeStatus();
-    const arcanosWorkers = {
-      enabled: runtimeStatus.enabled,
-      count: runtimeStatus.configuredCount,
-      model: runtimeStatus.model,
-      status: runtimeStatus.started ? 'Active' : runtimeStatus.enabled ? 'Pending' : 'Disabled',
-      runtime: runtimeStatus
-    };
-
-    const payload: WorkerStatusResponseDTO = {
-      timestamp: new Date().toISOString(),
-      workersDirectory: workersDir,
-      totalWorkers: workers.length,
-      availableWorkers: workers.filter(w => w.available).length,
-      workers,
-      arcanosWorkers,
-      system: {
-        model: process.env.AI_MODEL || 'gpt-4-turbo',
-        environment: process.env.NODE_ENV || 'development'
-      }
-    };
-
+    const payload = await buildStatusPayload();
     res.json(payload);
   } catch (error) {
     console.error('Error getting worker status:', error);
@@ -90,6 +105,51 @@ router.get(
   }
   }
 );
+
+router.post('/workers/heal', confirmGate, async (req: Request, res: Response) => {
+  try {
+    const payload = await buildStatusPayload();
+    const plan = await buildAutoHealPlan(payload);
+    const shouldExecute = req.body?.execute === true || req.body?.mode === 'execute';
+
+    let execution: Record<string, unknown> | undefined;
+    if (shouldExecute) {
+      const restartSummary = startWorkers(true);
+      execution = {
+        restart: restartSummary
+      };
+      const existingState = loadState() as Record<string, unknown>;
+      const rawWorkers = existingState?.workers;
+      const existingWorkersState =
+        rawWorkers && typeof rawWorkers === 'object' ? (rawWorkers as Record<string, unknown>) : {};
+      updateState({
+        workers: {
+          ...existingWorkersState,
+          lastHeal: {
+            executedAt: new Date().toISOString(),
+            planId: plan.planId,
+            severity: plan.severity,
+            recommendedAction: plan.recommendedAction
+          }
+        }
+      });
+    }
+
+    res.json({
+      timestamp: new Date().toISOString(),
+      plan,
+      autoHeal: payload.autoHeal,
+      execution,
+      runtime: getWorkerRuntimeStatus()
+    });
+  } catch (error) {
+    console.error('[AUTO-HEAL] Failed to process request', error);
+    res.status(500).json({
+      error: 'Auto-heal failed',
+      message: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+});
 
 /**
  * POST /workers/run/:workerId - Run a specific worker

--- a/src/services/autoHealService.ts
+++ b/src/services/autoHealService.ts
@@ -1,0 +1,122 @@
+import { callOpenAI, getDefaultModel } from './openai.js';
+import type { WorkerInfoDTO, WorkerStatusResponseDTO } from '../types/dto.js';
+
+export type AutoHealSeverity = 'ok' | 'warning' | 'critical';
+
+export interface AutoHealPlan {
+  planId: string;
+  severity: AutoHealSeverity;
+  recommendedAction: 'monitor' | 'restart-workers' | 'fallback-model' | 'escalate';
+  message: string;
+  steps: string[];
+  fallbackModel?: string;
+  generatedAt: string;
+}
+
+export interface AutoHealContext {
+  failingWorkers: WorkerInfoDTO[];
+  lastError?: string;
+  lastDispatchAt?: string;
+  totalDispatched: number;
+}
+
+function buildHeuristicPlan(context: AutoHealContext, model: string): AutoHealPlan {
+  const severity: AutoHealSeverity = context.failingWorkers.length > 0 || context.lastError ? 'critical' : 'ok';
+  const recommendedAction = severity === 'critical' ? 'restart-workers' : 'monitor';
+  const steps =
+    severity === 'critical'
+      ? [
+          'Restart ARCANOS workers with force flag',
+          'Verify fallback model health',
+          'Monitor /workers/status after restart'
+        ]
+      : ['Monitor /workers/status for anomalies'];
+
+  return {
+    planId: 'heuristic',
+    severity,
+    recommendedAction,
+    message:
+      severity === 'critical'
+        ? 'Detected worker failures or runtime errors that require a restart'
+        : 'Workers operating normally',
+    steps,
+    fallbackModel: model,
+    generatedAt: new Date().toISOString()
+  };
+}
+
+export async function buildAutoHealPlan(status: WorkerStatusResponseDTO): Promise<AutoHealPlan> {
+  const model = getDefaultModel();
+  const context: AutoHealContext = {
+    failingWorkers: status.workers.filter(worker => !worker.available),
+    lastError: status.arcanosWorkers.runtime.lastError,
+    lastDispatchAt: status.arcanosWorkers.runtime.lastDispatchAt,
+    totalDispatched: status.arcanosWorkers.runtime.totalDispatched
+  };
+
+  const heuristics = buildHeuristicPlan(context, model);
+  const shouldConsultAI = context.failingWorkers.length > 0 || Boolean(context.lastError);
+  if (!shouldConsultAI) {
+    return heuristics;
+  }
+
+  try {
+    const payload = {
+      context,
+      status: {
+        timestamp: status.timestamp,
+        model: status.system.model,
+        arcanosWorkers: status.arcanosWorkers
+      },
+      heuristic: heuristics
+    };
+
+    const prompt = [
+      `You are ARCANOS reliability control operating on fine-tuned model ${model}.`,
+      'Analyze the worker status JSON and produce recovery guidance in JSON with fields planId, severity, recommendedAction,',
+      'message, steps (array), and fallbackModel.',
+      'Recommended actions must be one of monitor, restart-workers, fallback-model, or escalate.',
+      'JSON input:',
+      JSON.stringify(payload)
+    ].join('\n');
+
+    const result = await callOpenAI(model, prompt, 1200, false, {
+      responseFormat: { type: 'json_object' },
+      metadata: { route: 'auto-heal' }
+    });
+
+    const parsed = JSON.parse(result.output || '{}');
+    const steps = Array.isArray(parsed.steps) ? parsed.steps.map((step: unknown) => String(step)) : [];
+
+    return {
+      planId: typeof parsed.planId === 'string' ? parsed.planId : 'ai-plan',
+      severity: ['ok', 'warning', 'critical'].includes(parsed.severity)
+        ? (parsed.severity as AutoHealSeverity)
+        : heuristics.severity,
+      recommendedAction: ['monitor', 'restart-workers', 'fallback-model', 'escalate'].includes(parsed.recommendedAction)
+        ? parsed.recommendedAction
+        : heuristics.recommendedAction,
+      message: typeof parsed.message === 'string' ? parsed.message : heuristics.message,
+      steps: steps.length > 0 ? steps : heuristics.steps,
+      fallbackModel: typeof parsed.fallbackModel === 'string' ? parsed.fallbackModel : heuristics.fallbackModel,
+      generatedAt: new Date().toISOString()
+    };
+  } catch (error) {
+    console.error('[AUTO-HEAL] Failed to consult AI for plan', error);
+    return heuristics;
+  }
+}
+
+export function summarizeAutoHeal(status: WorkerStatusResponseDTO) {
+  const failingWorkers = status.workers.filter(worker => !worker.available).map(worker => worker.id);
+  const lastError = status.arcanosWorkers.runtime.lastError;
+  const severity: AutoHealSeverity = failingWorkers.length > 0 || lastError ? 'critical' : 'ok';
+
+  return {
+    status: severity,
+    failingWorkers,
+    lastError,
+    recommendedAction: severity === 'critical' ? 'review /workers/heal for plan' : 'monitor'
+  };
+}

--- a/src/services/dailySummaryService.ts
+++ b/src/services/dailySummaryService.ts
@@ -1,0 +1,147 @@
+import fs from 'fs';
+import path from 'path';
+import { callOpenAI, getDefaultModel } from './openai.js';
+import { loadState, updateState } from './stateManager.js';
+
+interface SummarySources {
+  systemState: Record<string, unknown>;
+  memoryState?: Record<string, unknown>;
+  healthHistory?: unknown;
+  logsPreview: string[];
+}
+
+export interface DailySummaryResult {
+  model: string;
+  file: string;
+  summary: Record<string, unknown>;
+  generatedAt: string;
+  triggeredBy: string;
+}
+
+const MEMORY_DIR = path.join(process.cwd(), 'memory');
+
+function readJsonFile(filePath: string): Record<string, unknown> | undefined {
+  try {
+    if (!fs.existsSync(filePath)) {
+      return undefined;
+    }
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return raw ? (JSON.parse(raw) as Record<string, unknown>) : undefined;
+  } catch (error) {
+    console.error(`[DAILY-SUMMARY] Failed to read ${filePath}`, error);
+    return undefined;
+  }
+}
+
+function collectLogsPreview(): string[] {
+  const logsDir = path.join(process.cwd(), 'logs');
+  if (!fs.existsSync(logsDir)) return [];
+
+  const previews: string[] = [];
+  const files = fs.readdirSync(logsDir).filter(file => file.endsWith('.log') || file.endsWith('.json'));
+  for (const file of files) {
+    const filePath = path.join(logsDir, file);
+    try {
+      const raw = fs.readFileSync(filePath, 'utf8');
+      previews.push(`${file}: ${raw.slice(0, 400)}`);
+    } catch (error) {
+      console.error('[DAILY-SUMMARY] Failed to read log file', filePath, error);
+    }
+  }
+  return previews.slice(0, 5);
+}
+
+async function buildSummarySources(): Promise<SummarySources> {
+  const systemState = loadState() as Record<string, unknown>;
+  const memoryState = readJsonFile(path.join(MEMORY_DIR, 'state.json'));
+  const healthHistory = readJsonFile(path.join(process.cwd(), 'logs', 'healthcheck.json'));
+  const logsPreview = collectLogsPreview();
+
+  return {
+    systemState,
+    memoryState,
+    healthHistory,
+    logsPreview
+  };
+}
+
+function ensureSummaryDir(): void {
+  if (!fs.existsSync(MEMORY_DIR)) {
+    fs.mkdirSync(MEMORY_DIR, { recursive: true });
+  }
+}
+
+function resolveSummaryFile(date: Date): string {
+  ensureSummaryDir();
+  const isoDate = date.toISOString().split('T')[0];
+  return path.join(MEMORY_DIR, `summary-${isoDate}.json`);
+}
+
+function buildPrompt(model: string, sources: SummarySources): string {
+  return [
+    `You are the ARCANOS daily journal running on the fine-tuned model ${model}.`,
+    'Summarize the following state into JSON with keys summary, highlights (array of strings), risks (array), and nextSteps (array).',
+    'Keep entries factual and reference observed data only. Include model provenance metadata.',
+    'Data:',
+    JSON.stringify(sources)
+  ].join('\n');
+}
+
+export async function generateDailySummary(triggeredBy: string = 'cli'): Promise<DailySummaryResult> {
+  const sources = await buildSummarySources();
+  const model = process.env.DAILY_SUMMARY_MODEL || getDefaultModel();
+  const prompt = buildPrompt(model, sources);
+
+  let parsed: Record<string, unknown> = {};
+  try {
+    const result = await callOpenAI(model, prompt, 1500, false, {
+      responseFormat: { type: 'json_object' },
+      metadata: { route: 'daily-summary', triggeredBy }
+    });
+    parsed = JSON.parse(result.output || '{}');
+  } catch (error) {
+    console.error('[DAILY-SUMMARY] Failed to generate via OpenAI, falling back to heuristic summary', error);
+    parsed = {
+      summary: 'Daily summary fallback',
+      highlights: [
+        `Self tests recorded: ${Array.isArray((sources.healthHistory as any)?.history) ? (sources.healthHistory as any).history.length : 0}`
+      ],
+      risks: ['Unable to reach OpenAI - verify API key'],
+      nextSteps: ['Retry summary generation once connectivity is restored']
+    };
+  }
+
+  const generatedAt = new Date().toISOString();
+  const file = resolveSummaryFile(new Date());
+  fs.writeFileSync(
+    file,
+    JSON.stringify(
+      {
+        generatedAt,
+        model,
+        triggeredBy,
+        sources,
+        summary: parsed
+      },
+      null,
+      2
+    )
+  );
+
+  updateState({
+    dailySummary: {
+      generatedAt,
+      file,
+      model,
+      triggeredBy
+    }
+  });
+
+  return {
+    model,
+    file,
+    summary: parsed,
+    generatedAt,
+    triggeredBy
+  };
+}

--- a/src/services/selfTestPipeline.ts
+++ b/src/services/selfTestPipeline.ts
@@ -1,0 +1,212 @@
+import fs from 'fs';
+import path from 'path';
+import { updateState } from './stateManager.js';
+
+export interface SelfTestPrompt {
+  id: string;
+  prompt: string;
+  expectation: string;
+}
+
+export interface SelfTestResult {
+  id: string;
+  prompt: string;
+  expectation: string;
+  statusCode: number;
+  latencyMs: number;
+  success: boolean;
+  message?: string;
+  activeModel?: string;
+  module?: string;
+  responsePreview?: string;
+}
+
+export interface SelfTestSummary {
+  triggeredBy: string;
+  baseUrl: string;
+  targetModel: string;
+  completedAt: string;
+  passCount: number;
+  failCount: number;
+  results: SelfTestResult[];
+}
+
+export interface SelfTestOptions {
+  baseUrl?: string;
+  prompts?: SelfTestPrompt[];
+  triggeredBy?: string;
+  targetModel?: string;
+}
+
+const defaultPrompts: SelfTestPrompt[] = [
+  {
+    id: 'readiness',
+    prompt: 'Respond with a concise status update proving ARCANOS is online and ready for work.',
+    expectation: 'Model responds with operational readiness signal.'
+  },
+  {
+    id: 'memory-awareness',
+    prompt: 'Summarize any memory context you can access in one paragraph.',
+    expectation: 'Model references stored memory context without errors.'
+  },
+  {
+    id: 'module-routing',
+    prompt: 'Which internal module handled this request? Reply in JSON {"module":"name"}.',
+    expectation: 'Model identifies the executing module and formats JSON correctly.'
+  }
+];
+
+const LOG_FILE = path.join(process.cwd(), 'logs', 'healthcheck.json');
+
+function resolveBaseUrl(): string {
+  if (process.env.SELF_TEST_BASE_URL) return process.env.SELF_TEST_BASE_URL;
+  if (process.env.SERVER_URL) return process.env.SERVER_URL.replace(/\/$/, '');
+  const port = process.env.PORT || '8080';
+  return `http://127.0.0.1:${port}`;
+}
+
+function ensureLogFile(): void {
+  const dir = path.dirname(LOG_FILE);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  if (!fs.existsSync(LOG_FILE)) {
+    const seed = {
+      history: [] as SelfTestSummary[],
+      updatedAt: new Date().toISOString()
+    };
+    fs.writeFileSync(LOG_FILE, JSON.stringify(seed, null, 2));
+  }
+}
+
+function appendLog(summary: SelfTestSummary): void {
+  ensureLogFile();
+  try {
+    const existingRaw = fs.readFileSync(LOG_FILE, 'utf8');
+    const parsed = existingRaw ? JSON.parse(existingRaw) : { history: [] };
+    const history: SelfTestSummary[] = Array.isArray(parsed.history) ? parsed.history : [];
+    history.push(summary);
+    const trimmed = history.slice(-20);
+    fs.writeFileSync(
+      LOG_FILE,
+      JSON.stringify(
+        {
+          updatedAt: new Date().toISOString(),
+          history: trimmed
+        },
+        null,
+        2
+      )
+    );
+  } catch (error) {
+    console.error('[SELF-TEST] Failed to append log', error);
+  }
+}
+
+async function executePrompt(
+  baseUrl: string,
+  targetModel: string,
+  prompt: SelfTestPrompt
+): Promise<SelfTestResult> {
+  const started = Date.now();
+  const endpoint = `${baseUrl.replace(/\/$/, '')}/ask`;
+  try {
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'user-agent': 'arcanos-self-test/1.0',
+        'x-confirmed': 'yes'
+      },
+      body: JSON.stringify({
+        prompt: prompt.prompt,
+        sessionId: 'self-test',
+        overrideAuditSafe: 'self-test'
+      })
+    });
+
+    const latencyMs = Date.now() - started;
+    const statusCode = res.status;
+
+    if (!res.ok) {
+      return {
+        id: prompt.id,
+        prompt: prompt.prompt,
+        expectation: prompt.expectation,
+        statusCode,
+        latencyMs,
+        success: false,
+        message: `HTTP ${res.status} ${res.statusText}`
+      };
+    }
+
+    const data = (await res.json()) as Record<string, any>;
+    const activeModel = typeof data.activeModel === 'string' ? data.activeModel : undefined;
+    const moduleName = typeof data.module === 'string' ? data.module : undefined;
+    const responsePreview = typeof data.result === 'string' ? data.result.slice(0, 200) : undefined;
+    const modelMatches = activeModel ? activeModel.includes(targetModel) : true;
+    const success = Boolean(data.result) && modelMatches;
+
+    return {
+      id: prompt.id,
+      prompt: prompt.prompt,
+      expectation: prompt.expectation,
+      statusCode,
+      latencyMs,
+      success,
+      message: success
+        ? 'Model responded successfully'
+        : `Active model mismatch: expected ${targetModel}, received ${activeModel || 'unknown'}`,
+      activeModel,
+      module: moduleName,
+      responsePreview
+    };
+  } catch (error) {
+    return {
+      id: prompt.id,
+      prompt: prompt.prompt,
+      expectation: prompt.expectation,
+      statusCode: 0,
+      latencyMs: Date.now() - started,
+      success: false,
+      message: error instanceof Error ? error.message : 'Unknown error'
+    };
+  }
+}
+
+export async function runSelfTestPipeline(options: SelfTestOptions = {}): Promise<SelfTestSummary> {
+  const baseUrl = options.baseUrl || resolveBaseUrl();
+  const prompts = options.prompts && options.prompts.length > 0 ? options.prompts : defaultPrompts;
+  const targetModel = options.targetModel || process.env.FINETUNED_MODEL_ID || process.env.AI_MODEL || 'gpt-4-turbo';
+  const triggeredBy = options.triggeredBy || 'cli';
+
+  const results: SelfTestResult[] = [];
+  for (const prompt of prompts) {
+    const result = await executePrompt(baseUrl, targetModel, prompt);
+    results.push(result);
+  }
+
+  const passCount = results.filter(r => r.success).length;
+  const failCount = results.length - passCount;
+  const summary: SelfTestSummary = {
+    triggeredBy,
+    baseUrl,
+    targetModel,
+    completedAt: new Date().toISOString(),
+    passCount,
+    failCount,
+    results
+  };
+
+  appendLog(summary);
+  updateState({
+    selfTest: {
+      ...summary,
+      lastRun: summary.completedAt,
+      status: failCount === 0 ? 'pass' : 'fail'
+    }
+  });
+
+  return summary;
+}

--- a/src/types/dto.ts
+++ b/src/types/dto.ts
@@ -180,13 +180,23 @@ export const workerStatusResponseSchema = z.object({
   system: z.object({
     model: z.string(),
     environment: z.string()
-  })
+  }),
+  autoHeal: z
+    .object({
+      status: z.enum(['ok', 'warning', 'critical']),
+      failingWorkers: z.array(z.string()).optional(),
+      lastError: z.string().optional(),
+      recommendedAction: z.string().optional()
+    })
+    .optional()
 });
 
 /**
  * Worker status response data transfer object type inferred from the validation schema.
  */
 export type WorkerStatusResponseDTO = z.infer<typeof workerStatusResponseSchema>;
+
+export type AutoHealStatusDTO = NonNullable<WorkerStatusResponseDTO['autoHeal']>;
 
 /**
  * Schema for worker execution results.


### PR DESCRIPTION
## Summary
- add a Railway cron definition plus CLI/HTTP entry points that run the `/ask` self-test pipeline and write results into `logs/healthcheck.json`/`systemState.json`
- generate daily GPT-4 (fine-tune) summaries of memory, logs, and state with a reusable service + command and expose `/devops/daily-summary`
- extend the worker status route with GPT-backed auto-heal recommendations and a confirmation-gated `/workers/heal` restart endpoint

## Testing
- npm run type-check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69184886fb908325b233f2cfbc70a86d)