### PR TITLE
Enable automation secret bypass for confirmation gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Key environment variables used by the backend:
 | `RUN_WORKERS` | Enables worker bootstrap (defaults to `true` outside of tests). |
 | `WORKER_COUNT` / `WORKER_MODEL` / `WORKER_API_TIMEOUT_MS` | Worker concurrency, default model, and request timeout controls. |
 | `TRUSTED_GPT_IDS` | Comma-separated GPT identifiers allowed to bypass confirmation headers. The active fine-tuned model ID (from `FINE_TUNED_MODEL_ID`/`OPENAI_MODEL`) is automatically appended so it can act autonomously when supplied via `x-gpt-id`. |
+| `ARCANOS_AUTOMATION_SECRET` / `ARCANOS_AUTOMATION_HEADER` | Optional secret/header pair that lets internal automations self-approve confirmation-gated routes. Set the secret and send it via `x-arcanos-automation` (or your custom header) when a GPT ID isn’t available. |
 | `CONFIRMATION_CHALLENGE_TTL_MS` | Lifetime of pending confirmation challenges issued by the middleware (defaults to 120000). |
 | `SESSION_CACHE_TTL_MS` / `SESSION_CACHE_CAPACITY` / `SESSION_RETENTION_MINUTES` | Memory cache retention and capacity tuning. |
 | `NOTION_API_KEY` / `RESEARCH_MAX_CONTENT_CHARS` / `HRC_MODEL` | Feature-specific integrations for Notion sync, research ingestion, and HRC analysis. |
@@ -88,12 +89,16 @@ A full configuration matrix is maintained in
 
 All routes are registered in [`src/routes/register.ts`](src/routes/register.ts).
 Confirmation-sensitive endpoints require the `x-confirmed` header unless the
-caller supplies a trusted GPT ID via `x-gpt-id` or request payload. Manual runs
-send `x-confirmed: yes`; automated flows should wait for the middleware’s
-pending challenge response and then retry with `x-confirmed: token:<challengeId>`.
-The active fine-tuned model is now trusted automatically—issuing
-`x-gpt-id: <your fine-tuned model id>` allows that model to dispatch heals and
-other remediation steps without needing a separate confirmation cycle.
+caller supplies a trusted GPT ID via `x-gpt-id`/`gptId` or provides the
+automation secret header. Manual runs send `x-confirmed: yes`; automated flows
+should wait for the middleware’s pending challenge response and then retry with
+`x-confirmed: token:<challengeId>`. The active fine-tuned model is now trusted
+automatically—issuing `x-gpt-id: <your fine-tuned model id>` allows that model
+to dispatch heals and other remediation steps without needing a separate
+confirmation cycle. If your automation cannot expose a GPT ID (for example,
+API-based fine-tunes), set `ARCANOS_AUTOMATION_SECRET` and send the secret via
+`x-arcanos-automation` (or your configured header) to achieve the same
+autonomous approval path.
 
 ### Conversational & Reasoning Endpoints
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -98,6 +98,7 @@ report the degraded state for observability.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `TRUSTED_GPT_IDS` | – | Comma-separated GPT identifiers that bypass the confirmation gate. The active fine-tuned model ID (from `FINE_TUNED_MODEL_ID` / `OPENAI_MODEL`) is appended automatically so it can run automation via `x-gpt-id`. |
+| `ARCANOS_AUTOMATION_SECRET` / `ARCANOS_AUTOMATION_HEADER` | – | Shared secret/header pair that lets backend automations self-identify when a GPT ID isn’t available. The header defaults to `x-arcanos-automation`; matching requests bypass `confirmGate` like a trusted GPT. |
 | `CONFIRMATION_CHALLENGE_TTL_MS` | `120000` | Lifetime (in milliseconds) for pending confirmation challenges returned by `confirmGate`. |
 | `ALLOW_ROOT_OVERRIDE` | `false` | Enables elevated persistence operations when paired with `ROOT_OVERRIDE_TOKEN`. |
 | `ROOT_OVERRIDE_TOKEN` | – | Secret required when root override mode is enabled. |
@@ -166,6 +167,10 @@ Confirmation behaviour is implemented in
   `workers/` is empty).
 - **Trusted GPT IDs** – Ensure `TRUSTED_GPT_IDS` and the caller’s `x-gpt-id`
   value match exactly (case-sensitive).
+- **Automation secret header** – Configure `ARCANOS_AUTOMATION_SECRET` (and
+  optionally `ARCANOS_AUTOMATION_HEADER`) when your automation cannot send a
+  GPT ID. Requests must include the shared secret header to bypass the
+  confirmation challenge.
 
 Keep this document aligned with changes to `src/config`, `src/utils/env.ts`, and
 any new feature-specific services that rely on environment variables.

--- a/docs/SELF_HEALING.md
+++ b/docs/SELF_HEALING.md
@@ -18,6 +18,13 @@ operator repeating `x-confirmed: yes`. This change keeps human approvals in
 place for untrusted callers while allowing the same fine-tuned model that builds
 the auto-heal plan to carry it out end-to-end.【F:src/middleware/confirmGate.ts†L1-L116】
 
+If your automation does not expose a GPT identifier (for example, API-only
+fine-tunes), set `ARCANOS_AUTOMATION_SECRET` (and optionally
+`ARCANOS_AUTOMATION_HEADER`) so the backend can self-identify via a shared
+secret header like `x-arcanos-automation`. Matching requests now bypass the
+confirmation prompt just like a trusted GPT ID while still requiring explicit
+operator approval for everything else.【F:src/middleware/confirmGate.ts†L26-L190】
+
 ## How Auto-Heal Plans Are Built
 
 1. `buildStatusPayload()` captures the file-system inventory, current runtime telemetry, and embeds an `autoHeal` summary for downstream consumers.【F:src/routes/workers.ts†L18-L88】

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -5,9 +5,13 @@
 This guide summarises the HTTP API exposed by the Arcanos backend. All routes
 are registered in [`src/routes/register.ts`](../../src/routes/register.ts).
 Mutating endpoints require the `x-confirmed` header unless the caller is a
-trusted GPT (`TRUSTED_GPT_IDS` + `x-gpt-id`). Manual calls send `x-confirmed: yes`;
-automations should wait for the confirmation challenge response and retry with
-`x-confirmed: token:<challengeId>` once the operator approves.
+trusted GPT (`TRUSTED_GPT_IDS` + `x-gpt-id`), provides the `gptId` field in the
+body, or sends the automation secret header. Manual calls send `x-confirmed:
+yes`; automations should wait for the confirmation challenge response and retry
+with `x-confirmed: token:<challengeId>` once the operator approves. When GPT IDs
+aren’t available, configure `ARCANOS_AUTOMATION_SECRET` and supply the secret via
+`x-arcanos-automation` (or your custom header) to gain the same autonomous fast
+path.
 
 ---
 


### PR DESCRIPTION
## Summary
- add an optional automation secret/header pair to `confirmGate` so backend remediations can self-approve when a GPT ID is not available
- expose the new bypass details through the confirm gate configuration payload and enrich the 403 instructions with automation guidance
- document the new environment variables and self-healing flow so operators know how to configure and use the automation header

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c5a7f2f88325a2f81af1c7c14d17)