### PR TITLE
Add GPT-5.1 reasoning configuration support

### DIFF
--- a/OPTIMIZATION_REPORT.md
+++ b/OPTIMIZATION_REPORT.md
@@ -165,7 +165,7 @@ Memory: Optimized with --max-old-space-size=7168
 
 - `DATABASE_URL` - PostgreSQL connection (falls back to in-memory)
 - `RUN_WORKERS` - Enable background workers (default: false)
-- `GPT5_MODEL` - Advanced model configuration
+- `GPT51_MODEL` / `GPT5_MODEL` - Advanced model configuration for GPT-5.1 reasoning
 - `RAILWAY_ENVIRONMENT` - Railway platform detection
 
 ### Validation Features:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Key environment variables used by the backend:
 | `OPENAI_API_KEY` | API key for the OpenAI SDK. Missing keys enable mock responses. |
 | `OPENAI_MODEL` / `FINETUNED_MODEL_ID` / `FINE_TUNED_MODEL_ID` / `AI_MODEL` | Preferred model identifiers (first non-empty wins). |
 | `RESEARCH_MODEL_ID` | Optional override for the research pipeline; defaults to the selected AI model. |
-| `GPT5_MODEL` | Override identifier used for GPT‑5.1 reasoning fallbacks (default `gpt-5`). |
+| `GPT51_MODEL` / `GPT5_MODEL` | Override identifiers used for GPT‑5.1 reasoning fallbacks (defaults to `gpt-5.1`, then `gpt-5`). |
 | `PORT` / `HOST` / `SERVER_URL` | Server binding details. `PORT` defaults to `8080`. |
 | `DATABASE_URL` (+ `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE`) | PostgreSQL connection string with automatic assembly from discrete settings. |
 | `ARC_LOG_PATH` / `ARC_MEMORY_PATH` | Filesystem paths for log storage and memory snapshots. |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -47,7 +47,7 @@ Additional model-related variables:
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `GPT5_MODEL` | `gpt-5` | Identifier used for GPT‑5.1 reasoning fallbacks. |
+| `GPT51_MODEL` / `GPT5_MODEL` | `gpt-5.1` / `gpt-5` | Identifiers used for GPT‑5.1 reasoning fallbacks (the service checks `GPT51_MODEL` first, then `GPT5_MODEL`). |
 | `API_KEY` | – | Legacy alias checked before `OPENAI_API_KEY`. |
 
 ---

--- a/docs/GPT5_INTEGRATION_SUMMARY.md
+++ b/docs/GPT5_INTEGRATION_SUMMARY.md
@@ -7,7 +7,7 @@ Successfully implemented GPT-5 as the primary reasoning engine while preserving 
 
 ### Core Routing Logic (`src/logic/arcanos.ts`)
 - **Updated GPT-5 Integration**: Changed delegation from GPT-4 Turbo to GPT-5
-- **Model Configuration**: Uses `model: "gpt-5"` with `chat.completions.create` endpoint as specified
+- **Model Configuration**: Uses `model: "gpt-5.1"` by default (configurable via `GPT51_MODEL` / `GPT5_MODEL`) with `chat.completions.create` endpoint as specified
 - **Function Names**: Updated from `shouldDelegateToGPT4()` to `shouldDelegateToGPT5()`
 - **Delegation Function**: Updated from `delegateToGPT4()` to `delegateToGPT5()`
 
@@ -25,7 +25,7 @@ Successfully implemented GPT-5 as the primary reasoning engine while preserving 
 ```javascript
 // Exact API syntax as specified in requirements
 const gpt5Response = await createResponseWithLogging(client, {
-  model: 'gpt-5',  // ✅ Updated from 'gpt-4-turbo'
+  model: 'gpt-5.1',  // ✅ Updated from 'gpt-4-turbo'
   messages: [
     { 
       role: 'system', 
@@ -116,7 +116,7 @@ const gpt5Response = await createResponseWithLogging(client, {
 - [x] No direct GPT-5 output to users
 - [x] Complete audit logging with GPT-5 tracking
 - [x] Memory handling, compliance, and execution within ARCANOS
-- [x] Latest OpenAI SDK syntax with model: "gpt-5"
+- [x] Latest OpenAI SDK syntax with model: "gpt-5.1" (configurable via `GPT51_MODEL` / `GPT5_MODEL`)
 
 ## Production Readiness
 

--- a/docs/ORCHESTRATION_API.md
+++ b/docs/ORCHESTRATION_API.md
@@ -152,7 +152,7 @@ npm test
 ## Environment Variables
 
 - `OPENAI_API_KEY` or `API_KEY`: OpenAI API key for GPT-5 access
-- `GPT5_MODEL`: GPT-5 model identifier (defaults to 'gpt-5')
+- `GPT51_MODEL` / `GPT5_MODEL`: GPT-5.1 reasoning model identifiers (defaults to `gpt-5.1` then `gpt-5`)
 - `ORCHESTRATION_LAST_RESET`: Timestamp of last reset (automatically set)
 
 ## Error Handling

--- a/docs/arcanos-overview.md
+++ b/docs/arcanos-overview.md
@@ -122,7 +122,7 @@ Key environment variables:
   sentinel, mock responses are returned.
 - `OPENAI_MODEL`, `FINETUNED_MODEL_ID`, `FINE_TUNED_MODEL_ID`, `AI_MODEL` – Model
   preference chain.
-- `RESEARCH_MODEL_ID`, `GPT5_MODEL` – Optional overrides for specialized flows.
+- `RESEARCH_MODEL_ID`, `GPT51_MODEL` / `GPT5_MODEL` – Optional overrides for specialized flows.
 - `DATABASE_URL` or discrete PG settings – PostgreSQL connection parameters.
 - `RUN_WORKERS`, `WORKER_COUNT`, `WORKER_MODEL`, `WORKER_API_TIMEOUT_MS` – Worker
   scheduling and capacity controls.

--- a/docs/legacy/original-readme/configuration.md
+++ b/docs/legacy/original-readme/configuration.md
@@ -29,7 +29,8 @@ WORKER_API_TIMEOUT_MS=60000    # Worker API timeout in milliseconds
 
 ## OpenAI Advanced Features
 ```bash
-GPT5_MODEL=gpt-5               # GPT-5 model configuration
+GPT51_MODEL=gpt-5.1            # Preferred GPT-5.1 model configuration
+GPT5_MODEL=gpt-5               # Backwards compatible GPT-5 model configuration
 BOOKER_TOKEN_LIMIT=512         # Token limit for backstage booking prompts
 TUTOR_DEFAULT_TOKEN_LIMIT=200  # Default token limit for tutor queries
 ```

--- a/railway.json
+++ b/railway.json
@@ -29,6 +29,7 @@
         "OPENAI_API_KEY": "$OPENAI_API_KEY",
         "OPENAI_BASE_URL": "$OPENAI_BASE_URL",
         "AI_MODEL": "$AI_MODEL",
+        "GPT51_MODEL": "$GPT51_MODEL",
         "GPT5_MODEL": "$GPT5_MODEL",
         "RAILWAY_ENVIRONMENT": "production",
         "RUN_WORKERS": "false",

--- a/railway/config.example.json
+++ b/railway/config.example.json
@@ -29,6 +29,7 @@
         "OPENAI_API_KEY": "$OPENAI_API_KEY",
         "OPENAI_BASE_URL": "$OPENAI_BASE_URL",
         "AI_MODEL": "$AI_MODEL",
+        "GPT51_MODEL": "$GPT51_MODEL",
         "GPT5_MODEL": "$GPT5_MODEL",
         "RUN_WORKERS": "false",
         "WORKER_API_TIMEOUT_MS": "60000",

--- a/src/services/arcanosQuery.ts
+++ b/src/services/arcanosQuery.ts
@@ -1,8 +1,8 @@
-import { getOpenAIClient, getDefaultModel } from './openai.js';
+import { getOpenAIClient, getDefaultModel, getGPT5Model } from './openai.js';
 
 // Use centralized model configuration
 const FT_MODEL = getDefaultModel();
-const REASONING_MODEL = "gpt-5";
+const REASONING_MODEL = getGPT5Model();
 
 export async function arcanosQuery(prompt: string): Promise<string> {
   try {

--- a/src/services/openai/credentialProvider.ts
+++ b/src/services/openai/credentialProvider.ts
@@ -98,6 +98,6 @@ export function getFallbackModel(): string {
 }
 
 export function getGPT5Model(): string {
-  return process.env.GPT5_MODEL || 'gpt-5';
+  return process.env.GPT51_MODEL || process.env.GPT5_MODEL || 'gpt-5.1';
 }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,6 +14,7 @@ export const APPLICATION_CONSTANTS = {
   MODEL_GPT_4_TURBO: 'gpt-4-turbo',
   MODEL_GPT_4O: 'gpt-4o',
   MODEL_GPT_5: 'gpt-5',
+  MODEL_GPT_5_1: 'gpt-5.1',
   MODEL_GPT_3_5_TURBO: 'gpt-3.5-turbo',
   
   // Timeout values (in milliseconds)  

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -94,6 +94,7 @@ export const env = {
   OPENAI_API_KEY: Environment.get('OPENAI_API_KEY'),
   OPENAI_BASE_URL: Environment.get('OPENAI_BASE_URL'),
   AI_MODEL: Environment.get('AI_MODEL', APPLICATION_CONSTANTS.MODEL_GPT_4_TURBO),
+  GPT51_MODEL: Environment.get('GPT51_MODEL', APPLICATION_CONSTANTS.MODEL_GPT_5_1),
   GPT5_MODEL: Environment.get('GPT5_MODEL', APPLICATION_CONSTANTS.MODEL_GPT_5),
   
   // Database Configuration

--- a/src/utils/tokenParameterHelper.ts
+++ b/src/utils/tokenParameterHelper.ts
@@ -14,7 +14,8 @@ import OpenAI from 'openai';
 const MAX_COMPLETION_TOKENS_MODELS = new Set<string>([
   // Add specific model names here as they are discovered
   // This will be populated based on API testing and documentation
-  'gpt-5'
+  'gpt-5',
+  'gpt-5.1'
 ]);
 
 // Cache for model capability testing to avoid repeated API calls


### PR DESCRIPTION
## Summary
- introduce the `GPT51_MODEL` override (defaulting to `gpt-5.1`) so the reasoning layer can target a real GPT-5.1 model when available
- update the OpenAI credential utilities, routing helpers, and documentation to respect the new configuration and clarify deployment guidance
- refresh sample Railway configs and legacy docs to surface the new variable everywhere GPT-5 settings are described

## Testing
- npm test -- openai-prompt.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b9a5e14148325ab3d10e6383dccaf)