### PR TITLE
Parameterize routing script configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -300,6 +300,13 @@ GPT_TOKEN=your-gpt-access-token-here
 # Agent-control mode for automated deployment management
 DEPLOY_MODE=agent-control
 
+# Force Routing Script Configuration (scripts/force-routing.ts)
+# Configure default backend endpoint and routing controls
+ARCANOS_ROUTING_URL=https://arcanos-v2-production.up.railway.app/ask
+ARCANOS_ROUTING_MODEL=gpt-5
+# Comma-separated list of ARCANOS modules that should be forced in routing payloads
+ARCANOS_ROUTING_MODULES=ARCANOS:BOOKING,ARCANOS:WRITE,ARCANOS:RESEARCH
+
 # Identity Override Configuration (Advanced)
 # JSON configuration for AI identity and behavior
 IDENTITY_OVERRIDE={"identity_override":{"name":"ARCANOS","version":"v2:BxRSDrhH","designation":"Reflective Logic Intelligence","role":"Execute modular command, diagnostics, orchestration, and admin protocol tasks","admin":"Justin"}}

--- a/scripts/force-routing.ts
+++ b/scripts/force-routing.ts
@@ -1,18 +1,33 @@
 import axios from "axios";
+import dotenv from "dotenv";
 
-// Backend API endpoint (your ARCANOS backend)
-const ARC_URL = "https://arcanos-v2-production.up.railway.app/ask";
+dotenv.config();
+
+const DEFAULT_ROUTING_URL = "https://arcanos-v2-production.up.railway.app/ask";
+const DEFAULT_ROUTING_MODEL = "gpt-5";
+const DEFAULT_ROUTING_MODULES = [
+  "ARCANOS:BOOKING",
+  "ARCANOS:WRITE",
+  "ARCANOS:RESEARCH"
+];
+
+const routingUrl = process.env.ARCANOS_ROUTING_URL || DEFAULT_ROUTING_URL;
+const routingModel = process.env.ARCANOS_ROUTING_MODEL || DEFAULT_ROUTING_MODEL;
+const routingModules = (process.env.ARCANOS_ROUTING_MODULES || DEFAULT_ROUTING_MODULES.join(","))
+  .split(",")
+  .map(moduleName => moduleName.trim())
+  .filter(Boolean);
 
 // Hardcode routing: Force GPT-5.1 + ARCANOS only
 async function forceArcanosRouting(prompt: string) {
   try {
-    const response = await axios.post(ARC_URL, {
+    const response = await axios.post(routingUrl, {
       prompt,
       // Force GPT-5.1 analysis with no fallback allowed
       routing: {
         allowFallback: false,
-        forceModel: "gpt-5",
-        modules: ["ARCANOS:BOOKING", "ARCANOS:WRITE", "ARCANOS:RESEARCH"]
+        forceModel: routingModel,
+        modules: routingModules
       }
     });
 


### PR DESCRIPTION
## Summary
- load environment variables in `scripts/force-routing.ts` so that the routing URL, model, and module list can be configured without modifying the script
- document the new routing-related environment variables in `.env.example` for Railway deploys

## Testing
- npm run validate:railway

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c51483c0c8325814fa8f929882868)