### PR TITLE
Enable auto self-heal for trusted GPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ See [`docs/TRINITY_PIPELINE.md`](docs/TRINITY_PIPELINE.md) for a detailed walkth
 - `POST /workers/run/:workerId` – Executes a worker by filename (requires
   confirmation).
 - `POST /workers/heal` – Generates a GPT-backed recovery plan and optionally
-  restarts the worker pool (requires confirmation header).
+  restarts the worker pool (requires confirmation header). Trusted GPT callers
+  auto-execute the restart unless they request `mode: "plan"`.
 - `POST /heartbeat` – Records operator heartbeats to `logs/heartbeat.log`
   (requires confirmation).
 - `POST /devops/self-test` – Runs the automated `/ask` self-test suite and

--- a/docs/AI_AUTONOMOUS_HEALING_RECOMMENDATIONS.md
+++ b/docs/AI_AUTONOMOUS_HEALING_RECOMMENDATIONS.md
@@ -12,7 +12,7 @@ This guide distills the concrete steps required to let the Arcanos AI supervise 
 ## 2. Automate the Heal Lifecycle
 
 1. **Probe worker health continuously** – Poll `GET /workers/status` on a short cadence (e.g., every minute) and inspect the embedded `autoHeal` summary to decide when to trigger `/workers/heal`.
-2. **Execute heals with `mode: "execute"`** – Post `{ "mode": "execute", "reason": "automated-detection" }` to `/workers/heal` as soon as severity escalates to `major` or `critical`. This restarts the pool through `startWorkers(true)` and tags the attempt in `systemState.json` for later correlation.
+2. **Execute heals with `mode: "execute"`** – Post `{ "mode": "execute", "reason": "automated-detection" }` to `/workers/heal` as soon as severity escalates to `major` or `critical`. Trusted GPT callers and automation-secret flows automatically inherit execute mode even without the flag, so the restart kicks off immediately unless you explicitly request `mode: "plan"` for a dry run. Every execution restarts the pool through `startWorkers(true)` and tags the attempt in `systemState.json` for later correlation.
 3. **Replay self-tests post-heal** – After each automated restart, call `/devops/self-test` (or the `runSelfTestPipeline` helper) so the AI can confirm the environment stabilized before resuming normal dispatching.
 
 ## 3. Maintain Observability


### PR DESCRIPTION
## Summary
- expose confirmation metadata on each request so downstream routes know when a trusted automation was approved
- allow trusted GPT IDs or automation-secret callers to automatically execute `/workers/heal` unless they request plan-only mode and surface that metadata in the response
- update the self-healing documentation and README to explain the new automatic execution behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d0d760e448325ab9f19804a25f07c)