### PR TITLE
Add web-grounded context for gaming module

### DIFF
--- a/docs/ai-guides/custom-gpt/arcanos-gaming.md
+++ b/docs/ai-guides/custom-gpt/arcanos-gaming.md
@@ -11,11 +11,15 @@
 ```json
 {
   "prompt": "How do I beat the Guardian Ape in Sekiro?",
-  "url": "https://example.com/sekiro/guardian-ape-guide"
+  "url": "https://example.com/sekiro/guardian-ape-guide",
+  "urls": [
+    "https://example.com/sekiro/phase-two-tips"
+  ]
 }
 ```
 - `prompt` (string) – Required user question or context. A raw string is also accepted when the calling workflow does not wrap the payload.
 - `url` (string, optional) – Remote guide to hydrate the prompt. The service attempts to fetch and clean this URL before intake.
+- `urls` (string[], optional) – Additional live sources that will be fetched, cleaned, and summarized into the prompt to keep answers fresh and reduce hallucinations.
 - `metadata` (object, optional) – Include `{ "gpt_id": "<custom gpt id>", "module": "ARCANOS:GAMING" }` when called from ChatGPT. The `/api/ask` shim records this information for telemetry.
 
 ## Pipeline
@@ -29,14 +33,20 @@ If OpenAI access is unavailable, the module emits deterministic mock text plus a
 ```json
 {
   "gaming_response": "Final audited answer...",
-"audit_trace": {
+  "audit_trace": {
     "intake": "Refined prompt...",
     "reasoning": "Raw GPT-5.1 output...",
     "finalized": "Audited answer"
-  }
+  },
+  "sources": [
+    {
+      "url": "https://example.com/sekiro/guardian-ape-guide",
+      "snippet": "Cleaned reference text used to ground the response"
+    }
+  ]
 }
 ```
-The `audit_trace` fields mirror the three pipeline stages, enabling downstream logging or escalation flows.
+The `audit_trace` fields mirror the three pipeline stages, enabling downstream logging or escalation flows. The optional `sources` array lists every fetched URL (and any errors) so operators can confirm the grounding material that was used to avoid hallucinations.
 
 ## Implementation Notes
 - Module name: `ARCANOS:GAMING` (`src/modules/arcanos-gaming.ts`).

--- a/src/modules/arcanos-gaming.ts
+++ b/src/modules/arcanos-gaming.ts
@@ -6,7 +6,9 @@ export const ArcanosGaming = {
   gptIds: ['arcanos-gaming', 'gaming'],
   actions: {
     async query(payload: any) {
-      return runGaming(payload?.prompt || payload, payload?.url);
+      const prompt = payload?.prompt || payload;
+      const urls = payload?.urls || payload?.guideUrls;
+      return runGaming(prompt, payload?.url, Array.isArray(urls) ? urls : []);
     },
   },
 };

--- a/src/services/webFetcher.ts
+++ b/src/services/webFetcher.ts
@@ -1,14 +1,42 @@
 import axios from 'axios';
 import { load } from 'cheerio';
 
+const DEFAULT_MAX_CHARS = 12000;
+
+function assertHttpUrl(rawUrl: string): URL {
+  if (!rawUrl || !rawUrl.trim()) {
+    throw new Error('A URL is required for web fetching');
+  }
+
+  const parsed = new URL(rawUrl);
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('Only http/https URLs are supported for web fetching');
+  }
+
+  return parsed;
+}
+
 /**
  * Fetches a URL and returns cleaned text content.
- * Removes script and style tags and condenses whitespace.
+ * Removes script and style tags, condenses whitespace, and truncates overly long pages.
  */
-export async function fetchAndClean(url: string): Promise<string> {
-  const { data } = await axios.get<string>(url);
+export async function fetchAndClean(url: string, maxChars = DEFAULT_MAX_CHARS): Promise<string> {
+  const parsed = assertHttpUrl(url);
+  const { data } = await axios.get<string>(parsed.toString(), {
+    timeout: 8000,
+    maxContentLength: 1_500_000,
+    responseType: 'text',
+    headers: {
+      'User-Agent': 'Arcanos-WebFetcher/1.0',
+      Accept: 'text/html,text/plain;q=0.9,*/*;q=0.8'
+    }
+  });
+
   const $ = load(data);
-  $('script, style').remove();
+  $('script, style, noscript').remove();
   const text = $('body').text();
-  return text.replace(/\s+/g, ' ').trim();
+
+  return text.replace(/\s+/g, ' ').trim().slice(0, Math.max(0, maxChars));
 }
+
+export { assertHttpUrl };

--- a/tests/webFetcher.test.ts
+++ b/tests/webFetcher.test.ts
@@ -1,0 +1,53 @@
+import http from 'http';
+import { fetchAndClean } from '../src/services/webFetcher.js';
+
+describe('fetchAndClean', () => {
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    server = http.createServer((_, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(`
+        <html>
+          <head>
+            <style>body { color: red; }</style>
+            <script>console.log('ignore me')</script>
+          </head>
+          <body>
+            Hello <strong>World</strong>!
+            <noscript>fallback</noscript>
+          </body>
+        </html>
+      `);
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => {
+        const address = server.address();
+        if (address && typeof address === 'object') {
+          baseUrl = `http://127.0.0.1:${address.port}`;
+        }
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('strips non-text elements and condenses whitespace', async () => {
+    const cleaned = await fetchAndClean(baseUrl);
+    expect(cleaned).toBe('Hello World!');
+  });
+
+  it('enforces http/https schemes', async () => {
+    await expect(fetchAndClean('ftp://example.com/resource')).rejects.toThrow('http/https');
+  });
+
+  it('truncates content when maxChars is provided', async () => {
+    const cleaned = await fetchAndClean(baseUrl, 5);
+    expect(cleaned).toBe('Hello');
+  });
+});


### PR DESCRIPTION
## Summary
- harden the web fetcher with URL validation, timeouts, and truncation to return cleaned text
- allow the ARCANOS gaming module to hydrate prompts with multiple web sources and surface the fetched context in responses
- document the new `urls` option for Custom GPT actions and add Jest coverage for the web fetcher

## Testing
- npm test -- webFetcher.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e36dd9528832580ee1532bbd9eefc)