### PR TITLE
Refine reasoning layer helpers and telemetry config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -362,6 +362,16 @@ ARCANOS_AUDIT_TRACE=true
 # Values: error | warn | info | debug
 LOG_LEVEL=info
 
+# ================================
+# TELEMETRY & OBSERVABILITY
+# ================================
+
+# Limit the number of recent logs returned by telemetry endpoints
+TELEMETRY_RECENT_LOGS_LIMIT=100
+
+# Maximum trace events to retain for diagnostics
+TELEMETRY_TRACE_EVENT_LIMIT=200
+
 # Development Features
 # Enable additional debug output and development tools
 DEBUG=false

--- a/src/config/reasoningTemplates.ts
+++ b/src/config/reasoningTemplates.ts
@@ -1,0 +1,26 @@
+export const REASONING_TOKEN_LIMIT = 1500;
+export const REASONING_TEMPERATURE = 0.7;
+export const REASONING_LOG_SUMMARY_LENGTH = 200;
+
+export const REASONING_SYSTEM_PROMPT =
+  'You are an advanced reasoning layer for ARCANOS AI. Your role is to refine and enhance ARCANOS responses through deeper analysis while preserving the original intent and structure. Focus on logical consistency, completeness, and clarity.';
+
+export function buildReasoningPrompt(originalPrompt: string, arcanosResult: string, context?: string): string {
+  const contextSection = context ? `ADDITIONAL CONTEXT:\n${context}\n` : '';
+
+  return `As an advanced reasoning engine, analyze and refine the following ARCANOS response:
+
+ORIGINAL USER REQUEST:
+${originalPrompt}
+
+ARCANOS RESPONSE:
+${arcanosResult}
+
+${contextSection}Your task:
+1. Evaluate the logical consistency and completeness of the ARCANOS response
+2. Identify any gaps in reasoning or potential improvements
+3. Provide a refined, enhanced version that maintains ARCANOS's core analysis while adding deeper insights
+4. Ensure the response is well-structured and comprehensive
+
+Return only the refined response without meta-commentary about your analysis process.`;
+}


### PR DESCRIPTION
## Summary
- extract GPT-5.1 reasoning templates and constants into a shared config helper
- simplify reasoning layer request construction using reusable builder with defined numeric constants
- document telemetry log and trace limits in .env.example for Railway readiness

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3a6a44808325bcdd81e1de3f41fd)