### PR TITLE
Refactor OpenAI service constants

### DIFF
--- a/src/services/openai/constants.ts
+++ b/src/services/openai/constants.ts
@@ -1,0 +1,9 @@
+export const DEFAULT_SYSTEM_PROMPT = 'You are a helpful AI assistant.';
+
+export const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export const REQUEST_ID_HEADER = 'X-Request-ID';
+
+export const DEFAULT_MAX_RETRIES = 3;
+
+export const IMAGE_PROMPT_TOKEN_LIMIT = 256;


### PR DESCRIPTION
## Summary
- extract reusable OpenAI service constants for system prompt, cache TTL, request headers, and defaults
- replace hardcoded literals in the OpenAI service with shared constants to simplify maintenance

## Testing
- npm run lint -- src/services/openai.ts src/services/openai/constants.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e3e0066a48325b3454067c19c6979)