### PR TITLE
Refactor OpenAI helpers into modular utilities

### DIFF
--- a/src/config/openaiPrompts.ts
+++ b/src/config/openaiPrompts.ts
@@ -1,0 +1,1 @@
+export const STRICT_ASSISTANT_PROMPT = 'You are a precise and safe code assistant.';

--- a/src/services/openai/messageBuilder.ts
+++ b/src/services/openai/messageBuilder.ts
@@ -1,0 +1,34 @@
+import { buildContextualSystemPrompt } from '../contextualReinforcement.js';
+import { CallOpenAIOptions, ChatCompletionMessageParam } from './types.js';
+
+export function buildChatMessages(
+  prompt: string,
+  systemPrompt: string,
+  options: CallOpenAIOptions
+): ChatCompletionMessageParam[] {
+  const contextAwarePrompt = buildContextualSystemPrompt(systemPrompt);
+  let preparedMessages: ChatCompletionMessageParam[];
+
+  if (options.messages && options.messages.length > 0) {
+    let systemInjected = false;
+    preparedMessages = options.messages.map((message) => {
+      if (message.role === 'system' && typeof message.content === 'string') {
+        systemInjected = true;
+        return { ...message, content: buildContextualSystemPrompt(message.content) };
+      }
+      return message;
+    });
+
+    const hasSystemMessage = preparedMessages.some((message) => message.role === 'system');
+    if (!hasSystemMessage || !systemInjected) {
+      preparedMessages = [{ role: 'system', content: contextAwarePrompt }, ...preparedMessages];
+    }
+  } else {
+    preparedMessages = [
+      { role: 'system', content: contextAwarePrompt },
+      { role: 'user', content: prompt }
+    ];
+  }
+
+  return preparedMessages;
+}

--- a/src/services/openai/requestTransforms.ts
+++ b/src/services/openai/requestTransforms.ts
@@ -1,0 +1,41 @@
+import { getTokenParameter } from '../../utils/tokenParameterHelper.js';
+import { REASONING_SYSTEM_PROMPT, REASONING_TEMPERATURE, REASONING_TOKEN_LIMIT, buildReasoningPrompt } from '../../config/reasoningTemplates.js';
+import { RESILIENCE_CONSTANTS } from './resilience.js';
+
+export function prepareGPT5Request(payload: any): any {
+  if (payload.model && typeof payload.model === 'string' && payload.model.includes('gpt-5')) {
+    if (payload.max_tokens) {
+      payload.max_output_tokens = payload.max_tokens;
+      delete payload.max_tokens;
+    }
+    if (payload.max_completion_tokens) {
+      payload.max_output_tokens = payload.max_completion_tokens;
+      delete payload.max_completion_tokens;
+    }
+    if (!payload.max_output_tokens) {
+      payload.max_output_tokens = RESILIENCE_CONSTANTS.DEFAULT_MAX_TOKENS;
+    }
+  }
+  return payload;
+}
+
+export function buildReasoningRequestPayload(
+  model: string,
+  originalPrompt: string,
+  arcanosResult: string,
+  context?: string
+) {
+  const tokenParams = getTokenParameter(model, REASONING_TOKEN_LIMIT);
+
+  return prepareGPT5Request({
+    model,
+    input: [
+      { role: 'system' as const, content: REASONING_SYSTEM_PROMPT },
+      { role: 'user' as const, content: buildReasoningPrompt(originalPrompt, arcanosResult, context) }
+    ],
+    text: { verbosity: 'medium' as const },
+    reasoning: { effort: 'low' as const },
+    ...tokenParams,
+    temperature: REASONING_TEMPERATURE
+  });
+}

--- a/src/services/openai/types.ts
+++ b/src/services/openai/types.ts
@@ -1,0 +1,27 @@
+import OpenAI from 'openai';
+
+export type ChatCompletionMessageParam = OpenAI.Chat.Completions.ChatCompletionMessageParam;
+export type ChatCompletionResponseFormat =
+  OpenAI.Chat.Completions.ChatCompletionCreateParams['response_format'];
+
+export interface CallOpenAIOptions {
+  systemPrompt?: string;
+  messages?: ChatCompletionMessageParam[];
+  temperature?: number;
+  top_p?: number;
+  frequency_penalty?: number;
+  presence_penalty?: number;
+  responseFormat?: ChatCompletionResponseFormat;
+  user?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CallOpenAICacheEntry {
+  response: any;
+  output: string;
+  model: string;
+}
+
+export interface CallOpenAIResult extends CallOpenAICacheEntry {
+  cached?: boolean;
+}


### PR DESCRIPTION
## Summary
- extract OpenAI helper types and request transformations into dedicated modules to shrink the main service
- centralize chat message preparation logic to reduce complexity in the OpenAI caller
- move the strict assistant system prompt into configuration for easier reuse

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e41dfb4f483258bda3287c6043ff2)