### PR TITLE
Add process cache fallback for session memory retrieval

### DIFF
--- a/tests/session-memory-roundtrip.test.ts
+++ b/tests/session-memory-roundtrip.test.ts
@@ -1,4 +1,6 @@
 import { saveMessage, getConversation } from '../src/services/sessionMemoryService';
+import { SessionMemoryRepository } from '../src/services/sessionMemoryRepository';
+import memoryStore from '../src/memory/store';
 
 describe('session memory round trip', () => {
   it('stores and retrieves raw messages with metadata', async () => {
@@ -39,6 +41,44 @@ describe('session memory round trip', () => {
         content: 'Hi there',
         timestamp: 2,
         meta: { tokens: 2, audit_tag: 'test', timestamp: 2 }
+      }
+    ]);
+  });
+
+  it('falls back to process cache when persistent channels are unavailable', async () => {
+    const sessionId = 'process-cache-session';
+    const repository = new SessionMemoryRepository({ fallbackTtlMs: 0 });
+
+    // Reset the in-process cache for a clean test run
+    (memoryStore as any).sessions = new Map();
+
+    memoryStore.saveSession({
+      sessionId,
+      conversations_core: [
+        {
+          role: 'user',
+          content: 'Here is my Arcanos Gaming guide',
+          timestamp: 123
+        }
+      ],
+      metadata: {
+        tokens: 42,
+        audit_tag: 'guide',
+        timestamp: 123
+      }
+    });
+
+    const convo = await repository.getConversation(sessionId);
+    expect(convo).toEqual([
+      {
+        role: 'user',
+        content: 'Here is my Arcanos Gaming guide',
+        timestamp: 123,
+        meta: {
+          tokens: 42,
+          audit_tag: 'guide',
+          timestamp: 123
+        }
       }
     ]);
   });


### PR DESCRIPTION
## Summary
- add process cache fallback so session memory retrieval still returns saved messages when persistence is unavailable
- warn when process cache is used for session channels
- extend session memory roundtrip tests to cover process cache fallback behaviour


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f60eec0008325ba22e0db0e8bd9e4)