### PR TITLE
Capture client context metadata for ask responses

### DIFF
--- a/src/utils/requestHandler.ts
+++ b/src/utils/requestHandler.ts
@@ -31,6 +31,8 @@ export function validateAIRequest(
 ): { client: any; input: string; body: AIRequestDTO } | null {
   console.log(`📨 /${endpointName} received`);
 
+  const clientContext = (req.body as AIRequestDTO).clientContext;
+
   const parsed = aiRequestSchema.safeParse(req.body);
   if (!parsed.success) {
     const details = parsed.error.errors.map(err => `${err.path.join('.') || 'body'}: ${err.message}`);
@@ -54,7 +56,7 @@ export function validateAIRequest(
   if (!hasValidAPIKey()) {
     console.log(`🤖 Returning mock response for /${endpointName} (no API key)`);
     const mockResponse = generateMockResponse(input, endpointName);
-    res.json(mockResponse as AIResponseDTO);
+    res.json({ ...(mockResponse as AIResponseDTO), clientContext });
     return null;
   }
 
@@ -62,7 +64,7 @@ export function validateAIRequest(
   if (!openai) {
     console.log(`🤖 Returning mock response for /${endpointName} (client init failed)`);
     const mockResponse = generateMockResponse(input, endpointName);
-    res.json(mockResponse as AIResponseDTO);
+    res.json({ ...(mockResponse as AIResponseDTO), clientContext });
     return null;
   }
 

--- a/tests/placeholder.test.ts
+++ b/tests/placeholder.test.ts
@@ -66,6 +66,15 @@ describe('AI endpoints in mock mode', () => {
     const payload = await response.json();
     expect(payload.result).toContain('[MOCK AI RESPONSE]');
     expect(payload.routingStages).toContain('ARCANOS-INTAKE:MOCK');
+    expect(payload.clientContext.basePrompt).toBe('How does the system behave?');
+    expect(payload.clientContext.flags).toMatchObject({
+      domain: 'diagnostics',
+      useRAG: true,
+      useHRC: false,
+      sourceField: 'message'
+    });
+    expect(payload.clientContext.routingDirectives).toContain('Domain routing hint: diagnostics');
+    expect(payload.clientContext.normalizedPrompt).toContain('[ARCANOS CONTEXT]');
   });
 
   it('provides deterministic mock diagnostics for /arcanos', async () => {


### PR DESCRIPTION
## Summary
- add a client context schema to capture normalized prompts and routing hints from frontend payloads
- propagate client context through /api/ask and ask handler responses, including mock mode
- extend mock-mode regression test to verify routed context metadata

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ff572983883259aeac0e4f2daf64d)