### PR TITLE
Improve Railway API configuration handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -170,8 +170,8 @@ RAILWAY_API_TOKEN=
 # RAILWAY_GRAPHQL_ENDPOINT=https://backboard.railway.app/graphql/v2
 
 # Railway GraphQL Timeout (milliseconds)
-# Default: 10000ms (10 seconds)
-# RAILWAY_GRAPHQL_TIMEOUT_MS=10000
+# Default: 15000ms (15 seconds). Override to match your Railway plan limits.
+# RAILWAY_GRAPHQL_TIMEOUT_MS=15000
 
 # Railway Validation Patterns (comma-separated list of validation patterns)
 # Used for deployment validation and health checks

--- a/src/config/railway.ts
+++ b/src/config/railway.ts
@@ -1,0 +1,30 @@
+export interface RailwayApiConfig {
+  endpoint: string;
+  timeoutMs: number;
+}
+
+const DEFAULT_GRAPHQL_ENDPOINT = 'https://backboard.railway.app/graphql/v2';
+const DEFAULT_GRAPHQL_TIMEOUT_MS = 15_000;
+
+function parseTimeout(rawTimeout: string | undefined): number {
+  if (!rawTimeout) return DEFAULT_GRAPHQL_TIMEOUT_MS;
+
+  const parsed = Number.parseInt(rawTimeout.trim(), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_GRAPHQL_TIMEOUT_MS;
+  }
+
+  return parsed;
+}
+
+export function getRailwayApiConfig(): RailwayApiConfig {
+  return {
+    endpoint: process.env.RAILWAY_GRAPHQL_ENDPOINT?.trim() || DEFAULT_GRAPHQL_ENDPOINT,
+    timeoutMs: parseTimeout(process.env.RAILWAY_GRAPHQL_TIMEOUT_MS),
+  };
+}
+
+export const RAILWAY_DEFAULTS = {
+  GRAPHQL_ENDPOINT: DEFAULT_GRAPHQL_ENDPOINT,
+  GRAPHQL_TIMEOUT_MS: DEFAULT_GRAPHQL_TIMEOUT_MS,
+};

--- a/src/services/railwayClient.ts
+++ b/src/services/railwayClient.ts
@@ -1,25 +1,19 @@
+import { getRailwayApiConfig, RAILWAY_DEFAULTS } from '../config/railway.js';
 import { logger } from '../utils/structuredLogging.js';
 
-const DEFAULT_GRAPHQL_ENDPOINT = 'https://backboard.railway.app/graphql/v2';
-const GRAPHQL_ENDPOINT = process.env.RAILWAY_GRAPHQL_ENDPOINT || DEFAULT_GRAPHQL_ENDPOINT;
-const DEFAULT_GRAPHQL_TIMEOUT_MS = 15_000;
+const railwayApiConfig = getRailwayApiConfig();
 
-const GRAPHQL_TIMEOUT_MS = (() => {
-  const rawTimeout = process.env.RAILWAY_GRAPHQL_TIMEOUT_MS?.trim();
-  if (!rawTimeout) {
-    return DEFAULT_GRAPHQL_TIMEOUT_MS;
-  }
+if (
+  process.env.RAILWAY_GRAPHQL_TIMEOUT_MS &&
+  railwayApiConfig.timeoutMs === RAILWAY_DEFAULTS.GRAPHQL_TIMEOUT_MS &&
+  process.env.RAILWAY_GRAPHQL_TIMEOUT_MS.trim() !== `${RAILWAY_DEFAULTS.GRAPHQL_TIMEOUT_MS}`
+) {
+  logger.warn('Ignoring invalid RAILWAY_GRAPHQL_TIMEOUT_MS value', {
+    rawTimeout: process.env.RAILWAY_GRAPHQL_TIMEOUT_MS,
+  });
+}
 
-  const parsed = Number.parseInt(rawTimeout, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    logger.warn('Ignoring invalid RAILWAY_GRAPHQL_TIMEOUT_MS value', {
-      rawTimeout
-    });
-    return DEFAULT_GRAPHQL_TIMEOUT_MS;
-  }
-
-  return parsed;
-})();
+const { endpoint: GRAPHQL_ENDPOINT, timeoutMs: GRAPHQL_TIMEOUT_MS } = railwayApiConfig;
 
 interface GraphQLErrorPayload {
   message: string;


### PR DESCRIPTION
## Summary
- centralize Railway GraphQL endpoint and timeout resolution in a shared config helper
- warn when invalid timeout overrides are supplied and document Railway defaults

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692424e2b2c883259102c4a8ac7d5110)