### PR TITLE
Refactor arcanos query prompts into reusable utilities

### DIFF
--- a/src/config/arcanosPrompts.ts
+++ b/src/config/arcanosPrompts.ts
@@ -1,0 +1,19 @@
+export const ARCANOS_PROMPTS = {
+  system: 'You are ARCANOS core AI.',
+  reasoningLayer: 'You are GPT-5.1 reasoning layer. Refine and audit the response for clarity, alignment, and safety.'
+};
+
+export function formatPromptPreview(prompt: string, maxLength = 50): string {
+  const trimmed = prompt.substring(0, maxLength);
+  return `${trimmed}${prompt.length > maxLength ? '...' : ''}`;
+}
+
+export function buildMockArcanosResponse(prompt: string, fineTunedModel: string): string {
+  const preview = formatPromptPreview(prompt);
+  return [
+    '[MOCK ARCANOS QUERY] Two-step processing simulation:',
+    `1. Fine-tuned model (${fineTunedModel}): Processing "${preview}"`,
+    '2. GPT-5.1 reasoning: Enhanced analysis and safety audit',
+    'Result: Mock refined response for your query.'
+  ].join('\n');
+}

--- a/src/services/arcanosQuery.ts
+++ b/src/services/arcanosQuery.ts
@@ -1,43 +1,51 @@
 import { getOpenAIClient, getDefaultModel, getGPT5Model } from './openai.js';
+import { ARCANOS_PROMPTS, buildMockArcanosResponse } from '../config/arcanosPrompts.js';
 
 // Use centralized model configuration
 const FT_MODEL = getDefaultModel();
 const REASONING_MODEL = getGPT5Model();
 
+function buildFineTunedMessages(prompt: string) {
+  return [
+    { role: 'system' as const, content: ARCANOS_PROMPTS.system },
+    { role: 'user' as const, content: prompt }
+  ];
+}
+
+function buildReasoningMessages(fineTunedOutput: string) {
+  return [
+    { role: 'system' as const, content: ARCANOS_PROMPTS.reasoningLayer },
+    { role: 'user' as const, content: `Original fine-tuned model output:\n${fineTunedOutput}` }
+  ];
+}
+
 export async function arcanosQuery(prompt: string): Promise<string> {
   try {
     // Get OpenAI client - will return null if no API key
     const client = getOpenAIClient();
-    
+
     if (!client) {
       // Return mock response when no API key is configured
-      return `[MOCK ARCANOS QUERY] Two-step processing simulation:\n1. Fine-tuned model (${FT_MODEL}): Processing "${prompt.substring(0, 50)}${prompt.length > 50 ? '...' : ''}"\n2. GPT-5.1 reasoning: Enhanced analysis and safety audit\nResult: Mock refined response for your query.`;
+      return buildMockArcanosResponse(prompt, FT_MODEL);
     }
 
     // Step 1 → Fine-tuned GPT-4.1
     const ftResponse = await client.chat.completions.create({
       model: FT_MODEL,
-      messages: [
-        { role: "system", content: "You are ARCANOS core AI." },
-        { role: "user", content: prompt },
-      ],
+      messages: buildFineTunedMessages(prompt)
     });
 
-    const ftOutput = ftResponse.choices[0].message.content;
+    const ftOutput = ftResponse.choices[0].message.content || '';
 
     // Step 2 → Reasoning with GPT-5.1
     const reasoningResponse = await client.chat.completions.create({
       model: REASONING_MODEL,
-      messages: [
-        { role: "system", content: "You are GPT-5.1 reasoning layer. Refine and audit the response for clarity, alignment, and safety." },
-        { role: "user", content: `Original fine-tuned model output:\n${ftOutput}` },
-      ],
+      messages: buildReasoningMessages(ftOutput)
     });
 
     return reasoningResponse.choices[0].message.content || '';
-
   } catch (error) {
-    console.error("ARCANOS error:", error);
+    console.error('ARCANOS error:', error);
     throw error;
   }
 }


### PR DESCRIPTION
## Summary
- move arcanos prompt strings and mock builder into shared configuration utilities
- refactor arcanosQuery to use helper message builders and centralized prompts

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69242bebf6688325bcdde0155cac7b6a)