### PR TITLE
Refactor GPT sync configuration and remove unused logger helper

### DIFF
--- a/src/config/gptSyncMessages.ts
+++ b/src/config/gptSyncMessages.ts
@@ -1,0 +1,8 @@
+export const GPT_SYNC_STRINGS = {
+  baseInstruction: 'You are Arcanos, a custom GPT assistant.',
+  backendStateLabel: 'Always use the following backend state as the source of truth:',
+  additionalContextLabel: 'Additional Context:',
+  defaultTrustMessage: 'Do not rely on past memory — only trust this state for system information.',
+  contextTrustMessage: 'Always use this information as your source of truth.',
+  diagnosticPrompt: 'Run a system diagnostic and report the current backend state.'
+} as const;

--- a/src/services/gptSync.ts
+++ b/src/services/gptSync.ts
@@ -8,15 +8,7 @@ import { getTokenParameter } from '../utils/tokenParameterHelper.js';
 import { getOpenAIClient } from './openai.js';
 
 import config from '../config/index.js';
-
-const GPT_SYNC_STRINGS = {
-  baseInstruction: 'You are Arcanos, a custom GPT assistant.',
-  backendStateLabel: 'Always use the following backend state as the source of truth:',
-  additionalContextLabel: 'Additional Context:',
-  defaultTrustMessage: 'Do not rely on past memory — only trust this state for system information.',
-  contextTrustMessage: 'Always use this information as your source of truth.',
-  diagnosticPrompt: 'Run a system diagnostic and report the current backend state.'
-} as const;
+import { GPT_SYNC_STRINGS } from '../config/gptSyncMessages.js';
 
 function getRequiredOpenAIClient() {
   const client = getOpenAIClient();

--- a/src/utils/bootLogger.ts
+++ b/src/utils/bootLogger.ts
@@ -41,21 +41,6 @@ export function logAIConfig(defaultModel: string, fallbackModel: string): void {
 }
 
 /**
- * Logs worker initialization results
- */
-export function logWorkerStatus(workerResults: WorkerInitResult): void {
-  console.log(`🤖 Active Model: ${workerResults.database.connected ? 'Connected' : 'Using fallback'}`);
-  console.log(`🔌 Database: ${workerResults.database.connected ? 'Connected' : 'Disconnected'}`);
-  console.log(`📁 Workers Directory: ${SERVER_CONSTANTS.WORKERS_DIRECTORY}`);
-  console.log(`🔧 Workers Initialized: ${workerResults.initialized.length}`);
-  console.log(`📅 Workers Scheduled: ${workerResults.scheduled.length}`);
-  
-  if (workerResults.failed.length > 0) {
-    console.log(`❌ Workers Failed: ${workerResults.failed.length}`);
-  }
-}
-
-/**
  * Logs core route information
  */
 export function logCoreRoutes(): void {


### PR DESCRIPTION
## Summary
- move GPT sync prompt strings into a shared configuration module
- simplify boot logging utilities by removing unused worker status helper
- keep GPT sync building prompts from centralized constants

## Testing
- npm test -- --runTestsByPath tests/test-pr-assistant.test.ts --runInBand --watchAll=false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924d2740cf08325a933f2e300baaf8b)