### PR TITLE
Refine reasoning prompt handling and centralize JSON file writes

### DIFF
--- a/src/config/reasoningTemplates.ts
+++ b/src/config/reasoningTemplates.ts
@@ -5,22 +5,26 @@ export const REASONING_LOG_SUMMARY_LENGTH = 200;
 export const REASONING_SYSTEM_PROMPT =
   'You are an advanced reasoning layer for ARCANOS AI. Your role is to refine and enhance ARCANOS responses through deeper analysis while preserving the original intent and structure. Focus on logical consistency, completeness, and clarity.';
 
-export function buildReasoningPrompt(originalPrompt: string, arcanosResult: string, context?: string): string {
-  const contextSection = context ? `ADDITIONAL CONTEXT:\n${context}\n` : '';
-
-  return `As an advanced reasoning engine, analyze and refine the following ARCANOS response:
+export const REASONING_PROMPT_TEMPLATE = `As an advanced reasoning engine, analyze and refine the following ARCANOS response:
 
 ORIGINAL USER REQUEST:
-${originalPrompt}
+{{originalPrompt}}
 
 ARCANOS RESPONSE:
-${arcanosResult}
+{{arcanosResult}}
 
-${contextSection}Your task:
+{{contextSection}}Your task:
 1. Evaluate the logical consistency and completeness of the ARCANOS response
 2. Identify any gaps in reasoning or potential improvements
 3. Provide a refined, enhanced version that maintains ARCANOS's core analysis while adding deeper insights
 4. Ensure the response is well-structured and comprehensive
 
 Return only the refined response without meta-commentary about your analysis process.`;
+
+export function buildReasoningPrompt(originalPrompt: string, arcanosResult: string, context?: string): string {
+  const contextSection = context ? `ADDITIONAL CONTEXT:\n${context}\n\n` : '';
+
+  return REASONING_PROMPT_TEMPLATE.replace('{{originalPrompt}}', originalPrompt)
+    .replace('{{arcanosResult}}', arcanosResult)
+    .replace('{{contextSection}}', contextSection);
 }

--- a/src/logic/aiCron.ts
+++ b/src/logic/aiCron.ts
@@ -2,6 +2,7 @@ import cron from 'node-cron';
 import fs from 'fs/promises';
 import path from 'path';
 import { logger } from '../utils/structuredLogging.js';
+import { writeJsonFile } from '../utils/fileStorage.js';
 
 /**
  * Sets up recurring AI maintenance tasks.
@@ -12,8 +13,7 @@ const HB_FILE = path.join(process.cwd(), 'memory', 'heartbeat.json');
 async function writeHeartbeat(): Promise<void> {
   const hb = { ts: Date.now(), pid: process.pid };
   try {
-    await fs.mkdir(path.dirname(HB_FILE), { recursive: true });
-    await fs.writeFile(HB_FILE, JSON.stringify(hb));
+    await writeJsonFile(HB_FILE, hb, { space: 0 });
   } catch (err) {
     logger.error('Failed to write heartbeat file', {
       module: 'aiCron',

--- a/src/services/openai-assistants.ts
+++ b/src/services/openai-assistants.ts
@@ -1,8 +1,8 @@
 import fs from 'fs/promises';
-import path from 'path';
 import { getOpenAIClient } from './openai.js';
 import config from '../config/index.js';
 import { aiLogger } from '../utils/structuredLogging.js';
+import { writeJsonFile } from '../utils/fileStorage.js';
 
 export interface AssistantInfo {
   id: string;
@@ -83,10 +83,6 @@ export function normalizeAssistantName(name: string | null | undefined): string 
   return sanitized.replace(/\s+/g, '_').toUpperCase();
 }
 
-async function ensureRegistryDirectory(): Promise<void> {
-  await fs.mkdir(path.dirname(REGISTRY_PATH), { recursive: true });
-}
-
 export async function loadAssistantRegistry(): Promise<AssistantRegistry> {
   try {
     const content = await fs.readFile(REGISTRY_PATH, 'utf8');
@@ -115,8 +111,7 @@ export async function loadAssistantRegistry(): Promise<AssistantRegistry> {
 }
 
 export async function saveAssistantRegistry(registry: AssistantRegistry): Promise<void> {
-  await ensureRegistryDirectory();
-  await fs.writeFile(REGISTRY_PATH, JSON.stringify(registry, null, 2));
+  await writeJsonFile(REGISTRY_PATH, registry);
 }
 
 export async function getAssistantRegistry(): Promise<AssistantRegistry> {

--- a/src/utils/fileStorage.ts
+++ b/src/utils/fileStorage.ts
@@ -1,0 +1,24 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { logger } from './structuredLogging.js';
+
+interface JsonWriteOptions {
+  space?: number;
+}
+
+export async function ensureDirectoryForFile(filePath: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+}
+
+export async function writeJsonFile<T>(filePath: string, data: T, options: JsonWriteOptions = {}): Promise<void> {
+  const { space = 2 } = options;
+  const serialized = JSON.stringify(data, null, space);
+
+  try {
+    await ensureDirectoryForFile(filePath);
+    await fs.writeFile(filePath, serialized);
+  } catch (error) {
+    logger.error('Failed to write JSON file', { module: 'fileStorage', operation: 'writeJsonFile', filePath }, error as Error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable JSON file storage helper to centralize directory creation and error logging
- use the new helper for heartbeat persistence and assistant registry saves
- move the reasoning prompt template into configuration for easier maintenance

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924ddf9b1f08325a76264d950a2fdfa)