### PR TITLE
Refine fallback messaging configuration

### DIFF
--- a/src/config/fallbackResponseMessages.ts
+++ b/src/config/fallbackResponseMessages.ts
@@ -1,0 +1,9 @@
+export const FALLBACK_RESPONSE_MESSAGES = {
+  cacheUnavailable: 'Service temporarily unavailable - returning cached response',
+  cachedResponsePlaceholder: 'Cached response available',
+  degradedMode: 'AI services temporarily unavailable - operating in degraded mode',
+  fallbackTestPrompt: 'Test degraded mode functionality',
+  fallbackTestMessage: 'Fallback system test - this endpoint simulates degraded mode',
+  defaultPrompt: 'No input provided',
+  healthCheckPrompt: 'Health check triggered fallback'
+} as const;


### PR DESCRIPTION
## Summary
- centralize fallback response messaging in a dedicated configuration module
- remove unused fallback request handler and associated OpenAI call
- update fallback middleware and test route to consume the shared strings

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924e07d92d48325adc6915e3c0bb5f8)