### PR TITLE
Refactor ARCANOS pipeline handling

### DIFF
--- a/src/config/arcanosPipelinePrompts.ts
+++ b/src/config/arcanosPipelinePrompts.ts
@@ -1,0 +1,5 @@
+export const ARCANOS_PIPELINE_PROMPTS = {
+  subAgent:
+    'You are a supportive sub-agent for ARCANOS. Refine or validate the prior response.',
+  overseer: 'You are the reasoning overseer for ARCANOS.'
+};

--- a/src/routes/openai-arcanos-pipeline.ts
+++ b/src/routes/openai-arcanos-pipeline.ts
@@ -1,85 +1,23 @@
 import express, { Request, Response } from 'express';
-import { getOpenAIClient, getDefaultModel, getGPT5Model } from '../services/openai.js';
 import OpenAI from 'openai';
+import { executeArcanosPipeline } from '../services/arcanosPipeline.js';
 
 const router = express.Router();
-
-// Use centralized OpenAI client
-const client = getOpenAIClient();
-
-// Models - use centralized configuration
-const ARC_V2 = getDefaultModel();
-const ARC_V2_FALLBACK = 'gpt-4o-mini'; // Use gpt-4o-mini as cost-effective fallback
-const GPT5 = getGPT5Model();
-const GPT35_SUBAGENT = 'gpt-4o-mini'; // Use gpt-4o-mini instead of deprecated gpt-3.5-turbo
 
 router.post('/arcanos-pipeline', async (req: Request, res: Response) => {
   const { messages } = req.body as { messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] };
 
-  if (!client) {
-    return res.status(503).json({ error: 'OpenAI client not available' });
-  }
-
   try {
-    // Step 1: First pass through ARCANOS fine-tuned model
-    const arcFirst = await client.chat.completions.create({
-      model: ARC_V2,
-      messages
-    });
-    const arcFirstOutput = arcFirst.choices[0].message;
+    const pipelineResult = await executeArcanosPipeline(messages);
 
-    // Step 2: GPT-3.5 sub agent processes ARCANOS output
-    const subAgentResp = await client.chat.completions.create({
-      model: GPT35_SUBAGENT,
-      messages: [
-        { role: 'system', content: 'You are a supportive sub-agent for ARCANOS. Refine or validate the prior response.' },
-        { role: 'assistant', content: arcFirstOutput.content || '' }
-      ]
-    });
-    const subAgentOutput = subAgentResp.choices[0].message;
-
-    // Step 3: Delegate to GPT-5.1 for higher-level reasoning
-    const gpt5Response = await client.chat.completions.create({
-      model: GPT5,
-      messages: [
-        { role: 'system', content: 'You are the reasoning overseer for ARCANOS.' },
-        { role: 'assistant', content: arcFirstOutput.content || '' },
-        { role: 'assistant', content: subAgentOutput.content || '' }
-      ]
-    });
-    const gpt5Reasoning = gpt5Response.choices[0].message;
-
-    // Step 4: Re-ingest GPT-5.1 reasoning back into ARCANOS fine-tune
-    const arcFinal = await client.chat.completions.create({
-      model: ARC_V2,
-      messages: [
-        ...messages,
-        { role: 'assistant', content: arcFirstOutput.content || '' },
-        { role: 'assistant', content: subAgentOutput.content || '' },
-        { role: 'assistant', content: gpt5Reasoning.content || '' }
-      ]
-    });
-    const finalOutput = arcFinal.choices[0].message;
-
-    res.json({
-      result: finalOutput,
-      stages: {
-        arcFirst: arcFirstOutput,
-        subAgent: subAgentOutput,
-        gpt5Reasoning
-      }
-    });
-  } catch (err) {
-    console.error('Pipeline error:', err);
-    try {
-      const fallback = await client.chat.completions.create({
-        model: ARC_V2_FALLBACK,
-        messages
-      });
-      res.json({ result: fallback.choices[0].message, fallback: true });
-    } catch (fallbackErr: any) {
-      res.status(500).json({ error: 'Pipeline failed', details: fallbackErr.message });
+    if (pipelineResult.fallback) {
+      return res.json({ result: pipelineResult.result, fallback: true });
     }
+
+    res.json({ result: pipelineResult.result, stages: pipelineResult.stages });
+  } catch (err: any) {
+    console.error('Pipeline error:', err);
+    res.status(500).json({ error: 'Pipeline failed', details: err?.message || 'Unknown error' });
   }
 });
 

--- a/src/services/arcanosPipeline.ts
+++ b/src/services/arcanosPipeline.ts
@@ -1,0 +1,86 @@
+import OpenAI from 'openai';
+import { getDefaultModel, getGPT5Model, getOpenAIClient } from './openai.js';
+import { ARCANOS_PIPELINE_PROMPTS } from '../config/arcanosPipelinePrompts.js';
+
+const ARC_V2 = getDefaultModel();
+const ARC_V2_FALLBACK = 'gpt-4o-mini';
+const GPT5 = getGPT5Model();
+const GPT35_SUBAGENT = 'gpt-4o-mini';
+
+export interface PipelineStages {
+  arcFirst: OpenAI.Chat.Completions.ChatCompletionMessage;
+  subAgent: OpenAI.Chat.Completions.ChatCompletionMessage;
+  gpt5Reasoning: OpenAI.Chat.Completions.ChatCompletionMessage;
+}
+
+export interface PipelineResult {
+  result: OpenAI.Chat.Completions.ChatCompletionMessage;
+  stages?: PipelineStages;
+  fallback: boolean;
+}
+
+export async function executeArcanosPipeline(
+  messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[]
+): Promise<PipelineResult> {
+  const client = getOpenAIClient();
+
+  if (!client) {
+    throw new Error('OpenAI client not available');
+  }
+
+  try {
+    const arcFirst = await client.chat.completions.create({
+      model: ARC_V2,
+      messages
+    });
+    const arcFirstOutput = arcFirst.choices[0].message;
+
+    const subAgentResp = await client.chat.completions.create({
+      model: GPT35_SUBAGENT,
+      messages: [
+        { role: 'system', content: ARCANOS_PIPELINE_PROMPTS.subAgent },
+        { role: 'assistant', content: arcFirstOutput.content || '' }
+      ]
+    });
+    const subAgentOutput = subAgentResp.choices[0].message;
+
+    const gpt5Response = await client.chat.completions.create({
+      model: GPT5,
+      messages: [
+        { role: 'system', content: ARCANOS_PIPELINE_PROMPTS.overseer },
+        { role: 'assistant', content: arcFirstOutput.content || '' },
+        { role: 'assistant', content: subAgentOutput.content || '' }
+      ]
+    });
+    const gpt5Reasoning = gpt5Response.choices[0].message;
+
+    const arcFinal = await client.chat.completions.create({
+      model: ARC_V2,
+      messages: [
+        ...messages,
+        { role: 'assistant', content: arcFirstOutput.content || '' },
+        { role: 'assistant', content: subAgentOutput.content || '' },
+        { role: 'assistant', content: gpt5Reasoning.content || '' }
+      ]
+    });
+    const finalOutput = arcFinal.choices[0].message;
+
+    return {
+      result: finalOutput,
+      stages: {
+        arcFirst: arcFirstOutput,
+        subAgent: subAgentOutput,
+        gpt5Reasoning
+      },
+      fallback: false
+    };
+  } catch (err) {
+    console.warn('Primary ARCANOS pipeline failed, using fallback model', err);
+    const fallback = await client.chat.completions.create({
+      model: ARC_V2_FALLBACK,
+      messages
+    });
+
+    return { result: fallback.choices[0].message, fallback: true };
+  }
+}


### PR DESCRIPTION
## Summary
- extract ARCANOS pipeline prompts into centralized configuration
- move ARCANOS pipeline execution into a reusable service with clearer fallback handling
- simplify the route handler to delegate to the shared service

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924e1fe14b883258a512844c35a9f28)