### PR TITLE
Refactor research prompts into shared config

### DIFF
--- a/src/config/researchPrompts.ts
+++ b/src/config/researchPrompts.ts
@@ -1,0 +1,5 @@
+export const RESEARCH_SUMMARIZER_PROMPT =
+  'You are ARCANOS Research Summarizer. Provide a concise, factual summary of the provided source. Highlight key points relevant to the topic and keep it under 180 words.';
+
+export const RESEARCH_SYNTHESIS_PROMPT =
+  'You are ARCANOS Research Synthesizer. Combine provided source notes into a cohesive research brief with citations in the form [Source #]. Finish with a sentence that states how many sources were analyzed.';


### PR DESCRIPTION
## Summary
- extract research summarizer and synthesis prompts into a shared configuration module
- add a reusable helper for research completions and reuse it for summarization and synthesis paths

## Testing
- npm test -- --runInBand --passWithNoTests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924e9ea15cc8325b50dfe963ea0df83)