### PR TITLE
Refine fallback helpers and runtime probe config

### DIFF
--- a/src/config/runtimeProbeScripts.ts
+++ b/src/config/runtimeProbeScripts.ts
@@ -1,0 +1,8 @@
+export const RUNTIME_PROBE_SUMMARY_SCRIPT = `
+const summary = {
+  nodeVersion: process.version,
+  hasFetch: typeof fetch === 'function',
+  hasIntl: typeof Intl !== 'undefined'
+};
+console.log(JSON.stringify(summary));
+`;

--- a/src/middleware/fallbackHandler.ts
+++ b/src/middleware/fallbackHandler.ts
@@ -59,6 +59,14 @@ export function generateDegradedResponse(
   };
 }
 
+function getEndpointFromRequest(req: Request): string {
+  return req.path.split('/').pop() || 'unknown';
+}
+
+function extractPromptFromRequest(req: Request, defaultPrompt: string = FALLBACK_RESPONSE_MESSAGES.defaultPrompt): string {
+  return req.body?.prompt || req.body?.scenario || req.body?.query || defaultPrompt;
+}
+
 /**
  * Fallback middleware that intercepts errors and provides degraded responses
  */
@@ -79,9 +87,8 @@ export function createFallbackMiddleware() {
     }
 
     // Determine endpoint from request path
-    const endpoint = req.path.split('/').pop() || 'unknown';
-    const prompt =
-      req.body?.prompt || req.body?.scenario || req.body?.query || FALLBACK_RESPONSE_MESSAGES.defaultPrompt;
+    const endpoint = getEndpointFromRequest(req);
+    const prompt = extractPromptFromRequest(req);
 
     console.log(`🔄 Fallback mode activated for ${endpoint} - ${err.message}`);
 
@@ -154,9 +161,8 @@ export function createHealthCheckMiddleware() {
 
     // If OpenAI client is not available, immediately trigger degraded mode
     if (!client && enforcePreemptive) {
-      const endpoint = req.path.split('/').pop() || 'unknown';
-      const prompt =
-        req.body?.prompt || req.body?.scenario || req.body?.query || FALLBACK_RESPONSE_MESSAGES.healthCheckPrompt;
+      const endpoint = getEndpointFromRequest(req);
+      const prompt = extractPromptFromRequest(req, FALLBACK_RESPONSE_MESSAGES.healthCheckPrompt);
 
       console.log(`🔄 Preemptive fallback mode activated for ${endpoint} - OpenAI client unavailable`);
 

--- a/src/utils/environmentSecurity.ts
+++ b/src/utils/environmentSecurity.ts
@@ -4,6 +4,7 @@ import { spawn } from 'child_process';
 import { logger } from './structuredLogging.js';
 import { KNOWN_ENVIRONMENT_FINGERPRINTS, EnvironmentFingerprintRecord } from '../config/environmentFingerprints.js';
 import { setAuditSafeMode } from '../persistenceManagerHierarchy.js';
+import { RUNTIME_PROBE_SUMMARY_SCRIPT } from '../config/runtimeProbeScripts.js';
 
 export interface EnvironmentFingerprint {
   platform: NodeJS.Platform | string;
@@ -201,7 +202,7 @@ export async function executeInSandbox(
 
 async function probeRuntimeApis(): Promise<{ issues: string[]; sandbox: SandboxExecutionResult }> {
   const sandbox = await executeInSandbox(
-    "const summary = { nodeVersion: process.version, hasFetch: typeof fetch === 'function', hasIntl: typeof Intl !== 'undefined' }; console.log(JSON.stringify(summary));"
+    RUNTIME_PROBE_SUMMARY_SCRIPT.trim()
   );
 
   const issues: string[] = [];


### PR DESCRIPTION
## Summary
- extract shared helpers for fallback endpoint and prompt handling to reduce duplicated logic
- centralize the sandbox runtime probe script in configuration for easier maintenance
- wire the sandbox probe to use the shared script constant

## Testing
- npm test -- --runInBand


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924f20307608325a2e852df00825033)