### PR TITLE
Refactor PR assistant utilities into modules

### DIFF
--- a/src/services/prAssistant/checkResults.ts
+++ b/src/services/prAssistant/checkResults.ts
@@ -1,0 +1,61 @@
+import { CHECK_TITLES, REPORT_TEMPLATE } from '../../config/prAssistantTemplates.js';
+import type { CheckResult } from './types.js';
+
+export function createCheckResult(
+  issuesCount: number,
+  successMessage: string,
+  warningMessage: string,
+  errorMessage: string,
+  warningThreshold: number,
+  details: string[]
+): CheckResult {
+  if (issuesCount === 0) {
+    return {
+      status: '✅',
+      message: successMessage,
+      details: details.length > 0 ? details : ['No issues detected']
+    };
+  } else if (issuesCount < warningThreshold) {
+    return {
+      status: '⚠️',
+      message: warningMessage,
+      details
+    };
+  }
+
+  return {
+    status: '❌',
+    message: errorMessage,
+    details
+  };
+}
+
+export function getStatusMessage(status: '✅' | '❌' | '⚠️'): string {
+  switch (status) {
+    case '✅':
+      return REPORT_TEMPLATE.statusMessages.approved;
+    case '⚠️':
+      return REPORT_TEMPLATE.statusMessages.conditional;
+    case '❌':
+      return REPORT_TEMPLATE.statusMessages.rejected;
+  }
+}
+
+export function formatChecksMarkdown(checks: Record<string, CheckResult>): string {
+  let markdownSection = '';
+
+  Object.entries(checks).forEach(([key, check]) => {
+    const title = CHECK_TITLES[key as keyof typeof CHECK_TITLES];
+    markdownSection += `### ${check.status} ${title}\n`;
+    markdownSection += `${check.message}\n\n`;
+
+    if (check.details.length > 0) {
+      check.details.forEach(detail => {
+        markdownSection += `- ${detail}\n`;
+      });
+      markdownSection += '\n';
+    }
+  });
+
+  return markdownSection;
+}

--- a/src/services/prAssistant/commandUtils.ts
+++ b/src/services/prAssistant/commandUtils.ts
@@ -1,0 +1,23 @@
+import { spawn, type SpawnOptions } from 'child_process';
+
+function sanitizeArgs(args: string[]): string[] {
+  return args.map(a => a.replace(/[^\w:/.-]/g, ''));
+}
+
+export function runCommand(command: string, args: string[], options: SpawnOptions = {}): Promise<{ stdout: string; stderr: string; }> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, sanitizeArgs(args), { ...options, shell: false });
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout?.on('data', d => { stdout += d; });
+    proc.stderr?.on('data', d => { stderr += d; });
+    proc.on('close', code => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+      } else {
+        reject(new Error(stderr || `Command failed: ${command} ${args.join(' ')}`));
+      }
+    });
+  });
+}

--- a/src/services/prAssistant/constants.ts
+++ b/src/services/prAssistant/constants.ts
@@ -1,0 +1,16 @@
+export const VALIDATION_CONSTANTS = {
+  LARGE_FILE_THRESHOLD: 500, // Lines threshold for large file detection
+  LARGE_STRING_THRESHOLD: 100, // Character threshold for large inline strings
+  TEST_TIMEOUT: 120000, // 2 minutes timeout for test execution
+  BUILD_TIMEOUT: 120000, // 2 minutes timeout for build execution
+  LINT_TIMEOUT: 60000, // 1 minute timeout for linting
+  DEFAULT_PORT: 3000 // Fallback default port if config is unavailable
+} as const;
+
+export const RAILWAY_VALIDATION_PATTERNS = [
+  { pattern: /(?:http:\/\/|https:\/\/)(?!localhost|127\.0\.0\.1|example\.com)/gi, message: 'Hardcoded URLs detected' },
+  { pattern: /['"`]\w+\.\w+\.\w+['"`]/gi, message: 'Potential hardcoded domains' },
+  { pattern: /:\s*\d{4,5}(?!\s*[,}\]])/gi, message: 'Hardcoded port numbers' },
+  { pattern: /password\s*[=:]\s*['"`][^'"`]{3,}['"`]/gi, message: 'Hardcoded password detected' },
+  { pattern: /api[_-]?key\s*[=:]\s*['"`][^'"`]{10,}['"`]/gi, message: 'Hardcoded API key detected' }
+] as const;

--- a/src/services/prAssistant/types.ts
+++ b/src/services/prAssistant/types.ts
@@ -1,0 +1,20 @@
+export interface CheckResult {
+  status: '✅' | '❌' | '⚠️';
+  message: string;
+  details: string[];
+}
+
+export interface PRAnalysisResult {
+  status: '✅' | '❌' | '⚠️';
+  summary: string;
+  checks: {
+    deadCodeRemoval: CheckResult;
+    simplification: CheckResult;
+    openaiCompatibility: CheckResult;
+    railwayReadiness: CheckResult;
+    automatedValidation: CheckResult;
+    finalDoubleCheck: CheckResult;
+  };
+  reasoning: string;
+  recommendations: string[];
+}


### PR DESCRIPTION
## Summary
- extract reusable PR assistant helpers into dedicated modules for command execution, check rendering, constants, and shared types
- simplify PRAssistant by importing helpers and using centralized validation constants with configurable default port
- streamline markdown generation through shared formatting utility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692509dc11908325b28cd2aadcbc4a2f)