### PR TITLE
Refactor PR assistant checks into reusable utilities

### DIFF
--- a/src/services/prAssistant/analysisRules.ts
+++ b/src/services/prAssistant/analysisRules.ts
@@ -1,0 +1,20 @@
+export const DEAD_CODE_PATTERNS = {
+  todo: /^\+.*(?:TODO|FIXME|XXX|HACK)/gim,
+  debug: /^\+.*console\.(?:log|debug|warn|error)/gim,
+  duplicate: /^\+.*(\w+.*){3,}/gim
+} as const;
+
+export const SIMPLIFICATION_PATTERNS = {
+  functionAddition: /^\+.*(?:function|=>|\bconst\s+\w+\s*=)/gim,
+  longFunction: /^\+.*(?:function|=>)[\s\S]*?(?=^[+-]|\n\n|$)/gim,
+  complexity: /^\+.*(?:if|for|while|switch).*{[\s\S]*?(?:if|for|while|switch)/gim,
+  largeString: (threshold: number) => new RegExp(`^\\+.*['"\`][^'"\`]{${threshold},}['"\`]`, 'gim'),
+  magicNumbers: /^\+.*(?<![.\w])\d{3,}(?![.\w])/gim
+} as const;
+
+export const CHECK_THRESHOLDS = {
+  maxDebugStatements: 3,
+  maxComplexityPatterns: 2,
+  maxMagicNumbers: 2,
+  longFunctionLineCount: 50
+} as const;

--- a/src/services/prAssistant/utils.ts
+++ b/src/services/prAssistant/utils.ts
@@ -1,0 +1,19 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export async function getFileLineCount(basePath: string, file: string): Promise<number> {
+  const content = await fs.readFile(path.join(basePath, file), 'utf-8');
+  return content.split('\n').length;
+}
+
+export function collectMatches(diff: string, pattern: RegExp): string[] {
+  return diff.match(pattern) || [];
+}
+
+export function hasLongFunctionAddition(longFunctions: string[], threshold: number): boolean {
+  return longFunctions.some(fn => fn.split('\n').length > threshold);
+}
+
+export function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}


### PR DESCRIPTION
## Summary
- extract shared analysis rules for PR assistant checks to reduce inline complexity
- add reusable utilities for line counting, regex matching, and deduplicating recommendations
- refactor code quality, simplification, and Railway readiness checks to use shared helpers and avoid repetitive details

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925381f2c9c8325aa9995583358420f)