### PR TITLE
Use responses API for OpenAI call helper

### DIFF
--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -65,7 +65,7 @@ const FALLBACK_TEXT_SELECTOR = '[No text output]';
 type ResponseRequestConfig = {
   model: string;
   messages: ChatCompletionMessageParam[];
-  tokenParams: Record<string, unknown>;
+  tokenParams: ReturnType<typeof getTokenParameter>;
   options: CallOpenAIOptions;
 };
 


### PR DESCRIPTION
## Summary
- add shared request/output helpers so callOpenAI uses the OpenAI responses API
- normalize token parameters for responses compatibility with newer SDKs

## Testing
- npm test -- --runInBand


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b29d115088325a66b9d6954033187)