### PR TITLE
Refactor OpenAI client initialization into dedicated module

### DIFF
--- a/src/services/openai-assistants.ts
+++ b/src/services/openai-assistants.ts
@@ -1,3 +1,4 @@
+import type OpenAI from 'openai';
 import fs from 'fs/promises';
 import { getOpenAIClient } from './openai.js';
 import config from '../config/index.js';
@@ -18,6 +19,8 @@ export interface AssistantRecord extends AssistantInfo {
 
 export type AssistantRegistry = Record<string, AssistantRecord>;
 
+type AssistantListPage = Awaited<ReturnType<OpenAI['beta']['assistants']['list']>>;
+
 const LOG_CONTEXT = { module: 'assistant-sync' } as const;
 const REGISTRY_PATH = config.assistantSync.registryPath;
 
@@ -32,7 +35,7 @@ export async function getAllAssistants(): Promise<AssistantInfo[]> {
   let cursor: string | undefined = undefined;
 
   while (true) {
-    const resp = await client.beta.assistants.list({ limit: 20, after: cursor });
+    const resp: AssistantListPage = await client.beta.assistants.list({ limit: 20, after: cursor });
     resp.data.forEach((a: any) => {
       assistants.push({
         id: a.id,

--- a/src/services/openai/clientFactory.ts
+++ b/src/services/openai/clientFactory.ts
@@ -1,0 +1,118 @@
+import OpenAI from 'openai';
+import { getRoutingActiveMessage } from '../../config/prompts.js';
+import { aiLogger } from '../../utils/structuredLogging.js';
+import { responseCache } from '../../utils/cache.js';
+import { recordTraceEvent } from '../../utils/telemetry.js';
+import {
+  getCircuitBreakerSnapshot,
+  RESILIENCE_CONSTANTS
+} from './resilience.js';
+import {
+  resolveOpenAIKey,
+  resolveOpenAIBaseURL,
+  getOpenAIKeySource,
+  hasValidAPIKey,
+  setDefaultModel,
+  getDefaultModel,
+  getFallbackModel
+} from './credentialProvider.js';
+
+export const API_TIMEOUT_MS = parseInt(process.env.WORKER_API_TIMEOUT_MS || '60000', 10);
+export const ARCANOS_ROUTING_MESSAGE = getRoutingActiveMessage();
+const ARCANOS_ROUTING_LOG = `${ARCANOS_ROUTING_MESSAGE} - all calls will use configured model by default`;
+
+let openai: OpenAI | null = null;
+
+export const initializeOpenAI = (): OpenAI | null => {
+  if (openai) return openai;
+
+  try {
+    const apiKey = resolveOpenAIKey();
+    if (!apiKey) {
+      aiLogger.warn('OpenAI API key not configured - AI endpoints will return mock responses', {
+        operation: 'initialization'
+      });
+      return null;
+    }
+
+    const baseURL = resolveOpenAIBaseURL();
+    openai = new OpenAI({
+      apiKey,
+      timeout: API_TIMEOUT_MS,
+      ...(baseURL ? { baseURL } : {})
+    });
+
+    const configuredDefaultModel =
+      process.env.OPENAI_MODEL ||
+      process.env.RAILWAY_OPENAI_MODEL ||
+      process.env.FINETUNED_MODEL_ID ||
+      process.env.FINE_TUNED_MODEL_ID ||
+      process.env.AI_MODEL ||
+      'gpt-4o';
+
+    setDefaultModel(configuredDefaultModel);
+
+    console.log('✅ OpenAI client initialized');
+    console.log(`🧠 Default AI Model: ${configuredDefaultModel}`);
+    console.log(`🔄 Fallback Model: ${getFallbackModel()}`);
+    console.log(`🎯 ${ARCANOS_ROUTING_LOG}`);
+
+    return openai;
+  } catch (error) {
+    console.error('❌ Failed to initialize OpenAI client:', error);
+    return null;
+  }
+};
+
+export const getOpenAIClient = (): OpenAI | null => {
+  return openai || initializeOpenAI();
+};
+
+export const validateAPIKeyAtStartup = (): boolean => {
+  const apiKey = resolveOpenAIKey();
+  if (!apiKey) {
+    console.warn('⚠️ OPENAI_API_KEY not set - will return mock responses');
+    return true;
+  }
+  console.log(
+    `✅ OPENAI_API_KEY validation passed${getOpenAIKeySource() ? ` (source: ${getOpenAIKeySource()})` : ''}`
+  );
+  return true;
+};
+
+export const getOpenAIServiceHealth = () => {
+  const circuitBreakerMetrics = getCircuitBreakerSnapshot();
+  const cacheStats = responseCache.getStats();
+  const configured = hasValidAPIKey();
+
+  return {
+    apiKey: {
+      configured,
+      status: configured ? 'valid' : 'missing_or_invalid',
+      source: getOpenAIKeySource()
+    },
+    client: {
+      initialized: openai !== null,
+      model: getDefaultModel(),
+      timeout: API_TIMEOUT_MS,
+      baseURL: resolveOpenAIBaseURL()
+    },
+    circuitBreaker: {
+      ...circuitBreakerMetrics,
+      healthy: circuitBreakerMetrics.state !== 'OPEN'
+    },
+    cache: {
+      ...cacheStats,
+      enabled: true
+    },
+    lastHealthCheck: new Date().toISOString(),
+    defaults: {
+      maxTokens: RESILIENCE_CONSTANTS.DEFAULT_MAX_TOKENS
+    }
+  };
+};
+
+export const resetOpenAIClient = () => {
+  openai = null;
+  recordTraceEvent('openai.client.reset');
+};


### PR DESCRIPTION
## Summary
- extract OpenAI client setup, health reporting, and routing message into a dedicated clientFactory module for reuse
- update openai service exports to leverage the shared client factory and keep named exports consistent for callers
- add explicit OpenAI assistant list typing to align with current SDK typings

## Testing
- npm run type-check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cbbb6a6d08325a05e94d3e933f81d)