### PR TITLE
Normalize gaming query inputs and guide URLs

### DIFF
--- a/src/modules/arcanos-gaming.ts
+++ b/src/modules/arcanos-gaming.ts
@@ -6,9 +6,38 @@ export const ArcanosGaming = {
   gptIds: ['arcanos-gaming', 'gaming'],
   actions: {
     async query(payload: any) {
-      const prompt = payload?.prompt || payload;
-      const urls = payload?.urls || payload?.guideUrls;
-      return runGaming(prompt, payload?.url, Array.isArray(urls) ? urls : []);
+      const prompt =
+        payload?.prompt ||
+        payload?.message ||
+        payload?.text ||
+        payload?.content ||
+        payload?.query ||
+        payload;
+
+      if (typeof prompt !== 'string' || !prompt.trim()) {
+        throw new Error('ARCANOS:GAMING query requires a text prompt.');
+      }
+
+      const guideUrl = typeof payload?.url === 'string' && payload.url.trim() ? payload.url.trim() : undefined;
+
+      const extraGuidesRaw = [payload?.urls, payload?.guideUrls];
+      const guideUrls: string[] = [];
+
+      for (const raw of extraGuidesRaw) {
+        if (typeof raw === 'string' && raw.trim()) {
+          guideUrls.push(raw.trim());
+        } else if (Array.isArray(raw)) {
+          for (const entry of raw) {
+            if (typeof entry === 'string' && entry.trim()) {
+              guideUrls.push(entry.trim());
+            }
+          }
+        }
+      }
+
+      const normalizedGuides = Array.from(new Set(guideUrls));
+
+      return runGaming(prompt.trim(), guideUrl, normalizedGuides);
     },
   },
 };

--- a/tests/arcanos-gaming.test.ts
+++ b/tests/arcanos-gaming.test.ts
@@ -1,0 +1,52 @@
+import { jest } from '@jest/globals';
+
+const runGamingSpy = jest.fn();
+
+jest.unstable_mockModule('../src/services/gaming.js', () => ({
+  runGaming: runGamingSpy
+}));
+
+const { default: ArcanosGaming } = await import('../src/modules/arcanos-gaming.js');
+
+describe('ArcanosGaming module', () => {
+
+  beforeEach(() => {
+    runGamingSpy.mockResolvedValue({ ok: true } as any);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('accepts message alias and single guide url', async () => {
+    const payload = {
+      message: 'How do I beat the boss?',
+      url: ' https://example.com/guide '
+    } as any;
+
+    await ArcanosGaming.actions.query(payload);
+
+    expect(runGamingSpy).toHaveBeenCalledWith('How do I beat the boss?', 'https://example.com/guide', []);
+  });
+
+  it('normalizes additional guide collections', async () => {
+    const payload = {
+      prompt: 'Show me the path',
+      urls: ['https://example.com/a', '  ', 42, 'https://example.com/a'],
+      guideUrls: 'https://example.com/b'
+    } as any;
+
+    await ArcanosGaming.actions.query(payload);
+
+    expect(runGamingSpy).toHaveBeenCalledWith('Show me the path', undefined, [
+      'https://example.com/a',
+      'https://example.com/b'
+    ]);
+  });
+
+  it('rejects missing prompts', async () => {
+    await expect(ArcanosGaming.actions.query({ url: 'https://example.com' } as any)).rejects.toThrow(
+      'ARCANOS:GAMING query requires a text prompt.'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- normalize gaming module prompt extraction to accept common aliases and guard against empty prompts
- normalize and deduplicate guide URLs before invoking the gaming service
- add tests covering prompt aliasing, guide URL normalization, and missing prompt validation

## Testing
- npm test -- tests/arcanos-gaming.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cdb63a6688325a836b766e7b15fc8)