### PR TITLE
Refine server boot helpers

### DIFF
--- a/src/config/serverMessages.ts
+++ b/src/config/serverMessages.ts
@@ -38,6 +38,14 @@ export const SERVER_MESSAGES = {
   }
 } as const;
 
+export const SERVER_TEXT = {
+  DIAGNOSTIC_START: 'Running system diagnostic...',
+  DIAGNOSTIC_FAILURE_PREFIX: 'System diagnostic failed: ',
+  PORT_CONFLICT_TIP: 'Consider stopping other services or setting a different PORT in .env',
+  STATE_INIT_SUCCESS: 'System state initialized',
+  STATE_INIT_FAILURE_PREFIX: 'Failed to initialize system state: '
+} as const;
+
 export const SERVER_CONSTANTS = {
   WORKERS_DIRECTORY: './workers',
   DIAGNOSTIC_DELAY_MS: 2000, // Delay before running system diagnostic


### PR DESCRIPTION
## Summary
- centralize repeated boot-time status strings into server configuration constants
- extract reusable helpers for port availability logging and state initialization to simplify server startup
- ensure diagnostic and state logging use shared text constants for consistency

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d0a83708083259169c2ab1e30a96c)