### PR TITLE
Refactor prompt utilities and move HRC prompt to config

### DIFF
--- a/src/config/hrcPrompts.ts
+++ b/src/config/hrcPrompts.ts
@@ -1,0 +1,3 @@
+export const HRC_SYSTEM_PROMPT =
+  'You are the Hallucination-Resistant Core. Analyse the user message and return JSON {"fidelity":0-1,"resilience":0-1,"verdict":string}.';
+

--- a/src/modules/arcanos-gaming.ts
+++ b/src/modules/arcanos-gaming.ts
@@ -1,4 +1,5 @@
 import { runGaming } from '../services/gaming.js';
+import { extractTextPrompt, normalizeStringList } from '../utils/payloadNormalization.js';
 
 export const ArcanosGaming = {
   name: 'ARCANOS:GAMING',
@@ -6,38 +7,17 @@ export const ArcanosGaming = {
   gptIds: ['arcanos-gaming', 'gaming'],
   actions: {
     async query(payload: any) {
-      const prompt =
-        payload?.prompt ||
-        payload?.message ||
-        payload?.text ||
-        payload?.content ||
-        payload?.query ||
-        payload;
+      const prompt = extractTextPrompt(payload);
 
-      if (typeof prompt !== 'string' || !prompt.trim()) {
+      if (!prompt) {
         throw new Error('ARCANOS:GAMING query requires a text prompt.');
       }
 
       const guideUrl = typeof payload?.url === 'string' && payload.url.trim() ? payload.url.trim() : undefined;
 
-      const extraGuidesRaw = [payload?.urls, payload?.guideUrls];
-      const guideUrls: string[] = [];
+      const normalizedGuides = normalizeStringList(payload?.urls, payload?.guideUrls);
 
-      for (const raw of extraGuidesRaw) {
-        if (typeof raw === 'string' && raw.trim()) {
-          guideUrls.push(raw.trim());
-        } else if (Array.isArray(raw)) {
-          for (const entry of raw) {
-            if (typeof entry === 'string' && entry.trim()) {
-              guideUrls.push(entry.trim());
-            }
-          }
-        }
-      }
-
-      const normalizedGuides = Array.from(new Set(guideUrls));
-
-      return runGaming(prompt.trim(), guideUrl, normalizedGuides);
+      return runGaming(prompt, guideUrl, normalizedGuides);
     },
   },
 };

--- a/src/modules/hrc.ts
+++ b/src/modules/hrc.ts
@@ -1,5 +1,6 @@
 import { getOpenAIClient } from '../services/openai.js';
 import { getDefaultModel } from '../services/openai.js';
+import { HRC_SYSTEM_PROMPT } from '../config/hrcPrompts.js';
 
 export interface HRCResult {
   fidelity: number;
@@ -33,11 +34,7 @@ export class HRCCore {
         model,
         response_format: { type: 'json_object' },
         messages: [
-          {
-            role: 'system',
-            content:
-              'You are the Hallucination-Resistant Core. Analyse the user message and return JSON {"fidelity":0-1,"resilience":0-1,"verdict":string}.',
-          },
+          { role: 'system', content: HRC_SYSTEM_PROMPT },
           { role: 'user', content: input }
         ],
         temperature: 0

--- a/src/services/commandCenter.ts
+++ b/src/services/commandCenter.ts
@@ -1,6 +1,7 @@
 import { sanitizeInput } from '../utils/security.js';
 import { createCentralizedCompletion, generateMockResponse, hasValidAPIKey } from './openai.js';
 import { getAuditSafeMode, interpretCommand, setAuditSafeMode } from './auditSafeToggle.js';
+import { extractTextPrompt } from '../utils/payloadNormalization.js';
 
 export type CommandName = 'audit-safe:set-mode' | 'audit-safe:interpret' | 'ai:prompt';
 
@@ -76,7 +77,7 @@ const commandHandlers: Record<CommandName, CommandHandler> = {
     });
   },
   'ai:prompt': async (payload) => {
-    const prompt = typeof payload?.prompt === 'string' ? payload.prompt.trim() : '';
+    const prompt = extractTextPrompt(payload, ['prompt']);
 
     if (!prompt) {
       return buildResult('ai:prompt', false, 'Prompt text is required.');

--- a/src/utils/payloadNormalization.ts
+++ b/src/utils/payloadNormalization.ts
@@ -1,0 +1,43 @@
+export function extractTextPrompt(
+  payload: unknown,
+  candidateKeys: string[] = ['prompt', 'message', 'text', 'content', 'query']
+): string {
+  if (typeof payload === 'string') {
+    return payload.trim();
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    return '';
+  }
+
+  for (const key of candidateKeys) {
+    const value = (payload as Record<string, unknown>)[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return '';
+}
+
+export function normalizeStringList(...candidates: Array<unknown>): string[] {
+  const results: string[] = [];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      results.push(candidate.trim());
+      continue;
+    }
+
+    if (Array.isArray(candidate)) {
+      for (const entry of candidate) {
+        if (typeof entry === 'string' && entry.trim()) {
+          results.push(entry.trim());
+        }
+      }
+    }
+  }
+
+  return Array.from(new Set(results));
+}
+


### PR DESCRIPTION
## Summary
- extract shared payload normalization helpers for text prompts and string lists
- update gaming and command center modules to use centralized utilities
- move the HRC system prompt into configuration for reuse and maintainability

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e3532368483258473863cb0288399)