### PR TITLE
Extract shared reasoning response parsing helper

### DIFF
--- a/src/config/reasoningTemplates.ts
+++ b/src/config/reasoningTemplates.ts
@@ -1,6 +1,7 @@
 export const REASONING_TOKEN_LIMIT = 1500;
 export const REASONING_TEMPERATURE = 0.7;
 export const REASONING_LOG_SUMMARY_LENGTH = 200;
+export const REASONING_FALLBACK_TEXT = '[No reasoning provided]';
 
 export const REASONING_SYSTEM_PROMPT =
   'You are an advanced reasoning layer for ARCANOS AI. Your role is to refine and enhance ARCANOS responses through deeper analysis while preserving the original intent and structure. Focus on logical consistency, completeness, and clarity.';


### PR DESCRIPTION
## Summary
- add a shared fallback text constant for reasoning responses
- centralize extraction of reasoning text from OpenAI responses
- reuse the helper in GPT-5 reasoning flows to reduce duplication

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e378c43788325aa0268d379766a4b)