### PR TITLE
Trim model overrides before calling OpenAI

### DIFF
--- a/src/controllers/openaiController.ts
+++ b/src/controllers/openaiController.ts
@@ -51,10 +51,8 @@ export async function handlePrompt(
   if (!validation) return; // Response already handled (mock or error)
 
   const { input: prompt } = validation;
-  const model =
-    typeof req.body.model === 'string' && req.body.model.trim().length > 0
-      ? req.body.model
-      : getDefaultModel();
+  const modelOverride = typeof req.body.model === 'string' ? req.body.model.trim() : undefined;
+  const model = modelOverride && modelOverride.length > 0 ? modelOverride : getDefaultModel();
 
   try {
     const { output } = await callOpenAI(model, prompt, 256);

--- a/tests/openai-prompt.test.ts
+++ b/tests/openai-prompt.test.ts
@@ -69,6 +69,24 @@ describe('handlePrompt', () => {
     );
   });
 
+  it('trims provided model names before sending to OpenAI', async () => {
+    validateAIRequest.mockReturnValue({ input: 'hi', client: {} });
+    callOpenAI.mockResolvedValue({ response: {}, output: 'ok', model: 'ft:custom-model', cached: false });
+
+    const req: any = { body: { prompt: 'hi', model: '  ft:custom-model  ' } };
+    const res: any = { json: jest.fn() };
+
+    await handlePrompt(req, res);
+
+    expect(callOpenAI).toHaveBeenCalledWith('ft:custom-model', 'hi', 256);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'ft:custom-model',
+        activeModel: 'ft:custom-model'
+      })
+    );
+  });
+
   it('falls back to default model when none provided', async () => {
     validateAIRequest.mockReturnValue({ input: 'hello', client: {} });
     getDefaultModel.mockReturnValue('ft:default-model');


### PR DESCRIPTION
## Summary
- trim provided model overrides for prompt requests before invoking OpenAI
- add unit coverage to ensure whitespace-stripped model names are used in responses

## Testing
- npm test -- --runTestsByPath tests/openai-prompt.test.ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2e19cf488325866a0da7443e4c8b)