### PR TITLE
Fix SDK compliance version check

### DIFF
--- a/scripts/sdk-compliance-audit.js
+++ b/scripts/sdk-compliance-audit.js
@@ -124,12 +124,14 @@ async function auditSDKCompliance(result) {
         const packageJson = JSON.parse(await fs.readFile(path.join(projectRoot, 'package.json'), 'utf8'));
         result.sdkValidation.version = packageJson.dependencies?.openai || 'not found';
         console.log(`   📦 OpenAI SDK Version: ${result.sdkValidation.version}`);
-        if (!result.sdkValidation.version.includes('5.')) {
+        const majorVersionMatch = result.sdkValidation.version.match(/\d+/);
+        const majorVersion = majorVersionMatch ? parseInt(majorVersionMatch[0], 10) : 0;
+        if (majorVersion < 5) {
             result.summary.recommendedActions.push('Update OpenAI SDK to version 5.x or higher');
             result.summary.overallRisk = 'high';
         }
         else {
-            console.log('   ✅ SDK version is compliant (v5.x)');
+            console.log(`   ✅ SDK version is compliant (v${majorVersion}.x)`);
         }
     }
     catch (error) {


### PR DESCRIPTION
## Summary
- update SDK compliance audit to parse the OpenAI SDK major version and treat v5+ as compliant

## Testing
- npm run audit:sdk-compliance

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f31c2c1a083258f40a4a307e19352)