### PR TITLE
Add safe HTML fetch helper

### DIFF
--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,63 @@
+export interface SafeFetchHtmlResult {
+  raw: string | null;
+  error: string | null;
+  status?: number;
+  contentType?: string;
+}
+
+const HTML_CONTENT_TYPE = /text\/html/i;
+const DEFAULT_TIMEOUT_MS = 10000;
+
+function buildErrorResult(message: string, status?: number, contentType?: string): SafeFetchHtmlResult {
+  return {
+    raw: null,
+    error: message,
+    status,
+    contentType
+  };
+}
+
+/**
+ * Safely fetch HTML content while enforcing content-type validation and timeouts.
+ * Never throws; instead returns a structured result indicating success or failure.
+ */
+export async function safeFetchHtml(url: string, options: RequestInit = {}): Promise<SafeFetchHtmlResult> {
+  try {
+    // Validate URL upfront to avoid runtime fetch errors.
+    new URL(url);
+  } catch {
+    return buildErrorResult('Invalid URL provided');
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      redirect: 'follow',
+      ...options,
+      signal: controller.signal
+    });
+
+    const contentType = response.headers.get('content-type') ?? undefined;
+
+    if (!response.ok) {
+      return buildErrorResult(`Request failed with status ${response.status}`, response.status, contentType);
+    }
+
+    if (!contentType || !HTML_CONTENT_TYPE.test(contentType)) {
+      return buildErrorResult('Response is not HTML content', response.status, contentType);
+    }
+
+    const raw = await response.text();
+    return { raw, error: null, status: response.status, contentType };
+  } catch (error) {
+    const message = (error as Error)?.name === 'AbortError'
+      ? 'Request timed out'
+      : (error instanceof Error ? error.message : 'Unknown error');
+
+    return buildErrorResult(message);
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { safeFetchHtml } from '../src/utils/http';
+
+describe('safeFetchHtml', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('rejects invalid urls before attempting fetch', async () => {
+    const result = await safeFetchHtml('not a url');
+    expect(result.error).toMatch(/Invalid URL/);
+    expect(result.raw).toBeNull();
+  });
+
+  it('returns an error when response is not ok', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: new Headers({ 'content-type': 'text/html' })
+    } as Response);
+
+    const result = await safeFetchHtml('https://example.com');
+    expect(result.error).toContain('status 500');
+    expect(result.status).toBe(500);
+  });
+
+  it('rejects non-html content types', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: async () => '"hello"'
+    } as Response);
+
+    const result = await safeFetchHtml('https://example.com');
+    expect(result.error).toBe('Response is not HTML content');
+    expect(result.raw).toBeNull();
+  });
+
+  it('returns html content when the response is valid', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
+      text: async () => '<html><body>ok</body></html>'
+    } as Response);
+
+    const result = await safeFetchHtml('https://example.com');
+    expect(result.error).toBeNull();
+    expect(result.raw).toContain('ok');
+    expect(result.contentType).toContain('text/html');
+  });
+});


### PR DESCRIPTION
## Summary
- add a safeFetchHtml utility that validates URLs, enforces HTML content-type checks, and handles timeouts
- cover safeFetchHtml behavior with unit tests for failures and successful HTML responses

## Testing
- npm test -- --runInBand --testPathPattern=http.test.ts
- npm run type-check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f508c894483259b079cc81045067e)