### PR TITLE
Refine self-test config and shared error responses

### DIFF
--- a/src/config/selfTestConfig.ts
+++ b/src/config/selfTestConfig.ts
@@ -1,0 +1,25 @@
+export interface SelfTestPrompt {
+  id: string;
+  prompt: string;
+  expectation: string;
+}
+
+export const DEFAULT_SELF_TEST_PROMPTS: SelfTestPrompt[] = [
+  {
+    id: 'readiness',
+    prompt: 'Respond with a concise status update proving ARCANOS is online and ready for work.',
+    expectation: 'Model responds with operational readiness signal.'
+  },
+  {
+    id: 'memory-awareness',
+    prompt: 'Summarize any memory context you can access in one paragraph.',
+    expectation: 'Model references stored memory context without errors.'
+  },
+  {
+    id: 'module-routing',
+    prompt: 'Which internal module handled this request? Reply in JSON {"module":"name"}.',
+    expectation: 'Model identifies the executing module and formats JSON correctly.'
+  }
+];
+
+export const SELF_TEST_USER_AGENT = 'arcanos-self-test/1.0';

--- a/src/routes/status.ts
+++ b/src/routes/status.ts
@@ -9,6 +9,7 @@ import { confirmGate } from '../middleware/confirmGate.js';
 import { getOpenAIServiceHealth } from '../services/openai.js';
 import { queryCache, configCache } from '../utils/cache.js';
 import { getStatus as getDbStatus } from '../db.js';
+import { sendJsonError } from '../utils/responseHelpers.js';
 
 const router = express.Router();
 
@@ -21,10 +22,12 @@ router.get('/status', (_: Request, res: Response) => {
     res.json(state);
   } catch (error) {
     console.error('[STATUS] Error retrieving system state:', error);
-    res.status(500).json({
-      error: 'Failed to retrieve system state',
-      message: error instanceof Error ? error.message : 'Unknown error'
-    });
+    sendJsonError(
+      res,
+      500,
+      'Failed to retrieve system state',
+      error instanceof Error ? error.message : 'Unknown error'
+    );
   }
 });
 
@@ -66,12 +69,13 @@ router.get('/health', async (_: Request, res: Response) => {
     
   } catch (error) {
     console.error('[HEALTH] Error retrieving health status:', error);
-    res.status(500).json({
-      status: 'unhealthy',
-      error: 'Failed to retrieve health status',
-      message: error instanceof Error ? error.message : 'Unknown error',
-      timestamp: new Date().toISOString()
-    });
+    sendJsonError(
+      res,
+      500,
+      'Failed to retrieve health status',
+      error instanceof Error ? error.message : 'Unknown error',
+      { status: 'unhealthy' }
+    );
   }
 });
 
@@ -92,14 +96,16 @@ router.post('/status', confirmGate, (req: Request, res: Response) => {
     
     const updatedState = updateState(updates);
     console.log('[STATUS] System state updated:', Object.keys(updates));
-    
+
     res.json(updatedState);
   } catch (error) {
     console.error('[STATUS] Error updating system state:', error);
-    res.status(500).json({
-      error: 'Failed to update system state',
-      message: error instanceof Error ? error.message : 'Unknown error'
-    });
+    sendJsonError(
+      res,
+      500,
+      'Failed to update system state',
+      error instanceof Error ? error.message : 'Unknown error'
+    );
   }
 });
 

--- a/src/services/selfTestPipeline.ts
+++ b/src/services/selfTestPipeline.ts
@@ -1,12 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { updateState } from './stateManager.js';
-
-export interface SelfTestPrompt {
-  id: string;
-  prompt: string;
-  expectation: string;
-}
+import { DEFAULT_SELF_TEST_PROMPTS, SELF_TEST_USER_AGENT, SelfTestPrompt } from '../config/selfTestConfig.js';
 
 export interface SelfTestResult {
   id: string;
@@ -37,24 +32,6 @@ export interface SelfTestOptions {
   triggeredBy?: string;
   targetModel?: string;
 }
-
-const defaultPrompts: SelfTestPrompt[] = [
-  {
-    id: 'readiness',
-    prompt: 'Respond with a concise status update proving ARCANOS is online and ready for work.',
-    expectation: 'Model responds with operational readiness signal.'
-  },
-  {
-    id: 'memory-awareness',
-    prompt: 'Summarize any memory context you can access in one paragraph.',
-    expectation: 'Model references stored memory context without errors.'
-  },
-  {
-    id: 'module-routing',
-    prompt: 'Which internal module handled this request? Reply in JSON {"module":"name"}.',
-    expectation: 'Model identifies the executing module and formats JSON correctly.'
-  }
-];
 
 const LOG_FILE = path.join(process.cwd(), 'logs', 'healthcheck.json');
 
@@ -116,7 +93,7 @@ async function executePrompt(
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'user-agent': 'arcanos-self-test/1.0',
+        'user-agent': SELF_TEST_USER_AGENT,
         'x-confirmed': 'yes'
       },
       body: JSON.stringify({
@@ -177,7 +154,7 @@ async function executePrompt(
 
 export async function runSelfTestPipeline(options: SelfTestOptions = {}): Promise<SelfTestSummary> {
   const baseUrl = options.baseUrl || resolveBaseUrl();
-  const prompts = options.prompts && options.prompts.length > 0 ? options.prompts : defaultPrompts;
+  const prompts = options.prompts && options.prompts.length > 0 ? options.prompts : DEFAULT_SELF_TEST_PROMPTS;
   const targetModel = options.targetModel || process.env.FINETUNED_MODEL_ID || process.env.AI_MODEL || 'gpt-4o';
   const triggeredBy = options.triggeredBy || 'cli';
 

--- a/src/utils/responseHelpers.ts
+++ b/src/utils/responseHelpers.ts
@@ -1,0 +1,18 @@
+import { Response } from 'express';
+
+export function sendJsonError(
+  res: Response,
+  statusCode: number,
+  error: string,
+  message: string,
+  context: Record<string, unknown> = {}
+): void {
+  const payload = {
+    error,
+    message,
+    timestamp: new Date().toISOString(),
+    ...context
+  };
+
+  res.status(statusCode).json(payload);
+}


### PR DESCRIPTION
## Summary
- move self-test prompt text and user agent into a shared configuration module
- add a reusable JSON error response helper and apply it to status endpoints
- wire the self-test pipeline to the shared defaults to reduce inline configuration noise

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fde6a91248325961c0178dee44e0e)