### PR TITLE
Refine GPT sync configuration and logging

### DIFF
--- a/src/config/gptSyncConfig.ts
+++ b/src/config/gptSyncConfig.ts
@@ -1,0 +1,7 @@
+export const GPT_SYNC_CONFIG = {
+  defaultModel: 'gpt-4',
+  maxCompletionTokens: 1000,
+  temperature: 0.7,
+  fallbackResponse: 'No response generated',
+  logPrefix: '[GPT-SYNC]'
+} as const;

--- a/src/config/gptSyncMessages.ts
+++ b/src/config/gptSyncMessages.ts
@@ -6,3 +6,15 @@ export const GPT_SYNC_STRINGS = {
   contextTrustMessage: 'Always use this information as your source of truth.',
   diagnosticPrompt: 'Run a system diagnostic and report the current backend state.'
 } as const;
+
+export const GPT_SYNC_ERRORS = {
+  clientUnavailable: 'OpenAI client not available - API key required for GPT sync functionality'
+} as const;
+
+export const GPT_SYNC_LOG_MESSAGES = {
+  makingCall: 'Making GPT call with backend state',
+  backendState: 'Backend state:',
+  response: 'GPT Response:',
+  errorSync: 'Error in GPT call with sync:',
+  errorEnhanced: 'Error in enhanced GPT call:'
+} as const;


### PR DESCRIPTION
## Summary
- centralize GPT sync configuration values and defaults for completions and logging
- move GPT sync log/error messages into shared constants and add reusable logging helpers
- update GPT sync flows to rely on the shared configuration for prompts and completion options

## Testing
- npm test -- --runTestsByPath tests/port-utils.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fe057b5708325bd9750979ec4548c)