### PR TITLE
Centralize fallback logging messages

### DIFF
--- a/src/config/fallbackLogMessages.ts
+++ b/src/config/fallbackLogMessages.ts
@@ -1,0 +1,15 @@
+/**
+ * Centralized fallback logging templates to keep middleware messaging consistent
+ */
+
+export const FALLBACK_LOG_MESSAGES = {
+  degraded: (endpoint: string, reason: string): string =>
+    `🔄 Fallback mode activated for ${endpoint} - ${reason}`,
+  preemptive: (endpoint: string): string =>
+    `🔄 Preemptive fallback mode activated for ${endpoint} - OpenAI client unavailable`
+} as const;
+
+export const FALLBACK_LOG_REASON = {
+  unknown: 'unknown',
+  unavailable: 'OpenAI client unavailable'
+} as const;


### PR DESCRIPTION
## Summary
- add centralized fallback log message templates for degraded and preemptive modes
- reuse shared logging helper in fallback middleware and streamline telemetry metadata

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69308bcf280483258635deba37918f99)