### PR TITLE
Refine OpenAI configuration defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,8 @@ TUTOR_DEFAULT_TOKEN_LIMIT=200
 
 # Image generation model (default: gpt-image-1)
 IMAGE_MODEL=gpt-image-1
+# Default image size for generation responses
+IMAGE_DEFAULT_SIZE=1024x1024
 
 # ================================
 # API SERVER CONFIGURATION

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -31,8 +31,15 @@ import {
   CallOpenAIResult,
   CallOpenAICacheEntry,
   ChatCompletionMessageParam,
-  ChatCompletionResponseFormat
+  ChatCompletionResponseFormat,
+  ImageSize
 } from './openai/types.js';
+import {
+  DEFAULT_IMAGE_SIZE,
+  IMAGE_GENERATION_MODEL,
+  OPENAI_REQUEST_LOG_CONTEXT,
+  ROUTING_MAX_TOKENS
+} from './openai/config.js';
 import {
   getDefaultModel,
   getFallbackModel,
@@ -59,13 +66,9 @@ export type {
   CallOpenAIResult,
   CallOpenAICacheEntry,
   ChatCompletionMessageParam,
-  ChatCompletionResponseFormat
+  ChatCompletionResponseFormat,
+  ImageSize
 };
-
-const DEFAULT_ROUTING_MAX_TOKENS = 4096;
-const ROUTING_MAX_TOKENS = Number(process.env.ROUTING_MAX_TOKENS) || DEFAULT_ROUTING_MAX_TOKENS;
-const IMAGE_GENERATION_MODEL = process.env.IMAGE_MODEL || 'gpt-image-1';
-const OPENAI_REQUEST_LOG_CONTEXT = { module: 'openai' } as const;
 
 const logOpenAIEvent = (
   level: 'debug' | 'info' | 'warn' | 'error',
@@ -454,16 +457,6 @@ export async function call_gpt5_strict(prompt: string, kwargs: any = {}): Promis
  * @param size - Image size (e.g., '256x256', '512x512', '1024x1024')
  * @returns Object containing base64 image data and metadata
  */
-type ImageSize =
-  | '256x256'
-  | '512x512'
-  | '1024x1024'
-  | '1536x1024'
-  | '1024x1536'
-  | '1792x1024'
-  | '1024x1792'
-  | 'auto';
-
 const buildEnhancedImagePrompt = async (input: string): Promise<string> => {
   try {
     const { output } = await callOpenAI(getDefaultModel(), input, IMAGE_PROMPT_TOKEN_LIMIT, false);
@@ -479,7 +472,7 @@ const buildEnhancedImagePrompt = async (input: string): Promise<string> => {
 
 export async function generateImage(
   input: string,
-  size: ImageSize = '1024x1024'
+  size: ImageSize = DEFAULT_IMAGE_SIZE
 ): Promise<{ image: string; prompt: string; meta: { id: string; created: number }; error?: string }> {
   const client = getOpenAIClient();
   if (!client) {

--- a/src/services/openai/config.ts
+++ b/src/services/openai/config.ts
@@ -1,0 +1,30 @@
+import { ImageSize } from './types.js';
+
+const VALID_IMAGE_SIZES: ImageSize[] = [
+  '256x256',
+  '512x512',
+  '1024x1024',
+  '1536x1024',
+  '1024x1536',
+  '1792x1024',
+  '1024x1792',
+  'auto'
+];
+
+export const DEFAULT_ROUTING_MAX_TOKENS = 4096;
+export const ROUTING_MAX_TOKENS = Number(process.env.ROUTING_MAX_TOKENS ?? DEFAULT_ROUTING_MAX_TOKENS);
+
+const DEFAULT_IMAGE_GENERATION_MODEL = 'gpt-image-1';
+export const IMAGE_GENERATION_MODEL = process.env.IMAGE_MODEL || DEFAULT_IMAGE_GENERATION_MODEL;
+
+const resolveDefaultImageSize = (): ImageSize => {
+  const configuredSize = (process.env.IMAGE_DEFAULT_SIZE || '').trim() as ImageSize;
+  if (configuredSize && VALID_IMAGE_SIZES.includes(configuredSize)) {
+    return configuredSize;
+  }
+  return '1024x1024';
+};
+
+export const DEFAULT_IMAGE_SIZE = resolveDefaultImageSize();
+
+export const OPENAI_REQUEST_LOG_CONTEXT = { module: 'openai' } as const;

--- a/src/services/openai/types.ts
+++ b/src/services/openai/types.ts
@@ -4,6 +4,16 @@ export type ChatCompletionMessageParam = OpenAI.Chat.Completions.ChatCompletionM
 export type ChatCompletionResponseFormat =
   OpenAI.Chat.Completions.ChatCompletionCreateParams['response_format'];
 
+export type ImageSize =
+  | '256x256'
+  | '512x512'
+  | '1024x1024'
+  | '1536x1024'
+  | '1024x1536'
+  | '1792x1024'
+  | '1024x1792'
+  | 'auto';
+
 export interface CallOpenAIOptions {
   systemPrompt?: string;
   messages?: ChatCompletionMessageParam[];


### PR DESCRIPTION
## Summary
- Extract OpenAI configuration constants (routing tokens, image model, logging context) into a shared module to reduce in-file bloat
- Introduce a reusable ImageSize type and configurable default image size for image generation helpers
- Document the IMAGE_DEFAULT_SIZE environment variable in the sample configuration

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946d9f177a0832599b6a6b57219b9fe)