### PR TITLE
Make OpenAI defaults configurable via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,16 @@ OPENAI_API_KEY=your-openai-api-key-here
 #   4. RAILWAY_OPENAI_MODEL (Railway-specific override)
 AI_MODEL=ft:gpt-3.5-turbo-0125:personal:arcanos-v2:BxRSDrhH
 
+# Override the default system prompt for general completions
+OPENAI_SYSTEM_PROMPT=You are a helpful AI assistant.
+
+# OpenAI Responses cache TTL (milliseconds) and retry budget for API calls
+OPENAI_CACHE_TTL_MS=300000
+OPENAI_MAX_RETRIES=3
+
+# Token limit for generating enhanced image prompts before image creation
+OPENAI_IMAGE_PROMPT_TOKEN_LIMIT=256
+
 # OpenAI Base URL Override (Advanced)
 # Override the default OpenAI API base URL (useful for proxies or Azure OpenAI)
 # Leave blank to use default: https://api.openai.com/v1

--- a/src/services/openai/constants.ts
+++ b/src/services/openai/constants.ts
@@ -1,9 +1,25 @@
-export const DEFAULT_SYSTEM_PROMPT = 'You are a helpful AI assistant.';
+const parseIntegerEnv = (key: string, defaultValue: number): number => {
+  const raw = process.env[key];
+  if (!raw) return defaultValue;
 
-export const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : defaultValue;
+};
+
+const parseStringEnv = (key: string, defaultValue: string): string => {
+  const raw = process.env[key];
+  return raw && raw.trim().length > 0 ? raw.trim() : defaultValue;
+};
+
+export const DEFAULT_SYSTEM_PROMPT = parseStringEnv(
+  'OPENAI_SYSTEM_PROMPT',
+  'You are a helpful AI assistant.'
+);
+
+export const CACHE_TTL_MS = parseIntegerEnv('OPENAI_CACHE_TTL_MS', 5 * 60 * 1000); // 5 minutes
 
 export const REQUEST_ID_HEADER = 'X-Request-ID';
 
-export const DEFAULT_MAX_RETRIES = 3;
+export const DEFAULT_MAX_RETRIES = parseIntegerEnv('OPENAI_MAX_RETRIES', 3);
 
-export const IMAGE_PROMPT_TOKEN_LIMIT = 256;
+export const IMAGE_PROMPT_TOKEN_LIMIT = parseIntegerEnv('OPENAI_IMAGE_PROMPT_TOKEN_LIMIT', 256);


### PR DESCRIPTION
## Summary
- allow overriding the OpenAI system prompt, cache TTL, retry budget, and image prompt token limits via environment variables
- document new OpenAI configuration flags in `.env.example` to aid deployment environments

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946de20108c8325b0321ee49b362215)