### PR TITLE
Docs: Normalize GPT-5 / 5.1 references to GPT-5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Key environment variables used by the backend:
 | `OPENAI_API_KEY` | API key for the OpenAI SDK. Missing keys enable mock responses. |
 | `OPENAI_MODEL` / `FINETUNED_MODEL_ID` / `FINE_TUNED_MODEL_ID` / `AI_MODEL` | Preferred model identifiers (first non-empty wins). |
 | `RESEARCH_MODEL_ID` | Optional override for the research pipeline; defaults to the selected AI model. |
-| `GPT51_MODEL` / `GPT5_MODEL` | Override identifiers used for GPT‑5.2 reasoning fallbacks (defaults to `gpt-5.2`, then `gpt-5`). |
+| `GPT51_MODEL` / `GPT5_MODEL` | Override identifiers used for GPT‑5.2 reasoning fallbacks (defaults to `gpt-5.2`). |
 | `PORT` / `HOST` / `SERVER_URL` | Server binding details. `PORT` defaults to `8080`. |
 | `DATABASE_URL` (+ `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE`) | PostgreSQL connection string with automatic assembly from discrete settings. |
 | `ARC_LOG_PATH` / `ARC_MEMORY_PATH` | Filesystem paths for log storage and memory snapshots. |

--- a/docs/ARCANOS_ROUTING_ARCHITECTURE.md
+++ b/docs/ARCANOS_ROUTING_ARCHITECTURE.md
@@ -31,7 +31,7 @@ The fine-tuned model analyzes each request and decides:
 - **Complex requests**: Route to GPT-5.2 via JSON hook:
   ```json
   {
-    "next_model": "gpt-5",
+    "next_model": "gpt-5.2",
     "purpose": "Advanced reasoning required",
     "input": "Specific prompt for GPT-5.2"
   }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -47,7 +47,7 @@ Additional model-related variables:
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `GPT51_MODEL` / `GPT5_MODEL` | `gpt-5.2` / `gpt-5` | Identifiers used for GPT‑5.2 reasoning fallbacks (the service checks `GPT51_MODEL` first, then `GPT5_MODEL`). |
+| `GPT51_MODEL` / `GPT5_MODEL` | `gpt-5.2` | Identifiers used for GPT‑5.2 reasoning fallbacks (the service checks `GPT51_MODEL` first, then `GPT5_MODEL`). |
 | `API_KEY` | – | Legacy alias checked before `OPENAI_API_KEY`. |
 
 ---

--- a/docs/ORCHESTRATION_API.md
+++ b/docs/ORCHESTRATION_API.md
@@ -29,7 +29,7 @@ curl -X POST http://localhost:8080/orchestration/reset
     "id": "orchestration_reset_...",
     "created": 1754881108
   },
-  "activeModel": "gpt-5",
+  "activeModel": "gpt-5.2",
   "fallbackFlag": false,
   "gpt5Used": true,
   "routingStages": ["ORCHESTRATION_RESET", "ISOLATE_MODULE", "PURGE_MEMORY", "REDEPLOY_SAFEGUARDS", "VERIFY_DEPLOYMENT"],
@@ -54,7 +54,7 @@ curl -X POST http://localhost:8080/orchestration/reset
     "meta": {
       "timestamp": "2025-08-11T02:58:28.299Z",
       "stages": ["ISOLATE_MODULE", "PURGE_MEMORY", "REDEPLOY_SAFEGUARDS", "VERIFY_DEPLOYMENT"],
-      "gpt5Model": "gpt-5",
+      "gpt5Model": "gpt-5.2",
       "safeguardsApplied": true
     },
     "logs": [
@@ -87,7 +87,7 @@ curl -X GET http://localhost:8080/orchestration/status
     "message": "Status retrieved successfully",
     "status": {
       "active": true,
-      "model": "gpt-5",
+      "model": "gpt-5.2",
       "memoryEntries": 0,
       "lastReset": "2025-08-11T02:58:28.299Z"
     }
@@ -152,7 +152,7 @@ npm test
 ## Environment Variables
 
 - `OPENAI_API_KEY` or `API_KEY`: OpenAI API key for GPT-5.2 access
-- `GPT51_MODEL` / `GPT5_MODEL`: GPT-5.2 reasoning model identifiers (defaults to `gpt-5.2` then `gpt-5`)
+- `GPT51_MODEL` / `GPT5_MODEL`: GPT-5.2 reasoning model identifiers (defaults to `gpt-5.2`)
 - `ORCHESTRATION_LAST_RESET`: Timestamp of last reset (automatically set)
 
 ## Error Handling

--- a/docs/ai-guides/custom-gpt/arcanos-tutor.md
+++ b/docs/ai-guides/custom-gpt/arcanos-tutor.md
@@ -64,7 +64,7 @@ Each module can override token limits, temperature, and custom prompts when invo
     },
     "model": {
       "intake": "gpt-4.1-mini",
-      "reasoning": "gpt-5.0",
+      "reasoning": "gpt-5.2",
       "audit": "gpt-4.1-mini"
     }
   },

--- a/docs/legacy/original-readme/configuration.md
+++ b/docs/legacy/original-readme/configuration.md
@@ -30,7 +30,7 @@ WORKER_API_TIMEOUT_MS=60000    # Worker API timeout in milliseconds
 ## OpenAI Advanced Features
 ```bash
 GPT51_MODEL=gpt-5.2            # Preferred GPT-5.2 model configuration
-GPT5_MODEL=gpt-5               # Backwards compatible GPT-5.2 model configuration
+GPT5_MODEL=gpt-5.2             # Backwards compatible GPT-5.2 model configuration
 BOOKER_TOKEN_LIMIT=512         # Token limit for backstage booking prompts
 TUTOR_DEFAULT_TOKEN_LIMIT=200  # Default token limit for tutor queries
 ```


### PR DESCRIPTION
### Motivation
- Standardize all documentation to refer to the correct reasoning model name `gpt-5.2` instead of legacy `gpt-5`/`gpt-5.0`/`5.1` variants.
- Remove ambiguous fallback wording so configuration and orchestration docs consistently show `gpt-5.2` as the reasoning identifier.
- Align examples, sample payloads, and audit traces so routing, orchestration, and tutor guides reflect the intended runtime behavior.

### Description
- Updated environment variable and configuration docs in `README.md`, `docs/CONFIGURATION.md`, and `docs/legacy/original-readme/configuration.md` to use `gpt-5.2` as the default/compatible identifier.
- Replaced sample payloads and orchestration examples in `docs/ORCHESTRATION_API.md` and `docs/ARCANOS_ROUTING_ARCHITECTURE.md` to reference `gpt-5.2` (including `next_model`, `activeModel`, and `gpt5Model` fields).
- Updated the tutor guide `docs/ai-guides/custom-gpt/arcanos-tutor.md` to mark the reasoning stage model as `gpt-5.2` in the audit metadata.
- This is a documentation-only PR with no runtime code or behavior changes to application logic or tests.

### Testing
- No automated test suites were executed because this is a documentation-only change and contains no code modifications.
- Performed repository-wide pattern checks with `rg` to locate and confirm updated `gpt-5.2` occurrences in markdown files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695497d71d688325987d4d8a9a7bfabc)