### PR TITLE
Add stateless mode to disable state persistence

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -28,6 +28,7 @@ const reinforcementMode = (process.env.ARCANOS_CONTEXT_MODE || 'reinforcement') 
 const reinforcementWindow = parseNumber(process.env.ARCANOS_CONTEXT_WINDOW, 50, 1);
 const reinforcementDigestSize = parseNumber(process.env.ARCANOS_MEMORY_DIGEST_SIZE, 8, 1);
 const reinforcementMinimumClearScore = parseNumber(process.env.ARCANOS_CLEAR_MIN_SCORE, 0.85);
+const statelessMode = process.env.ARCANOS_STATELESS === 'true';
 const fallbackStrictEnvironments = (process.env.FALLBACK_STRICT_ENVIRONMENTS || 'production,staging')
   .split(',')
   .map(value => value.trim())
@@ -40,7 +41,8 @@ export const config = {
     host: serverHost,
     environment: process.env.NODE_ENV || 'development',
     baseUrl: serverBaseUrl,
-    statusEndpoint
+    statusEndpoint,
+    stateless: statelessMode
   },
 
   // AI configuration

--- a/src/services/sessionMemoryService.ts
+++ b/src/services/sessionMemoryService.ts
@@ -1,10 +1,15 @@
 import sessionMemoryRepository from './sessionMemoryRepository.js';
 import { recordConversationSnippet } from './webRag.js';
 import { logger } from '../utils/structuredLogging.js';
+import config from '../config/index.js';
 
 const sessionMemoryLogger = logger.child({ module: 'sessionMemory' });
 
 export async function saveMessage(sessionId: string, channel: string, message: any): Promise<void> {
+  if (config.server.stateless) {
+    return;
+  }
+
   await sessionMemoryRepository.appendMessage(sessionId, channel, message);
 
   if (channel === 'conversations_core') {
@@ -52,13 +57,25 @@ export async function saveMessage(sessionId: string, channel: string, message: a
 }
 
 export async function getChannel(sessionId: string, channel: string): Promise<any[]> {
+  if (config.server.stateless) {
+    return [];
+  }
+
   return sessionMemoryRepository.getChannel(sessionId, channel);
 }
 
 export async function getConversation(sessionId: string): Promise<any[]> {
+  if (config.server.stateless) {
+    return [];
+  }
+
   return sessionMemoryRepository.getConversation(sessionId);
 }
 
 export function getCachedSessions() {
+  if (config.server.stateless) {
+    return [];
+  }
+
   return sessionMemoryRepository.getCachedSessions();
 }


### PR DESCRIPTION
### Motivation
- Provide an option to run the server without persistent or session state to support stateless deployments and testing.
- Prevent accidental reads/writes of the on-disk `systemState.json` when the server is configured to be stateless.
- Avoid persisting or reading session memory when operating in stateless mode to reduce side effects and storage requirements.

### Description
- Introduce an `ARCANOS_STATELESS` environment flag exposed as `config.server.stateless` in `src/config/index.ts`.
- Make `src/services/stateManager.ts` return a transient default state and skip file reads/writes when `config.server.stateless` is true by adding a `defaultState()` helper and early checks in `loadState()` and `updateState()`.
- Short-circuit session memory operations in `src/services/sessionMemoryService.ts` to no-ops or empty results when `config.server.stateless` is true, preventing calls to `sessionMemoryRepository` and `recordConversationSnippet`.
- Modified files: `src/config/index.ts`, `src/services/stateManager.ts`, and `src/services/sessionMemoryService.ts`.

### Testing
- No automated tests were executed as part of this change.
- Manual inspection and local file edits were performed (no unit/integration test runs were requested or executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c0f9758c48325834f172acbf2143f)