### PR TITLE
Add ai-guides purpose to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ requests through a centralized OpenAI integration, persists state to disk, and
 exposes a collection of HTTP APIs for AI orchestration, diagnostics, memory
 management, and background worker coordination.
 
+## 🤖 AI Guides Purpose
+
+This backend powers the **ai-guides** experience—handling prompt routing,
+structured content generation, memory snapshots, and the operational workflows
+that keep guides accurate, auditable, and continuously refreshed. In short:
+ai-guides uses Arcanos to generate, manage, and maintain guided AI content at
+scale with confirmation-gated controls and health monitoring baked in.
+
 ---
 
 ## 🧠 Core Architecture & Features


### PR DESCRIPTION
### Motivation
- Make the repository README explicitly state how the backend is used to power the `ai-guides` experience so contributors and operators understand its role.
- Surface the operational responsibilities (prompt routing, content generation, memory, and health/confirmation controls) for `ai-guides` users and integrators.

### Description
- Updated `README.md` to add a new `AI Guides Purpose` section explaining that Arcanos powers `ai-guides` by handling prompt routing, structured content generation, memory snapshots, and operational workflows.
- The new text highlights confirmation-gated controls and health monitoring as part of the `ai-guides` operational model.
- This change is documentation-only and does not modify runtime code or behavior.

### Testing
- No automated tests were run because this is a documentation-only change and does not affect executable code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d967ac86883258466f9f01699e3ed)