### PR TITLE
Update AI Guides section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ requests through a centralized OpenAI integration, persists state to disk, and
 exposes a collection of HTTP APIs for AI orchestration, diagnostics, memory
 management, and background worker coordination.
 
-## 🤖 AI Guides Purpose
+## 🤖 AI Guides
 
-This backend powers the **ai-guides** experience—handling prompt routing,
-structured content generation, memory snapshots, and the operational workflows
-that keep guides accurate, auditable, and continuously refreshed. In short:
-ai-guides uses Arcanos to generate, manage, and maintain guided AI content at
-scale with confirmation-gated controls and health monitoring baked in.
+Explore the **[AI Guides](docs/ai-guides/README.md)** for the curated, living
+documentation set that captures how Arcanos powers guided AI workflows. These
+guides cover the operational playbooks, resilience patterns, memory systems,
+and integration details that keep the ai-guides experience accurate, auditable,
+and continuously refreshed.
 
 ---
 


### PR DESCRIPTION
### Motivation

- Replace the existing verbose "AI Guides Purpose" paragraph with a concise pointer to the curated AI Guides index to make navigation clearer. 
- Emphasize that the AI Guides are a living documentation set covering operational playbooks and integration details. 
- Keep README focused and avoid duplicating the detailed guides which live under `docs/ai-guides/`.

### Description

- Rename the section header from `## 🤖 AI Guides Purpose` to `## 🤖 AI Guides` in `README.md`.
- Replace the original multi-line purpose copy with a short paragraph linking to `docs/ai-guides/README.md` and summarizing what the guides cover. 
- This is a documentation-only change confined to the `README.md` file.

### Testing

- No automated tests were run because this is a documentation-only change. 
- The change was committed and the repository shows `README.md` as modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dd0860e448325ad3ec7ec87aa9e44)