### PR TITLE
Add Custom GPT docs link and brief explanation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ guides cover the operational playbooks, resilience patterns, memory systems,
 and integration details that keep the ai-guides experience accurate, auditable,
 and continuously refreshed.
 
+Need to wire up a ChatGPT Custom GPT to the backend? Start with the
+[Custom GPT integration overview](docs/ai-guides/custom-gpt/overview.md), which
+explains what a Custom GPT is (a ChatGPT-configured assistant with Actions that
+call your ARCANOS endpoints) and walks through the required setup checklist.
+
 ---
 
 ## 🧠 Core Architecture & Features


### PR DESCRIPTION
### Motivation
- Make it easier for integrators to find guidance for wiring ChatGPT Custom GPTs into the backend.  
- Explain briefly what a Custom GPT is so readers understand the integration context before opening the deeper docs.

### Description
- Added a short paragraph to `README.md` that links to the Custom GPT overview at `docs/ai-guides/custom-gpt/overview.md`.  
- The new paragraph clarifies that a Custom GPT is a ChatGPT-configured assistant with Actions that call ARCANOS endpoints and references the required setup checklist.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695df26e6e548325b189a5b3d429eb01)