### PR TITLE
Enable SSL only for non-local Postgres connections (fix DB pool SSL logic)

### DIFF
--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -111,10 +111,12 @@ export async function initializeDatabase(workerId = ''): Promise<boolean> {
   console.log('[🔌 DB] Initializing PostgreSQL connection pool...');
 
   try {
-    const isRailway = !!process.env.RAILWAY_ENVIRONMENT || !!process.env.PGHOST;
+    const shouldUseSsl =
+      !!process.env.RAILWAY_ENVIRONMENT ||
+      (host !== 'localhost' && host !== '127.0.0.1');
     pool = new Pool({
       connectionString: databaseUrl,
-      ...(isRailway ? { ssl: { rejectUnauthorized: false } } : {}),
+      ...(shouldUseSsl ? { ssl: { rejectUnauthorized: false } } : {}),
       max: 10,
       min: 2,
       idleTimeoutMillis: 30000,


### PR DESCRIPTION
### Motivation
- The code previously enabled SSL for the pool based on an `isRailway` flag that incorrectly used `!!process.env.PGHOST`, which can cause SSL to be forced for local Postgres connections.
- We need to avoid forcing SSL when connecting to `localhost` or `127.0.0.1` to prevent local connection failures.
- Railway and other non-local environments should still get SSL configured to remain secure.

### Description
- Introduced a `shouldUseSsl` variable computed as `!!process.env.RAILWAY_ENVIRONMENT || (host !== 'localhost' && host !== '127.0.0.1')` to decide SSL usage.
- Replaced the previous `isRailway` usage with `shouldUseSsl` and conditionally spread `ssl: { rejectUnauthorized: false }` into the `Pool` config when appropriate.
- Kept existing logic that appends `sslmode=require` to the `databaseUrl` for non-local hosts.

### Testing
- No automated tests were run on this change.
- The file was updated and committed successfully, but no CI/test runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f0fa4f3888325840b01d516997623)