### PR TITLE
Fix max_tokens compatibility detection

### DIFF
--- a/src/services/prAssistant/checks.ts
+++ b/src/services/prAssistant/checks.ts
@@ -152,7 +152,7 @@ export async function checkOpenAICompatibility(context: CheckContext, diff: stri
     const oldPatterns = [
       { pattern: /openai\.Completion\.create/gi, message: 'Legacy Completion API usage' },
       { pattern: /engine\s*:/gi, message: 'Deprecated engine parameter' },
-      { pattern: /max_tokens(?!\s*:)/gi, message: 'Consider using max_completion_tokens for GPT-5.2' },
+      { pattern: /max_tokens\s*:/gi, message: 'Consider using max_completion_tokens for GPT-5.2' },
       { pattern: /text-davinci/gi, message: 'Legacy model identifier' },
       { pattern: /text-curie/gi, message: 'Legacy model identifier' },
       { pattern: /davinci/gi, message: 'Legacy model identifier' }


### PR DESCRIPTION
### Motivation
- Ensure the OpenAI compatibility checker flags deprecated `max_tokens` usage in diffs.
- The previous regex missed typical `max_tokens:` occurrences due to an incorrect negative lookahead.

### Description
- Update the pattern in `src/services/prAssistant/checks.ts` to `/max_tokens\s*:/gi` so occurrences like `max_tokens:` are detected.
- This change improves `checkOpenAICompatibility` so it will recommend `max_completion_tokens` for GPT-5.2 when appropriate.
- Change is limited to the OpenAI compatibility pattern list and does not modify other logic.

### Testing
- No automated tests were run for this change.
- The modification is a targeted regex fix and does not affect other runtime behavior in this file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69601b647a60832584b759a0cac4cd07)