### PR TITLE
Fix memory list limit parsing

### DIFF
--- a/src/routes/api-memory.ts
+++ b/src/routes/api-memory.ts
@@ -99,7 +99,9 @@ router.delete("/delete", confirmGate, asyncHandler(async (req: Request, res: Res
 
 // List recent memory entries
 router.get("/list", asyncHandler(async (req: Request, res: Response) => {
-  const limit = parseInt(req.query.limit as string) || 50;
+  const limitParam = Array.isArray(req.query.limit) ? req.query.limit[0] : req.query.limit;
+  const parsedLimit = Number.parseInt(limitParam ?? '', 10);
+  const limit = Number.isNaN(parsedLimit) || parsedLimit <= 0 ? 50 : parsedLimit;
   
   const result = await query(
     'SELECT key, value, created_at, updated_at FROM memory ORDER BY updated_at DESC LIMIT $1',


### PR DESCRIPTION
### Motivation
- Ensure the `/list` endpoint parses the `limit` query parameter robustly to avoid unexpected values being passed to the database.
- The previous expression used `parseInt(req.query.limit as string) || 50`, which could behave incorrectly for array query values or non-numeric inputs.
- Provide a safe default and enforce a positive integer for the `limit` to prevent malformed queries or runtime issues.

### Description
- Update `src/routes/api-memory.ts` to normalize `req.query.limit` by handling array values and selecting the first element when needed.
- Parse the value with `Number.parseInt` and default to `50` when the parsed value is `NaN` or not a positive integer.
- Keep the prepared query usage intact, passing the validated `limit` to the database call.

### Testing
- No automated tests were run for this change.
- No CI or test-suite execution was performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696022718750832584668a33d6a175e3)