### PR TITLE
Extract shared OpenAI embedding helper

### DIFF
--- a/src/services/openai/embeddings.ts
+++ b/src/services/openai/embeddings.ts
@@ -1,0 +1,20 @@
+import OpenAI from 'openai';
+import { getOpenAIClient } from './clientFactory.js';
+
+const DEFAULT_EMBEDDING_MODEL = 'text-embedding-3-small';
+
+export async function createEmbedding(
+  input: string,
+  client: OpenAI | null = getOpenAIClient()
+): Promise<number[]> {
+  if (!client) {
+    throw new Error('OpenAI client not initialized');
+  }
+
+  const embeddingRes = await client.embeddings.create({
+    model: DEFAULT_EMBEDDING_MODEL,
+    input
+  });
+
+  return embeddingRes.data[0].embedding;
+}


### PR DESCRIPTION
### Motivation
- Reduce duplicated embedding code by centralizing OpenAI embedding creation into a single helper.
- Make it easier to change the embedding model or client usage in one place via `createEmbedding`.
- Improve readability and maintainability in the web RAG ingestion and session resolution code paths.

### Description
- Add `src/services/openai/embeddings.ts` which exports `createEmbedding(input, client?)` and defaults to the model `text-embedding-3-small`.
- Replace direct `client.embeddings.create(...)` calls with `createEmbedding(...)` in `src/services/webRag.ts` for `ingestUrl`, `ingestContent`, and `answerQuestion`.
- Replace direct embedding calls in `src/services/sessionResolver.ts` with `createEmbedding(...)` for query and metadata embeddings.
- This is a refactor only and keeps the same embedding model and behaviour.

### Testing
- No new unit tests were added and no local test suite was executed for this change.
- The repository's automated validation previously reported TypeScript type checking and linting passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69604550a9c083259180fc999ba1a5d9)