### PR TITLE
Add TypeScript worker scaffold with typed queue and OpenAI/memory handlers

### DIFF
--- a/workers/package.json
+++ b/workers/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "arcanos-workers",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build:workers": "tsc",
+    "start:openai": "node dist/workers/openai-worker.js",
+    "start:memory": "node dist/workers/memory-worker.js"
+  },
+  "dependencies": {
+    "openai": "^6.15.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.2"
+  }
+}

--- a/workers/src/handlers/memory.ts
+++ b/workers/src/handlers/memory.ts
@@ -1,0 +1,12 @@
+import type { JobHandler } from '../jobs/index.js';
+
+const memoryStore = new Map<string, string>();
+
+export const memorySetHandler: JobHandler<'MEMORY_SET'> = async ({ payload }) => {
+  memoryStore.set(payload.key, payload.value);
+  return { ok: true };
+};
+
+export const memoryGetHandler: JobHandler<'MEMORY_GET'> = async ({ payload }) => {
+  return { value: memoryStore.get(payload.key) ?? null };
+};

--- a/workers/src/handlers/openai.ts
+++ b/workers/src/handlers/openai.ts
@@ -1,0 +1,22 @@
+import OpenAI from 'openai';
+import type { JobHandler } from '../jobs/index.js';
+
+const client = new OpenAI();
+
+export const openaiCompletionHandler: JobHandler<'OPENAI_COMPLETION'> = async ({ payload }) => {
+  const response = await client.chat.completions.create({
+    model: payload.model ?? 'gpt-4-turbo',
+    messages: [{ role: 'user', content: payload.prompt }]
+  });
+
+  return { response: response.choices[0].message?.content ?? '' };
+};
+
+export const openaiEmbeddingHandler: JobHandler<'OPENAI_EMBEDDING'> = async ({ payload }) => {
+  const response = await client.embeddings.create({
+    model: payload.model ?? 'text-embedding-3-large',
+    input: payload.input
+  });
+
+  return { embedding: response.data[0]?.embedding ?? [] };
+};

--- a/workers/src/jobs/index.ts
+++ b/workers/src/jobs/index.ts
@@ -1,0 +1,56 @@
+export type JobName =
+  | 'OPENAI_COMPLETION'
+  | 'OPENAI_EMBEDDING'
+  | 'MEMORY_SET'
+  | 'MEMORY_GET';
+
+export type OpenAICompletionJob = {
+  type: 'OPENAI_COMPLETION';
+  payload: {
+    prompt: string;
+    model?: string;
+  };
+};
+
+export type OpenAIEmbeddingJob = {
+  type: 'OPENAI_EMBEDDING';
+  payload: {
+    input: string;
+    model?: string;
+  };
+};
+
+export type MemorySetJob = {
+  type: 'MEMORY_SET';
+  payload: {
+    key: string;
+    value: string;
+  };
+};
+
+export type MemoryGetJob = {
+  type: 'MEMORY_GET';
+  payload: {
+    key: string;
+  };
+};
+
+export type Job =
+  | OpenAICompletionJob
+  | OpenAIEmbeddingJob
+  | MemorySetJob
+  | MemoryGetJob;
+
+export type JobResultMap = {
+  OPENAI_COMPLETION: { response: string };
+  OPENAI_EMBEDDING: { embedding: number[] };
+  MEMORY_SET: { ok: true };
+  MEMORY_GET: { value: string | null };
+};
+
+export type JobPayload<T extends JobName> = Extract<Job, { type: T }>['payload'];
+
+export type JobHandler<T extends JobName> = (job: {
+  type: T;
+  payload: JobPayload<T>;
+}) => Promise<JobResultMap[T]>;

--- a/workers/src/queue/index.ts
+++ b/workers/src/queue/index.ts
@@ -1,0 +1,43 @@
+import { EventEmitter } from 'events';
+import type { JobHandler, JobName, JobResultMap, JobPayload } from '../jobs/index.js';
+
+export class TypedWorkerQueue extends EventEmitter {
+  register<T extends JobName>(job: T, handler: JobHandler<T>): void {
+    this.on(job, handler);
+  }
+
+  async dispatch<T extends JobName>(
+    job: T,
+    payload: JobPayload<T>,
+    options: { attempts?: number; backoffMs?: number } = {}
+  ): Promise<JobResultMap[T][]> {
+    const listeners = this.listeners(job) as JobHandler<T>[];
+    const { attempts = 3, backoffMs = 500 } = options;
+    const results: JobResultMap[T][] = [];
+
+    for (const listener of listeners) {
+      let attempt = 0;
+      let delay = backoffMs;
+
+      while (attempt < attempts) {
+        try {
+          const result = await listener({ type: job, payload });
+          results.push(result);
+          break;
+        } catch (error) {
+          attempt += 1;
+          if (attempt >= attempts) {
+            throw error;
+          }
+          await new Promise<void>(resolve => {
+            const timeout = setTimeout(resolve, delay);
+            if (typeof timeout.unref === 'function') timeout.unref();
+          });
+          delay *= 2;
+        }
+      }
+    }
+
+    return results;
+  }
+}

--- a/workers/src/workers/memory-worker.ts
+++ b/workers/src/workers/memory-worker.ts
@@ -1,0 +1,32 @@
+import { fileURLToPath } from 'url';
+import { TypedWorkerQueue } from '../queue/index.js';
+import { memoryGetHandler, memorySetHandler } from '../handlers/memory.js';
+import type { JobName } from '../jobs/index.js';
+
+const queue = new TypedWorkerQueue();
+
+queue.register('MEMORY_SET', memorySetHandler);
+queue.register('MEMORY_GET', memoryGetHandler);
+
+export function startMemoryWorker() {
+  return queue;
+}
+
+async function runFromEnv() {
+  const jobType = process.env.WORKER_JOB as JobName | undefined;
+  const payloadRaw = process.env.WORKER_PAYLOAD;
+
+  if (!jobType || !payloadRaw) {
+    return;
+  }
+
+  const payload = JSON.parse(payloadRaw) as unknown;
+  const results = await queue.dispatch(jobType, payload as never);
+  console.log(JSON.stringify({ jobType, results }));
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  console.log('[workers] Memory worker ready');
+  void runFromEnv();
+  process.stdin.resume();
+}

--- a/workers/src/workers/openai-worker.ts
+++ b/workers/src/workers/openai-worker.ts
@@ -1,0 +1,32 @@
+import { fileURLToPath } from 'url';
+import { TypedWorkerQueue } from '../queue/index.js';
+import { openaiCompletionHandler, openaiEmbeddingHandler } from '../handlers/openai.js';
+import type { JobName } from '../jobs/index.js';
+
+const queue = new TypedWorkerQueue();
+
+queue.register('OPENAI_COMPLETION', openaiCompletionHandler);
+queue.register('OPENAI_EMBEDDING', openaiEmbeddingHandler);
+
+export function startOpenAIWorker() {
+  return queue;
+}
+
+async function runFromEnv() {
+  const jobType = process.env.WORKER_JOB as JobName | undefined;
+  const payloadRaw = process.env.WORKER_PAYLOAD;
+
+  if (!jobType || !payloadRaw) {
+    return;
+  }
+
+  const payload = JSON.parse(payloadRaw) as unknown;
+  const results = await queue.dispatch(jobType, payload as never);
+  console.log(JSON.stringify({ jobType, results }));
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  console.log('[workers] OpenAI worker ready');
+  void runFromEnv();
+  process.stdin.resume();
+}

--- a/workers/tsconfig.json
+++ b/workers/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
### Motivation
- Introduce a standalone TypeScript workers package to provide strict typing and clearer contracts for background jobs.  
- Provide a type-safe EventEmitter-based queue with retry/backoff to centralize worker dispatch semantics.  
- Add OpenAI SDK integration for completions and embeddings to support LLM tasks from workers.  
- Make workers Railway-friendly with simple entrypoints that can be invoked via environment variables.

### Description
- Add a new `workers` package including `tsconfig.json` and `package.json` with `build:workers` and start scripts for `openai` and `memory` workers.  
- Implement typed job contracts in `workers/src/jobs/index.ts` and a `TypedWorkerQueue` with retry/backoff in `workers/src/queue/index.ts`.  
- Add handlers `workers/src/handlers/openai.ts` (completion + embedding using the `openai` SDK) and `workers/src/handlers/memory.ts` (in-memory `Map` for `MEMORY_SET`/`MEMORY_GET`).  
- Add runnable entrypoints `workers/src/workers/openai-worker.ts` and `workers/src/workers/memory-worker.ts` that register handlers and can dispatch jobs from `WORKER_JOB`/`WORKER_PAYLOAD`, using `fileURLToPath(import.meta.url)` for the entry check.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696180e45ff083258559d95e37eb955b)