### PR TITLE
Guard requestHandler body access, add audit notes and stronger logging

### DIFF
--- a/src/utils/requestHandler.ts
+++ b/src/utils/requestHandler.ts
@@ -14,15 +14,21 @@ import {
 } from '../types/dto.js';
 
 /**
- * Extract input text from various possible field names in request body
+ * Extract input text from various possible field names in request body.
+ * Purpose: normalize request payloads that use alternate input keys.
+ * Inputs/Outputs: accepts a validated AIRequestDTO and returns the first matching string or null.
+ * Edge cases: returns null when all known input fields are missing or empty.
  */
 export function extractInput(body: AIRequestDTO): string | null {
+  //audit Assumption: request body may include multiple input fields; first non-empty wins. Risk: prioritization hides later fields. Invariant: return a string or null. Handling: short-circuit on first truthy field.
   return body.prompt || body.userInput || body.content || body.text || body.query || null;
 }
 
 /**
- * Validate and handle standard AI request preprocessing
- * Returns the OpenAI client if validation passes, null if mock response should be used
+ * Validate and handle standard AI request preprocessing.
+ * Purpose: enforce schema validation, provide mock fallback, and return the OpenAI client when available.
+ * Inputs/Outputs: accepts Express request/response and endpoint name; returns client/input/body or null when handled.
+ * Edge cases: missing body yields a 400 response; missing API key triggers mock response.
  */
 export function validateAIRequest(
   req: Request<{}, AIResponseDTO | ErrorResponseDTO, AIRequestDTO>,
@@ -31,9 +37,14 @@ export function validateAIRequest(
 ): { client: any; input: string; body: AIRequestDTO } | null {
   console.log(`📨 /${endpointName} received`);
 
-  const clientContext = (req.body as AIRequestDTO).clientContext;
+  //audit Assumption: request body might be undefined or non-object. Risk: runtime crash on property access. Invariant: clientContext remains undefined unless body is object. Handling: guarded extraction.
+  const clientContext =
+    req.body && typeof req.body === 'object'
+      ? (req.body as AIRequestDTO).clientContext
+      : undefined;
 
   const parsed = aiRequestSchema.safeParse(req.body);
+  //audit Assumption: payload must satisfy schema. Risk: malformed payload. Invariant: reject invalid payloads with 400. Handling: return detailed errors.
   if (!parsed.success) {
     const details = parsed.error.errors.map(err => `${err.path.join('.') || 'body'}: ${err.message}`);
     res.status(400).json({
@@ -43,6 +54,7 @@ export function validateAIRequest(
     return null;
   }
 
+  //audit Assumption: parsed data yields a single canonical input string. Risk: no input fields. Invariant: input must be non-empty string. Handling: 400 with guidance.
   const input = extractInput(parsed.data);
 
   if (!input || typeof input !== 'string') {
@@ -53,6 +65,7 @@ export function validateAIRequest(
   }
 
   // Check if we have a valid API key
+  //audit Assumption: missing API key should use mock response. Risk: unintended real call without credentials. Invariant: when no key, return mock. Handling: short-circuit response.
   if (!hasValidAPIKey()) {
     console.log(`🤖 Returning mock response for /${endpointName} (no API key)`);
     const mockResponse = generateMockResponse(input, endpointName);
@@ -61,6 +74,7 @@ export function validateAIRequest(
   }
 
   const openai = getOpenAIClient();
+  //audit Assumption: OpenAI client may fail to initialize. Risk: null client causing runtime errors. Invariant: fallback to mock response. Handling: return mock and stop.
   if (!openai) {
     console.log(`🤖 Returning mock response for /${endpointName} (client init failed)`);
     const mockResponse = generateMockResponse(input, endpointName);
@@ -74,7 +88,10 @@ export function validateAIRequest(
 }
 
 /**
- * Handle errors in AI request processing with consistent error response format
+ * Handle errors in AI request processing with consistent error response format.
+ * Purpose: ensure failures return a structured mock response with error context.
+ * Inputs/Outputs: accepts error, input, endpoint name, response; writes JSON response.
+ * Edge cases: non-Error throwables are stringified for message clarity.
  */
 export function handleAIError(
   err: unknown,
@@ -82,10 +99,12 @@ export function handleAIError(
   endpointName: string,
   res: Response<AIResponseDTO | ErrorResponseDTO>
 ): void {
+  //audit Assumption: errors may be non-Error types. Risk: losing error context. Invariant: errorMessage string always defined. Handling: stringify fallback.
   const errorMessage = err instanceof Error ? err.message : String(err);
   console.error(`❌ ${endpointName} processing error:`, errorMessage);
   
   // Return mock response as fallback
+  //audit Assumption: returning mock response is acceptable on failure. Risk: masking upstream errors. Invariant: response includes error detail. Handling: attach error field.
   console.log(`🤖 Returning mock response for /${endpointName} (processing failed)`);
   const mockResponse = generateMockResponse(input, endpointName);
   res.json({
@@ -95,18 +114,23 @@ export function handleAIError(
 }
 
 /**
- * Log request details for feedback and debugging (optional)
+ * Log request details for feedback and debugging (optional).
+ * Purpose: persist a truncated prompt for local diagnostics.
+ * Inputs/Outputs: accepts input and endpoint name; writes to /tmp or logs failure.
+ * Edge cases: filesystem write errors are logged without interrupting request flow.
  */
 export function logRequestFeedback(input: string, endpointName: string): void {
   try {
+    //audit Assumption: writing to /tmp is permissible. Risk: permission/FS errors. Invariant: feedback data is JSON-serializable. Handling: catch and log errors.
     const feedbackData = {
       timestamp: new Date().toISOString(),
       endpoint: endpointName,
       prompt: input.substring(0, 500) // Limit length for privacy
     };
+    //audit Assumption: feedback file path is safe. Risk: IO failure. Invariant: file contents are JSON string. Handling: throw to catch and log.
     fs.writeFileSync('/tmp/last-gpt-request', JSON.stringify(feedbackData));
   } catch (error) {
-    // Silently fail - feedback logging is not critical
-    console.log('Could not write feedback file:', error instanceof Error ? error.message : 'Unknown error');
+    //audit Assumption: logging failure is sufficient. Risk: losing diagnostics. Invariant: request flow continues. Handling: log error details.
+    console.error('Could not write feedback file:', error instanceof Error ? error.message : 'Unknown error');
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent a runtime crash when `req.body` is missing or not an object by guarding property access. 
- Improve auditability and maintainability of AI request handling by adding docstrings and `//audit` notes at key branches. 
- Ensure failures in non-critical diagnostics (feedback file writes) are surfaced as errors rather than silently logged. 

### Description
- Guard `clientContext` extraction with a type-safe check (`req.body && typeof req.body === 'object'`) to avoid crashes when `req.body` is undefined. 
- Expanded docstrings for `extractInput`, `validateAIRequest`, `handleAIError`, and `logRequestFeedback` to document purpose, inputs/outputs, and edge cases. 
- Inserted `//audit` comments around conditionals, error handling, and fallback branches to record assumptions, risks, invariants, and handling strategies. 
- Changed feedback-write failure logging from `console.log` to `console.error` and kept the mock-response fallback behavior when API/client initialization fails. 

### Testing
- Ran the full test suite with `npm test -- --runInBand`, which reported all test suites passing (25 suites, 116 tests). 
- No new unit tests were added in this change. 
- Existing integration/behavioral tests exercised the AI request handling and mock fallback paths during the run. 
- All automated tests referenced above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69632e767b508325a0dd1ac3038caf6f)