### PR TITLE
Refactor shared readiness checks

### DIFF
--- a/AUDIT_LOG.md
+++ b/AUDIT_LOG.md
@@ -511,3 +511,11 @@ The codebase is:
 - **Maintainable:** Modular architecture, clean separation of concerns
 
 No further autonomous optimizations are required at this time.
+
+---
+
+## Refactor Pass 4 Audit (2026-01-11)
+
+- Simplified 2 modules, extracted 1 utility, removed 1 redundancy.
+- Added shared readiness evaluation for database/OpenAI health checks.
+- Centralized readiness status mapping for /readyz and /health endpoints.

--- a/refactor-plan.json
+++ b/refactor-plan.json
@@ -3,9 +3,9 @@
     "version": "1.0",
     "date": "2026-01-11",
     "codebase": "Arcanos AI Backend",
-    "status": "PASS_COMPLETE",
+    "status": "PASS_ACTIVE",
     "totalPasses": 7,
-    "completedPasses": 3,
+    "completedPasses": 4,
     "baseline": {
       "totalFiles": 220,
       "totalLines": 24751,
@@ -138,6 +138,36 @@
           "functionsCreated": 4,
           "errorTypesStandardized": ["validation", "server", "notFound", "unauthorized"],
           "potentialUsagePoints": "33 route files"
+        }
+      },
+      {
+        "passNumber": 4,
+        "name": "Shared Health Readiness Evaluation",
+        "status": "COMPLETED",
+        "changes": [
+          {
+            "type": "CREATE",
+            "file": "src/utils/healthChecks.ts",
+            "lines": 56,
+            "description": "Reusable readiness evaluation for database and OpenAI services"
+          },
+          {
+            "type": "UPDATE",
+            "file": "src/routes/health.ts",
+            "linesChanged": 20,
+            "description": "Use shared readiness helper for /readyz"
+          },
+          {
+            "type": "UPDATE",
+            "file": "src/routes/status.ts",
+            "linesChanged": 24,
+            "description": "Use shared readiness helper for /health"
+          }
+        ],
+        "impact": {
+          "duplicationRemoved": "2 readiness checks → 1 helper",
+          "filesChanged": 3,
+          "complexityReduction": "Centralized readiness evaluation and status mapping"
         }
       }
     ],

--- a/src/utils/healthChecks.ts
+++ b/src/utils/healthChecks.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared health and readiness evaluation helpers.
+ * Provides reusable, side-effect-free checks for core service readiness.
+ */
+
+export type DatabaseStatusLike = {
+  connected: boolean;
+  error?: string | null;
+};
+
+export type OpenAIHealthLike = {
+  circuitBreaker: {
+    healthy: boolean;
+  };
+};
+
+export type CoreServiceReadiness = {
+  isDatabaseReady: boolean;
+  isOpenAIReady: boolean;
+  isReady: boolean;
+};
+
+/**
+ * Determine database readiness based on connectivity and configuration.
+ * Inputs: database status and optional database URL override.
+ * Outputs: boolean indicating if the database is ready.
+ * Edge cases: Treats missing DATABASE_URL as "ready" to allow stateless deployments.
+ */
+export function resolveDatabaseReadiness(
+  dbStatus: DatabaseStatusLike,
+  databaseUrl: string | undefined
+): boolean {
+  const hasDatabaseUrl = Boolean(databaseUrl);
+  //audit Assumption: missing database URL implies DB is optional; risk: false positive readiness; invariant: readiness remains true when DB not configured; handling: mark ready when DB is not required.
+  return dbStatus.connected || !hasDatabaseUrl;
+}
+
+/**
+ * Evaluate core service readiness for database and OpenAI dependencies.
+ * Inputs: database status, OpenAI health, and optional database URL override.
+ * Outputs: readiness flags for database, OpenAI, and overall readiness.
+ * Edge cases: Missing database URL still returns ready if OpenAI is healthy.
+ */
+export function assessCoreServiceReadiness(
+  dbStatus: DatabaseStatusLike,
+  openaiHealth: OpenAIHealthLike,
+  databaseUrl: string | undefined
+): CoreServiceReadiness {
+  const isDatabaseReady = resolveDatabaseReadiness(dbStatus, databaseUrl);
+  const isOpenAIReady = openaiHealth.circuitBreaker.healthy;
+  //audit Assumption: OpenAI circuit breaker health reflects current availability; risk: stale health; invariant: readiness requires healthy circuit; handling: use circuit breaker state.
+  const isReady = isDatabaseReady && isOpenAIReady;
+
+  //audit Assumption: readiness is a pure derivation of the inputs; risk: incorrect mapping; invariant: output mirrors input states; handling: return explicit readiness flags.
+  return {
+    isDatabaseReady,
+    isOpenAIReady,
+    isReady
+  };
+}


### PR DESCRIPTION
### Motivation
- Remove duplicated readiness logic from multiple routes and centralize evaluation for maintainability.
- Improve modularity by extracting pure, side-effect-free helpers for health/readiness checks.
- Add explicit `//audit` guidance at decision points to satisfy auditability requirements.
- Keep runtime behavior unchanged while reducing places to update readiness criteria.

### Description
- Added `src/utils/healthChecks.ts` with `resolveDatabaseReadiness` and `assessCoreServiceReadiness` helper functions and typed input/output shapes.
- Updated `src/routes/health.ts` to use `assessCoreServiceReadiness` for `/readyz` and replaced inline readiness logic with the shared helper and `//audit` comments.
- Updated `src/routes/status.ts` to use `assessCoreServiceReadiness` for `/health`, added `//audit` comments, and kept response semantics unchanged.
- Documented the change in `refactor-plan.json`, `REFACTORING_BEFORE_AFTER.md`, and `AUDIT_LOG.md` to record the refactor pass and before/after examples.

### Testing
- No automated tests were executed specifically for this change.
- Existing refactor artifacts report a previously passing test suite (reported as 102/102 in the refactor plan), but this PR did not run CI or test commands.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69633d7576908325b09bf87517637bc7)