### PR TITLE
Standardize core docs for Railway deployment and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 
 ## Overview
 
-Arcanos is a TypeScript/Express backend that centralizes OpenAI access, provides AI-oriented
-HTTP APIs, and persists state to disk or PostgreSQL. The runtime boots from
-`src/start-server.ts`, registers routes in `src/routes/register.ts`, and uses a shared OpenAI
-client from `src/services/openai.ts` for chat, reasoning, and image generation.
+Arcanos is a TypeScript/Express backend that centralizes OpenAI access, provides AI-focused
+HTTP APIs, and persists state to disk or PostgreSQL. The server boots from
+`src/start-server.ts`, registers routes in `src/routes/register.ts`, and initializes the
+OpenAI client via `src/services/openai.ts` and `src/services/openai/*`.
 
 ## Prerequisites
 
 - Node.js 18+ and npm 8+ (see `package.json` engines).
 - An OpenAI API key for live responses (`OPENAI_API_KEY`).
-- Optional: PostgreSQL for persistent memory (`DATABASE_URL` or `PG*` variables).
+- Optional: PostgreSQL for persistence (`DATABASE_URL` or `PG*` variables).
 
 ## Setup
 
@@ -26,11 +26,13 @@ Populate at least `OPENAI_API_KEY` in `.env` before running locally.
 
 ## Configuration
 
-Key environment variables (see `docs/CONFIGURATION.md` for the full matrix):
+Key environment variables (see `docs/CONFIGURATION.md` for the complete matrix):
 
 - `OPENAI_API_KEY` – required for live OpenAI calls (missing keys return mock responses).
 - `OPENAI_MODEL`, `FINETUNED_MODEL_ID`, `FINE_TUNED_MODEL_ID`, `AI_MODEL` – model selection
   chain used by the OpenAI client.
+- `FALLBACK_MODEL`, `AI_FALLBACK_MODEL`, `RAILWAY_OPENAI_FALLBACK_MODEL` – fallback model
+  chain used when the primary model fails.
 - `GPT51_MODEL` / `GPT5_MODEL` – GPT-5.2 reasoning model override (defaults to `gpt-5.2`).
 - `DATABASE_URL` or `PGHOST`/`PGPORT`/`PGUSER`/`PGPASSWORD`/`PGDATABASE` – database connection.
 - `RUN_WORKERS`, `WORKER_COUNT`, `WORKER_MODEL`, `WORKER_API_TIMEOUT_MS` – background workers.
@@ -46,7 +48,7 @@ npm start
 Common scripts:
 
 ```bash
-npm run dev        # Compile TypeScript and start the compiled server (no watch mode)
+npm run dev        # Build workers + TypeScript, then start the compiled server
 npm run dev:watch  # Rebuild TypeScript incrementally; run "npm start" in another shell
 npm test           # Run Jest test suites
 npm run lint       # Lint TypeScript sources
@@ -67,7 +69,7 @@ Railway deployment is configured via `railway.json` and `Procfile`:
 - Build: `npm ci --include=dev && npm run build`
 - Start: `node --max-old-space-size=7168 dist/start-server.js`
 - Health check: `GET /health`
-- `RUN_WORKERS` is set to `false` by default in Railway deploy config.
+- `RUN_WORKERS` defaults to `false` in Railway deploy config.
 
 High-level steps:
 
@@ -75,6 +77,7 @@ High-level steps:
 2. Add required environment variables (`OPENAI_API_KEY`, optional model overrides).
 3. (Optional) Provision PostgreSQL and set `DATABASE_URL` if not auto-injected.
 4. Deploy and confirm health checks pass.
+5. Roll back from the Railway **Deployments** view if needed.
 
 See `docs/RAILWAY_DEPLOYMENT.md` for a detailed, step-by-step guide.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,12 +1,12 @@
 # Arcanos Configuration Guide
 
-> **Last Updated:** 2026-01-09 | **Version:** 1.0.0
+> **Last Updated:** 2026-01-10 | **Version:** 1.0.0
 
 ## Overview
 
 This guide documents the environment variables used by the Arcanos backend. Defaults are
-sourced from `src/utils/env.ts`, `src/config/index.ts`, and the OpenAI client helpers in
-`src/services/openai/*`.
+sourced from `src/utils/env.ts`, `src/config/index.ts`, `src/services/openai/*`, and
+`src/config/workerConfig.ts`.
 
 ## Prerequisites
 
@@ -16,7 +16,7 @@ sourced from `src/utils/env.ts`, `src/config/index.ts`, and the OpenAI client he
 
 1. Copy `.env.example` to `.env`.
 2. Populate required variables (minimum: `OPENAI_API_KEY`).
-3. Keep the final values in sync with Railway variables when deploying.
+3. Keep final values aligned with Railway variables when deploying.
 
 ## Configuration
 
@@ -24,14 +24,26 @@ sourced from `src/utils/env.ts`, `src/config/index.ts`, and the OpenAI client he
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `OPENAI_API_KEY` | – | Required for live OpenAI calls. Missing keys yield mock responses. |
-| `PORT` | `8080` | Preferred HTTP port; the server falls back to the next available port. |
+| `NODE_ENV` | `development` | Controls logging, health checks, and worker defaults. |
+| `PORT` | `8080` | Preferred HTTP port. |
 | `HOST` | `0.0.0.0` | Bind address for the HTTP server. |
 | `SERVER_URL` | `http://127.0.0.1:<port>` | Used for internal callbacks and self-tests. |
-| `NODE_ENV` | `development` | Controls logging, health checks, and worker defaults. |
+| `BACKEND_STATUS_ENDPOINT` | `/status` | Status endpoint path used by internal checks. |
 | `LOG_LEVEL` | `info` | Logging verbosity for the structured logger. |
 | `ARC_LOG_PATH` | `/tmp/arc/log` | Directory for logs and audit output. |
 | `ARC_MEMORY_PATH` | `/tmp/arc/memory` | Filesystem cache for memory snapshots. |
+| `JSON_LIMIT` | `10mb` | JSON payload size limit. |
+| `REQUEST_TIMEOUT` | `30000` | Request timeout in milliseconds. |
+| `ALLOWED_ORIGINS` | – | Comma-separated CORS allow list (non-development). |
+
+### OpenAI API key resolution
+
+The OpenAI client resolves keys in this order, skipping placeholders:
+
+1. `OPENAI_API_KEY`
+2. `RAILWAY_OPENAI_API_KEY`
+3. `API_KEY`
+4. `OPENAI_KEY`
 
 ### OpenAI model selection
 
@@ -44,22 +56,33 @@ The OpenAI client selects the first non-empty model in this order:
 5. `AI_MODEL`
 6. `gpt-4o` (fallback)
 
+Fallback model selection (used when primary calls fail):
+
+1. `FALLBACK_MODEL`
+2. `AI_FALLBACK_MODEL`
+3. `RAILWAY_OPENAI_FALLBACK_MODEL`
+4. `FINETUNED_MODEL_ID`
+5. `FINE_TUNED_MODEL_ID`
+6. `AI_MODEL`
+7. `gpt-4` (fallback)
+
 Additional model-related variables:
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `GPT51_MODEL` / `GPT5_MODEL` | `gpt-5.2` | GPT-5.2 reasoning model (checks `GPT51_MODEL` first). |
+| `GPT51_MODEL` / `GPT5_MODEL` | `gpt-5.2` | GPT-5.2 reasoning model override (checks `GPT51_MODEL` first). |
 | `RESEARCH_MODEL_ID` | – | Optional override for the research pipeline model. |
 | `IMAGE_MODEL` | `gpt-image-1` | Image generation model. |
 | `IMAGE_DEFAULT_SIZE` | `1024x1024` | Default image size if not supplied in requests. |
+| `ROUTING_MAX_TOKENS` | `4096` | Token ceiling for routing decisions. |
 
 ### OpenAI client behavior
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `OPENAI_BASE_URL` / `OPENAI_API_BASE_URL` | – | Optional API base URL override. |
-| `OPENAI_SYSTEM_PROMPT` | – | Optional default system prompt for requests. |
-| `OPENAI_CACHE_TTL_MS` | `300000` | Cache TTL for OpenAI responses. |
+| `OPENAI_BASE_URL` / `OPENAI_API_BASE_URL` / `OPENAI_API_BASE` | – | Optional API base URL override. |
+| `OPENAI_SYSTEM_PROMPT` | `You are a helpful AI assistant.` | Default system prompt if none supplied. |
+| `OPENAI_CACHE_TTL_MS` | `300000` | Cache TTL for OpenAI responses (5 minutes). |
 | `OPENAI_MAX_RETRIES` | `3` | Retry budget for OpenAI calls. |
 | `OPENAI_IMAGE_PROMPT_TOKEN_LIMIT` | `256` | Token limit for image prompt expansion. |
 
@@ -70,6 +93,7 @@ Additional model-related variables:
 | `DATABASE_URL` | – | PostgreSQL connection string. |
 | `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` | – | Used to build `DATABASE_URL` if absent. |
 | `SESSION_PERSISTENCE_URL` | – | Optional override for session persistence connection. |
+| `BACKEND_REGISTRY_URL` | – | Optional registry endpoint for backend discovery. |
 
 ### Workers & automation
 
@@ -77,7 +101,7 @@ Additional model-related variables:
 | --- | --- | --- |
 | `RUN_WORKERS` | `true` (disabled in tests) | Controls worker bootstrap. |
 | `WORKER_COUNT` | `4` | Worker count for diagnostics and scheduling. |
-| `WORKER_MODEL` | `AI_MODEL` | Model used by worker tasks. |
+| `WORKER_MODEL` | `AI_MODEL` or `gpt-4o` | Model used by worker tasks. |
 | `WORKER_API_TIMEOUT_MS` | `60000` | Timeout for OpenAI calls from workers. |
 
 ### Confirmation gate & security
@@ -87,15 +111,33 @@ Additional model-related variables:
 | `TRUSTED_GPT_IDS` | – | Comma-separated GPT identifiers that bypass confirmation checks. |
 | `ARCANOS_AUTOMATION_SECRET` | – | Shared secret for automation bypass. |
 | `ARCANOS_AUTOMATION_HEADER` | `x-arcanos-automation` | Header name for automation bypass. |
+| `ADMIN_KEY` | – | Admin API key for protected routes. |
+| `REGISTER_KEY` | – | Registration key for protected routes. |
 | `CONFIRMATION_CHALLENGE_TTL_MS` | `120000` | TTL for confirmation challenges. |
 
-### HTTP server tuning
+### Feature flags, telemetry, and audit
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `JSON_LIMIT` | `10mb` | JSON payload size limit. |
-| `REQUEST_TIMEOUT` | `30000` | Request timeout in milliseconds. |
-| `ALLOWED_ORIGINS` | – | Comma-separated CORS allow list (non-development). |
+| `ENABLE_GITHUB_ACTIONS` | `false` | Enables GitHub actions-related workflows. |
+| `ENABLE_GPT_USER_HANDLER` | `true` | Enables GPT user handler endpoints. |
+| `ARCANOS_AUDIT_TRACE` | `true` | Enables audit tracing when not set to `false`. |
+| `TELEMETRY_RECENT_LOGS_LIMIT` | `100` | Recent log ring buffer size. |
+| `TELEMETRY_TRACE_EVENT_LIMIT` | `200` | Trace event buffer size. |
+
+### Assistant sync & reinforcement
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `ASSISTANT_SYNC_ENABLED` | `true` | Enables assistant sync when not set to `false`. |
+| `ASSISTANT_SYNC_CRON` | `15,45 * * * *` | Cron schedule for assistant sync. |
+| `ASSISTANT_REGISTRY_PATH` | `config/assistants.json` | Path to the assistant registry file. |
+| `ARCANOS_CONTEXT_MODE` | `reinforcement` | Context mode for memory reinforcement. |
+| `ARCANOS_CONTEXT_WINDOW` | `50` | Reinforcement context window size. |
+| `ARCANOS_MEMORY_DIGEST_SIZE` | `8` | Memory digest size for reinforcement. |
+| `ARCANOS_CLEAR_MIN_SCORE` | `0.85` | Minimum score threshold for clear operations. |
+| `FALLBACK_STRICT_ENVIRONMENTS` | `production,staging` | CSV list for strict fallback handling. |
+| `ENABLE_PREEMPTIVE_FALLBACK` | `false` | Enables preemptive fallback when `true`. |
 
 ## Run locally
 

--- a/docs/RAILWAY_DEPLOYMENT.md
+++ b/docs/RAILWAY_DEPLOYMENT.md
@@ -1,12 +1,12 @@
 # Arcanos Railway Deployment Guide
 
-> **Last Updated:** 2026-01-09 | **Version:** 1.0.0 | **OpenAI SDK:** v6.15.0
+> **Last Updated:** 2026-01-10 | **Version:** 1.0.0 | **OpenAI SDK:** v6.16.0
 
 ## Overview
 
 This guide describes how to deploy the Arcanos backend to Railway using the repository’s
-existing `railway.json` and `Procfile` configuration. It reflects the current build/start
-commands and health checks defined in the repo.
+`railway.json` and `Procfile` configuration. It reflects the current build/start commands
+and health checks defined in the repo.
 
 ## Prerequisites
 
@@ -53,6 +53,7 @@ Railway uses `railway.json` as the source of truth:
 - **Build:** `npm ci --include=dev && npm run build`
 - **Start:** `node --max-old-space-size=7168 dist/start-server.js`
 - **Health check path:** `/health`
+- **Health check timeout:** `300s`
 - **Restart policy:** `ON_FAILURE` with `restartPolicyMaxRetries=10`
 
 The `Procfile` mirrors the start command for compatibility.
@@ -77,7 +78,7 @@ The `Procfile` mirrors the start command for compatibility.
 - `WORKER_API_TIMEOUT_MS=60000`
 - `PORT=$PORT` (injected by Railway)
 
-If you attach PostgreSQL, Railway injects `DATABASE_URL` or `PG*` values. The backend
+If you attach PostgreSQL, Railway injects `DATABASE_URL` (or `PG*` values). The backend
 constructs `DATABASE_URL` from `PG*` if needed.
 
 ### Environment separation
@@ -111,7 +112,7 @@ curl http://localhost:8080/health
 ### Rollback
 
 - Use the Railway dashboard **Deployments** view to redeploy a previous deployment.
-- TODO: Confirm the exact Railway CLI rollback command for this repo.
+- TODO: Confirm whether the Railway CLI exposes a stable rollback command for this repo.
 
 ## Troubleshooting
 


### PR DESCRIPTION
### Motivation

- Align user-facing documentation with the repository’s actual runtime and deployment configuration to avoid mismatches and deployment failures.  
- Provide Railway-first deployment instructions and accurate environment variable guidance that reflect the current codebase and `railway.json` settings.  
- Ensure OpenAI SDK examples and model-selection/fallback notes are current and not aspirational.  

### Description

- Updated `README.md` to reflect the actual boot entry (`src/start-server.ts`), clarify Railway deployment steps, and add the fallback model variables used by the code.  
- Rewrote `docs/RAILWAY_DEPLOYMENT.md` to match `railway.json` and `Procfile` (build/start commands, health check path and timeout, `RUN_WORKERS` defaults) and bumped the documented OpenAI SDK version.  
- Rewrote `docs/CONFIGURATION.md` to expand the environment matrix with the OpenAI key resolution order, primary/fallback model selection chain, client defaults (cache TTL, retries, image prompt limits), worker defaults, telemetry, assistant-sync, and reinforcement settings based on `src/utils/env.ts`, `src/config/index.ts`, `src/services/openai/*`, and `src/config/workerConfig.ts`.  
- These changes are documentation-only and do not modify runtime code or application logic.  

### Testing

- No automated tests were executed because this is a documentation-only change; CI/test runs can be triggered after merge if desired.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69634a0aa32883259ce40817cd1a69f9)