### PR TITLE
Adjust GPT‑5.2 reasoning worker cadence to every 6 hours

### DIFF
--- a/docs/BACKGROUND_WORKERS.md
+++ b/docs/BACKGROUND_WORKERS.md
@@ -78,7 +78,7 @@ The repository includes several ready-to-run modules under `workers/`:
 | `worker-logger` | Heartbeat only | Initializes the centralized worker execution logger and emits periodic heartbeats so status dashboards stay warm. |
 | `worker-planner-engine` | `*/5 * * * *` | Scans the `job_data` table, logs queue depth, and can coordinate future scheduling. Scheduling is automatically skipped when the database is offline. |
 | `worker-memory` | `*/10 * * * *` | Counts rows in the `memory` table and records synchronization telemetry. |
-| `worker-gpt5-reasoning` | `*/15 * * * *` | Requests a GPT‑5.2 reasoning summary about background services and stores the response via the worker context. |
+| `worker-gpt5-reasoning` | `0 */6 * * *` | Requests a GPT‑5.2 reasoning summary about background services and stores the response via the worker context. |
 
 Each worker follows the same default-export contract, which keeps new modules
 straightforward to author.

--- a/workers/src/worker-gpt5-reasoning.ts
+++ b/workers/src/worker-gpt5-reasoning.ts
@@ -2,7 +2,7 @@ import type { WorkerContext } from './workerTypes.js';
 
 export const id = 'worker-gpt5-reasoning';
 export const description = 'Provides scheduled GPT-5.2 reasoning pulses for diagnostics.';
-export const schedule = '*/15 * * * *';
+export const schedule = '0 */6 * * *';
 
 async function requestStatusSummary(context: WorkerContext) {
   try {


### PR DESCRIPTION
### Motivation
- Reduce the frequency of recurring GPT reasoning calls to lower AI usage and noise by running the diagnostic pulse less often. 
- Keep the runtime behavior identical while decreasing operational cost and rate of external calls. 

### Description
- Change the cron schedule in `workers/src/worker-gpt5-reasoning.ts` from `*/15 * * * *` to `0 */6 * * *` so the worker runs every six hours. 
- Update the `docs/BACKGROUND_WORKERS.md` table to reflect the new schedule for `worker-gpt5-reasoning`. 
- The worker logic remains the same: it logs a timestamp, calls `context.ai.ask()` with a single-sentence status prompt, and returns the summary or a fallback string on error. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69636ec6dcfc8325a2844974789a0ab5)