### PR TITLE
Standardize core documentation structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Populate at least `OPENAI_API_KEY` in `.env` before running locally.
 Key environment variables (see `docs/CONFIGURATION.md` for the complete matrix):
 
 - `OPENAI_API_KEY` – required for live OpenAI calls (missing keys return mock responses).
-- `OPENAI_MODEL`, `FINETUNED_MODEL_ID`, `FINE_TUNED_MODEL_ID`, `AI_MODEL` – model selection
-  chain used by the OpenAI client.
+- `OPENAI_MODEL`, `RAILWAY_OPENAI_MODEL`, `FINETUNED_MODEL_ID`, `FINE_TUNED_MODEL_ID`, `AI_MODEL`
+  – model selection chain used by the OpenAI client (default: `gpt-4o`).
 - `FALLBACK_MODEL`, `AI_FALLBACK_MODEL`, `RAILWAY_OPENAI_FALLBACK_MODEL` – fallback model
-  chain used when the primary model fails.
+  chain used when the primary model fails (default: `gpt-4`).
 - `GPT51_MODEL` / `GPT5_MODEL` – GPT-5.2 reasoning model override (defaults to `gpt-5.2`).
 - `DATABASE_URL` or `PGHOST`/`PGPORT`/`PGUSER`/`PGPASSWORD`/`PGDATABASE` – database connection.
 - `RUN_WORKERS`, `WORKER_COUNT`, `WORKER_MODEL`, `WORKER_API_TIMEOUT_MS` – background workers.
@@ -75,8 +75,8 @@ High-level steps:
 
 1. Create a Railway project and connect the GitHub repository.
 2. Add required environment variables (`OPENAI_API_KEY`, optional model overrides).
-3. (Optional) Provision PostgreSQL and set `DATABASE_URL` if not auto-injected.
-4. Deploy and confirm health checks pass.
+3. (Optional) Provision PostgreSQL and confirm `DATABASE_URL` is injected.
+4. Deploy and confirm the `/health` check passes.
 5. Roll back from the Railway **Deployments** view if needed.
 
 See `docs/RAILWAY_DEPLOYMENT.md` for a detailed, step-by-step guide.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -85,6 +85,11 @@ Additional model-related variables:
 | `OPENAI_CACHE_TTL_MS` | `300000` | Cache TTL for OpenAI responses (5 minutes). |
 | `OPENAI_MAX_RETRIES` | `3` | Retry budget for OpenAI calls. |
 | `OPENAI_IMAGE_PROMPT_TOKEN_LIMIT` | `256` | Token limit for image prompt expansion. |
+| `OPENAI_DEFAULT_MAX_TOKENS` | `256` | Default max tokens for responses when not specified. |
+| `OPENAI_DEFAULT_TEMPERATURE` | `0.7` | Default temperature for responses. |
+| `OPENAI_DEFAULT_TOP_P` | `1` | Default nucleus sampling value. |
+| `OPENAI_DEFAULT_FREQUENCY_PENALTY` | `0` | Default frequency penalty. |
+| `OPENAI_DEFAULT_PRESENCE_PENALTY` | `0` | Default presence penalty. |
 
 ### Database & persistence
 

--- a/docs/RAILWAY_DEPLOYMENT.md
+++ b/docs/RAILWAY_DEPLOYMENT.md
@@ -108,6 +108,12 @@ curl http://localhost:8080/health
 2. Railway triggers a build using `railway.json`.
 3. Confirm `/health` passes after deploy.
 4. (Optional) Run `npm run validate:railway` locally to pre-check Railway readiness.
+5. Verify the `RUN_WORKERS` toggle and `DATABASE_URL` are set for the target environment.
+
+### Health checks
+
+- Railway uses `GET /health` for deploy readiness.
+- `/healthz` and `/readyz` are also available for local validation.
 
 ### Rollback
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,9 @@ Start with these documents in order:
 
 Configuration details live in `CONFIGURATION.md` and the `.env.example` template at the
 repository root. Use those documents to align environment variables with the runtime.
+Every documentation file in this repo should follow the standard structure:
+Overview → Prerequisites → Setup → Configuration → Run locally → Deploy (Railway) →
+Troubleshooting → References.
 
 ## Run locally
 
@@ -48,6 +51,9 @@ If a document is missing, outdated, or contradictory, log the gap in
 - `arcanos-overview.md`
 - `backend.md`
 - `AFOL_OVERVIEW.md`
+
+**SDK usage**
+- `../README.md` (Node + Python OpenAI SDK examples)
 
 **Deployment**
 - `RAILWAY_DEPLOYMENT.md`


### PR DESCRIPTION
### Motivation
- Align user-facing documentation with the repository's current code, OpenAI env resolution, and Railway deployment config.
- Ensure SDK usage examples are accurate for the `openai` v6 Node client and Python `OpenAI` client.
- Adopt a uniform documentation structure across the repo for discoverability and consistency.
- Document Railway-first deployment validation (health checks, env toggles) to reduce deployment surprises.

### Description
- Updated `README.md` to reflect the actual OpenAI env resolution order, default models, Railway defaults, and confirmed SDK examples for Node and Python (files: `README.md`).
- Added a required doc structure note and SDK usage pointer to the docs index (file: `docs/README.md`).
- Enhanced the Railway deployment guide to include health-check validation, environment verification (e.g. `RUN_WORKERS`, `DATABASE_URL`), and deploy/rollback guidance (file: `docs/RAILWAY_DEPLOYMENT.md`).
- Expanded the configuration matrix to document OpenAI client defaults such as `OPENAI_DEFAULT_MAX_TOKENS`, `OPENAI_DEFAULT_TEMPERATURE`, `OPENAI_DEFAULT_TOP_P`, `OPENAI_DEFAULT_FREQUENCY_PENALTY`, and `OPENAI_DEFAULT_PRESENCE_PENALTY` (file: `docs/CONFIGURATION.md`).

### Testing
- No automated tests were executed because these are documentation-only changes.
- Changes were validated against runtime sources such as `src/services/openai/credentialProvider.ts`, `src/services/openai/constants.ts`, and `railway.json` to ensure accuracy.
- A manual spot-check ensured the documented health-check paths and Railway build/start commands match `railway.json` and `Procfile`.
- Risk is low since the PR modifies only docs and does not alter runtime code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69653f0166e08325a90ea004c87f07d6)