### PR TITLE
Add DB adapters for audit/session persistence and clarify Prisma as migration source of truth

### DIFF
--- a/docs/DATABASE_INTEGRATION.md
+++ b/docs/DATABASE_INTEGRATION.md
@@ -18,6 +18,8 @@ re-exports stable helpers for backward compatibility:
 | `schema.ts` | Zod schemas plus the SQL migrations executed during boot (`initializeTables`, `refreshDatabaseCollation`). |
 | `query.ts` | Centralized query helper with caching, retry, and transaction utilities. |
 | `repositories/` | Entity-specific helpers (`memoryRepository`, `ragRepository`, `executionLogRepository`, `jobRepository`, `reasoningLogRepository`, `selfReflectionRepository`). |
+| `auditStore.ts` | Audit/persistence adapter that hides the underlying SQL client (Knex today, Prisma-ready interface). |
+| `sessionCacheStore.ts` | Session cache adapter for the session persistence layer, isolated behind a DB-neutral contract. |
 | `index.ts` | Public surface that wires the client, schema, and repositories, and exposes `initializeDatabaseWithSchema()` for worker/server boot. |
 
 `src/db.ts` re-exports everything from `src/db/index.ts` so existing imports continue to work while the modular layout remains organized.
@@ -39,6 +41,16 @@ re-exports stable helpers for backward compatibility:
 
 Every schema export also ships with a matching Zod type so higher-level modules
 can validate payloads before writing to the database.
+
+--- 
+
+## Migration source of truth
+
+Prisma is the source of truth for **domain** tables. Add or change core
+application models in `prisma/schema.prisma` and ship migrations from there to
+avoid drift. The SQL bootstrapping in `schema.ts` is a transitional layer for
+legacy/infra tables (for example, audit logs or session caches) and should stay
+aligned with Prisma migrations as those tables are migrated or deprecated.
 
 ---
 

--- a/docs/deployment/PRISMA_SETUP.md
+++ b/docs/deployment/PRISMA_SETUP.md
@@ -27,6 +27,10 @@ model User {
 }
 ```
 
+Prisma migrations are the source of truth for domain tables. Add or change core
+entities in the Prisma schema first, then run the migration workflow to apply
+those updates in each environment to avoid drift.
+
 ### 4. Prisma Commands
 Available npm scripts for Prisma:
 ```bash

--- a/docs/sql/ORM_RECOMMENDATIONS.md
+++ b/docs/sql/ORM_RECOMMENDATIONS.md
@@ -22,7 +22,7 @@ Knex can remain in narrow, infrastructure-oriented scopes when it provides concr
 - Thin persistence layers (e.g., session or cache tables) where raw SQL control is useful.
 - Data pipelines or admin utilities that already rely on Knex.
 
-In these cases, isolate Knex behind a dedicated module so the rest of the app stays ORM-agnostic.
+In these cases, isolate Knex behind a dedicated module so the rest of the app stays ORM-agnostic. The audit/persistence and session cache layers now flow through `src/db/auditStore.ts` and `src/db/sessionCacheStore.ts` to keep Knex usage contained until they are migrated.
 
 ## Recommendations to Improve SQL Layer Quality
 1. **Standardize on a single primary ORM**
@@ -32,6 +32,7 @@ In these cases, isolate Knex behind a dedicated module so the rest of the app st
 2. **Define a single migration source of truth**
    - Prisma migrations should be the canonical schema path for domain data.
    - Avoid separate migration stacks that drift over time.
+   - Legacy/infra tables still created via SQL bootstraps should be tracked for migration or retirement.
 
 3. **Create a DB access boundary**
    - Centralize all data access in a `src/db/` or `src/data/` layer.

--- a/src/db/auditStore.ts
+++ b/src/db/auditStore.ts
@@ -1,0 +1,113 @@
+import knexPkg from 'knex';
+import type { Knex } from 'knex';
+import { logger } from '../utils/structuredLogging.js';
+
+const knexFactory = knexPkg as unknown as (config: Knex.Config) => Knex;
+
+export interface AuditStoreTransaction {
+  /**
+   * Insert a save snapshot during an active transaction.
+   * Inputs: moduleName (string), payload (stringified JSON), timestamp (epoch millis).
+   * Output: resolves once the record is persisted.
+   * Edge cases: throws if the insert fails or the transaction is closed.
+   */
+  insertSave(moduleName: string, payload: string, timestamp: number): Promise<void>;
+}
+
+export interface AuditStore {
+  /**
+   * Run a unit of work inside a single transaction.
+   * Inputs: handler callback that receives a transactional writer.
+   * Output: resolves with the handler result.
+   * Edge cases: throws if the transaction cannot be opened.
+   */
+  runInTransaction<T>(handler: (transaction: AuditStoreTransaction) => Promise<T>): Promise<T>;
+  /**
+   * Insert an audit log event outside of a transactional save.
+   * Inputs: event name, payload object, timestamp in epoch millis.
+   * Output: resolves once the audit log is stored.
+   * Edge cases: throws if the insert fails.
+   */
+  insertAuditLog(event: string, payload: Record<string, unknown>, timestamp: number): Promise<void>;
+  /**
+   * Check whether a table exists in the backing database.
+   * Inputs: table name.
+   * Output: resolves with true/false.
+   * Edge cases: throws if the connection is unavailable.
+   */
+  hasTable(tableName: string): Promise<boolean>;
+}
+
+export interface AuditStoreConfig {
+  connectionString?: string;
+  pool?: { min: number; max: number };
+}
+
+class KnexAuditStore implements AuditStore {
+  private readonly db: Knex;
+
+  constructor(config: AuditStoreConfig) {
+    //audit assumption: caller provides a valid connection string; risk: missing config prevents writes; invariant: db is usable.
+    if (!config.connectionString) {
+      throw new Error('Audit store requires a DATABASE_URL');
+    }
+    this.db = knexFactory({
+      client: 'pg',
+      connection: config.connectionString,
+      pool: config.pool ?? { min: 2, max: 10 }
+    });
+  }
+
+  async runInTransaction<T>(handler: (transaction: AuditStoreTransaction) => Promise<T>): Promise<T> {
+    return this.db.transaction(async trx => {
+      const transactionWriter: AuditStoreTransaction = {
+        insertSave: async (moduleName, payload, timestamp) => {
+          await trx('saves').insert({
+            module: moduleName,
+            data: payload,
+            timestamp
+          });
+        }
+      };
+      return handler(transactionWriter);
+    });
+  }
+
+  async insertAuditLog(event: string, payload: Record<string, unknown>, timestamp: number): Promise<void> {
+    await this.db('audit_logs').insert({
+      event,
+      //audit assumption: payload is JSON-serializable; risk: stringify throws; invariant: payload persists as string.
+      payload: JSON.stringify(payload),
+      timestamp
+    });
+  }
+
+  async hasTable(tableName: string): Promise<boolean> {
+    return this.db.schema.hasTable(tableName);
+  }
+}
+
+/**
+ * Build the audit store adapter used by persistence and audit flows.
+ * Inputs: connection string and optional pool sizing.
+ * Output: a configured audit store or null when no database is configured.
+ * Edge cases: returns null if the connection string is missing.
+ */
+export function createAuditStore(config: AuditStoreConfig): AuditStore | null {
+  if (!config.connectionString) {
+    //audit assumption: audit storage is optional at boot; risk: missing logs; invariant: callers must handle null.
+    logger.warn('Audit store skipped: DATABASE_URL is missing', { module: 'auditStore' });
+    return null;
+  }
+
+  try {
+    return new KnexAuditStore(config);
+  } catch (error) {
+    //audit assumption: constructor failure is recoverable; risk: audit writes unavailable; invariant: error is logged.
+    logger.warn('Audit store initialization failed', {
+      module: 'auditStore',
+      error: error instanceof Error ? error.message : 'unknown'
+    });
+    return null;
+  }
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -75,6 +75,21 @@ export {
   saveSelfReflection
 } from './repositories/selfReflectionRepository.js';
 
+// Adapter exports
+export {
+  createAuditStore,
+  type AuditStore,
+  type AuditStoreTransaction,
+  type AuditStoreConfig
+} from './auditStore.js';
+
+export {
+  createSessionCacheStore,
+  type SessionCacheStore,
+  type SessionCacheStoreConfig,
+  type SessionCacheRow
+} from './sessionCacheStore.js';
+
 /**
  * Initialize database with full schema setup
  * This is the main entry point for database initialization

--- a/src/db/sessionCacheStore.ts
+++ b/src/db/sessionCacheStore.ts
@@ -1,0 +1,131 @@
+import knexPkg from 'knex';
+import type { Knex } from 'knex';
+
+const knexFactory = knexPkg as unknown as (config: Knex.Config) => Knex;
+
+export interface SessionCacheRow {
+  sessionId: string;
+  data: string;
+  updatedAt: Date;
+}
+
+export interface SessionCacheStore {
+  /**
+   * Ensure the session cache table exists.
+   * Inputs: none.
+   * Output: resolves once the table exists.
+   * Edge cases: throws if the schema operation fails.
+   */
+  initialize(): Promise<void>;
+  /**
+   * Load all cached session rows.
+   * Inputs: none.
+   * Output: array of session cache rows.
+   * Edge cases: throws if the query fails.
+   */
+  loadSessions(): Promise<SessionCacheRow[]>;
+  /**
+   * Upsert a session cache row.
+   * Inputs: session id, serialized data, updated timestamp.
+   * Output: resolves once persisted.
+   * Edge cases: throws if the insert fails.
+   */
+  persistSession(sessionId: string, data: string, updatedAt: Date): Promise<void>;
+  /**
+   * Remove a cached session by id.
+   * Inputs: session id.
+   * Output: resolves once deleted.
+   * Edge cases: throws if the delete fails.
+   */
+  removeSession(sessionId: string): Promise<void>;
+  /**
+   * Delete sessions older than the provided cutoff.
+   * Inputs: cutoff date.
+   * Output: resolves once deletes complete.
+   * Edge cases: throws if the delete fails.
+   */
+  purgeExpired(cutoff: Date): Promise<void>;
+}
+
+export interface SessionCacheStoreConfig {
+  client: 'pg' | 'better-sqlite3';
+  connection: string | Knex.StaticConnectionConfig;
+}
+
+class KnexSessionCacheStore implements SessionCacheStore {
+  private readonly tableName = 'session_cache';
+  private readonly db: Knex;
+  private readonly client: 'pg' | 'better-sqlite3';
+
+  constructor(config: SessionCacheStoreConfig) {
+    this.client = config.client;
+    this.db = knexFactory({
+      client: config.client,
+      connection: config.connection,
+      useNullAsDefault: config.client === 'better-sqlite3'
+    });
+  }
+
+  async initialize(): Promise<void> {
+    const exists = await this.db.schema.hasTable(this.tableName);
+    //audit assumption: table should exist before reads; risk: missing table yields runtime errors; invariant: table created if absent.
+    if (!exists) {
+      await this.db.schema.createTable(this.tableName, table => {
+        table.string('session_id').primary();
+        if (this.client === 'pg') {
+          //audit assumption: pg jsonb is supported; risk: incompatible driver; invariant: data column is non-null.
+          table.jsonb('data').notNullable();
+        } else {
+          //audit assumption: sqlite stores JSON as text; risk: invalid JSON; invariant: data column is non-null.
+          table.text('data').notNullable();
+        }
+        table.dateTime('updated_at').notNullable().index();
+      });
+    }
+  }
+
+  async loadSessions(): Promise<SessionCacheRow[]> {
+    const rows = await this.db<{
+      session_id: string;
+      data: string | Record<string, unknown>;
+      updated_at: Date;
+    }>(this.tableName).select('session_id', 'data', 'updated_at');
+
+    return rows.map(row => ({
+      sessionId: row.session_id,
+      //audit assumption: row.data is JSON; risk: stringify throws; invariant: stored as string for parsing.
+      data: typeof row.data === 'string' ? row.data : JSON.stringify(row.data),
+      //audit assumption: timestamp is parseable; risk: invalid date; invariant: updatedAt is Date.
+      updatedAt: row.updated_at instanceof Date ? row.updated_at : new Date(row.updated_at)
+    }));
+  }
+
+  async persistSession(sessionId: string, data: string, updatedAt: Date): Promise<void> {
+    await this.db(this.tableName)
+      .insert({
+        session_id: sessionId,
+        data,
+        updated_at: updatedAt
+      })
+      .onConflict('session_id')
+      .merge({ data, updated_at: updatedAt });
+  }
+
+  async removeSession(sessionId: string): Promise<void> {
+    await this.db(this.tableName).where({ session_id: sessionId }).del();
+  }
+
+  async purgeExpired(cutoff: Date): Promise<void> {
+    await this.db(this.tableName).where('updated_at', '<', cutoff).del();
+  }
+}
+
+/**
+ * Build the session cache store adapter for DB-backed sessions.
+ * Inputs: store configuration with client and connection info.
+ * Output: a session cache store instance.
+ * Edge cases: throws if the configuration is invalid.
+ */
+export function createSessionCacheStore(config: SessionCacheStoreConfig): SessionCacheStore {
+  return new KnexSessionCacheStore(config);
+}

--- a/src/persistenceManagerHierarchy.ts
+++ b/src/persistenceManagerHierarchy.ts
@@ -2,17 +2,37 @@
 // Purpose: Unified patch for persistence, audit, and override hierarchy
 // Kernel Failsafe → Audit Layer → Root Override
 
-import knexPkg from 'knex';
-const knex = (knexPkg as any).default || knexPkg;
+import { createAuditStore, type AuditStore, type AuditStoreTransaction } from './db/auditStore.js';
 
 // ----------------------
 // Database Config
 // ----------------------
-const db = knex({
-  client: 'pg', // swap if using mysql/sqlite
-  connection: process.env.DATABASE_URL,
+const auditStore = createAuditStore({
+  connectionString: process.env.DATABASE_URL,
   pool: { min: 2, max: 10 }
 });
+let auditStoreOverride: AuditStore | null = null;
+
+/**
+ * Inject a custom audit store for testing or alternate adapters.
+ * Inputs: audit store instance or null to clear the override.
+ * Output: none.
+ * Edge cases: passing null resets to the default store.
+ */
+export function configureAuditStore(store: AuditStore | null): void {
+  //audit assumption: override is intentional; risk: misconfiguration; invariant: override replaces default when set.
+  auditStoreOverride = store;
+}
+
+function requireAuditStore(): AuditStore {
+  //audit assumption: audit store must exist for persistence flows; risk: missing logs; invariant: throws when unavailable.
+  const activeStore = auditStoreOverride ?? auditStore;
+  //audit assumption: override can disable store; risk: missing persistence; invariant: throw on null.
+  if (!activeStore) {
+    throw new Error('Audit store is not configured. Set DATABASE_URL to enable persistence.');
+  }
+  return activeStore;
+}
 
 // ----------------------
 // State
@@ -25,28 +45,34 @@ const MAX_FAILED_ATTEMPTS = 5;
 // ----------------------
 // Kernel Failsafe (Always Active)
 // ----------------------
-async function kernelSafeWrite(trx: any, moduleName: string, payload: string) {
+/**
+ * Write a payload within the kernel transaction boundary.
+ * Inputs: transaction writer, module name, payload string.
+ * Output: resolves once the save snapshot is stored.
+ * Edge cases: throws when payload size exceeds the safety threshold.
+ */
+async function kernelSafeWrite(trx: AuditStoreTransaction, moduleName: string, payload: string) {
+  //audit assumption: payload size limit prevents oversized writes; risk: data loss; invariant: payload <= 50k.
   if (payload.length > 50000) {
     throw new Error('Payload too large for save.');
   }
-  await trx('saves').insert({
-    module: moduleName,
-    data: payload,
-    timestamp: Date.now()
-  });
+  await trx.insertSave(moduleName, payload, Date.now());
 }
 
 // ----------------------
 // Audit Layer (Async, Non-Blocking)
 // ----------------------
-export async function logAuditEvent(event: string, payload: any) {
+/**
+ * Persist an audit event to the audit log table.
+ * Inputs: event name, payload object.
+ * Output: resolves once the audit entry is stored.
+ * Edge cases: throws when the audit store is unavailable or insert fails.
+ */
+export async function logAuditEvent(event: string, payload: Record<string, unknown>) {
   try {
-    await db('audit_logs').insert({
-      event,
-      payload: JSON.stringify(payload),
-      timestamp: Date.now()
-    });
+    await requireAuditStore().insertAuditLog(event, payload, Date.now());
   } catch (err: any) {
+    //audit assumption: audit failures are critical; risk: missing compliance record; invariant: error is surfaced.
     console.error('⚠️ Audit log failed:', err.message);
     throw new Error('Critical audit logging failure.');
   }
@@ -55,7 +81,14 @@ export async function logAuditEvent(event: string, payload: any) {
 // ----------------------
 // Root Override Manager
 // ----------------------
+/**
+ * Check whether the caller can enable root override mode.
+ * Inputs: user role, override token.
+ * Output: boolean indicating authorization.
+ * Edge cases: returns false when env flags are missing or roles mismatch.
+ */
 function canEnableRootOverride(userRole: string, token: string) {
+  //audit assumption: override requires env flag, admin role, and token; risk: escalation; invariant: all conditions true.
   return (
     process.env.ALLOW_ROOT_OVERRIDE === 'true' &&
     userRole === 'admin' &&
@@ -63,17 +96,26 @@ function canEnableRootOverride(userRole: string, token: string) {
   );
 }
 
+/**
+ * Set the audit safety mode with optional root override.
+ * Inputs: mode flag plus optional override metadata.
+ * Output: resolves once the mode change is recorded.
+ * Edge cases: throws on invalid modes or unauthorized overrides.
+ */
 export async function setAuditSafeMode(
   mode: 'true' | 'false' | 'passive',
   { rootOverride = false, userRole = 'guest', token = '' }: { rootOverride?: boolean; userRole?: string; token?: string } = {}
 ) {
+  //audit assumption: mode must be explicit; risk: invalid configuration; invariant: only allowed values pass.
   if (!['true', 'false', 'passive'].includes(mode)) {
     throw new Error("Invalid mode. Use 'true', 'false', or 'passive'.");
   }
 
+  //audit assumption: root override is privileged; risk: unauthorized escalation; invariant: validated before enabling.
   if (rootOverride && !canEnableRootOverride(userRole, token)) {
     failedRootOverrideAttempts++;
     await logAuditEvent('ROOT_OVERRIDE_DENIED', { userRole, failedRootOverrideAttempts });
+    //audit assumption: repeated failures indicate abuse; risk: brute force; invariant: block after threshold.
     if (failedRootOverrideAttempts > MAX_FAILED_ATTEMPTS) {
       throw new Error('🚫 Too many failed override attempts.');
     }
@@ -87,6 +129,12 @@ export async function setAuditSafeMode(
   await logAuditEvent('MODE_CHANGE', { auditSafeMode, rootOverrideActive });
 }
 
+/**
+ * Read the current audit safe mode and override status.
+ * Inputs: none.
+ * Output: object with auditSafeMode and rootOverrideActive values.
+ * Edge cases: none (pure getter).
+ */
 export function getAuditSafeMode() {
   return { auditSafeMode, rootOverrideActive };
 }
@@ -94,40 +142,52 @@ export function getAuditSafeMode() {
 // ----------------------
 // Persistence Layer (DB Writes + Rollbacks)
 // ----------------------
+/**
+ * Persist data with audit-safe validation and rollback handling.
+ * Inputs: module name, payload data, validator function.
+ * Output: resolves true when persisted.
+ * Edge cases: throws on validation failures or persistence errors.
+ */
 export async function saveWithAuditCheck(moduleName: string, data: any, validator: (d: any) => boolean) {
   const { auditSafeMode, rootOverrideActive } = getAuditSafeMode();
+  //audit assumption: data is JSON-serializable; risk: stringify throws; invariant: payload string created.
   const payload = JSON.stringify(data);
 
   try {
-    return await db.transaction(async (trx: any) => {
+    return await requireAuditStore().runInTransaction(async trx => {
+      //audit assumption: root override bypasses validation; risk: invalid data; invariant: audit event logged.
       if (rootOverrideActive) {
         await kernelSafeWrite(trx, moduleName, payload);
         await logAuditEvent('ROOT_OVERRIDE_SAVE', { moduleName, data });
         return true;
       }
 
+      //audit assumption: auditSafeMode true enforces validation; risk: rejected writes; invariant: validator required.
       if (auditSafeMode === 'true') {
-        if (!isValid(validator, data)) {
+        if (!(await isValid(validator, data))) {
           throw new Error(`❌ Audit-Safe rejected invalid data for ${moduleName}`);
         }
         await kernelSafeWrite(trx, moduleName, payload);
         return true;
       }
 
+      //audit assumption: passive mode logs warnings but allows save; risk: invalid data stored; invariant: warning logged.
       if (auditSafeMode === 'passive') {
-        if (!isValid(validator, data)) {
+        if (!(await isValid(validator, data))) {
           await logAuditEvent('VALIDATOR_WARNING', { moduleName, data });
         }
         await kernelSafeWrite(trx, moduleName, payload);
         return true;
       }
 
+      //audit assumption: false mode disables validation; risk: invalid data stored; invariant: save always attempts.
       if (auditSafeMode === 'false') {
         await kernelSafeWrite(trx, moduleName, payload);
         return true;
       }
     });
   } catch (err: any) {
+    //audit assumption: failures must trigger rollback logging; risk: missing audit trail; invariant: rollback event recorded.
     await runRollback(moduleName, data, err.message);
     throw err;
   }
@@ -136,6 +196,12 @@ export async function saveWithAuditCheck(moduleName: string, data: any, validato
 // ----------------------
 // Rollback (Kernel Controlled)
 // ----------------------
+/**
+ * Record rollback metadata for failed writes.
+ * Inputs: module name, failed payload, error message.
+ * Output: resolves once rollback event is logged.
+ * Edge cases: throws if audit logging fails.
+ */
 async function runRollback(moduleName: string, failedData: any, errorMsg: string) {
   await logAuditEvent('ROLLBACK_TRIGGERED', {
     module: moduleName,
@@ -147,11 +213,18 @@ async function runRollback(moduleName: string, failedData: any, errorMsg: string
 // ----------------------
 // Validator Wrapper
 // ----------------------
-function isValid(validator: (d: any) => boolean, data: any) {
+/**
+ * Run validator with audit logging on failure.
+ * Inputs: validator function and payload.
+ * Output: boolean indicating validity.
+ * Edge cases: returns false when validator throws.
+ */
+async function isValid(validator: (d: any) => boolean, data: any) {
   try {
     return validator(data);
   } catch (err: any) {
-    logAuditEvent('VALIDATOR_EXCEPTION', { error: err.message, data });
+    //audit assumption: validator exceptions are non-fatal; risk: missing validation; invariant: exception is logged.
+    await logAuditEvent('VALIDATOR_EXCEPTION', { error: err.message, data });
     return false;
   }
 }
@@ -159,7 +232,14 @@ function isValid(validator: (d: any) => boolean, data: any) {
 // ----------------------
 // Schema Verification
 // ----------------------
+/**
+ * Verify required audit tables exist.
+ * Inputs: none (uses DATABASE_URL configuration).
+ * Output: resolves once verification completes.
+ * Edge cases: logs and exits early when no database is configured.
+ */
 export async function verifySchema() {
+  //audit assumption: missing DATABASE_URL disables verification; risk: false negatives; invariant: skip with log.
   if (!process.env.DATABASE_URL) {
     console.log('⚠️ No DATABASE_URL configured - skipping schema verification');
     return;
@@ -168,13 +248,15 @@ export async function verifySchema() {
   try {
     const tables = ['saves', 'audit_logs'];
     for (const table of tables) {
-      const exists = await db.schema.hasTable(table);
+      const exists = await requireAuditStore().hasTable(table);
+      //audit assumption: required tables must exist; risk: runtime errors; invariant: throws on missing.
       if (!exists) {
         throw new Error(`❌ Required table missing: ${table}`);
       }
     }
     console.log('✅ Schema verified.');
   } catch (error: any) {
+    //audit assumption: verification failure is recoverable; risk: degraded persistence; invariant: warning logged.
     console.error('❌ Schema verification failed:', error.message);
     console.log('⚠️ Continuing with in-memory fallback');
   }


### PR DESCRIPTION
### Motivation
- Consolidate DB access behind a single `src/db/` boundary to avoid tight coupling to Knex and make future migration to Prisma easier. 
- Make Prisma the canonical migration/source-of-truth for domain tables while isolating legacy/infra SQL usage. 
- Reduce drift and improve auditability by centralizing audit and session cache flows behind explicit adapters. 

### Description
- Added `src/db/auditStore.ts` which provides an `AuditStore` abstraction and a Knex-backed `KnexAuditStore`, plus `createAuditStore()` for initialization. 
- Added `src/db/sessionCacheStore.ts` which provides a `SessionCacheStore` abstraction and a Knex-backed `KnexSessionCacheStore`, plus `createSessionCacheStore()` for initialization. 
- Refactored `src/memory/sessionPersistence.ts` to consume the `SessionCacheStore` adapter instead of directly using Knex, and added audit comments and safer parsing. 
- Refactored `src/persistenceManagerHierarchy.ts` to use the `AuditStore` adapter (transaction abstraction, `kernelSafeWrite`, `logAuditEvent`, `saveWithAuditCheck`, `verifySchema`) and added an override hook `configureAuditStore` for testing. 
- Exported the new adapters from `src/db/index.ts` and updated docs (`docs/DATABASE_INTEGRATION.md`, `docs/sql/ORM_RECOMMENDATIONS.md`, `docs/deployment/PRISMA_SETUP.md`) to state that Prisma migrations are the source of truth for domain tables and to document the DB-layer contract. 

### Testing
- No automated tests were run as part of this change. 
- Existing test suites (Jest) are expected to continue exercising `initializeDatabase()` and DB fallbacks per the documented testing expectations in `docs/DATABASE_INTEGRATION.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966e47aba048325bb815a3417c0dadb)