### PR TITLE
Improve CLEAR audit validation and delivery logging

### DIFF
--- a/src/services/audit.ts
+++ b/src/services/audit.ts
@@ -5,42 +5,144 @@ import { sendClearFeedback } from './clearClient.js';
 
 const CLEAR_SYSTEM_IDENTIFIER = 'CLEAR';
 
-function validateClearPayload(payload: ClearFeedbackPayload): void {
-  if (payload.system !== CLEAR_SYSTEM_IDENTIFIER) {
-    throw new Error(`Unsupported audit system: ${payload.system}`);
-  }
+interface ClearPayloadValidationResult {
+  score: number;
+  patternId?: string;
+  payload: Record<string, unknown>;
+}
 
-  if (typeof payload.requestId !== 'string' || payload.requestId.length === 0) {
-    throw new Error('Audit payload is missing a requestId');
-  }
+class ClearAuditValidationError extends Error {
+  public readonly details: Record<string, unknown>;
 
-  if (payload.payload == null || typeof payload.payload !== 'object') {
-    throw new Error('Audit payload payload must be an object');
-  }
-
-  const score = (payload.payload as Record<string, unknown>).CLEAR_score;
-  if (typeof score !== 'number' || Number.isNaN(score)) {
-    throw new Error('Audit payload missing numeric CLEAR_score');
+  /**
+   * Describe an invalid CLEAR audit payload so callers can emit structured errors.
+   * Inputs: message + contextual details to log.
+   * Outputs: Error instance with details and name for classification.
+   * Edge cases: details may be empty for unknown validation failures.
+   */
+  public constructor(message: string, details: Record<string, unknown>) {
+    super(message);
+    this.name = 'ClearAuditValidationError';
+    this.details = details;
   }
 }
 
+/**
+ * Validate and normalize CLEAR audit payloads for downstream processing.
+ * Inputs: raw ClearFeedbackPayload from HTTP or internal callers.
+ * Outputs: normalized score, optional pattern id, and payload object.
+ * Edge cases: throws ClearAuditValidationError when required fields are missing.
+ */
+function validateClearPayload(payload: ClearFeedbackPayload): ClearPayloadValidationResult {
+  if (payload.system !== CLEAR_SYSTEM_IDENTIFIER) {
+    //audit assumption: only CLEAR system identifiers are supported
+    //audit failure risk: mis-routed audit data could be stored incorrectly
+    //audit expected invariant: payload.system matches CLEAR_SYSTEM_IDENTIFIER
+    //audit handling strategy: throw validation error with context
+    throw new ClearAuditValidationError('Unsupported audit system', { system: payload.system });
+  }
+
+  if (typeof payload.requestId !== 'string' || payload.requestId.length === 0) {
+    //audit assumption: requestId is a non-empty string for traceability
+    //audit failure risk: untraceable audit records
+    //audit expected invariant: requestId exists and is non-empty
+    //audit handling strategy: throw validation error with context
+    throw new ClearAuditValidationError('Audit payload is missing a requestId', { requestId: payload.requestId });
+  }
+
+  if (payload.payload == null || typeof payload.payload !== 'object') {
+    //audit assumption: payload payload is an object containing CLEAR fields
+    //audit failure risk: malformed payload cannot be parsed safely
+    //audit expected invariant: payload.payload is a non-null object
+    //audit handling strategy: throw validation error with context
+    throw new ClearAuditValidationError('Audit payload payload must be an object', { payloadType: typeof payload.payload });
+  }
+
+  const payloadRecord = payload.payload as Record<string, unknown>;
+  const score = payloadRecord.CLEAR_score;
+  if (typeof score !== 'number' || Number.isNaN(score)) {
+    //audit assumption: CLEAR_score is a valid number
+    //audit failure risk: accepting invalid scoring data
+    //audit expected invariant: CLEAR_score is numeric
+    //audit handling strategy: throw validation error with context
+    throw new ClearAuditValidationError('Audit payload missing numeric CLEAR_score', { score });
+  }
+
+  const patternId = typeof payloadRecord.pattern_id === 'string' ? payloadRecord.pattern_id : undefined;
+
+  return {
+    score,
+    patternId,
+    payload: payloadRecord
+  };
+}
+
+/**
+ * Attempt to deliver CLEAR feedback without mutating local audit state.
+ * Inputs: validated payload and sender dependency.
+ * Outputs: delivery status and optional message.
+ * Edge cases: network failures return a false delivery with message.
+ */
+async function attemptClearFeedbackDelivery(
+  payload: ClearFeedbackPayload,
+  sendClearFeedbackRequest: typeof sendClearFeedback
+): Promise<{ delivered: boolean; deliveryMessage?: string }> {
+  try {
+    const delivery = await sendClearFeedbackRequest(payload);
+    //audit assumption: sendClearFeedbackRequest resolves to a delivery result
+    //audit failure risk: missing message details for operators
+    //audit expected invariant: delivery.delivered reflects downstream response
+    //audit handling strategy: return structured delivery status
+    return { delivered: delivery.delivered, deliveryMessage: delivery.message };
+  } catch (error) {
+    //audit assumption: delivery may fail due to network or endpoint issues
+    //audit failure risk: silent delivery failures
+    //audit expected invariant: errors are logged and propagated as messages
+    //audit handling strategy: log warning and return failure message
+    aiLogger.warn('Failed to deliver CLEAR feedback to external service', {
+      operation: 'audit:transport',
+      errorMessage: error instanceof Error ? error.message : 'Unknown transport error'
+    }, error instanceof Error ? error : undefined);
+    return {
+      delivered: false,
+      deliveryMessage: error instanceof Error ? error.message : 'Unknown transport error'
+    };
+  }
+}
+
+/**
+ * Process CLEAR feedback by validating input, storing an audit record, and forwarding feedback.
+ * Inputs: ClearFeedbackPayload from the audit route.
+ * Outputs: AuditResult describing acceptance, delivery, and stored record metadata.
+ * Edge cases: throws validation errors for malformed payloads.
+ */
 export async function processClearFeedback(payload: ClearFeedbackPayload): Promise<AuditResult> {
-  validateClearPayload(payload);
+  const { score, patternId, payload: normalizedPayload } = validateClearPayload(payload);
 
   const { minimumClearScore } = getReinforcementConfig();
-  const score = payload.payload.CLEAR_score;
-  const patternId = typeof payload.payload.pattern_id === 'string' ? payload.payload.pattern_id : undefined;
   const accepted = score >= minimumClearScore;
+  //audit assumption: minimumClearScore is configured within [0,1] range
+  //audit failure risk: acceptance threshold may be misconfigured
+  //audit expected invariant: accepted reflects score threshold comparison
+  //audit handling strategy: log acceptance decision and continue
 
   const record = createAuditRecord({
     requestId: payload.requestId,
     clearScore: score,
     patternId,
     accepted,
-    payload: payload.payload
+    payload: normalizedPayload
   });
+  //audit assumption: audit record creation is deterministic from inputs
+  //audit failure risk: record creation could fail silently
+  //audit expected invariant: record includes requestId and score
+  //audit handling strategy: rely on createAuditRecord to throw on failure
 
   registerAuditRecord(record);
+  //audit assumption: record registration is idempotent per record id
+  //audit failure risk: partial state if registration fails
+  //audit expected invariant: record stored in reinforcement window
+  //audit handling strategy: allow error propagation to caller
 
   aiLogger.info('CLEAR feedback processed', {
     operation: 'audit:process',
@@ -51,21 +153,7 @@ export async function processClearFeedback(payload: ClearFeedbackPayload): Promi
     accepted
   });
 
-  let delivered = false;
-  let deliveryMessage: string | undefined;
-
-  try {
-    const delivery = await sendClearFeedback(payload);
-    delivered = delivery.delivered;
-    deliveryMessage = delivery.message;
-  } catch (error) {
-    delivered = false;
-    deliveryMessage = error instanceof Error ? error.message : 'Unknown transport error';
-    aiLogger.warn('Failed to deliver CLEAR feedback to external service', {
-      operation: 'audit:transport',
-      traceId: record.id
-    }, error instanceof Error ? error : undefined);
-  }
+  const { delivered, deliveryMessage } = await attemptClearFeedbackDelivery(payload, sendClearFeedback);
 
   return {
     accepted,

--- a/src/services/clearClient.ts
+++ b/src/services/clearClient.ts
@@ -14,15 +14,33 @@ function resolveEndpoint(): string | undefined {
   for (const key of CLEAR_ENDPOINT_ENV_KEYS) {
     const value = process.env[key];
     if (typeof value === 'string' && value.trim().length > 0) {
+      //audit assumption: the first configured endpoint should be used
+      //audit failure risk: misconfigured endpoints may be ignored
+      //audit expected invariant: returns first non-empty endpoint
+      //audit handling strategy: trim and return the first match
       return value.trim();
     }
   }
+  //audit assumption: no endpoint is configured
+  //audit failure risk: delivery is skipped without operator awareness
+  //audit expected invariant: undefined indicates no endpoint
+  //audit handling strategy: return undefined and log caller decision
   return undefined;
 }
 
+/**
+ * Send CLEAR audit feedback to the configured external endpoint.
+ * Inputs: validated ClearFeedbackPayload.
+ * Outputs: delivery metadata including status and response body.
+ * Edge cases: missing endpoints or network failures return delivered=false.
+ */
 export async function sendClearFeedback(payload: ClearFeedbackPayload): Promise<ClearDeliveryResult> {
   const endpoint = resolveEndpoint();
   if (!endpoint) {
+    //audit assumption: outbound delivery is optional and can be skipped
+    //audit failure risk: missing endpoint might hide operational misconfiguration
+    //audit expected invariant: no endpoint means no delivery attempt
+    //audit handling strategy: log debug and return nondelivery result
     aiLogger.debug('CLEAR endpoint not configured, skipping delivery', {
       operation: 'clearClient:deliver'
     });
@@ -45,11 +63,19 @@ export async function sendClearFeedback(payload: ClearFeedbackPayload): Promise<
       try {
         parsed = JSON.parse(text);
       } catch {
+        //audit assumption: non-JSON response is still valuable for diagnostics
+        //audit failure risk: non-JSON payload could be misinterpreted
+        //audit expected invariant: parsed contains either JSON or raw text
+        //audit handling strategy: store raw text when JSON parsing fails
         parsed = text;
       }
     }
 
     if (!response.ok) {
+      //audit assumption: non-2xx responses indicate delivery failure
+      //audit failure risk: upstream endpoint rejects payload silently
+      //audit expected invariant: response.ok reflects delivery success
+      //audit handling strategy: log warning and return failure metadata
       aiLogger.warn('CLEAR endpoint returned non-success status', {
         operation: 'clearClient:deliver',
         status: response.status,
@@ -77,6 +103,10 @@ export async function sendClearFeedback(payload: ClearFeedbackPayload): Promise<
       response: parsed
     };
   } catch (error) {
+    //audit assumption: fetch can throw on network or runtime errors
+    //audit failure risk: delivery exceptions could go unnoticed
+    //audit expected invariant: errors are logged with endpoint context
+    //audit handling strategy: log warning and return failure metadata
     aiLogger.warn('Failed to deliver CLEAR feedback', {
       operation: 'clearClient:deliver',
       endpoint


### PR DESCRIPTION
### Motivation
- Ensure CLEAR feedback is validated and normalized before recording to avoid storing malformed audit data.
- Isolate delivery/transport logic from audit state mutation to make failures observable and avoid partial commits.
- Improve observability and auditability by adding structured errors, docstrings, and `//audit` annotations at decision points.

### Description
- Add `ClearAuditValidationError` and a typed `validateClearPayload` that returns normalized `{ score, patternId, payload }` and throws structured validation errors for bad inputs. 
- Introduce `attemptClearFeedbackDelivery` to isolate `sendClearFeedback` calls and centralize delivery error handling and logging. 
- Update `processClearFeedback` to use the normalized payload, create/register the audit record deterministically, and call the isolated delivery helper. 
- Add docstrings and `//audit` comments in `src/services/clearClient.ts` for `resolveEndpoint` and `sendClearFeedback` to clarify assumptions, failure risks, invariants, and handling strategies. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967f9a097108325991e9756b73e4569)