### PR TITLE
Refactor AI reflections: extract templates and env parsers

### DIFF
--- a/src/config/aiReflectionTemplates.ts
+++ b/src/config/aiReflectionTemplates.ts
@@ -1,0 +1,89 @@
+export const AI_REFLECTION_DEFAULT_SYSTEM_PROMPT =
+  'You are the ARCANOS self-reflection engine. Provide concise, actionable improvement notes that help engineers iterate on the system.';
+
+const AI_REFLECTION_PROMPT_TEMPLATE = `Generate a system improvement reflection for an AI system.
+Priority level: {priority}
+Category: {category}
+Memory mode: {memoryMode}
+
+Please provide:
+1. A brief analysis of current system state
+2. Specific improvement recommendations
+3. Implementation suggestions
+
+Keep the response concise and actionable.`;
+
+const AI_REFLECTION_PATCH_TEMPLATE = `Automated system improvement patch ({priority} priority)
+
+Category: {category}
+Memory mode: {memoryMode}
+Generated: {generatedAt}
+
+This patch represents an automated improvement to the ARCANOS system.
+The changes are designed to enhance system performance and reliability.`;
+
+const AI_REFLECTION_FALLBACK_PATCH_TEMPLATE = `Fallback system improvement patch
+
+Generated due to AI service unavailability.
+Priority: {priority}
+Category: {category}
+Memory mode: {memoryMode}
+Timestamp: {generatedAt}
+
+This is a minimal fallback improvement patch that maintains system functionality
+while providing basic enhancement capabilities.`;
+
+/**
+ * Build the AI reflection prompt string.
+ * Inputs: priority/category/memoryMode values.
+ * Outputs: formatted prompt string for OpenAI.
+ * Edge cases: assumes inputs are safe string values.
+ */
+export const buildReflectionPrompt = (params: {
+  priority: string;
+  category: string;
+  memoryMode: string;
+}): string => {
+  return AI_REFLECTION_PROMPT_TEMPLATE
+    .replace('{priority}', params.priority)
+    .replace('{category}', params.category)
+    .replace('{memoryMode}', params.memoryMode);
+};
+
+/**
+ * Build the default patch content when AI output is missing.
+ * Inputs: priority/category/memoryMode/generatedAt values.
+ * Outputs: formatted patch content string.
+ * Edge cases: assumes inputs are safe string values.
+ */
+export const buildDefaultPatchContent = (params: {
+  priority: string;
+  category: string;
+  memoryMode: string;
+  generatedAt: string;
+}): string => {
+  return AI_REFLECTION_PATCH_TEMPLATE
+    .replace('{priority}', params.priority)
+    .replace('{category}', params.category)
+    .replace('{memoryMode}', params.memoryMode)
+    .replace('{generatedAt}', params.generatedAt);
+};
+
+/**
+ * Build the fallback patch content when AI calls fail.
+ * Inputs: priority/category/memoryMode/generatedAt values.
+ * Outputs: formatted fallback patch string.
+ * Edge cases: assumes inputs are safe string values.
+ */
+export const buildFallbackPatchContent = (params: {
+  priority: string;
+  category: string;
+  memoryMode: string;
+  generatedAt: string;
+}): string => {
+  return AI_REFLECTION_FALLBACK_PATCH_TEMPLATE
+    .replace('{priority}', params.priority)
+    .replace('{category}', params.category)
+    .replace('{memoryMode}', params.memoryMode)
+    .replace('{generatedAt}', params.generatedAt);
+};

--- a/src/utils/envParsers.ts
+++ b/src/utils/envParsers.ts
@@ -1,0 +1,45 @@
+/**
+ * Parse an integer from an environment variable string.
+ * Inputs: raw string value, fallback number.
+ * Outputs: parsed integer or fallback when invalid.
+ * Edge cases: undefined, empty, or non-numeric values fall back.
+ */
+export const parseEnvInt = (value: string | undefined, fallback: number): number => {
+  //audit Assumption: undefined or empty input means "use fallback"; risk: unintended default; invariant: return a number; handling: guard and return fallback.
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  //audit Assumption: non-numeric input should not throw; risk: NaN propagation; invariant: numeric output; handling: fallback on NaN.
+  return Number.isNaN(parsed) ? fallback : parsed;
+};
+
+/**
+ * Parse a float from an environment variable string.
+ * Inputs: raw string value, fallback number.
+ * Outputs: parsed float or fallback when invalid.
+ * Edge cases: undefined, empty, or non-numeric values fall back.
+ */
+export const parseEnvFloat = (value: string | undefined, fallback: number): number => {
+  //audit Assumption: undefined or empty input means "use fallback"; risk: unintended default; invariant: return a number; handling: guard and return fallback.
+  if (!value) return fallback;
+  const parsed = Number.parseFloat(value);
+  //audit Assumption: non-numeric input should not throw; risk: NaN propagation; invariant: numeric output; handling: fallback on NaN.
+  return Number.isNaN(parsed) ? fallback : parsed;
+};
+
+/**
+ * Parse a boolean from an environment variable string.
+ * Inputs: raw string value, fallback boolean.
+ * Outputs: parsed boolean or fallback when value is unrecognized.
+ * Edge cases: undefined or unexpected strings fall back.
+ */
+export const parseEnvBoolean = (value: string | undefined, fallback: boolean): boolean => {
+  //audit Assumption: undefined means "use fallback"; risk: misconfig; invariant: boolean output; handling: guard and return fallback.
+  if (value === undefined) return fallback;
+  const normalized = value.trim().toLowerCase();
+  //audit Assumption: "false"/"0"/"off"/"no" are explicit false; risk: misread; invariant: boolean output; handling: explicit false mapping.
+  if (['false', '0', 'off', 'no'].includes(normalized)) return false;
+  //audit Assumption: "true"/"1"/"on"/"yes" are explicit true; risk: misread; invariant: boolean output; handling: explicit true mapping.
+  if (['true', '1', 'on', 'yes'].includes(normalized)) return true;
+  //audit Assumption: unknown values should not override fallback; risk: misconfig masked; invariant: boolean output; handling: return fallback.
+  return fallback;
+};


### PR DESCRIPTION
### Motivation

- Centralize large prompt and patch strings to improve reuse and simplify the AI reflections service. 
- Move environment parsing logic into a shared utility to avoid repeated parsing code and improve auditability. 
- Improve resilience and observability of the reflections flow by adding `//audit` annotations and clearer fallback handling. 

### Description

- Added `src/config/aiReflectionTemplates.ts` to house the reflection prompt, patch, and fallback templates plus builder helpers (`buildReflectionPrompt`, `buildDefaultPatchContent`, `buildFallbackPatchContent`).
- Added `src/utils/envParsers.ts` with `parseEnvInt`, `parseEnvFloat`, and `parseEnvBoolean` helpers and `//audit` comments for assumptions and fallback behavior.
- Updated `src/services/ai-reflections.ts` to use the new template builders and env parsers, to centralize system prompt configuration, and to add audit annotations around branching, persistence fallback, and error handling.
- Adjusted fallback metadata/timestamps and ensured persistence failures are non-blocking while still logging warnings.

### Testing

- Repository automated validation (TypeScript type checking) completed successfully in prior CI/analysis runs. 
- No new unit tests were added for these refactors. 
- Full test suite was not run locally as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69680fec0ca483259354f5ba07a7ba4d)