### PR TITLE
Add command log for CLEAR 2.0 inquiry

### DIFF
--- a/docs/command-log.md
+++ b/docs/command-log.md
@@ -1,0 +1,14 @@
+# Command Log (Ad Hoc)
+
+Commands executed to answer the Clear 2.0 question:
+
+- `ls`
+- `find .. -name AGENTS.md -print`
+- `rg -n "Clear 2\\.0|Clear 2" -S .`
+- `rg -n "Clear" -S docs README.md src`
+- `rg -n "CLEAR" -S docs src README.md`
+- `sed -n '1,240p' docs/resiliency-patches-and-clear.md`
+- `sed -n '240,520p' docs/resiliency-patches-and-clear.md`
+- `sed -n '1,220p' docs/api/CONTEXTUAL_REINFORCEMENT.md`
+- `sed -n '1,200p' docs/clear-2.0-domain-generalization.md`
+- `sed -n '1,200p' AUDIT_LOG.md`


### PR DESCRIPTION
### Motivation
- Add a small ad-hoc command log to record shell commands used while researching and answering questions about `CLEAR 2.0`, improving traceability and reproducibility.

### Description
- Add `docs/command-log.md` which lists the executed commands (e.g., `ls`, `rg`, `sed`) used to locate and extract CLEAR 2.0 documentation.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69688df03d208325931d369962e47159)