### PR TITLE
Add CLEAR scorecard normalization, scale-aware gating, and operational guide

### DIFF
--- a/docs/clear-2.0-operational-guide.md
+++ b/docs/clear-2.0-operational-guide.md
@@ -1,0 +1,119 @@
+# CLEAR 2.0 Operational Guide
+
+This guide explains how CLEAR 2.0 works inside ARCANOS, how scores are evaluated and normalized, and how to integrate scorecards into audit payloads. It also documents the improvements added to support repeatable CLEAR audits and codebase hygiene.
+
+## 1. CLEAR 2.0 Overview
+
+CLEAR 2.0 evaluates orchestration assets across five principles:
+
+- **Clarity** — Trace inputs, decisions, and outputs with metadata.
+- **Leverage** — Reuse shared modules instead of duplicating logic.
+- **Efficiency** — Meet latency, cost, and resource targets.
+- **Alignment** — Ensure decisions match policy and intent.
+- **Resilience** — Validate fallback and recovery paths.
+
+Scores are computed on a 0–10 scale, weighted, and combined into a composite score. Composite thresholds gate deployments and patch activations.
+
+## 2. Scorecard Computation
+
+The CLEAR scorecard uses the default weights below:
+
+| Principle | Weight |
+|-----------|--------|
+| Clarity | 0.25 |
+| Leverage | 0.15 |
+| Efficiency | 0.20 |
+| Alignment | 0.20 |
+| Resilience | 0.20 |
+
+The composite score is calculated as the weighted sum of the five principle scores. Thresholds classify the composite score into a status label:
+
+| Status | Threshold |
+|--------|-----------|
+| Green | ≥ 8.0 |
+| Yellow | ≥ 6.0 and < 8.0 |
+| Red | < 6.0 |
+
+The runtime scorecard helper (`src/services/clearScorecard.ts`) computes the composite score, applies normalized weights, and returns a status label for auditing and reporting.
+
+## 3. CLEAR Audit Payload Schema
+
+The `/audit` endpoint accepts payloads in one of two shapes:
+
+1. **Composite-only** (backward compatible):
+
+```json
+{
+  "system": "CLEAR",
+  "requestId": "req_123",
+  "payload": {
+    "CLEAR_score": 8.7,
+    "pattern_id": "semantic-guardrail@3.2.0",
+    "score_scale": "0-10"
+  }
+}
+```
+
+2. **Scorecard-first** (preferred):
+
+```json
+{
+  "system": "CLEAR",
+  "requestId": "req_123",
+  "payload": {
+    "scores": {
+      "clarity": 8.5,
+      "leverage": 7.2,
+      "efficiency": 8.1,
+      "alignment": 9.0,
+      "resilience": 8.9
+    },
+    "asset": "workflow:narrative-response",
+    "revision": "1.18.4",
+    "recommendations": [
+      "Refactor duplicate summarization logic",
+      "Add latency probes to failover worker"
+    ]
+  }
+}
+```
+
+If `scores` are supplied, ARCANOS computes the composite score and stores a `clear_scorecard` summary on the audit record payload. If a `CLEAR_score` is also provided, it is used directly to preserve upstream authority.
+
+## 4. Score Scale Normalization
+
+CLEAR score payloads may use a 0–10 or 0–1 scale. The audit service normalizes the score before comparing it to `ARCANOS_CLEAR_MIN_SCORE`:
+
+- If the configured minimum is ≤ 1, scores are normalized to 0–1.
+- If the configured minimum is > 1, scores are normalized to 0–10.
+- A payload can include `score_scale` (`"0-1"` or `"0-10"`) to override heuristic detection.
+
+The audit record stores:
+
+- `clearScore` (raw score)
+- `normalizedClearScore` (score aligned to the configured minimum scale)
+- `scoreScale` (declared or inferred scale)
+
+## 5. Audit Records and Contextual Reinforcement
+
+Each CLEAR audit is recorded in the reinforcement window with:
+
+- A summary string including raw score, scale, normalized score, and acceptance result.
+- Metadata fields containing `scoreScale` and `normalizedClearScore`.
+
+This ensures audit summaries remain interpretable even when upstream payloads use different scoring scales.
+
+## 6. Recommendations Implemented
+
+The following improvements were added to align the codebase with the documented CLEAR recommendations:
+
+1. **Scorecard Normalization & Validation** — A dedicated scorecard module now normalizes weights, validates scores, computes composite scores, and labels status. (`src/services/clearScorecard.ts`)
+2. **Payload Flexibility** — The audit endpoint now accepts either composite scores or full scorecards. (`src/services/audit.ts`)
+3. **Scale-aware Gating** — Acceptance gating normalizes scores to match the configured threshold scale. (`src/services/audit.ts`)
+4. **Richer Audit Summaries** — Audit records now capture raw and normalized scores with explicit scale metadata. (`src/services/contextualReinforcement.ts`)
+
+## 7. Minimal Test Plan
+
+- **Happy path**: submit a scorecard payload with all five principles and verify `clear_scorecard` is stored and accepted when above threshold.
+- **Edge cases**: submit a payload with `CLEAR_score` in 0–1 scale and verify normalization against the configured minimum.
+- **Failure modes**: submit a payload missing both `CLEAR_score` and `scores` and verify the endpoint returns a validation error.

--- a/src/services/clearScorecard.ts
+++ b/src/services/clearScorecard.ts
@@ -1,0 +1,208 @@
+export type ClearScorecardStatus = 'green' | 'yellow' | 'red';
+
+export interface ClearPrincipleScores {
+  clarity: number;
+  leverage: number;
+  efficiency: number;
+  alignment: number;
+  resilience: number;
+}
+
+export interface ClearScorecardWeights {
+  clarity: number;
+  leverage: number;
+  efficiency: number;
+  alignment: number;
+  resilience: number;
+}
+
+export interface ClearScorecardThresholds {
+  greenMinimum: number;
+  yellowMinimum: number;
+}
+
+export interface ClearScorecardSummary {
+  scores: ClearPrincipleScores;
+  weights: ClearScorecardWeights;
+  compositeScore: number;
+  status: ClearScorecardStatus;
+}
+
+const DEFAULT_CLEAR_SCORECARD_WEIGHTS: ClearScorecardWeights = {
+  clarity: 0.25,
+  leverage: 0.15,
+  efficiency: 0.2,
+  alignment: 0.2,
+  resilience: 0.2
+};
+
+const DEFAULT_CLEAR_SCORECARD_THRESHOLDS: ClearScorecardThresholds = {
+  greenMinimum: 8,
+  yellowMinimum: 6
+};
+
+const CLEAR_PRINCIPLE_KEYS: Array<keyof ClearPrincipleScores> = [
+  'clarity',
+  'leverage',
+  'efficiency',
+  'alignment',
+  'resilience'
+];
+
+/**
+ * Normalize scorecard weights so they sum to 1.
+ * Inputs: weight map to normalize.
+ * Outputs: normalized weight map.
+ * Edge cases: throws if weights sum to 0 or contain non-finite values.
+ */
+export function normalizeClearWeights(weights: ClearScorecardWeights = DEFAULT_CLEAR_SCORECARD_WEIGHTS): ClearScorecardWeights {
+  const entries = CLEAR_PRINCIPLE_KEYS.map(key => [key, weights[key]] as const);
+  const totalWeight = entries.reduce((sum, [, value]) => sum + value, 0);
+
+  if (!Number.isFinite(totalWeight) || totalWeight <= 0) {
+    //audit assumption: weights sum must be positive
+    //audit failure risk: division by zero or invalid composite scores
+    //audit expected invariant: totalWeight is finite and > 0
+    //audit handling strategy: throw with diagnostic context
+    throw new Error('CLEAR scorecard weights must sum to a positive number');
+  }
+
+  const normalizedWeights = {} as ClearScorecardWeights;
+  for (const [key, value] of entries) {
+    if (!Number.isFinite(value)) {
+      //audit assumption: each weight is finite
+      //audit failure risk: NaN propagating into composite score
+      //audit expected invariant: weight is finite
+      //audit handling strategy: throw with diagnostic context
+      throw new Error(`CLEAR scorecard weight for ${key} must be a finite number`);
+    }
+    normalizedWeights[key] = value / totalWeight;
+  }
+
+  return normalizedWeights;
+}
+
+/**
+ * Compute the CLEAR composite score using weighted principle scores.
+ * Inputs: principle scores (0-10) and optional weights.
+ * Outputs: composite score on a 0-10 scale.
+ * Edge cases: throws if scores are missing or non-finite.
+ */
+export function computeClearCompositeScore(
+  scores: ClearPrincipleScores,
+  weights: ClearScorecardWeights = DEFAULT_CLEAR_SCORECARD_WEIGHTS
+): number {
+  const normalizedWeights = normalizeClearWeights(weights);
+
+  let compositeTotal = 0;
+  for (const key of CLEAR_PRINCIPLE_KEYS) {
+    const scoreValue = scores[key];
+    if (!Number.isFinite(scoreValue)) {
+      //audit assumption: each score is numeric
+      //audit failure risk: invalid composite score output
+      //audit expected invariant: scoreValue is finite
+      //audit handling strategy: throw with diagnostic context
+      throw new Error(`CLEAR score for ${key} must be a finite number`);
+    }
+    compositeTotal += scoreValue * normalizedWeights[key];
+  }
+
+  return compositeTotal;
+}
+
+/**
+ * Evaluate CLEAR status based on composite score thresholds.
+ * Inputs: composite score (0-10) and optional thresholds.
+ * Outputs: status label (green/yellow/red).
+ * Edge cases: throws if thresholds are not finite.
+ */
+export function evaluateClearStatus(
+  compositeScore: number,
+  thresholds: ClearScorecardThresholds = DEFAULT_CLEAR_SCORECARD_THRESHOLDS
+): ClearScorecardStatus {
+  if (!Number.isFinite(thresholds.greenMinimum) || !Number.isFinite(thresholds.yellowMinimum)) {
+    //audit assumption: thresholds are numeric
+    //audit failure risk: incorrect status classification
+    //audit expected invariant: thresholds are finite numbers
+    //audit handling strategy: throw with diagnostic context
+    throw new Error('CLEAR scorecard thresholds must be finite numbers');
+  }
+
+  if (compositeScore >= thresholds.greenMinimum) {
+    //audit assumption: composite score above greenMinimum is healthy
+    //audit failure risk: misclassification if thresholds are misconfigured
+    //audit expected invariant: green scores are >= greenMinimum
+    //audit handling strategy: return green when threshold met
+    return 'green';
+  }
+
+  if (compositeScore >= thresholds.yellowMinimum) {
+    //audit assumption: composite score between thresholds is remediation state
+    //audit failure risk: false positive on remediation
+    //audit expected invariant: yellow scores fall between yellowMinimum and greenMinimum
+    //audit handling strategy: return yellow when threshold met
+    return 'yellow';
+  }
+
+  //audit assumption: composite score below yellowMinimum is blocking
+  //audit failure risk: permitting unsafe deployments
+  //audit expected invariant: red scores are below yellowMinimum
+  //audit handling strategy: return red for low scores
+  return 'red';
+}
+
+/**
+ * Build a full CLEAR scorecard summary from principle scores.
+ * Inputs: principle scores and optional weights/thresholds.
+ * Outputs: summary with composite score, status, and weights used.
+ * Edge cases: throws if scores or thresholds are invalid.
+ */
+export function buildClearScorecardSummary(
+  scores: ClearPrincipleScores,
+  weights: ClearScorecardWeights = DEFAULT_CLEAR_SCORECARD_WEIGHTS,
+  thresholds: ClearScorecardThresholds = DEFAULT_CLEAR_SCORECARD_THRESHOLDS
+): ClearScorecardSummary {
+  const normalizedWeights = normalizeClearWeights(weights);
+  const compositeScore = computeClearCompositeScore(scores, normalizedWeights);
+  const status = evaluateClearStatus(compositeScore, thresholds);
+
+  return {
+    scores,
+    weights: normalizedWeights,
+    compositeScore,
+    status
+  };
+}
+
+/**
+ * Safely parse and validate CLEAR principle scores from untyped input.
+ * Inputs: unknown value that should contain principle scores.
+ * Outputs: typed scores or null if validation fails.
+ * Edge cases: returns null when required keys are missing.
+ */
+export function parseClearPrincipleScores(input: unknown): ClearPrincipleScores | null {
+  if (input == null || typeof input !== 'object') {
+    //audit assumption: input must be an object
+    //audit failure risk: missing scorecard detail
+    //audit expected invariant: input is an object
+    //audit handling strategy: return null for invalid input
+    return null;
+  }
+
+  const candidate = input as Record<string, unknown>;
+  const scores: Partial<ClearPrincipleScores> = {};
+
+  for (const key of CLEAR_PRINCIPLE_KEYS) {
+    const value = candidate[key];
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+      //audit assumption: each principle score is numeric
+      //audit failure risk: incomplete scorecard scoring
+      //audit expected invariant: each score is number
+      //audit handling strategy: return null to force fallback
+      return null;
+    }
+    scores[key] = value;
+  }
+
+  return scores as ClearPrincipleScores;
+}

--- a/src/types/reinforcement.ts
+++ b/src/types/reinforcement.ts
@@ -1,4 +1,5 @@
 export type ReinforcementMode = 'off' | 'reinforcement';
+export type ClearScoreScale = '0-1' | '0-10';
 
 export interface ReinforcementConfig {
   mode: ReinforcementMode;
@@ -35,7 +36,18 @@ export interface ClearFeedbackPayload {
   system: string;
   requestId: string;
   payload: {
-    CLEAR_score: number;
+    CLEAR_score?: number;
+    scores?: {
+      clarity: number;
+      leverage: number;
+      efficiency: number;
+      alignment: number;
+      resilience: number;
+    };
+    asset?: string;
+    revision?: string;
+    recommendations?: string[];
+    score_scale?: ClearScoreScale;
     pattern_id?: string;
     [key: string]: unknown;
   };
@@ -46,6 +58,8 @@ export interface AuditRecord {
   requestId: string;
   timestamp: number;
   clearScore: number;
+  normalizedClearScore: number;
+  scoreScale: ClearScoreScale;
   patternId?: string;
   accepted: boolean;
   payload: Record<string, unknown>;


### PR DESCRIPTION
### Motivation
- Support richer CLEAR audit payloads including detailed per-principle scorecards and keep backward compatibility with single `CLEAR_score` values.
- Normalize scores across 0–1 and 0–10 scales so acceptance gating against `ARCANOS_CLEAR_MIN_SCORE` is robust regardless of upstream format.
- Surface normalized score metadata in reinforcement/audit summaries so contextual prompts and audit history remain interpretable.
- Document how CLEAR 2.0 works and provide a minimal test plan for operators and integrators.

### Description
- Added a new scorecard utility `src/services/clearScorecard.ts` with `normalizeClearWeights`, `computeClearCompositeScore`, `evaluateClearStatus`, `buildClearScorecardSummary`, and `parseClearPrincipleScores` to compute, validate, and summarize CLEAR scorecards.
- Extended types in `src/types/reinforcement.ts` to add `ClearScoreScale`, optional `scores` and `score_scale` in `ClearFeedbackPayload`, and to store `normalizedClearScore` and `scoreScale` in `AuditRecord`.
- Updated `src/services/audit.ts` to accept either a composite `CLEAR_score` or a `scores` scorecard, to compute a composite when needed (`buildClearScorecardSummary`), to infer or honor `score_scale` (`resolveClearScoreScale`), and to normalize scores to the configured threshold scale (`normalizeClearScoreForThreshold`) before acceptance gating.
- Enhanced `src/services/contextualReinforcement.ts` to persist and display `scoreScale` and `normalizedClearScore` in audit summaries and reinforcement entries, and added guarding/logging `//audit` comments for key branches.
- Added documentation `docs/clear-2.0-operational-guide.md` describing CLEAR 2.0 principles, payload shapes, scale normalization rules, and a minimal test plan.

### Testing
- Automated tests were not executed as part of this change (`no automated tests run`).
- A minimal test plan was added to `docs/clear-2.0-operational-guide.md` covering the happy path, scale edge cases, and validation failure modes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696892da1c48832582ab7785f0a6953a)