### PR TITLE
Enhance Trinity pipeline observability and add dry-run preview

### DIFF
--- a/src/logic/trinity.ts
+++ b/src/logic/trinity.ts
@@ -61,6 +61,14 @@ interface TrinityResult {
   gpt5Used?: boolean;
   gpt5Model?: string;
   gpt5Error?: string;
+  dryRun: boolean;
+  dryRunPreview?: TrinityDryRunPreview;
+  fallbackSummary: {
+    intakeFallbackUsed: boolean;
+    gpt5FallbackUsed: boolean;
+    finalFallbackUsed: boolean;
+    fallbackReasons: string[];
+  };
   auditSafe: {
     mode: boolean;
     overrideUsed: boolean;
@@ -72,11 +80,55 @@ interface TrinityResult {
     entriesAccessed: number;
     contextSummary: string;
     memoryEnhanced: boolean;
+    maxRelevanceScore: number;
+    averageRelevanceScore: number;
   };
   taskLineage: {
     requestId: string;
     logged: boolean;
   };
+}
+
+interface TrinityRunOptions {
+  dryRun?: boolean;
+  dryRunReason?: string;
+}
+
+interface TrinityDryRunPreview {
+  requestId: string;
+  intakeModelCandidate: string;
+  finalModelCandidate: string;
+  gpt5ModelCandidate: string;
+  routingPlan: string[];
+  auditSafeMode: boolean;
+  memoryEntryCount: number;
+  auditFlags: string[];
+  notes: string[];
+}
+
+interface TrinityIntakeOutput {
+  framedRequest: string;
+  activeModel: string;
+  fallbackUsed: boolean;
+  usage?: TrinityResult['meta']['tokens'];
+  responseId?: string;
+  created?: number;
+}
+
+interface TrinityReasoningOutput {
+  output: string;
+  model: string;
+  fallbackUsed: boolean;
+  error?: string;
+}
+
+interface TrinityFinalOutput {
+  output: string;
+  activeModel: string;
+  fallbackUsed: boolean;
+  usage?: TrinityResult['meta']['tokens'];
+  responseId?: string;
+  created?: number;
 }
 
 /**
@@ -90,7 +142,7 @@ interface TrinityResult {
 const validateModel = async (client: OpenAI): Promise<string> => {
   const defaultModel = getDefaultModel();
   try {
-    const modelToCheck = defaultModel.startsWith('ft:') ? defaultModel : defaultModel;
+    const modelToCheck = defaultModel;
     await client.models.retrieve(modelToCheck);
     logger.info('Fine-tuned model validation successful', { 
       module: 'trinity',
@@ -100,6 +152,7 @@ const validateModel = async (client: OpenAI): Promise<string> => {
     });
     return defaultModel;
   } catch (err) {
+    //audit Assumption: model fetch can fail transiently; Failure risk: default model unavailable; Expected invariant: fallback model is usable; Handling: log and switch to GPT-4.
     logger.warn('Model unavailable, falling back to GPT-4', {
       module: 'trinity',
       operation: 'model-fallback',
@@ -110,6 +163,18 @@ const validateModel = async (client: OpenAI): Promise<string> => {
     return APPLICATION_CONSTANTS.MODEL_GPT_4;
   }
 };
+
+function calculateMemoryScoreSummary(relevanceScores: number[]): { maxScore: number; averageScore: number } {
+  //audit Assumption: relevanceScores may be empty; Failure risk: divide-by-zero; Expected invariant: averageScore is finite; Handling: default to 0.
+  if (relevanceScores.length === 0) {
+    return { maxScore: 0, averageScore: 0 };
+  }
+
+  const maxScore = Math.max(...relevanceScores);
+  const totalScore = relevanceScores.reduce((sum, value) => sum + value, 0);
+  const averageScore = totalScore / relevanceScores.length;
+  return { maxScore, averageScore };
+}
 
 function buildFinalArcanosMessages(
   memoryContextSummary: string,
@@ -122,6 +187,184 @@ function buildFinalArcanosMessages(
     { role: 'assistant', content: `GPT-5.2 analysis: ${gpt5Output}` },
     { role: 'user', content: 'Provide the final ARCANOS response.' }
   ];
+}
+
+function logFallbackEvent(stage: string, requestedModel: string, fallbackModel: string, reason: string) {
+  //audit Assumption: fallback is a controlled resiliency behavior; Failure risk: silent model swap; Expected invariant: fallback logs remain auditable; Handling: structured warning log.
+  logger.warn('Trinity fallback invoked', {
+    module: 'trinity',
+    operation: 'model-fallback',
+    stage,
+    requestedModel,
+    fallbackModel,
+    reason
+  });
+}
+
+async function runIntakeStage(
+  client: OpenAI,
+  arcanosModel: string,
+  auditSafePrompt: string,
+  memoryContextSummary: string
+): Promise<TrinityIntakeOutput> {
+  const intakeSystemPrompt = ARCANOS_SYSTEM_PROMPTS.INTAKE(memoryContextSummary);
+  const intakeTokenParams = getTokenParameter(arcanosModel, 500);
+  const intakeResponse = await createChatCompletionWithFallback(client, {
+    messages: [
+      { role: 'system', content: intakeSystemPrompt },
+      { role: 'user', content: auditSafePrompt }
+    ],
+    temperature: 0.2,
+    ...intakeTokenParams
+  });
+
+  const framedRequest = intakeResponse.choices[0]?.message?.content || auditSafePrompt;
+  const actualModel = intakeResponse.activeModel || arcanosModel;
+  const isFallback = intakeResponse.fallbackFlag || false;
+
+  //audit Assumption: intake response exists or fallback to audit-safe prompt; Failure risk: undefined output; Expected invariant: framedRequest is non-empty; Handling: default to auditSafePrompt.
+  if (isFallback) {
+    logFallbackEvent('ARCANOS-INTAKE', arcanosModel, actualModel, 'Fallback flag set by intake completion');
+  }
+
+  return {
+    framedRequest,
+    activeModel: actualModel,
+    fallbackUsed: isFallback,
+    usage: intakeResponse.usage || undefined,
+    responseId: intakeResponse.id,
+    created: intakeResponse.created
+  };
+}
+
+async function runReasoningStage(
+  client: OpenAI,
+  framedRequest: string
+): Promise<TrinityReasoningOutput> {
+  logGPT5Invocation('Primary reasoning stage', framedRequest);
+  const gpt5Result = await createGPT5Reasoning(client, framedRequest, ARCANOS_SYSTEM_PROMPTS.GPT5_REASONING());
+  const gpt5ModelUsed = gpt5Result.model || getGPT5Model();
+  const fallbackUsed = Boolean(gpt5Result.error);
+
+  //audit Assumption: GPT-5.2 may fail and return fallback text; Failure risk: degraded reasoning quality; Expected invariant: gpt5Result.content is non-empty; Handling: log fallback and mark.
+  if (fallbackUsed) {
+    logger.warn('GPT-5.2 reasoning fallback in Trinity pipeline', {
+      module: 'trinity',
+      operation: 'gpt5-reasoning',
+      error: gpt5Result.error
+    });
+  } else {
+    logger.info('GPT-5.2 reasoning confirmed', {
+      module: 'trinity',
+      operation: 'gpt5-reasoning',
+      model: gpt5ModelUsed
+    });
+  }
+
+  return {
+    output: gpt5Result.content,
+    model: gpt5ModelUsed,
+    fallbackUsed,
+    error: gpt5Result.error
+  };
+}
+
+async function runFinalStage(
+  client: OpenAI,
+  activeModel: string,
+  memoryContextSummary: string,
+  auditSafePrompt: string,
+  gpt5Output: string
+): Promise<TrinityFinalOutput> {
+  const finalTokenParams = getTokenParameter(activeModel, APPLICATION_CONSTANTS.DEFAULT_TOKEN_LIMIT);
+  const finalResponse = await createChatCompletionWithFallback(client, {
+    messages: buildFinalArcanosMessages(memoryContextSummary, auditSafePrompt, gpt5Output),
+    temperature: 0.2,
+    ...finalTokenParams
+  });
+  const finalText = finalResponse.choices[0]?.message?.content || '';
+  const finalModel = finalResponse.activeModel || activeModel;
+  const finalFallback = finalResponse.fallbackFlag || false;
+
+  //audit Assumption: final response may be empty on model failure; Failure risk: empty output; Expected invariant: finalText is string; Handling: default to empty string.
+  if (finalFallback) {
+    logFallbackEvent('ARCANOS-FINAL', activeModel, finalModel, 'Fallback flag set by final completion');
+  }
+
+  return {
+    output: finalText,
+    activeModel: finalModel,
+    fallbackUsed: finalFallback,
+    usage: finalResponse.usage || undefined,
+    responseId: finalResponse.id,
+    created: finalResponse.created
+  };
+}
+
+function buildDryRunPreview(
+  requestId: string,
+  prompt: string,
+  auditSafePrompt: string,
+  auditFlags: string[],
+  memoryEntryCount: number,
+  auditSafeMode: boolean,
+  dryRunReason?: string
+): TrinityDryRunPreview {
+  const intakeModelCandidate = getDefaultModel();
+  const finalModelCandidate = intakeModelCandidate;
+  const gpt5ModelCandidate = getGPT5Model();
+  const routingPlan = [
+    `ARCANOS-INTAKE:${intakeModelCandidate}`,
+    `GPT5-REASONING:${gpt5ModelCandidate}`,
+    `ARCANOS-FINAL:${finalModelCandidate}`
+  ];
+  //audit Assumption: dryRunReason may be undefined; Failure risk: unclear dry run intent; Expected invariant: notes always include a reason; Handling: supply a default message.
+  const dryRunNote = dryRunReason ? `Dry run reason: ${dryRunReason}.` : 'Dry run reason: not provided.';
+
+  //audit Assumption: dry run should avoid side effects; Failure risk: accidental model calls; Expected invariant: preview contains no model outputs; Handling: only include metadata.
+  return {
+    requestId,
+    intakeModelCandidate,
+    finalModelCandidate,
+    gpt5ModelCandidate,
+    routingPlan,
+    auditSafeMode,
+    memoryEntryCount,
+    auditFlags,
+    notes: [
+      `Dry run only: prompt length ${prompt.length}, audit-safe prompt length ${auditSafePrompt.length}.`,
+      dryRunNote
+    ]
+  };
+}
+
+function buildAuditLogEntry(
+  requestId: string,
+  prompt: string,
+  finalText: string,
+  auditConfig: ReturnType<typeof getAuditSafeConfig>,
+  memoryContext: ReturnType<typeof getMemoryContext>,
+  actualModel: string,
+  gpt5ModelUsed: string,
+  finalProcessedSafely: boolean,
+  auditFlags: string[]
+): AuditLogEntry {
+  //audit Assumption: audit log is mandatory for non-dry runs; Failure risk: missing lineage; Expected invariant: audit log entry has required fields; Handling: assemble with defaults.
+  return {
+    timestamp: new Date().toISOString(),
+    requestId,
+    endpoint: 'trinity_gpt5_universal',
+    auditSafeMode: auditConfig.auditSafeMode,
+    overrideUsed: !!auditConfig.explicitOverride,
+    overrideReason: auditConfig.overrideReason,
+    inputSummary: createAuditSummary(prompt),
+    outputSummary: createAuditSummary(finalText),
+    modelUsed: `${actualModel}+${gpt5ModelUsed}`,
+    gpt5Delegated: true,
+    memoryAccessed: memoryContext.accessLog,
+    processedSafely: finalProcessedSafely,
+    auditFlags
+  };
 }
 
 /**
@@ -143,13 +386,15 @@ function buildFinalArcanosMessages(
  * @param prompt - User input prompt to process
  * @param sessionId - Optional session identifier for context continuity
  * @param overrideFlag - Optional audit-safe override flag for special handling
+ * @param options - Optional execution options (e.g., dry run preview)
  * @returns Promise<TrinityResult> - Comprehensive result with AI response and metadata
  */
 export async function runThroughBrain(
   client: OpenAI,
   prompt: string,
   sessionId?: string,
-  overrideFlag?: string
+  overrideFlag?: string,
+  options: TrinityRunOptions = {}
 ): Promise<TrinityResult> {
   const requestId = generateRequestId('trinity');
 
@@ -157,10 +402,71 @@ export async function runThroughBrain(
   const gpt5Used = true; // GPT-5.2 is now unconditional
 
   const auditConfig = getAuditSafeConfig(prompt, overrideFlag);
+  //audit Assumption: audit-safe mode can be toggled; Failure risk: incorrect mode reporting; Expected invariant: log reflects current mode; Handling: log boolean state.
   console.log(`[🔒 TRINITY AUDIT-SAFE] Mode: ${auditConfig.auditSafeMode ? 'ENABLED' : 'DISABLED'}`);
 
   const memoryContext = getMemoryContext(prompt, sessionId);
   console.log(`[🧠 TRINITY MEMORY] Retrieved ${memoryContext.relevantEntries.length} relevant entries`);
+
+  //audit Assumption: relevanceScore may be undefined; Failure risk: NaN in averages; Expected invariant: scores are numeric; Handling: default missing scores to 0.
+  const relevanceScores = memoryContext.relevantEntries.map(entry => entry.relevanceScore ?? 0);
+  const memoryScoreSummary = calculateMemoryScoreSummary(relevanceScores);
+
+  //audit Assumption: dry run should short-circuit before model calls; Failure risk: unintended API usage; Expected invariant: no model invocations during dry run; Handling: return preview response.
+  if (options.dryRun) {
+    const { userPrompt: auditSafePrompt, auditFlags } = applyAuditSafeConstraints('', prompt, auditConfig);
+    const dryRunPreview = buildDryRunPreview(
+      requestId,
+      prompt,
+      auditSafePrompt,
+      auditFlags,
+      memoryContext.relevantEntries.length,
+      auditConfig.auditSafeMode,
+      options.dryRunReason
+    );
+
+    return {
+      result: '[Dry run] Trinity pipeline preview generated.',
+      module: 'dry_run',
+      activeModel: 'dry_run',
+      fallbackFlag: false,
+      routingStages: dryRunPreview.routingPlan,
+      gpt5Used,
+      gpt5Model: dryRunPreview.gpt5ModelCandidate,
+      dryRun: true,
+      dryRunPreview,
+      fallbackSummary: {
+        intakeFallbackUsed: false,
+        gpt5FallbackUsed: false,
+        finalFallbackUsed: false,
+        fallbackReasons: ['Dry run: no model invocation']
+      },
+      auditSafe: {
+        mode: auditConfig.auditSafeMode,
+        overrideUsed: !!auditConfig.explicitOverride,
+        overrideReason: auditConfig.overrideReason,
+        auditFlags,
+        processedSafely: true
+      },
+      memoryContext: {
+        entriesAccessed: memoryContext.relevantEntries.length,
+        contextSummary: memoryContext.contextSummary,
+        //audit Assumption: memory enhancement indicates any entries present; Failure risk: false positives; Expected invariant: true only when entries exist; Handling: compare length > 0.
+        memoryEnhanced: memoryContext.relevantEntries.length > 0,
+        maxRelevanceScore: memoryScoreSummary.maxScore,
+        averageRelevanceScore: memoryScoreSummary.averageScore
+      },
+      taskLineage: {
+        requestId,
+        logged: false
+      },
+      meta: {
+        tokens: undefined,
+        id: requestId,
+        created: Date.now()
+      }
+    };
+  }
 
   const arcanosModel = await validateModel(client);
   logArcanosRouting('INTAKE', arcanosModel, `Input length: ${prompt.length}, Memory entries: ${memoryContext.relevantEntries.length}, AuditSafe: ${auditConfig.auditSafeMode}`);
@@ -170,57 +476,30 @@ export async function runThroughBrain(
   const { userPrompt: auditSafePrompt, auditFlags } = applyAuditSafeConstraints('', prompt, auditConfig);
 
   // ARCANOS intake prepares framed request for GPT-5.2
-  const intakeSystemPrompt = ARCANOS_SYSTEM_PROMPTS.INTAKE(memoryContext.contextSummary);
-  const intakeTokenParams = getTokenParameter(arcanosModel, 500);
-  const intakeResponse = await createChatCompletionWithFallback(client, {
-    messages: [
-      { role: 'system', content: intakeSystemPrompt },
-      { role: 'user', content: auditSafePrompt }
-    ],
-    temperature: 0.2,
-    ...intakeTokenParams
-  });
-  const framedRequest = intakeResponse.choices[0]?.message?.content || auditSafePrompt;
-  const actualModel = intakeResponse.activeModel || arcanosModel;
-  const isFallback = intakeResponse.fallbackFlag || false;
+  const intakeOutput = await runIntakeStage(client, arcanosModel, auditSafePrompt, memoryContext.contextSummary);
+  const framedRequest = intakeOutput.framedRequest;
+  const actualModel = intakeOutput.activeModel;
 
   // GPT-5.2 reasoning stage (always invoked)
-  logGPT5Invocation('Primary reasoning stage', framedRequest);
   routingStages.push('GPT5-REASONING');
-  const gpt5Result = await createGPT5Reasoning(client, framedRequest, ARCANOS_SYSTEM_PROMPTS.GPT5_REASONING());
-  const gpt5Output = gpt5Result.content;
-  const gpt5ModelUsed = gpt5Result.model || getGPT5Model();
-  if (gpt5Result.error) {
-    logger.warn('GPT-5.2 reasoning fallback in Trinity pipeline', {
-      module: 'trinity',
-      operation: 'gpt5-reasoning',
-      error: gpt5Result.error
-    });
-  } else {
-    logger.info('GPT-5.2 reasoning confirmed', {
-      module: 'trinity',
-      operation: 'gpt5-reasoning',
-      model: gpt5ModelUsed
-    });
-  }
+  const reasoningOutput = await runReasoningStage(client, framedRequest);
+  const gpt5Output = reasoningOutput.output;
+  const gpt5ModelUsed = reasoningOutput.model;
 
   // Final ARCANOS execution and filtering
   logArcanosRouting('FINAL_FILTERING', actualModel, 'Processing GPT-5.2 output through ARCANOS');
   routingStages.push('ARCANOS-FINAL');
-  const finalTokenParams = getTokenParameter(actualModel, APPLICATION_CONSTANTS.DEFAULT_TOKEN_LIMIT);
-  const finalResponse = await createChatCompletionWithFallback(client, {
-    messages: buildFinalArcanosMessages(memoryContext.contextSummary, auditSafePrompt, gpt5Output),
-    temperature: 0.2,
-    ...finalTokenParams
-  });
-  const finalText = finalResponse.choices[0]?.message?.content || '';
+  const finalOutput = await runFinalStage(client, actualModel, memoryContext.contextSummary, auditSafePrompt, gpt5Output);
+  const finalText = finalOutput.output;
 
   const finalProcessedSafely = validateAuditSafeOutput(finalText, auditConfig);
+  //audit Assumption: output must pass audit safe checks; Failure risk: unsafe output; Expected invariant: auditFlags records failure; Handling: append flag when validation fails.
   if (!finalProcessedSafely) {
     auditFlags.push('FINAL_OUTPUT_VALIDATION_FAILED');
   }
 
-  if (finalProcessedSafely && !isFallback) {
+  //audit Assumption: pattern storage should avoid fallback outputs; Failure risk: storing low-quality patterns; Expected invariant: store only safe, non-fallback outputs; Handling: gate on flags.
+  if (finalProcessedSafely && !intakeOutput.fallbackUsed && !finalOutput.fallbackUsed) {
     storePattern(
       'Successful Trinity pipeline',
       [
@@ -234,32 +513,42 @@ export async function runThroughBrain(
 
   logRoutingSummary(arcanosModel, true, 'ARCANOS-FINAL');
 
-  const auditLogEntry: AuditLogEntry = {
-    timestamp: new Date().toISOString(),
+  const auditLogEntry = buildAuditLogEntry(
     requestId,
-    endpoint: 'trinity_gpt5_universal',
-    auditSafeMode: auditConfig.auditSafeMode,
-    overrideUsed: !!auditConfig.explicitOverride,
-    overrideReason: auditConfig.overrideReason,
-    inputSummary: createAuditSummary(prompt),
-    outputSummary: createAuditSummary(finalText),
-    modelUsed: `${actualModel}+${gpt5ModelUsed}`,
-    gpt5Delegated: true,
-    memoryAccessed: memoryContext.accessLog,
-    processedSafely: finalProcessedSafely,
+    prompt,
+    finalText,
+    auditConfig,
+    memoryContext,
+    actualModel,
+    gpt5ModelUsed,
+    finalProcessedSafely,
     auditFlags
-  };
+  );
   logAITaskLineage(auditLogEntry);
+
+  //audit Assumption: fallback flags reflect upstream behavior; Failure risk: missing fallback visibility; Expected invariant: summary lists all fallbacks; Handling: build summary array.
+  const fallbackSummary = {
+    intakeFallbackUsed: intakeOutput.fallbackUsed,
+    gpt5FallbackUsed: reasoningOutput.fallbackUsed,
+    finalFallbackUsed: finalOutput.fallbackUsed,
+    fallbackReasons: [
+      ...(intakeOutput.fallbackUsed ? ['Intake fallback used'] : []),
+      ...(reasoningOutput.fallbackUsed ? ['GPT-5.2 fallback used'] : []),
+      ...(finalOutput.fallbackUsed ? ['Final fallback used'] : [])
+    ]
+  };
 
   return {
     result: finalText,
     module: actualModel,
     activeModel: actualModel,
-    fallbackFlag: isFallback,
+    fallbackFlag: intakeOutput.fallbackUsed || reasoningOutput.fallbackUsed || finalOutput.fallbackUsed,
     routingStages,
     gpt5Used,
     gpt5Model: gpt5ModelUsed,
-    gpt5Error: gpt5Result.error,
+    gpt5Error: reasoningOutput.error,
+    dryRun: false,
+    fallbackSummary,
     auditSafe: {
       mode: auditConfig.auditSafeMode,
       overrideUsed: !!auditConfig.explicitOverride,
@@ -270,16 +559,19 @@ export async function runThroughBrain(
     memoryContext: {
       entriesAccessed: memoryContext.relevantEntries.length,
       contextSummary: memoryContext.contextSummary,
-      memoryEnhanced: memoryContext.relevantEntries.length > 0
+      //audit Assumption: memory enhancement indicates any entries present; Failure risk: false positives; Expected invariant: true only when entries exist; Handling: compare length > 0.
+      memoryEnhanced: memoryContext.relevantEntries.length > 0,
+      maxRelevanceScore: memoryScoreSummary.maxScore,
+      averageRelevanceScore: memoryScoreSummary.averageScore
     },
     taskLineage: {
       requestId,
       logged: true
     },
     meta: {
-      tokens: finalResponse.usage || undefined,
-      id: finalResponse.id,
-      created: finalResponse.created
+      tokens: finalOutput.usage || undefined,
+      id: finalOutput.responseId || requestId,
+      created: finalOutput.created || Date.now()
     }
   };
 }


### PR DESCRIPTION
### Motivation
- Improve observability and auditability of the Trinity AI pipeline by surfacing per-stage metadata and explicit fallback summaries. 
- Make reasoning and intake/finalization stages deterministic and easier to reason about for integrations and debugging. 
- Provide a non-invasive dry-run preview mode for CI/validation workflows that avoids calling models. 
- Add memory relevance summaries so callers can assess how memory influenced a response.

### Description
- Introduced new typed interfaces and run options including `TrinityRunOptions`, `TrinityDryRunPreview`, `TrinityIntakeOutput`, `TrinityReasoningOutput`, and `TrinityFinalOutput`, and extended `TrinityResult` with `dryRun`, `dryRunPreview`, `fallbackSummary`, and memory score fields. 
- Refactored `runThroughBrain` into discrete stage helpers: `runIntakeStage`, `runReasoningStage`, and `runFinalStage`, plus supporting helpers `calculateMemoryScoreSummary`, `logFallbackEvent`, `buildDryRunPreview`, and `buildAuditLogEntry`. 
- Added a dry-run short-circuit (use `options.dryRun`) that returns a structured preview without invoking any models and includes a routing plan and candidate models. 
- Improved fallback tracking and logging (structured `fallbackSummary`), propagated per-stage fallback flags into the final result, and added `//audit` comments at key branches to explain assumptions and handling. 
- Updated documentation in `docs/TRINITY_PIPELINE.md` with stage contracts, dry-run guidance, extension examples, and a minimal test plan.

### Testing
- No automated tests were executed for this change (no CI/tests run as part of this PR). 
- A minimal test plan was added to the docs covering unit paths for happy path, dry-run edge case, and GPT-5.2 failure mode. 
- Integration scenarios are described for `/ask` and custom GPT dispatcher routes to validate end-to-end metadata and routing stages. 
- Manual or automated test runs are recommended before deploying to ensure behavior with the actual OpenAI client and configured models.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a90854b64832594aa48a65498fb28)