### PR TITLE
Refactor validation error responses to reuse shared builder

### DIFF
--- a/src/routes/research.ts
+++ b/src/routes/research.ts
@@ -3,6 +3,7 @@ import { confirmGate } from '../middleware/confirmGate.js';
 import { createValidationMiddleware } from '../utils/security.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 import { connectResearchBridge } from '../services/researchHub.js';
+import { buildValidationErrorResponse } from '../utils/errorResponse.js';
 
 const routeBridge = connectResearchBridge('ROUTE:RESEARCH');
 
@@ -30,11 +31,8 @@ router.post(
     const { topic, urls = [] } = req.body as { topic: string; urls?: string[] };
 
     if (!Array.isArray(urls) || urls.some(url => typeof url !== 'string')) {
-      return res.status(400).json({
-        error: 'Validation failed',
-        details: ["Field 'urls' must be an array of strings"],
-        timestamp: new Date().toISOString()
-      });
+      //audit Assumption: urls must be string array; risk: rejecting valid payloads; invariant: only strings allowed; handling: standardized validation error.
+      return res.status(400).json(buildValidationErrorResponse(["Field 'urls' must be an array of strings"]));
     }
 
     const result = await routeBridge.requestResearch({ topic, urls });

--- a/src/routes/sdk.ts
+++ b/src/routes/sdk.ts
@@ -16,6 +16,7 @@ import {
 } from '../config/workerConfig.js';
 import { createValidationMiddleware } from '../utils/security.js';
 import { connectResearchBridge } from '../services/researchHub.js';
+import { buildValidationErrorResponse } from '../utils/errorResponse.js';
 
 const router = express.Router();
 const sdkResearchBridge = connectResearchBridge('SDK:RESEARCH');
@@ -42,12 +43,10 @@ router.post(
     const { topic, urls = [] } = req.body as { topic: string; urls?: string[] };
 
     if (!Array.isArray(urls) || urls.some(url => typeof url !== 'string')) {
-      return res.status(400).json({
-        success: false,
-        error: 'Validation failed',
-        details: ["Field 'urls' must be an array of strings"],
-        timestamp: new Date().toISOString()
-      });
+      //audit Assumption: urls must be string array; risk: rejecting valid payloads; invariant: only strings allowed; handling: standardized validation error.
+      return res
+        .status(400)
+        .json({ success: false, ...buildValidationErrorResponse(["Field 'urls' must be an array of strings"]) });
     }
 
     const result = await sdkResearchBridge.requestResearch({ topic, urls });

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -4,6 +4,7 @@
  */
 
 import { Response } from 'express';
+import { buildValidationErrorResponse } from './errorResponse.js';
 
 // Input validation schemas
 export interface ValidationRule {
@@ -124,11 +125,8 @@ export function createValidationMiddleware(schema: ValidationSchema) {
     const validation = validateInput(req.body, schema);
     
     if (!validation.isValid) {
-      return res.status(400).json({
-        error: 'Validation failed',
-        details: validation.errors,
-        timestamp: new Date().toISOString()
-      });
+      //audit Assumption: validation errors map directly to client payload; risk: leaking schema details; invariant: only include validation errors; handling: standardized payload.
+      return res.status(400).json(buildValidationErrorResponse(validation.errors));
     }
     
     // Replace request body with sanitized version


### PR DESCRIPTION
### Motivation
- Standardize validation error payloads across the codebase to avoid duplicated response shapes and make it easy to enrich responses with optional metadata.
- Reduce repeated construction of validation responses in multiple routes and middleware and add auditable notes for branches that return validation errors.

### Description
- Add a reusable builder `buildValidationErrorResponse(details, options)` in `src/utils/errorResponse.ts` and keep `sendValidationError` routed through it, allowing optional `acceptedFields` and `maxLength` metadata.
- Replace inline validation error responses in `createValidationMiddleware` (`src/utils/security.ts`) to call `buildValidationErrorResponse` and add a `//audit` comment describing the assumption/risk/handling.
- Update request handlers to use the shared builder in `src/routes/ask.ts`, `src/routes/api-ask.ts`, `src/routes/research.ts`, and `src/routes/sdk.ts` for consistent validation error output and to include audit notes for the branches that return errors.
- Preserve existing response semantics while consolidating formatting and adding small documentation comments where validation behavior was changed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d52eeb3e883258275ecdc3d46e2fd)