### PR TITLE
Daemon: send GPT ID header

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ BACKEND_FALLBACK_TO_LOCAL=true
 BACKEND_SEND_UPDATES=true
 BACKEND_VISION_ENABLED=false
 BACKEND_TRANSCRIBE_ENABLED=false
+DAEMON_GPT_ID=
+DAEMON_GPT_ID_HEADER=OpenAI-GPT-ID
 MAX_REQUESTS_PER_HOUR=60
 MAX_TOKENS_PER_DAY=100000
 TELEMETRY_ENABLED=false
@@ -198,6 +200,8 @@ AUTO_START=false
 
 If `BACKEND_URL` is set, ARCANOS will prompt for backend login on startup and store `BACKEND_TOKEN` locally.
 Use `deep <prompt>` or `deep:` / `backend:` prefixes to route a request through the backend when running in hybrid mode.
+Set `DAEMON_GPT_ID` to send your custom GPT ID with backend requests. The daemon uses `DAEMON_GPT_ID_HEADER`
+(default `OpenAI-GPT-ID`) so the backend can read it if needed, without requiring backend changes.
 
 ### Privacy & Data Retention
 

--- a/daemon-python/.env.example
+++ b/daemon-python/.env.example
@@ -46,6 +46,10 @@ BACKEND_HISTORY_LIMIT=8
 BACKEND_VISION_ENABLED=false
 BACKEND_TRANSCRIBE_ENABLED=false
 
+# Optional daemon GPT ID header for backend identification
+DAEMON_GPT_ID=
+DAEMON_GPT_ID_HEADER=OpenAI-GPT-ID
+
 # ============================================
 # OPTIONAL - Rate Limiting
 # ============================================

--- a/daemon-python/cli.py
+++ b/daemon-python/cli.py
@@ -79,7 +79,9 @@ class ArcanosCLI:
             self.backend_client = BackendApiClient(
                 base_url=Config.BACKEND_URL,
                 token_provider=lambda: Config.BACKEND_TOKEN,
-                timeout_seconds=Config.BACKEND_REQUEST_TIMEOUT
+                timeout_seconds=Config.BACKEND_REQUEST_TIMEOUT,
+                daemon_gpt_id=Config.DAEMON_GPT_ID,
+                daemon_gpt_header_name=Config.DAEMON_GPT_ID_HEADER
             )
 
         # PTT Manager


### PR DESCRIPTION
## Summary
- add optional daemon GPT ID header injection for backend requests
- wire config/env/example + docs for DAEMON_GPT_ID and header name
- no backend changes

## Testing
- not run (not requested)