### PR TITLE
Draft: default bridge enabled on Railway

### DIFF
--- a/src/routes/bridge.ts
+++ b/src/routes/bridge.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { createRateLimitMiddleware, securityHeaders } from '../utils/security.js';
+import { isBridgeEnabled } from '../utils/bridgeEnv.js';
 
 const router = express.Router();
 
@@ -16,7 +17,7 @@ const BRIDGE_PATHS = [
 ];
 
 router.all(BRIDGE_PATHS, (_req, res) => {
-  const enabled = process.env.BRIDGE_ENABLED === 'true';
+  const enabled = isBridgeEnabled();
   res.json({
     status: enabled ? 'active' : 'disabled',
     bridgeEnabled: enabled,

--- a/src/services/bridgeSocket.ts
+++ b/src/services/bridgeSocket.ts
@@ -2,13 +2,10 @@ import type { IncomingMessage, Server } from 'http';
 import type { Duplex } from 'stream';
 import { WebSocket, WebSocketServer } from 'ws';
 import { logger } from '../utils/structuredLogging.js';
+import { isBridgeEnabled } from '../utils/bridgeEnv.js';
 
 const bridgeLogger = logger.child({ module: 'bridge-ipc' });
 const bridgeClients = new Set<WebSocket>();
-
-function isBridgeEnabled(): boolean {
-  return process.env.BRIDGE_ENABLED === 'true';
-}
 
 function resolvePath(url?: string): string {
   if (!url) return '/';

--- a/src/utils/bridgeEnv.ts
+++ b/src/utils/bridgeEnv.ts
@@ -1,0 +1,20 @@
+function hasExplicitBridgeFlag(): boolean {
+  return typeof process.env.BRIDGE_ENABLED === 'string';
+}
+
+export function isBridgeEnabled(): boolean {
+  const raw = process.env.BRIDGE_ENABLED;
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+
+  if (hasExplicitBridgeFlag()) {
+    return false;
+  }
+
+  // Default to enabled on Railway deployments so IPC can come online without manual env wiring.
+  return Boolean(process.env.RAILWAY_ENVIRONMENT || process.env.RAILWAY_PROJECT_ID);
+}
+
+export default {
+  isBridgeEnabled
+};

--- a/src/utils/bridgeRelay.ts
+++ b/src/utils/bridgeRelay.ts
@@ -1,6 +1,7 @@
 import type { Request } from 'express';
 import { tagRequest } from './tagRequest.js';
 import { broadcastBridgeEvent } from '../services/bridgeSocket.js';
+import { isBridgeEnabled } from './bridgeEnv.js';
 
 type RequestWithBridgeContext = Request & {
   requestId?: string;
@@ -46,7 +47,7 @@ export async function routeBridgeRequest(
   req: RequestWithBridgeContext,
   context: BridgeRouteContext
 ): Promise<void> {
-  if (process.env.BRIDGE_ENABLED !== 'true') {
+  if (!isBridgeEnabled()) {
     return;
   }
 


### PR DESCRIPTION
Enables bridge IPC by default on Railway when BRIDGE_ENABLED is unset, and keeps /ipc status endpoints consistent.\n\nNotes:\n- Do not merge.