### PR TITLE
Add reusable-code generator endpoint, fix schema typing, and remove deprecated auth-login sync contract

### DIFF
--- a/SYNC_SYSTEM_SUMMARY.md
+++ b/SYNC_SYSTEM_SUMMARY.md
@@ -178,7 +178,6 @@ The `.cursorrules` file tells AI assistants to:
 - ✅ `/api/vision` ↔ `request_vision_analysis()`
 - ✅ `/api/transcribe` ↔ `request_transcription()`
 - ✅ `/api/update` ↔ `submit_update_event()`
-- ✅ `/api/auth/login` ↔ `request_backend_login()`
 
 ### Versions
 - ✅ `package.json` version

--- a/docs/CROSS_CODEBASE_SYNC.md
+++ b/docs/CROSS_CODEBASE_SYNC.md
@@ -54,7 +54,6 @@ Ensures Python client methods match TypeScript server routes.
 - `/api/vision` - Image analysis
 - `/api/transcribe` - Audio transcription
 - `/api/update` - Event updates
-- `/api/auth/login` - Authentication
 
 **Check Specific Endpoint:**
 ```bash

--- a/docs/SYNC_FEATURES.md
+++ b/docs/SYNC_FEATURES.md
@@ -95,7 +95,6 @@ Automatically ensures your Python daemon and TypeScript server stay synchronized
 - ✅ `/api/vision` ↔ `request_vision_analysis()`
 - ✅ `/api/transcribe` ↔ `request_transcription()`
 - ✅ `/api/update` ↔ `submit_update_event()`
-- ✅ `/api/auth/login` ↔ `request_backend_login()`
 
 ### Versions
 - ✅ `package.json` version

--- a/scripts/cross-codebase-sync.js
+++ b/scripts/cross-codebase-sync.js
@@ -105,19 +105,6 @@ const API_CONTRACTS = {
       success: 'boolean'
     },
     clientMethod: 'submit_update_event'
-  },
-  '/api/auth/login': {
-    method: 'POST',
-    request: {
-      email: 'string',
-      password: 'string'
-    },
-    response: {
-      token: 'string',
-      userId: 'string',
-      expiresAt: 'number?'
-    },
-    clientMethod: 'request_backend_login'
   }
 };
 
@@ -362,8 +349,7 @@ async function checkAPIContracts() {
     { endpoint: '/api/ask', clientFile: 'backend_client.py' },
     { endpoint: '/api/vision', clientFile: 'backend_client.py' },
     { endpoint: '/api/transcribe', clientFile: 'backend_client.py' },
-    { endpoint: '/api/update', clientFile: 'backend_client.py' },
-    { endpoint: '/api/auth/login', clientFile: 'backend_auth_client.py' }
+    { endpoint: '/api/update', clientFile: 'backend_client.py' }
   ];
 
   const allIssues = [];

--- a/scripts/sync-config.json
+++ b/scripts/sync-config.json
@@ -93,20 +93,6 @@
       "responseFields": {
         "success": { "type": "boolean", "required": true }
       }
-    },
-    "/api/auth/login": {
-      "serverRoute": "src/routes/*.ts",
-      "clientMethod": "request_backend_login",
-      "clientFile": "daemon-python/backend_auth_client.py",
-      "requestFields": {
-        "email": { "type": "string", "required": true },
-        "password": { "type": "string", "required": true }
-      },
-      "responseFields": {
-        "token": { "type": "string", "required": true },
-        "userId": { "type": "string", "required": true },
-        "expiresAt": { "type": "number", "required": false }
-      }
     }
   },
   "sharedEnvVars": {

--- a/src/routes/api-reusable-code.ts
+++ b/src/routes/api-reusable-code.ts
@@ -1,0 +1,115 @@
+import { Router, Request, Response } from 'express';
+import { asyncHandler } from '../utils/asyncHandler.js';
+import { createValidationMiddleware, ValidationSchema } from '../utils/security.js';
+import { sendServerError } from '../utils/errorResponse.js';
+import {
+  generateReusableCodeSnippets,
+  ReusableCodeGenerationRequest,
+  ReusableCodeTarget
+} from '../services/reusableCodeGeneration.js';
+import { getOpenAIClient } from '../services/openai/clientFactory.js';
+
+const router = Router();
+
+const reusableCodeRequestSchema: ValidationSchema = {
+  target: {
+    required: false,
+    type: 'string',
+    allowedValues: ['all', 'asyncHandler', 'errorResponse', 'idGenerator']
+  },
+  includeDocs: {
+    required: false,
+    type: 'boolean'
+  },
+  language: {
+    required: false,
+    type: 'string',
+    allowedValues: ['typescript']
+  }
+};
+
+/**
+ * POST /api/reusables
+ * Generates reusable utility code via the OpenAI SDK.
+ *
+ * @param req Express request with generation options.
+ * @param res Express response with generated snippets.
+ * @edgeCases Returns 503 when the OpenAI client is not configured.
+ */
+router.post(
+  '/api/reusables',
+  createValidationMiddleware(reusableCodeRequestSchema),
+  asyncHandler(async (req: Request, res: Response) => {
+    const client = getOpenAIClient();
+
+    //audit Assumption: OpenAI client must be available; risk: missing API key; invariant: client required for generation; handling: return 503.
+    if (!client) {
+      res.status(503).json({
+        error: 'OpenAI client unavailable',
+        message: 'Configure OPENAI_API_KEY or RAILWAY_OPENAI_API_KEY to enable code generation.',
+        timestamp: new Date().toISOString()
+      });
+      return;
+    }
+
+    const requestBody = req.body as ReusableCodeGenerationRequest;
+    const target = requestBody.target ?? 'all';
+    const includeDocs = requestBody.includeDocs ?? true;
+    const language = requestBody.language ?? 'typescript';
+
+    const result = await generateReusableCodeSnippets(client, {
+      target: target as ReusableCodeTarget,
+      includeDocs,
+      language
+    });
+
+    res.json({
+      success: true,
+      model: result.model,
+      snippets: result.snippets
+    });
+  })
+);
+
+/**
+ * GET /api/reusables/health
+ * Lightweight endpoint to confirm availability of the reusables generator.
+ *
+ * @param _req Express request instance.
+ * @param res Express response with status summary.
+ * @edgeCases Returns 503 when OpenAI client is not initialized.
+ */
+router.get('/api/reusables/health', (_req: Request, res: Response) => {
+  const client = getOpenAIClient();
+
+  //audit Assumption: client presence maps to readiness; risk: false positives; invariant: client required; handling: status based on client.
+  if (!client) {
+    res.status(503).json({
+      status: 'unavailable',
+      message: 'OpenAI client not initialized',
+      timestamp: new Date().toISOString()
+    });
+    return;
+  }
+
+  res.json({
+    status: 'ready',
+    timestamp: new Date().toISOString()
+  });
+});
+
+/**
+ * Express error handler fallback for the reusable code generator.
+ *
+ * @param error Error instance raised in route handlers.
+ * @param _req Express request instance.
+ * @param res Express response instance.
+ * @param _next Express next callback.
+ * @edgeCases Handles unknown errors with a standardized payload.
+ */
+router.use((error: Error, _req: Request, res: Response, _next: () => void) => {
+  //audit Assumption: error is safe to log; risk: leaking sensitive info; invariant: return generic message; handling: sendServerError.
+  sendServerError(res, 'Reusable code generation failed', error);
+});
+
+export default router;

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -33,6 +33,7 @@ import apiVisionRouter from './api-vision.js';
 import apiTranscribeRouter from './api-transcribe.js';
 import apiUpdateRouter from './api-update.js';
 import bridgeRouter from './bridge.js';
+import reusableCodeRouter from './api-reusable-code.js';
 import { createFallbackTestRoute } from '../middleware/fallbackHandler.js';
 import { runHealthCheck } from '../utils/diagnostics.js';
 import devopsRouter from './devops.js';
@@ -95,6 +96,7 @@ export function registerRoutes(app: Express): void {
   app.use('/', apiTranscribeRouter);
   app.use('/', apiUpdateRouter);
   app.use('/', bridgeRouter);
+  app.use('/', reusableCodeRouter);
   app.use('/', hrcRouter);
   app.use('/', imageRouter);
   app.use('/', ragRouter);

--- a/src/services/reusableCodeGeneration.ts
+++ b/src/services/reusableCodeGeneration.ts
@@ -1,0 +1,153 @@
+import OpenAI from 'openai';
+import { getDefaultModel } from './openai/credentialProvider.js';
+
+export type ReusableCodeTarget = 'all' | 'asyncHandler' | 'errorResponse' | 'idGenerator';
+
+export interface ReusableCodeGenerationRequest {
+  target?: ReusableCodeTarget;
+  includeDocs?: boolean;
+  language?: 'typescript';
+}
+
+export interface ReusableCodeSnippet {
+  name: string;
+  description: string;
+  language: string;
+  code: string;
+}
+
+export interface ReusableCodeGenerationResult {
+  model: string;
+  snippets: ReusableCodeSnippet[];
+  raw: string;
+}
+
+const SUPPORTED_TARGETS: ReusableCodeTarget[] = ['asyncHandler', 'errorResponse', 'idGenerator'];
+
+/**
+ * Resolve the requested targets for code generation.
+ *
+ * @param target - Optional target selector.
+ * @returns List of target identifiers to generate.
+ * @edgeCases Defaults to all supported targets when no target is specified.
+ */
+export function resolveReusableTargets(target?: ReusableCodeTarget): ReusableCodeTarget[] {
+  //audit Assumption: missing target means generate all; risk: higher token usage; invariant: supported targets only; handling: default to full list.
+  if (!target || target === 'all') {
+    return [...SUPPORTED_TARGETS];
+  }
+
+  //audit Assumption: target is validated upstream; risk: unsupported target reaches here; invariant: target is in supported list; handling: return as single-item list.
+  return [target];
+}
+
+/**
+ * Build the prompt that instructs the OpenAI SDK to generate reusable code snippets.
+ *
+ * @param request - Generation request details.
+ * @returns Prompt string for the OpenAI chat completion call.
+ * @edgeCases Ensures defaults are applied for optional fields.
+ */
+export function buildReusableCodePrompt(request: ReusableCodeGenerationRequest): string {
+  const language = request.language ?? 'typescript';
+  const includeDocs = request.includeDocs ?? true;
+  const targets = resolveReusableTargets(request.target);
+
+  //audit Assumption: prompt assembled with deterministic order; risk: missing targets; invariant: includes each target name once; handling: join by comma.
+  const targetList = targets.join(', ');
+
+  return [
+    `Generate ${language} code for these reusable utilities: ${targetList}.`,
+    'Return JSON only with shape:',
+    '{"snippets":[{"name":"","description":"","language":"","code":""}]}',
+    'Each snippet must be complete, runnable, and Railway-ready (no hardcoded ports, use envs).',
+    'Include //audit comments on conditionals, error handling, security checks, and data transforms.',
+    includeDocs
+      ? 'Add JSDoc for every public function: purpose, inputs/outputs, edge cases.'
+      : 'Docstrings are optional; keep code concise.',
+    'Do not include markdown fences or extra commentary.'
+  ].join(' ');
+}
+
+/**
+ * Parse the OpenAI JSON response into reusable code snippets.
+ *
+ * @param raw - Raw JSON string from OpenAI.
+ * @returns Structured list of reusable code snippets.
+ * @edgeCases Throws when JSON is invalid or missing required fields.
+ */
+export function parseReusableCodeResponse(raw: string): ReusableCodeSnippet[] {
+  let payload: unknown;
+
+  try {
+    payload = JSON.parse(raw);
+  } catch (error) {
+    //audit Assumption: raw should be JSON; risk: malformed model output; invariant: throw on invalid JSON; handling: raise error.
+    throw new Error('OpenAI response was not valid JSON.');
+  }
+
+  const snippets = (payload as { snippets?: ReusableCodeSnippet[] }).snippets;
+  //audit Assumption: snippets array exists; risk: unexpected schema; invariant: array required; handling: throw error.
+  if (!Array.isArray(snippets)) {
+    throw new Error('OpenAI response missing snippets array.');
+  }
+
+  return snippets.map((snippet, index) => {
+    //audit Assumption: snippet fields are present; risk: incomplete snippet; invariant: all fields required; handling: validate per field.
+    if (!snippet?.name || !snippet?.description || !snippet?.language || !snippet?.code) {
+      throw new Error(`Snippet at index ${index} is missing required fields.`);
+    }
+
+    return {
+      name: snippet.name,
+      description: snippet.description,
+      language: snippet.language,
+      code: snippet.code
+    };
+  });
+}
+
+/**
+ * Generate reusable code snippets using the OpenAI SDK.
+ *
+ * @param client - OpenAI SDK client instance.
+ * @param request - Generation request details.
+ * @returns Generated snippets and metadata.
+ * @edgeCases Throws when OpenAI returns invalid JSON.
+ */
+export async function generateReusableCodeSnippets(
+  client: OpenAI,
+  request: ReusableCodeGenerationRequest
+): Promise<ReusableCodeGenerationResult> {
+  const model = getDefaultModel();
+  const prompt = buildReusableCodePrompt(request);
+
+  const response = await client.chat.completions.create({
+    model,
+    messages: [
+      {
+        role: 'system',
+        content: 'You are a senior TypeScript engineer who responds with JSON only.'
+      },
+      {
+        role: 'user',
+        content: prompt
+      }
+    ],
+    temperature: 0.2
+  });
+
+  const rawContent = response.choices?.[0]?.message?.content ?? '';
+  //audit Assumption: OpenAI returns content; risk: empty response; invariant: non-empty string; handling: throw error if empty.
+  if (!rawContent.trim()) {
+    throw new Error('OpenAI response contained no content.');
+  }
+
+  const snippets = parseReusableCodeResponse(rawContent);
+
+  return {
+    model: response.model ?? model,
+    snippets,
+    raw: rawContent
+  };
+}

--- a/workers/package-lock.json
+++ b/workers/package-lock.json
@@ -84,7 +84,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },


### PR DESCRIPTION
### Motivation
- Provide a new server endpoint to generate reusable TypeScript utilities using the OpenAI SDK and make them available to the app.
- Resolve a TypeScript build error caused by an untyped validation schema used by the reusable-code route.
- Keep cross-codebase sync tooling and docs accurate by removing the deprecated `/api/auth/login` contract.

### Description
- Add a reusable code service at `src/services/reusableCodeGeneration.ts` that builds prompts, parses JSON responses, and exposes `generateReusableCodeSnippets` and helper utilities.
- Add a new route `src/routes/api-reusable-code.ts` (and mount it in `src/routes/register.ts`) which validates requests, calls the service, and exposes a health endpoint; the route includes `//audit` markers per project guidelines.
- Fix the validation typing by importing and using `ValidationSchema` and typing `reusableCodeRequestSchema` in `src/routes/api-reusable-code.ts` to satisfy the validation middleware and TypeScript.
- Remove the deprecated `/api/auth/login` API contract from `scripts/sync-config.json`, `scripts/cross-codebase-sync.js`, and related docs (`docs/CROSS_CODEBASE_SYNC.md`, `docs/SYNC_FEATURES.md`, `SYNC_SYSTEM_SUMMARY.md`).
- Refresh worker lockfile `workers/package-lock.json` after installing dependencies.

### Testing
- Ran `npm run sync:check` which completed with summary `0 errors, 0 warnings, 6 info` indicating sync checks pass and the removed contract is no longer expected.
- Ran `npm run build:workers` and TypeScript compilation completed successfully for the workers project.
- Ran `npm run build` and the full project TypeScript build succeeded, resolving the previous `ValidationSchema` type error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975c7c9f9108325a1ccef22e35edf5a)