### PR TITLE
Fix: Correct logger.error parameter order in daemonStore.ts

### DIFF
--- a/src/routes/daemonStore.ts
+++ b/src/routes/daemonStore.ts
@@ -204,7 +204,7 @@ export function createDaemonStore(deps: DaemonStoreDependencies): DaemonStore {
       deps.logger.error('Failed to load daemon tokens', {
         module: 'daemonStore.loadTokens',
         tokensFilePath: deps.tokensFilePath
-      }, error instanceof Error ? error : undefined);
+      }, undefined, error instanceof Error ? error : undefined);
     }
   };
 
@@ -227,7 +227,7 @@ export function createDaemonStore(deps: DaemonStoreDependencies): DaemonStore {
       deps.logger.error('Failed to save daemon tokens', {
         module: 'daemonStore.saveTokens',
         tokensFilePath: deps.tokensFilePath
-      }, error instanceof Error ? error : undefined);
+      }, undefined, error instanceof Error ? error : undefined);
     }
   };
 


### PR DESCRIPTION
## Problem

After merging PR #1056, TypeScript compilation errors occurred:

\\\
src/routes/daemonStore.ts(207,10): error TS2345: Argument of type 'Error | undefined' is not assignable to parameter of type 'Record<string, unknown> | undefined'.
src/routes/daemonStore.ts(230,10): error TS2345: Argument of type 'Error | undefined' is not assignable to parameter of type 'Record<string, unknown> | undefined'.
\\\

## Root Cause

The \logger.error\ method signature is:
\\\	ypescript
error(message: string, context?: LogContext, metadata?: Record<string, unknown>, error?: Error): void
\\\

But we were passing the Error object as the third parameter (metadata) instead of the fourth parameter (error). This caused TypeScript compilation errors because \Error\ is not assignable to \Record<string, unknown>\.

## Solution

Fixed by passing \undefined\ as the metadata parameter and the error as the fourth parameter in both error logging calls.

## Changes

- Fixed \logger.error\ call in \loadTokens\ function (line 207)
- Fixed \logger.error\ call in \saveTokens\ function (line 230)

## Testing

- âœ… TypeScript compilation passes without errors
- âœ… Cross-codebase sync check passes