### PR TITLE
fix: Trinity pipeline 400s - null content and max_output_tokens

### DIFF
--- a/src/config/prompts.ts
+++ b/src/config/prompts.ts
@@ -220,16 +220,17 @@ export const buildFinalOriginalRequestMessage = (prompt: string): string => {
  */
 export const buildFinalGpt5AnalysisMessage = (analysis: string): string => {
   const safeAnalysis = analysis?.trim() ? analysis.trim().replace(/<\/\s*analysis_output\s*>/gi, '') : 'No analysis provided.';
-  const prefix = loadPromptsConfig().arcanos.final_gpt5_analysis_prefix;
+  const prefix = loadPromptsConfig().arcanos?.final_gpt5_analysis_prefix ?? 'GPT-5.1 analysis:';
   return `${prefix}\n<analysis_output>\n${safeAnalysis}\n</analysis_output>`;
 };
 
 /**
  * Retrieve the final response instruction for the last stage of Trinity.
  * Inputs/Outputs: no inputs, returns the configured instruction string.
- * Edge cases: relies on fallback config when the prompts file is missing.
+ * Edge cases: relies on fallback config when the prompts file is missing; never returns null/undefined (OpenAI requires string content).
  */
-export const getFinalResponseInstruction = (): string => loadPromptsConfig().arcanos.final_response_instruction;
+export const getFinalResponseInstruction = (): string =>
+  loadPromptsConfig().arcanos?.final_response_instruction ?? 'Provide the final response to the user.';
 
 /**
  * Trinity pipeline messages (dry run, audit, pattern storage).

--- a/src/services/openai/requestTransforms.ts
+++ b/src/services/openai/requestTransforms.ts
@@ -1,35 +1,13 @@
 import { getTokenParameter } from '../../utils/tokenParameterHelper.js';
-import { APPLICATION_CONSTANTS } from '../../utils/constants.js';
 import { REASONING_SYSTEM_PROMPT, REASONING_TEMPERATURE, REASONING_TOKEN_LIMIT, buildReasoningPrompt } from '../../config/reasoningTemplates.js';
-import { RESILIENCE_CONSTANTS } from './resilience.js';
 import type { ChatCompletionCreateParams } from './types.js';
 
 /**
- * Transform GPT-5 request payload to use correct token parameter names
- * @confidence 0.95 - GPT-5 API may use different parameter names
+ * Prepare GPT-5 request payload. OpenAI API uses max_tokens or max_completion_tokens,
+ * not max_output_tokens; we pass through token params unchanged.
  */
-type GPT5RequestPayload = ChatCompletionCreateParams & {
-  max_output_tokens?: number;
-};
-
 export function prepareGPT5Request(payload: ChatCompletionCreateParams): ChatCompletionCreateParams {
-  //audit Assumption: GPT-5 models need max_output_tokens; Handling: translate
-  if (payload.model && typeof payload.model === 'string' && payload.model.includes(APPLICATION_CONSTANTS.MODEL_GPT_5)) {
-    const gpt5Payload: GPT5RequestPayload = { ...payload };
-    if (payload.max_tokens) {
-      gpt5Payload.max_output_tokens = payload.max_tokens;
-      delete gpt5Payload.max_tokens;
-    }
-    if (payload.max_completion_tokens) {
-      gpt5Payload.max_output_tokens = payload.max_completion_tokens;
-      delete gpt5Payload.max_completion_tokens;
-    }
-    //audit Assumption: missing token limit should use resilience default
-    if (!gpt5Payload.max_output_tokens) {
-      gpt5Payload.max_output_tokens = RESILIENCE_CONSTANTS.DEFAULT_MAX_TOKENS;
-    }
-    return gpt5Payload;
-  }
+  //audit Assumption: OpenAI API accepts max_tokens / max_completion_tokens only; risk: max_output_tokens rejected; invariant: no max_output_tokens; strategy: return payload as-is.
   return payload;
 }
 

--- a/src/services/openai/responsePayload.ts
+++ b/src/services/openai/responsePayload.ts
@@ -8,10 +8,6 @@ const mapMessagesToResponseInput = (
   messages: ChatCompletionMessageParam[]
 ): ChatCompletionMessageParam[] => messages;
 
-type GPT5Payload = ChatCompletionCreateParams & {
-  max_output_tokens?: number;
-};
-
 export const buildResponseRequestPayload = ({
   model,
   messages,
@@ -22,8 +18,8 @@ export const buildResponseRequestPayload = ({
   messages: ChatCompletionMessageParam[];
   tokenParams: TokenParameterResult;
   options: CallOpenAIOptions;
-}): GPT5Payload => {
-  const basePayload = prepareGPT5Request({
+}): ChatCompletionCreateParams => {
+  return prepareGPT5Request({
     model,
     messages: mapMessagesToResponseInput(messages),
     ...tokenParams,
@@ -34,14 +30,6 @@ export const buildResponseRequestPayload = ({
     ...(options.responseFormat !== undefined ? { response_format: options.responseFormat } : {}),
     ...(options.user !== undefined ? { user: options.user } : {})
   });
-
-  const payload: GPT5Payload = { ...basePayload };
-  //audit Assumption: GPT-5 variants accept max_output_tokens; Handling: mirror
-  if (payload.max_output_tokens === undefined && typeof payload.max_tokens === 'number') {
-    payload.max_output_tokens = payload.max_tokens;
-  }
-
-  return payload;
 };
 
 type ResponseOutput = ChatCompletion & {


### PR DESCRIPTION
## Summary
Fixes backend /ask failures when the Trinity pipeline hits OpenAI:
- **400 Invalid value for 'content': expected a string, got null** — one or more final-stage messages had null/undefined content.
- **400 Unknown parameter: 'max_output_tokens'** — the API only accepts `max_tokens` / `max_completion_tokens`.

## Changes
- **Null-safe final-stage messages**: `getFinalResponseInstruction()` and `buildFinalGpt5AnalysisMessage` use safe fallbacks; `buildFinalArcanosMessages()` coerces every message content with `ensureStringContent()` so OpenAI never receives null.
- **Stop sending max_output_tokens**: `prepareGPT5Request()` no longer rewrites token params; `responsePayload.ts` no longer mirrors `max_tokens` to `max_output_tokens`.

## Testing
Restart backend and hit /ask; Trinity pipeline should complete without 400s (or surface a different error for follow-up).
