### PR TITLE
feat: add IDE backend debug support (launch configs, source maps, docs)

### DIFF
--- a/docs/IDE_AND_AGENTS.md
+++ b/docs/IDE_AND_AGENTS.md
@@ -50,7 +50,7 @@ Configs: [`.vscode/launch.json`](../.vscode/launch.json), [`.vscode/tasks.json`]
 3. **Source map integrity:** Call stack shows `src/.../*.ts`; stepping follows TS lines correctly.
 4. **Launch config:** VS Code → **Backend (TS) Launch**; pass if preLaunch build runs and server starts under debugger.
 5. **PORT:** Verify `PORT` env overrides default; otherwise uses 8080.
-6. **Python daemon (optional):** VS Code → **Daemon (Python)**; breakpoints in `daemon-python/arcanos/cli.py` hit. Debug HTTP server is available at `http://127.0.0.1:9999/debug/status` with `IDE_AGENT_DEBUG=1`.
+6. **Python daemon (optional):** VS Code → **Daemon (Python)**; breakpoints in `daemon-python/arcanos/cli.py` hit. Debug HTTP server is available at `http://127.0.0.1:9999/debug/status` with `IDE_AGENT_DEBUG=1`. Verify with `curl http://127.0.0.1:9999/debug/status` (returns JSON).
 
 **Automatable checks (optional)**
 


### PR DESCRIPTION
## Summary

- Add IDE backend debug support: VS Code/Cursor launch configs, source maps, and documentation
- Enable debugging live TypeScript backend code while it's running (attach to process)
- Add CLI debug server support so IDE agents can inspect the daemon via HTTP API

## Changes

### Launch Configs (`.vscode/launch.json`)
- **Backend (TS) Launch**: Builds then launches backend under debugger with inspector
- **Attach to Backend**: Attaches to running backend started with `npm run dev:inspect`
- **Daemon (Python)**: Breakpoint debugging in `daemon-python/arcanos/*.py`
- **CLI (debug server)**: Runs CLI with debug HTTP server for IDE agents (`http://127.0.0.1:9999`)

### Build Task (`.vscode/tasks.json`)
- `build` task for preLaunchTask (runs `npm run build`)

### Source Maps (`tsconfig.json`)
- `sourceMap: true` and `inlineSources: true` so breakpoints in `src/*.ts` resolve correctly

### NPM Script (`package.json`)
- `dev:inspect`: Runs backend with Node inspector on port 9229

### Documentation (`docs/IDE_AND_AGENTS.md`)
- "Debugging the backend" section with all 4 workflows
- Audit checklist (7-step manual verification, 3-5 minutes)
- CLEAR-style rubric for verification

## Primary Workflow

```bash
npm run dev:inspect  # Start backend with inspector
```

Then in VS Code: **Run and Debug** > **Attach to Backend** > set breakpoints in `src/*.ts`

## Test plan

- [ ] Run `npm run dev:inspect` - confirm "Debugger listening ...9229..." appears
- [ ] VS Code > Attach to Backend - confirm attaches cleanly
- [ ] Set breakpoint in `src/start-server.ts` - confirm it hits
- [ ] VS Code > Backend (TS) Launch - confirm build runs then server starts
- [ ] (Optional) VS Code > Daemon (Python) - confirm breakpoints work
- [ ] (Optional) VS Code > CLI (debug server) - confirm `curl http://127.0.0.1:9999/debug/status` returns JSON
