### PR TITLE
Refine bridge tag configuration and add auditable env overrides

### DIFF
--- a/daemon/bridge.js
+++ b/daemon/bridge.js
@@ -2,16 +2,49 @@ import { createServer } from "http";
 import { resolve } from "path";
 import { pathToFileURL } from "url";
 
-const DEFAULT_PORT = 7777;
+const DEFAULT_BRIDGE_PORT = 7777;
+const DEFAULT_TAG_PREFIX = "GPT";
+const DEFAULT_TAG_ID = "ARCANOS";
+const BRIDGE_STATUS_PATH = "/bridge-status";
+const BRIDGE_STATUS_RESPONSE = "active";
+const BRIDGE_NOT_FOUND_RESPONSE = "not found";
 const bridgeEnabled = process.env.BRIDGE_ENABLED === "true";
+
+function resolveTagPrefix() {
+  //audit Assumption: BRIDGE_TAG_PREFIX is a non-empty string; risk: empty prefix breaks routing tags; invariant: prefix defaults when invalid; handling: trim and fallback.
+  const envValue = process.env.BRIDGE_TAG_PREFIX;
+  const trimmed = typeof envValue === "string" ? envValue.trim() : "";
+  return trimmed.length > 0 ? trimmed : DEFAULT_TAG_PREFIX;
+}
+
+function resolveTagId() {
+  //audit Assumption: GPT_ID is a non-empty identifier; risk: missing ID obscures audit trails; invariant: default ID used when empty; handling: trim and fallback.
+  const envValue = process.env.GPT_ID;
+  const trimmed = typeof envValue === "string" ? envValue.trim() : "";
+  return trimmed.length > 0 ? trimmed : DEFAULT_TAG_ID;
+}
+
+function buildBridgeTag(reqId) {
+  //audit Assumption: reqId is defined; risk: undefined values create malformed tags; invariant: tag contains reqId; handling: stringify fallback.
+  const prefix = resolveTagPrefix();
+  const tagId = resolveTagId();
+  return `${prefix}-${tagId}-${String(reqId)}`;
+}
 
 export const bridge = {
   active: bridgeEnabled,
-  assignTag: (reqId) => `GPT-${process.env.GPT_ID || "ARCANOS"}-${reqId}`,
+  assignTag: (reqId) => buildBridgeTag(reqId),
   routeRequest: (payload) => sendToDaemon(payload),
 };
 
+/**
+ * Starts the bridge server when enabled.
+ * Inputs: none (uses env configuration).
+ * Outputs: http.Server instance or null when disabled.
+ * Edge cases: returns null if BRIDGE_ENABLED is not "true".
+ */
 export function startBridgeServer() {
+  //audit Assumption: bridgeEnabled gates server start; risk: unexpected start in managed runtimes; invariant: only start when enabled; handling: return null.
   if (!bridgeEnabled) {
     console.log("[Bridge] Disabled via environment variable.");
     return null;
@@ -19,14 +52,15 @@ export function startBridgeServer() {
 
   const port = resolveBridgePort();
   const server = createServer((req, res) => {
-    if (req.url === "/bridge-status") {
+    //audit Assumption: health check path is fixed; risk: misrouted probes; invariant: exact match; handling: return active status.
+    if (req.url === BRIDGE_STATUS_PATH) {
       res.writeHead(200, { "Content-Type": "text/plain" });
-      res.end("active");
+      res.end(BRIDGE_STATUS_RESPONSE);
       return;
     }
 
     res.writeHead(404, { "Content-Type": "text/plain" });
-    res.end("not found");
+    res.end(BRIDGE_NOT_FOUND_RESPONSE);
   });
 
   server.listen(port, () => {
@@ -37,22 +71,27 @@ export function startBridgeServer() {
 }
 
 function resolveBridgePort() {
+  //audit Assumption: BRIDGE_PORT is parseable; risk: invalid port prevents startup; invariant: port is finite and > 0; handling: fallback default.
   const raw = Number.parseInt(process.env.BRIDGE_PORT || "", 10);
+  //audit Assumption: raw port within valid range; risk: binding failure; invariant: only accept positive ints; handling: default port.
   if (Number.isFinite(raw) && raw > 0) {
     return raw;
   }
-  return DEFAULT_PORT;
+  return DEFAULT_BRIDGE_PORT;
 }
 
 function sendToDaemon(payload) {
+  //audit Assumption: payload safe to log; risk: sensitive data exposure; invariant: payload is sanitized upstream; handling: log for debug only.
   console.log("[Bridge] Routed payload:", payload);
   // Example: send to backend or handle IPC logic here.
 }
 
 const isDirectRun =
   process.argv[1] &&
+  //audit Assumption: process argv points to entrypoint; risk: false positives in loaders; invariant: URL equality indicates direct run; handling: start server only on match.
   import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
 
+//audit Assumption: direct run implies manual execution; risk: side effects in import; invariant: only start on direct execution; handling: conditional start.
 if (isDirectRun) {
   startBridgeServer();
 }


### PR DESCRIPTION
### Motivation
- Improve auditability and configurability of the daemon bridge by moving hardcoded tag/port/status values into named constants with environment overrides.
- Provide clearer runtime reasoning and safer defaults to avoid malformed tags or invalid ports during startup.
- Follow the system audit conventions by annotating conditionals, fallbacks, and data transforms for easier review.

### Description
- Replaced hardcoded values with named constants: `DEFAULT_BRIDGE_PORT`, `DEFAULT_TAG_PREFIX`, `DEFAULT_TAG_ID`, `BRIDGE_STATUS_PATH`, `BRIDGE_STATUS_RESPONSE`, and `BRIDGE_NOT_FOUND_RESPONSE` in `daemon/bridge.js`.
- Added helper functions `resolveTagPrefix()`, `resolveTagId()`, and `buildBridgeTag(reqId)` and switched `bridge.assignTag` to use `buildBridgeTag` for env-driven tag construction.
- Updated `resolveBridgePort()` to fall back to `DEFAULT_BRIDGE_PORT` and added defensive `//audit` comments around conditionals, error-prone branches, and logging in `sendToDaemon()` and `startBridgeServer()`.
- Documented `startBridgeServer()` behavior with a brief comment block and guarded direct-run startup with an audited `isDirectRun` check.

### Testing
- Ran cross-codebase sync check via `node scripts/cross-codebase-sync.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dc10b015083258259629b8c720bf8)