### PR TITLE
fix: add missing APPLICATION_CONSTANTS import in unifiedClient

### DIFF
--- a/src/services/openai/unifiedClient.ts
+++ b/src/services/openai/unifiedClient.ts
@@ -35,6 +35,7 @@ import {
 import { responseCache } from '../../utils/cache.js';
 import { getRoutingActiveMessage } from '../../config/prompts.js';
 import { getConfig } from '../../config/unifiedConfig.js';
+import { APPLICATION_CONSTANTS } from '../../utils/constants.js';
 import { resolveErrorMessage } from '../../lib/errors/index.js';
 
 /**


### PR DESCRIPTION
## What this fixes
- Adds the missing APPLICATION_CONSTANTS import in src/services/openai/unifiedClient.ts.
- Resolves TypeScript compile error: TS2304: Cannot find name 'APPLICATION_CONSTANTS'.

## Validation
- 
pm run build passes locally.

## Context
This is a follow-up fix for the regression surfaced after PR #1110.