### PR TITLE
Refactor dispatch v9 memory gate and add configurable reroute/readonly binding

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -77,7 +77,9 @@ export const config = {
   dispatchV9: {
     enabled: getEnv('DISPATCH_V9_ENABLED') === 'true',
     shadowOnly: getEnv('DISPATCH_V9_SHADOW_ONLY') === 'true',
-    snapshotCacheTtlMs: parseNumber(getEnv('DISPATCH_V9_SNAPSHOT_CACHE_TTL_MS'), 3000, 0)
+    snapshotCacheTtlMs: parseNumber(getEnv('DISPATCH_V9_SNAPSHOT_CACHE_TTL_MS'), 3000, 0),
+    defaultRerouteTarget: getEnv('DISPATCH_V9_DEFAULT_REROUTE_TARGET') || '/api/ask',
+    readonlyBindingId: getEnv('DISPATCH_V9_READONLY_BINDING_ID') || 'api.readonly'
   },
 
   // Logging configuration


### PR DESCRIPTION
### Motivation
- Reduce nested logic and centralize common response flows in the dispatch v9 memory consistency middleware to improve readability and maintainability.
- Make read-only binding id and default reroute target configurable via environment to support deployment flexibility.

### Description
- Added new `dispatchV9` config options `defaultRerouteTarget` and `readonlyBindingId` in `src/config/index.ts` to allow environment overrides for reroute and readonly binding behavior.
- Refactored `src/middleware/memoryConsistencyGate.ts` by introducing constants (`MAX_BODY_SERIALIZATION_BYTES`, `STATUS_CONFLICT`, `STATUS_SERVICE_UNAVAILABLE`), helper functions (`applyDispatchDecisionContext`, `respondWithFailsafe`, `respondWithConflict`) and an extracted async `handleRerouteDecision` to consolidate reroute and failsafe logic.
- Replaced inline branching with the new helpers and switched to use `deps.defaultRerouteTarget` and `deps.readonlyBindingId`, and applied body serialization size constant in `cloneJsonSafe`.
- Updated middleware dependency shaping to accept the new overrides and preserved original audit/logging behavior and invariants.

### Testing
- Ran `npm run sync:check` which completed successfully and reported sync checks (no errors, informational items only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986598e809083258f57a869c1de0d35)