### PR TITLE
ci: add missing lint/test/build steps to workflows

### DIFF
--- a/.github/workflows/api-endpoint-tests.yml
+++ b/.github/workflows/api-endpoint-tests.yml
@@ -21,6 +21,9 @@ jobs:
       - name: 📦 Install dependencies
         run: npm ci
 
+      - name: 🧹 Lint code
+        run: npm run lint
+
       - name: 🔨 Build project
         run: npm run build
 

--- a/.github/workflows/arcanos-ci-cd-pipeline.yml
+++ b/.github/workflows/arcanos-ci-cd-pipeline.yml
@@ -36,6 +36,10 @@ jobs:
       - name: Run dependency audit
         run: npm audit --production
 
+      # 3.5️⃣ Lint
+      - name: Lint code
+        run: npm run lint
+
       # 4️⃣ Run Tests
       - name: Run unit tests
         run: npm test

--- a/.github/workflows/arcanos-deploy.yml
+++ b/.github/workflows/arcanos-deploy.yml
@@ -53,11 +53,14 @@ jobs:
       - name: 📦 Install dependencies
         run: npm ci
 
+      - name: 🧹 Lint code
+        run: npm run lint
+
       - name: 🔧 Build project
         run: npm run build
 
       - name: 🧪 Run tests
-        run: npm test || echo "No tests defined, skipping..."
+        run: npm test
 
       - name: 🤖 ARCANOS Pre-deployment Analysis
         run: |

--- a/.github/workflows/arcanos-pr-assistant.yml
+++ b/.github/workflows/arcanos-pr-assistant.yml
@@ -36,6 +36,9 @@ jobs:
       - name: 📦 Install dependencies
         run: npm ci
 
+      - name: 🧹 Lint code
+        run: npm run lint
+
       - name: 🔧 Build project
         run: npm run build
 

--- a/.github/workflows/arcanos-release.yml
+++ b/.github/workflows/arcanos-release.yml
@@ -50,9 +50,17 @@ jobs:
         if: ${{ inputs.patch_only != true }}
         run: npm ci
 
+      - name: 🧹 Lint code
+        if: ${{ inputs.patch_only != true }}
+        run: npm run lint
+
       - name: 🔧 Build project
         if: ${{ inputs.patch_only != true }}
         run: npm run build
+
+      - name: 🧪 Run tests
+        if: ${{ inputs.patch_only != true }}
+        run: npm test
 
       - name: 🤖 ARCANOS Release Analysis
         if: ${{ inputs.patch_only != true }}

--- a/.github/workflows/build-sign-deploy.yml
+++ b/.github/workflows/build-sign-deploy.yml
@@ -45,6 +45,16 @@ jobs:
           cd backend-typescript
           npm install
 
+      - name: Lint code
+        run: |
+          cd backend-typescript
+          npm run lint
+
+      - name: Build project
+        run: |
+          cd backend-typescript
+          npm run build
+
       - name: Run tests
         run: |
           cd backend-typescript

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,12 @@ jobs:
         
     - name: 📦 Install dependencies
       run: npm ci
-      
+
+    - name: 🧹 Lint code
+      run: npm run lint
+
     - name: 🔨 Build project
       run: npm run build --if-present
-      
+
     - name: 🧪 Run tests
       run: npm test


### PR DESCRIPTION
## Summary
- Added `npm run lint` to **7 workflows** that were missing it — previously only `ci-cd.yml` ran lint
- Added `npm run build` and `npm test` to `build-sign-deploy.yml` and `arcanos-release.yml` which ship artifacts without verifying them
- Fixed `arcanos-deploy.yml` silently swallowing test failures (`npm test || echo "...skipping"` → `npm test`)

## Workflows patched
| Workflow | Added |
|---|---|
| `arcanos-ci-cd-pipeline.yml` | lint |
| `arcanos-deploy.yml` | lint, fixed swallowed test |
| `arcanos-pr-assistant.yml` | lint |
| `main.yml` | lint |
| `build-sign-deploy.yml` | lint, build |
| `arcanos-release.yml` | lint, test |
| `api-endpoint-tests.yml` | lint |

## Test plan
- [x] All 7 YAML files pass syntax validation
- [x] Each patched workflow confirmed to contain a lint step
- [ ] Verify workflows pass on next push/PR trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)