### PR TITLE
chore: add pyrightconfig.json for faster IDE indexing

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,4 +1,6 @@
 {
+  "pythonVersion": "3.11",
+  "venvPath": "daemon-python",
   "exclude": [
     "node_modules",
     "dist",


### PR DESCRIPTION
## Summary
- Adds `pyrightconfig.json` to exclude `node_modules/`, `dist/`, `daemon-python/.venv/`, and `.git/` from Pyright/Pylance file enumeration
- Fixes slow workspace indexing warning in VS Code

## Test plan
- [ ] Open workspace in VS Code and verify the slow enumeration warning is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)