### PR TITLE
feat: add shell completion for arcanos CLI

### DIFF
--- a/daemon-python/arcanos/cli.py
+++ b/daemon-python/arcanos/cli.py
@@ -3,6 +3,7 @@ ARCANOS CLI - Main Command Line Interface
 Human-like AI assistant with rich terminal UI.
 """
 
+import argparse
 import json
 import sys
 import threading
@@ -1575,6 +1576,25 @@ def main() -> None:
     Inputs/Outputs: None; runs the CLI loop and exits on fatal errors.
     Edge cases: Exits with status 1 when credential bootstrap fails.
     """
+    # Shell-level argument completion (argcomplete).
+    parser = argparse.ArgumentParser(
+        prog="arcanos",
+        description="ARCANOS CLI - Human-like AI assistant with rich terminal UI.",
+    )
+    parser.add_argument(
+        "--debug-mode",
+        action="store_true",
+        help="Run in non-interactive debug mode with file-based command input.",
+    )
+
+    try:
+        import argcomplete
+        argcomplete.autocomplete(parser)
+    except ImportError:  # argcomplete not installed — skip shell completion
+        pass
+
+    args = parser.parse_args()
+
     # //audit assumption: bootstrap runs before CLI; risk: missing credentials; invariant: credentials ready; strategy: bootstrap then run.
     try:
         bootstrap_credentials()
@@ -1587,10 +1607,8 @@ def main() -> None:
     # Fail-fast validation after bootstrap (ensures all required config is valid)
     validate_required_config(exit_on_error=True)
 
-    # //audit assumption: debug flag toggles mode; risk: unexpected behavior; invariant: boolean flag; strategy: parse argv.
-    debug_mode = "--debug-mode" in sys.argv
     cli = ArcanosCLI()
-    cli.run(debug_mode=debug_mode)
+    cli.run(debug_mode=args.debug_mode)
 
 
 # //audit assumption: module used as entrypoint; risk: unexpected import side effects; invariant: main guard; strategy: only run on direct execution.

--- a/daemon-python/arcanos/cli_runner.py
+++ b/daemon-python/arcanos/cli_runner.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Callable
 
 from .cli_config import CAMERA_INTENT_PATTERN, RUN_COMMAND_PATTERNS, SCREEN_INTENT_PATTERN
 from .cli_intents import detect_run_see_intent
+from .completer import install_completion
 from .config import Config
 from .env import get_env
 from .error_handler import ErrorHandler
@@ -256,6 +257,7 @@ def run_interactive_mode(cli: "ArcanosCLI") -> None:
     Inputs/Outputs: CLI instance; reads input from stdin and processes it.
     Edge cases: Exits cleanly on KeyboardInterrupt or "exit"/"quit"/"bye".
     """
+    install_completion()
     cli.show_welcome()
     try:
         while True:

--- a/daemon-python/arcanos/completer.py
+++ b/daemon-python/arcanos/completer.py
@@ -1,0 +1,82 @@
+"""
+In-REPL tab completion for ARCANOS slash commands.
+
+Uses Python's readline module to provide tab completion inside the
+interactive session.  Falls back gracefully when readline is unavailable
+(e.g. Windows without pyreadline3).
+"""
+
+from __future__ import annotations
+
+# All top-level slash commands available in the REPL.
+SLASH_COMMANDS: list[str] = [
+    "/backend",
+    "/bye",
+    "/clear",
+    "/deep",
+    "/exit",
+    "/help",
+    "/ptt",
+    "/quit",
+    "/reset",
+    "/run",
+    "/see",
+    "/speak",
+    "/stats",
+    "/update",
+    "/voice",
+]
+
+# Subcommands keyed by parent command.
+SUBCOMMANDS: dict[str, list[str]] = {
+    "/see": ["camera", "screen"],
+}
+
+
+def _complete(text: str, state: int) -> str | None:
+    """Readline completer callback.
+
+    ``text`` is the current token being completed.
+    ``state`` is the index into the list of matches (called repeatedly
+    until ``None`` is returned).
+    """
+    try:
+        import readline
+    except ImportError:  # pragma: no cover
+        return None
+
+    line = readline.get_line_buffer().lstrip()
+    parts = line.split()
+
+    # Completing first token — match slash commands.
+    if len(parts) <= 1 and not line.endswith(" "):
+        matches = [cmd for cmd in SLASH_COMMANDS if cmd.startswith(text)]
+    else:
+        # Completing a subcommand (e.g. "/see c<TAB>").
+        parent = parts[0] if parts else ""
+        subs = SUBCOMMANDS.get(parent, [])
+        prefix = text
+        matches = [s for s in subs if s.startswith(prefix)]
+
+    return matches[state] if state < len(matches) else None
+
+
+def install_completion() -> None:
+    """Set up readline tab completion for the REPL.
+
+    Safe to call on any platform — silently does nothing when readline
+    is not available.
+    """
+    try:
+        import readline
+    except ImportError:  # pragma: no cover
+        return
+
+    readline.set_completer(_complete)
+    readline.set_completer_delims(" \t")
+
+    # GNU readline (Linux/macOS) vs libedit (macOS default).
+    if "libedit" in (readline.__doc__ or ""):
+        readline.parse_and_bind("bind ^I rl_complete")
+    else:
+        readline.parse_and_bind("tab: complete")

--- a/daemon-python/pyproject.toml
+++ b/daemon-python/pyproject.toml
@@ -37,7 +37,9 @@ dependencies = [
   "webrtcvad>=2.0.10; platform_system != 'Windows'",
   "pystray>=0.19.5",
   "rich>=13.7.0",
-  "psycopg2-binary>=2.9.9"
+  "psycopg2-binary>=2.9.9",
+  "argcomplete>=3.1.0",
+  "pyreadline3>=3.1; platform_system == 'Windows'"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Add in-REPL tab completion for `/slash` commands (readline-based, works on Linux/macOS/Windows)
- Add shell-level completion for the `arcanos` binary via `argparse` + `argcomplete`
- Replace raw `sys.argv` parsing with proper `argparse` in `main()`

### Setup

**In-REPL** — works automatically after install, just press Tab.

**Shell-level** — one-time activation:
```bash
# Bash
eval "$(register-python-argcomplete arcanos)"

# Zsh
autoload -U bashcompinit && bashcompinit
eval "$(register-python-argcomplete arcanos)"

# PowerShell
register-python-argcomplete --shell powershell arcanos | Out-String | Invoke-Expression
```

## Test plan
- [ ] `pip install -e .` in `daemon-python/`
- [ ] Run `arcanos`, type `/h<TAB>` → completes to `/help`
- [ ] Type `/see c<TAB>` → completes to `/see camera`
- [ ] Verify `arcanos --debug-mode` still works
- [ ] Verify no import errors on platforms without readline

🤖 Generated with [Claude Code](https://claude.com/claude-code)