### PR TITLE
feat(governance): enforce /ask system modes with backend-owned intent state

### DIFF
--- a/daemon-python/arcanos/backend_client/__init__.py
+++ b/daemon-python/arcanos/backend_client/__init__.py
@@ -11,6 +11,7 @@ import requests
 from ..backend_auth_client import normalize_backend_url
 from .chat import request_ask_with_domain as _request_ask_with_domain
 from .chat import request_chat_completion as _request_chat_completion
+from .chat import request_system_state as _request_system_state
 from .daemon import request_confirm_daemon_actions as _request_confirm_daemon_actions
 from .plans import fetch_plan as _fetch_plan
 from .plans import approve_plan as _approve_plan
@@ -149,6 +150,19 @@ class BackendApiClient:
         metadata: Optional[Mapping[str, Any]] = None
     ) -> BackendResponse[BackendChatResult]:
         return _request_chat_completion(self, messages, temperature, model, stream, metadata)
+
+    def request_system_state(
+        self,
+        metadata: Optional[Mapping[str, Any]] = None,
+        expected_version: Optional[int] = None,
+        patch: Optional[Mapping[str, Any]] = None,
+    ) -> BackendResponse[dict[str, Any]]:
+        """
+        Purpose: Request backend system state through /ask mode=system_state.
+        Inputs/Outputs: optional metadata and optimistic-lock patch fields; returns raw state payload.
+        Edge cases: returns structured validation errors for partial update payloads.
+        """
+        return _request_system_state(self, metadata, expected_version, patch)
 
     def request_vision_analysis(
         self,

--- a/daemon-python/arcanos/cli.py
+++ b/daemon-python/arcanos/cli.py
@@ -31,6 +31,7 @@ if sys.platform == "win32":
 from rich.console import Console
 from rich.panel import Panel
 from rich.markdown import Markdown
+from rich.table import Table
 from collections import deque
 
 from .config import Config, validate_required_config
@@ -52,15 +53,9 @@ from .cli_config import (
 )
 from .cli_session import (
     SessionContext,
-    SESSION_CONFIDENCE_DECAY_ON_MISS,
-    SESSION_CONFIDENCE_GAIN_ON_HIT,
-    SESSION_GOAL_LOCK_CONFIDENCE_THRESHOLD,
-    SESSION_GOAL_LOCK_MIN_TURNS,
     SESSION_SUMMARY_HISTORY_LIMIT,
     SESSION_SUMMARY_TURN_INTERVAL,
     TONE_TO_PERSONA,
-    infer_phase,
-    infer_tone,
     sanitize_summary_for_prompt,
 )
 from .cli_intents import detect_domain_intent, truncate_for_tts
@@ -83,12 +78,10 @@ from .cli_daemon import (
 )
 from .cli_runner import run_debug_mode, run_interactive_mode
 from .daemon_system_definition import (
-    build_daemon_system_prompt,
     DEFAULT_BACKEND_BLOCK,
     format_registry_for_prompt,
 )
 from .conversation_routing import (
-    compute_backend_confidence,
     determine_conversation_route,
     build_conversation_messages,
     ConversationRouteDecision,
@@ -217,6 +210,13 @@ class ArcanosCLI:
 
         # Session context for conversation tracking
         self.session = SessionContext(session_id=self.instance_id)
+        self._backend_routing_preferred: str = "backend"
+
+        if self.backend_client:
+            # //audit assumption: startup should hydrate from backend source of truth; risk: stale local intent inference; invariant: backend state seeds session when available; strategy: best-effort hydration.
+            state_payload = self._request_backend_system_state_payload()
+            if state_payload:
+                self._hydrate_session_from_backend_state(state_payload)
 
         # System prompt for AI personality and daemon capabilities
         self.system_prompt = self._build_system_prompt()
@@ -470,6 +470,146 @@ class ArcanosCLI:
             self._report_backend_error(action_label, response.error)
 
         return response
+
+    def _request_backend_system_state_payload(self) -> Optional[dict[str, Any]]:
+        """
+        Purpose: Fetch backend-owned system state through /ask mode=system_state.
+        Inputs/Outputs: None; returns parsed state payload dict or None.
+        Edge cases: Returns None when backend is unavailable or request fails.
+        """
+        if not self.backend_client:
+            # //audit assumption: backend client may be missing; risk: attempted state call without backend; invariant: no request attempted; strategy: return None.
+            return None
+
+        metadata = self._build_backend_metadata()
+        response = self._request_with_auth_retry(
+            lambda: self.backend_client.request_system_state(metadata=metadata),
+            "system state",
+        )
+        if not response.ok or not response.value:
+            # //audit assumption: failed state calls should not hydrate local session; risk: stale/partial state; invariant: None on failure; strategy: return None.
+            return None
+
+        return response.value
+
+    def _hydrate_session_from_backend_state(self, state_payload: Mapping[str, Any]) -> None:
+        """
+        Purpose: Hydrate local session fields from backend state without mutating backend data.
+        Inputs/Outputs: backend state payload mapping; updates local session cache and routing preference.
+        Edge cases: Missing or malformed fields are ignored safely.
+        """
+        routing_payload = state_payload.get("routing")
+        if isinstance(routing_payload, Mapping):
+            preferred = routing_payload.get("preferred")
+            # //audit assumption: routing preference is constrained to local/backend; risk: invalid route values; invariant: only valid values applied; strategy: allowlist check.
+            if preferred in ("local", "backend"):
+                self._backend_routing_preferred = str(preferred)
+
+        intent_payload = state_payload.get("intent")
+        if not isinstance(intent_payload, Mapping):
+            # //audit assumption: missing intent payload means no active intent; risk: stale local intent display; invariant: retain existing local cache; strategy: return early.
+            return
+
+        intent_id = intent_payload.get("intentId")
+        if not isinstance(intent_id, str) or not intent_id.strip():
+            # //audit assumption: null/empty intent id means no active intent; risk: overwriting with empty fields; invariant: local intent unchanged; strategy: guard by intentId presence.
+            return
+
+        label = intent_payload.get("label")
+        if isinstance(label, str) and label.strip():
+            self.session.current_intent = label.strip()
+            self.session.conversation_goal = label.strip()
+
+        confidence = intent_payload.get("confidence")
+        if isinstance(confidence, (int, float)):
+            # //audit assumption: confidence is normalized to [0,1]; risk: malformed values; invariant: bounded local confidence; strategy: clamp.
+            self.session.intent_confidence = max(0.0, min(1.0, float(confidence)))
+
+        phase = intent_payload.get("phase")
+        if phase == "exploration":
+            # //audit assumption: exploration maps to active local phase; risk: phase taxonomy mismatch; invariant: local phase remains valid literal; strategy: deterministic map.
+            self.session.phase = "active"
+        elif phase == "execution":
+            # //audit assumption: execution maps to refining local phase; risk: phase taxonomy mismatch; invariant: local phase remains valid literal; strategy: deterministic map.
+            self.session.phase = "refining"
+
+    def _render_system_state_table(self, state_payload: Mapping[str, Any]) -> None:
+        """
+        Purpose: Render backend system state in table-only format for `arcanos status`.
+        Inputs/Outputs: backend state payload; prints a Rich table.
+        Edge cases: Missing fields are rendered as safe placeholders.
+        """
+        intent_payload = state_payload.get("intent") if isinstance(state_payload.get("intent"), Mapping) else {}
+        routing_payload = state_payload.get("routing") if isinstance(state_payload.get("routing"), Mapping) else {}
+        backend_payload = state_payload.get("backend") if isinstance(state_payload.get("backend"), Mapping) else {}
+        freshness_payload = (
+            state_payload.get("stateFreshness") if isinstance(state_payload.get("stateFreshness"), Mapping) else {}
+        )
+
+        table = Table(title="ARCANOS System State")
+        table.add_column("Field", style="cyan", no_wrap=True)
+        table.add_column("Value", style="green")
+
+        table.add_row("mode", str(state_payload.get("mode", "unknown")))
+        table.add_row("intent.intentId", str(intent_payload.get("intentId", "null")))
+        table.add_row("intent.label", str(intent_payload.get("label", "null")))
+        table.add_row("intent.status", str(intent_payload.get("status", "null")))
+        table.add_row("intent.phase", str(intent_payload.get("phase", "null")))
+        table.add_row("intent.confidence", str(intent_payload.get("confidence", 0.0)))
+        table.add_row("intent.version", str(intent_payload.get("version", 0)))
+        table.add_row("intent.lastTouchedAt", str(intent_payload.get("lastTouchedAt", "null")))
+        table.add_row("routing.preferred", str(routing_payload.get("preferred", "unknown")))
+        table.add_row("routing.lastUsed", str(routing_payload.get("lastUsed", "unknown")))
+        table.add_row("routing.confidenceGate", str(routing_payload.get("confidenceGate", "unknown")))
+        table.add_row("backend.connected", str(backend_payload.get("connected", False)))
+        table.add_row("backend.registryAvailable", str(backend_payload.get("registryAvailable", False)))
+        table.add_row("backend.lastHeartbeatAt", str(backend_payload.get("lastHeartbeatAt", "unknown")))
+        table.add_row("freshness.intent", str(freshness_payload.get("intent", "unknown")))
+        table.add_row("freshness.backend", str(freshness_payload.get("backend", "unknown")))
+        table.add_row("generatedAt", str(state_payload.get("generatedAt", "unknown")))
+
+        self.console.print(table)
+
+    def _is_working_context_query(self, message: str) -> bool:
+        """
+        Purpose: Detect user prompts asking for current work context/intent.
+        Inputs/Outputs: user message string; returns True when system-state answer should be used.
+        Edge cases: Empty messages return False.
+        """
+        normalized = (message or "").strip().lower()
+        if not normalized:
+            return False
+
+        # //audit assumption: narrow phrase matching avoids false positives; risk: missing uncommon phrasing; invariant: deterministic trigger set; strategy: substring allowlist.
+        phrases = (
+            "what was i working on",
+            "what am i working on",
+            "what's my current intent",
+            "what is my current intent",
+            "current intent",
+        )
+        return any(phrase in normalized for phrase in phrases)
+
+    def handle_status(self) -> bool:
+        """
+        Purpose: Show backend-owned governed status using /ask mode=system_state.
+        Inputs/Outputs: None; renders a table and returns success flag.
+        Edge cases: Returns False when backend is not configured or state fetch fails.
+        """
+        if not self.backend_client:
+            # //audit assumption: status requires backend source-of-truth; risk: stale local-only status; invariant: fail when backend missing; strategy: print error and return False.
+            self.console.print("[red]Backend is not configured.[/red]")
+            return False
+
+        state_payload = self._request_backend_system_state_payload()
+        if not state_payload:
+            # //audit assumption: failed state fetch cannot be substituted locally; risk: fabricated status; invariant: no synthetic state output; strategy: fail closed.
+            self.console.print("[red]Failed to fetch backend system state.[/red]")
+            return False
+
+        self._hydrate_session_from_backend_state(state_payload)
+        self._render_system_state_table(state_payload)
+        return True
 
     def _registry_cache_is_valid(self) -> bool:
         """
@@ -807,10 +947,10 @@ Guidelines:
         # Include daemon metadata
         metadata = self._build_backend_metadata()
 
-        # Use /api/ask endpoint with domain hint for natural language routing
+        # Use /ask endpoint with domain hint for natural language routing
         # The backend dispatcher will route to modules based on domain
         if domain:
-            # Call /api/ask with domain hint for module routing
+            # Call /ask with domain hint for module routing
             response = self._request_with_auth_retry(
                 lambda: self.backend_client.request_ask_with_domain(
                     message=message,
@@ -1018,32 +1158,40 @@ Guidelines:
         # ---- Session update (pre-routing) ----
         self.session.turn_count += 1
 
-        detected_intent = detect_domain_intent(message, DOMAIN_KEYWORDS)
-        # //audit assumption: intent hit should strengthen confidence; risk: overfitting on transient terms; invariant: confidence stays within [0,1]; strategy: bounded increment on hits.
-        if detected_intent:
-            self.session.current_intent = detected_intent
-            self.session.intent_confidence = min(
-                1.0,
-                self.session.intent_confidence + SESSION_CONFIDENCE_GAIN_ON_HIT
-            )
-        else:
-            # //audit assumption: missing intent should decay confidence gradually; risk: stale intent lock-in; invariant: confidence decays but remains non-negative; strategy: multiplicative decay.
-            self.session.intent_confidence *= SESSION_CONFIDENCE_DECAY_ON_MISS
+        # //audit assumption: intent-history questions should resolve from backend system state, not model chat; risk: fabricated recap; invariant: response derives from system_state payload; strategy: short-circuit with deterministic answer.
+        if self.backend_client and self._is_working_context_query(message):
+            state_payload = self._request_backend_system_state_payload()
+            if state_payload:
+                self._hydrate_session_from_backend_state(state_payload)
+                intent_payload = state_payload.get("intent") if isinstance(state_payload.get("intent"), Mapping) else {}
+                label = intent_payload.get("label")
+                status = intent_payload.get("status")
+                answer_label = label if isinstance(label, str) and label.strip() else "No active intent"
+                answer_status = status if isinstance(status, str) and status.strip() else "null"
+                answer_text = f"{answer_label} (status: {answer_status})"
 
-        self.session.phase = infer_phase(
-            self.session.turn_count,
-            self.session.intent_confidence
-        )
+                if return_result:
+                    return _ConversationResult(
+                        response_text=answer_text,
+                        tokens_used=ZERO_TOKENS_USED,
+                        cost_usd=ZERO_COST_USD,
+                        model=Config.BACKEND_CHAT_MODEL or "backend",
+                        source="backend",
+                    )
 
-        self.session.tone = infer_tone(self.session.current_intent)
+                table = Table(title="Current Work Context")
+                table.add_column("Field", style="cyan")
+                table.add_column("Value", style="green")
+                table.add_row("intent", answer_label)
+                table.add_row("status", answer_status)
+                self.console.print(table)
+                return None
 
-        if (
-            self.session.conversation_goal is None
-            and self.session.turn_count >= SESSION_GOAL_LOCK_MIN_TURNS
-            and self.session.intent_confidence >= SESSION_GOAL_LOCK_CONFIDENCE_THRESHOLD
-        ):
-            # //audit assumption: goal lock should occur only after stable evidence; risk: premature goal fixation; invariant: goal set once when threshold reached; strategy: gated assignment.
-            self.session.conversation_goal = self.session.current_intent
+        if self.backend_client:
+            state_payload = self._request_backend_system_state_payload()
+            if state_payload:
+                # //audit assumption: backend state is authoritative for intent/session context; risk: stale local inference; invariant: local cache follows backend; strategy: hydrate before routing.
+                self._hydrate_session_from_backend_state(state_payload)
 
         # Rebuild system prompt with updated session context
         self.system_prompt = self._build_system_prompt()
@@ -1060,16 +1208,13 @@ Guidelines:
                 normalized_message=message.strip() or message,
                 used_prefix=None
             )
-
-        # //audit: when route would be backend, apply confidence threshold; if below, keep local so “simple” stays on daemon.
-        if route_decision.route == "backend":
-            conf = compute_backend_confidence(route_decision.normalized_message)
-            if conf < Config.BACKEND_CONFIDENCE_THRESHOLD:
-                route_decision = ConversationRouteDecision(
-                    route="local",
-                    normalized_message=route_decision.normalized_message,
-                    used_prefix=None,
-                )
+        elif self.backend_client and self._backend_routing_preferred == "backend":
+            # //audit assumption: backend preference from system_state should drive default route; risk: local drift from backend-owned intent; invariant: backend route selected unless explicit override; strategy: enforce backend preference.
+            route_decision = ConversationRouteDecision(
+                route="backend",
+                normalized_message=message.strip() or message,
+                used_prefix=None,
+            )
 
         # Detect domain intent for natural language routing
         domain = detect_domain_intent(message, DOMAIN_KEYWORDS) if route_decision.route == "backend" else None
@@ -1157,6 +1302,12 @@ Guidelines:
             self._last_response = response_for_user
 
         self._send_backend_update("conversation_usage", update_payload)
+
+        if result.source == "backend" and self.backend_client:
+            refreshed_state = self._request_backend_system_state_payload()
+            if refreshed_state:
+                # //audit assumption: backend chat may advance intent/version; risk: stale local session cache after response; invariant: hydrate from latest backend state; strategy: refresh after successful backend turn.
+                self._hydrate_session_from_backend_state(refreshed_state)
 
         # ---- Post-response summarization ----
         self._update_short_term_summary()
@@ -1582,6 +1733,12 @@ def main() -> None:
         description="ARCANOS CLI - Human-like AI assistant with rich terminal UI.",
     )
     parser.add_argument(
+        "command",
+        nargs="?",
+        choices=["status"],
+        help="Run a one-shot command such as `status` and exit.",
+    )
+    parser.add_argument(
         "--debug-mode",
         action="store_true",
         help="Run in non-interactive debug mode with file-based command input.",
@@ -1608,6 +1765,12 @@ def main() -> None:
     validate_required_config(exit_on_error=True)
 
     cli = ArcanosCLI()
+
+    if args.command == "status":
+        # //audit assumption: status command should be non-interactive and backend-sourced; risk: entering chat loop unexpectedly; invariant: execute once then exit; strategy: call status handler and return process code.
+        succeeded = cli.handle_status()
+        sys.exit(0 if succeeded else 1)
+
     cli.run(debug_mode=args.debug_mode)
 
 

--- a/daemon-python/arcanos/cli_runner.py
+++ b/daemon-python/arcanos/cli_runner.py
@@ -176,6 +176,7 @@ def _build_command_handlers(cli: "ArcanosCLI", args: str) -> dict[str, Callable[
         "ptt": cli.handle_ptt,
         "run": lambda: cli.handle_run(args),
         "speak": cli.handle_speak,
+        "status": cli.handle_status,
         "stats": cli.handle_stats,
         "clear": cli.handle_clear,
         "reset": cli.handle_reset,

--- a/daemon-python/arcanos/cli_ui.py
+++ b/daemon-python/arcanos/cli_ui.py
@@ -96,6 +96,7 @@ Just type naturally — ask me anything, and I'll do my best to help.
   Example: `/run Get-Process` or `/run ls -la`
 
 ### Housekeeping
+- **/status** — Show backend-governed system state
 - **/stats** — See usage stats
 - **/clear** — Clear conversation history
 - **/update** — Check for updates

--- a/src/routes/ask.ts
+++ b/src/routes/ask.ts
@@ -1,16 +1,34 @@
 import express, { Request, Response } from 'express';
+import { z } from 'zod';
 import { runThroughBrain } from '../logic/trinity.js';
 import { validateAIRequest, handleAIError, logRequestFeedback } from '../utils/requestHandler.js';
 import { confirmGate } from '../middleware/confirmGate.js';
 import { createRateLimitMiddleware, securityHeaders } from '../utils/security.js';
+import { aiRequestSchema, type AIRequestDTO } from '../types/dto.js';
 import type {
   ConfirmationRequiredResponseDTO,
   ErrorResponseDTO
 } from '../types/dto.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 import { askValidationMiddleware } from './ask/validation.js';
-import type { AskRequest, AskResponse } from './ask/types.js';
+import type {
+  AskRequest,
+  AskResponse,
+  SchemaValidationBypassAuditFlag,
+  SystemReviewResponse,
+  SystemStateResponse
+} from './ask/types.js';
 import { tryDispatchDaemonTools } from './ask/daemonTools.js';
+import { getOpenAIClientOrAdapter } from '../services/openai/clientBridge.js';
+import { getGPT5Model, hasValidAPIKey } from '../services/openai.js';
+import {
+  getActiveIntentSnapshot,
+  getLastRoutingUsed,
+  recordChatIntent,
+  setLastRoutingUsed,
+  type IntentConflict,
+  updateIntentWithOptimisticLock
+} from './ask/intent_store.js';
 
 const router = express.Router();
 
@@ -18,17 +36,398 @@ const router = express.Router();
 router.use(securityHeaders);
 router.use(createRateLimitMiddleware(60, 15 * 60 * 1000)); // 60 requests per 15 minutes
 
+type AskRouteResponse =
+  | AskResponse
+  | ErrorResponseDTO
+  | ConfirmationRequiredResponseDTO
+  | SystemReviewResponse
+  | SystemStateResponse
+  | IntentConflict;
+
+const SYSTEM_REVIEW_PROMPT = `You are operating in SYSTEM_REVIEW mode.
+
+You are not an assistant.
+You are a system reviewer and architect.
+
+Rules:
+- Do not converse.
+- Do not ask questions.
+- Do not speculate beyond provided input.
+- Identify strengths, risks, gaps, and assumptions explicitly.
+- Output deterministic, structured JSON only.
+
+Output must conform exactly to the system_review schema.`;
+
+const SYSTEM_STATE_PROMPT = `⚠️ Do not use the model yet.
+Return backend data directly.`;
+
+const systemReviewSchema = z.object({
+  mode: z.literal('system_review'),
+  subject: z.literal('intent_system'),
+  verdict: z.enum(['approved', 'approved_with_risks', 'blocked']),
+  summary: z.string().min(1).max(2000),
+  strengths: z.array(z.string()),
+  risks: z.array(
+    z.object({
+      level: z.enum(['low', 'medium', 'high']),
+      area: z.string().min(1),
+      description: z.string().min(1),
+      mitigation: z.string().min(1)
+    })
+  ),
+  gaps: z.array(z.string()),
+  recommendations: z.array(
+    z.object({
+      priority: z.enum(['low', 'medium', 'high']),
+      action: z.string().min(1),
+      rationale: z.string().min(1)
+    })
+  ),
+  assumptions: z.array(z.string()),
+  confidence: z.number().min(0).max(1),
+  reviewedAt: z.string().datetime(),
+  reviewVersion: z.literal(1)
+});
+
+const systemStateSchema = z.object({
+  mode: z.literal('system_state'),
+  intent: z.object({
+    intentId: z.string().nullable(),
+    label: z.string().nullable(),
+    status: z.enum(['active', 'paused', 'completed']).nullable(),
+    phase: z.enum(['exploration', 'execution']).nullable(),
+    confidence: z.number().min(0).max(1),
+    version: z.number().int().min(1),
+    lastTouchedAt: z.string().datetime().nullable()
+  }),
+  routing: z.object({
+    preferred: z.enum(['local', 'backend']),
+    lastUsed: z.enum(['local', 'backend']),
+    confidenceGate: z.number().min(0).max(1)
+  }),
+  backend: z.object({
+    connected: z.literal(true),
+    registryAvailable: z.literal(true),
+    lastHeartbeatAt: z.string().datetime()
+  }),
+  stateFreshness: z.object({
+    intent: z.enum(['fresh', 'stale']),
+    backend: z.enum(['fresh', 'degraded']),
+    lastValidatedAt: z.string().datetime()
+  }),
+  limits: z.object({
+    rateLimited: z.boolean(),
+    remainingRequests: z.number().int().min(0)
+  }),
+  generatedAt: z.string().datetime(),
+  confidence: z.number().min(0).max(1)
+});
+
+const systemStateUpdateSchema = z
+  .object({
+    mode: z.literal('system_state'),
+    expectedVersion: z.number().int().min(1).optional(),
+    patch: z
+      .object({
+        confidence: z.number().min(0).max(1).optional(),
+        phase: z.enum(['exploration', 'execution']).optional(),
+        status: z.enum(['active', 'paused', 'completed']).optional(),
+        label: z.string().min(1).max(200).optional()
+      })
+      .optional()
+  })
+  .superRefine((data, ctx) => {
+    //audit Assumption: optimistic lock updates require both expectedVersion and patch; failure risk: partial contract writes; expected invariant: update fields provided together; handling strategy: reject incomplete update payload.
+    if ((data.expectedVersion === undefined) !== (data.patch === undefined)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "system_state updates require both 'expectedVersion' and 'patch'"
+      });
+    }
+  });
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function getMode(body: AskRequest): 'chat' | 'system_review' | 'system_state' {
+  if (body.mode === 'system_review') {
+    return 'system_review';
+  }
+  if (body.mode === 'system_state') {
+    return 'system_state';
+  }
+  return 'chat';
+}
+
+function extractTextInput(body: AskRequest): string | null {
+  const candidates = [body.prompt, body.message, body.userInput, body.content, body.text, body.query];
+  for (const candidate of candidates) {
+    //audit Assumption: first non-empty string should be treated as primary text input; failure risk: alias precedence mismatch; expected invariant: deterministic extraction order; handling strategy: fixed field ordering.
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+  return null;
+}
+
+function buildValidationBypassFlag(reason: string): SchemaValidationBypassAuditFlag {
+  return {
+    auditFlag: 'SCHEMA_VALIDATION_BYPASS',
+    reason,
+    timestamp: nowIso()
+  };
+}
+
+function parseJsonContent(rawContent: string): unknown {
+  const trimmed = rawContent.trim();
+  const fencedMatch = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  const jsonText = fencedMatch ? fencedMatch[1] : trimmed;
+  return JSON.parse(jsonText);
+}
+
+function buildSystemStateResponse(): SystemStateResponse {
+  const now = nowIso();
+  const activeIntent = getActiveIntentSnapshot();
+  const lastTouchedAt = activeIntent?.lastTouchedAt ?? null;
+  const isIntentFresh =
+    !!lastTouchedAt && Date.now() - Date.parse(lastTouchedAt) <= 15 * 60 * 1000;
+
+  return {
+    mode: 'system_state',
+    intent: {
+      intentId: activeIntent?.intentId ?? null,
+      label: activeIntent?.label ?? null,
+      status: activeIntent?.status ?? null,
+      phase: activeIntent?.phase ?? null,
+      confidence: activeIntent?.confidence ?? 0,
+      version: activeIntent?.version ?? 1,
+      lastTouchedAt
+    },
+    routing: {
+      preferred: 'backend',
+      lastUsed: getLastRoutingUsed(),
+      confidenceGate: 0.75
+    },
+    backend: {
+      connected: true,
+      registryAvailable: true,
+      lastHeartbeatAt: now
+    },
+    stateFreshness: {
+      intent: isIntentFresh ? 'fresh' : 'stale',
+      backend: 'fresh',
+      lastValidatedAt: now
+    },
+    limits: {
+      rateLimited: false,
+      remainingRequests: 0
+    },
+    generatedAt: now,
+    confidence: 0.99
+  };
+}
+
+function validateLenientChatRequest(body: AskRequest): {
+  ok: true;
+  normalizedBody: AIRequestDTO & AskRequest;
+  auditFlag?: SchemaValidationBypassAuditFlag;
+} | {
+  ok: false;
+  errorPayload: ErrorResponseDTO;
+} {
+  const extractedPrompt = extractTextInput(body);
+  //audit Assumption: chat mode requires textual input; failure risk: empty requests entering model pipeline; expected invariant: prompt exists; handling strategy: reject missing text fields.
+  if (!extractedPrompt) {
+    return {
+      ok: false,
+      errorPayload: {
+        error: 'Validation failed',
+        details: [
+          "Request must include one of 'prompt', 'message', 'userInput', 'content', 'text', or 'query' fields"
+        ]
+      }
+    };
+  }
+
+  const normalizedBody: AIRequestDTO & AskRequest = {
+    ...body,
+    prompt: extractedPrompt
+  };
+
+  const strictResult = aiRequestSchema.safeParse(normalizedBody);
+  if (strictResult.success) {
+    return { ok: true, normalizedBody: strictResult.data };
+  }
+
+  const fallbackBody: AIRequestDTO & AskRequest = {
+    prompt: extractedPrompt,
+    sessionId: typeof body.sessionId === 'string' ? body.sessionId : undefined,
+    overrideAuditSafe: typeof body.overrideAuditSafe === 'string' ? body.overrideAuditSafe : undefined,
+    metadata: typeof body.metadata === 'object' && body.metadata !== null ? body.metadata : undefined,
+    clientContext: typeof body.clientContext === 'object' && body.clientContext !== null ? body.clientContext : undefined
+  };
+
+  const fallbackStrictResult = aiRequestSchema.safeParse(fallbackBody);
+  //audit Assumption: lenient fallback should still respect base AI schema; failure risk: malformed payload bypass; expected invariant: fallback remains schema-valid; handling strategy: reject if fallback parse fails.
+  if (!fallbackStrictResult.success) {
+    return {
+      ok: false,
+      errorPayload: {
+        error: 'Validation failed',
+        details: fallbackStrictResult.error.issues.map(
+          issue => `${issue.path.join('.') || 'body'}: ${issue.message}`
+        )
+      }
+    };
+  }
+
+  return {
+    ok: true,
+    normalizedBody: fallbackStrictResult.data,
+    auditFlag: buildValidationBypassFlag(
+      'Lenient chat schema path accepted request after strict validation failure'
+    )
+  };
+}
 
 /**
  * Shared handler for both ask and brain endpoints
  * Handles AI request processing with standardized error handling and validation
  */
 export const handleAIRequest = async (
-  req: Request<{}, AskResponse | ErrorResponseDTO | ConfirmationRequiredResponseDTO, AskRequest>,
-  res: Response<AskResponse | ErrorResponseDTO | ConfirmationRequiredResponseDTO>,
+  req: Request<{}, any, AskRequest>,
+  res: Response<any>,
   endpointName: string
 ) => {
+  const mode = getMode(req.body);
+
+  if (mode === 'system_state') {
+    const stateRequest = systemStateUpdateSchema.safeParse(req.body);
+    //audit Assumption: system mode requests are strictly validated; failure risk: ambiguous mode behavior; expected invariant: strict contract before execution; handling strategy: hard fail on validation errors.
+    if (!stateRequest.success) {
+      return res.status(400).json({
+        error: 'SYSTEM_STATE_REQUEST_INVALID',
+        details: stateRequest.error.issues.map(issue => issue.message)
+      });
+    }
+
+    if (stateRequest.data.expectedVersion !== undefined && stateRequest.data.patch) {
+      const updateResult = updateIntentWithOptimisticLock(
+        stateRequest.data.expectedVersion,
+        stateRequest.data.patch
+      );
+      //audit Assumption: optimistic lock mismatch must return conflict; failure risk: stale write accepted; expected invariant: 409 on version mismatch; handling strategy: return conflict payload.
+      if (!updateResult.ok) {
+        return res.status(409).json(updateResult.conflict);
+      }
+    }
+
+    //audit Assumption: SYSTEM_STATE_PROMPT exists as governance artifact only; failure risk: accidental model usage; expected invariant: mode serves backend facts directly; handling strategy: never call model here.
+    void SYSTEM_STATE_PROMPT;
+
+    const stateResponse = buildSystemStateResponse();
+    const strictState = systemStateSchema.safeParse(stateResponse);
+    //audit Assumption: system_state responses must be schema-valid before send; failure risk: CLI drift on malformed payload; expected invariant: strict response contract; handling strategy: hard fail invalid payloads.
+    if (!strictState.success) {
+      return res.status(500).json({
+        error: 'SYSTEM_STATE_RESPONSE_INVALID',
+        details: strictState.error.issues.map(issue => issue.message)
+      });
+    }
+
+    return res.json(strictState.data);
+  }
+
+  if (mode === 'system_review') {
+    const reviewInput = extractTextInput(req.body);
+    //audit Assumption: review mode requires explicit input text; failure risk: speculative review; expected invariant: deterministic review subject; handling strategy: reject empty review requests.
+    if (!reviewInput) {
+      return res.status(400).json({
+        error: 'SYSTEM_REVIEW_REQUEST_INVALID',
+        details: ['system_review requires text input via prompt/message/userInput/content/text/query']
+      });
+    }
+
+    if (!hasValidAPIKey()) {
+      //audit Assumption: system_review cannot fall back to chat/mock; failure risk: non-deterministic fallback behavior; expected invariant: hard failure without model access; handling strategy: return explicit service error.
+      return res.status(503).json({
+        error: 'SYSTEM_REVIEW_MODEL_UNAVAILABLE',
+        details: ['OpenAI API key is not configured for strict system_review mode']
+      });
+    }
+
+    const { client } = getOpenAIClientOrAdapter();
+    if (!client) {
+      return res.status(503).json({
+        error: 'SYSTEM_REVIEW_MODEL_UNAVAILABLE',
+        details: ['OpenAI client initialization failed for strict system_review mode']
+      });
+    }
+
+    try {
+      const modelResponse = await client.chat.completions.create({
+        model: getGPT5Model(),
+        messages: [
+          { role: 'system', content: SYSTEM_REVIEW_PROMPT },
+          {
+            role: 'user',
+            content: `Subject: intent_system\n\nInput:\n${reviewInput}`
+          }
+        ],
+        temperature: 0,
+        stream: false
+      });
+
+      const rawContent = modelResponse.choices?.[0]?.message?.content;
+      //audit Assumption: strict review requires textual JSON payload; failure risk: empty model content; expected invariant: parseable JSON string; handling strategy: hard fail missing content.
+      if (typeof rawContent !== 'string' || rawContent.trim().length === 0) {
+        return res.status(500).json({
+          error: 'SYSTEM_REVIEW_RESPONSE_INVALID',
+          details: ['Model returned empty content for system_review mode']
+        });
+      }
+
+      const parsedContent = parseJsonContent(rawContent);
+      const normalizedReviewPayload = {
+        ...(typeof parsedContent === 'object' && parsedContent !== null ? parsedContent : {}),
+        mode: 'system_review',
+        subject: 'intent_system',
+        reviewVersion: 1,
+        reviewedAt: nowIso()
+      };
+
+      const strictReview = systemReviewSchema.safeParse(normalizedReviewPayload);
+      if (!strictReview.success) {
+        return res.status(500).json({
+          error: 'SYSTEM_REVIEW_RESPONSE_INVALID',
+          details: strictReview.error.issues.map(issue => issue.message)
+        });
+      }
+
+      return res.json(strictReview.data);
+    } catch (error) {
+      return res.status(500).json({
+        error: 'SYSTEM_REVIEW_EXECUTION_FAILED',
+        details: [error instanceof Error ? error.message : String(error)]
+      });
+    }
+  }
+
+  const lenientChatValidation = validateLenientChatRequest(req.body);
+  if (!lenientChatValidation.ok) {
+    return res.status(400).json(lenientChatValidation.errorPayload);
+  }
+
+  req.body = lenientChatValidation.normalizedBody;
+  const bypassAuditFlag = lenientChatValidation.auditFlag;
+
   const { sessionId, overrideAuditSafe, metadata } = req.body;
+  const normalizedPrompt = req.body.prompt || extractTextInput(req.body) || '';
+
+  //audit Assumption: backend-owned intent should persist independently of model availability; failure risk: missing state when model is unavailable; expected invariant: chat requests update intent record before model call; handling strategy: record prompt immediately after lenient validation.
+  recordChatIntent(normalizedPrompt);
+  setLastRoutingUsed('backend');
 
   // Use shared validation logic
   const validation = validateAIRequest(req, res, endpointName);
@@ -53,12 +452,20 @@ export const handleAIRequest = async (
         });
       }
       //audit Assumption: daemon tool response is terminal; risk: skipping trinity; invariant: tool actions queued; handling: return early.
-      return res.json({ ...daemonToolResponse, clientContext: req.body.clientContext });
+      return res.json({
+        ...daemonToolResponse,
+        clientContext: req.body.clientContext,
+        ...(bypassAuditFlag ? { auditFlag: bypassAuditFlag } : {})
+      });
     }
 
     // runThroughBrain now unconditionally routes through GPT-5.1 before final ARCANOS processing
     const output = await runThroughBrain(openai, prompt, sessionId, overrideAuditSafe);
-    return res.json({ ...(output as AskResponse), clientContext: req.body.clientContext });
+    return res.json({
+      ...(output as AskResponse),
+      clientContext: req.body.clientContext,
+      ...(bypassAuditFlag ? { auditFlag: bypassAuditFlag } : {})
+    });
   } catch (err) {
     handleAIError(err, prompt, endpointName, res);
   }

--- a/src/routes/ask/intent_store.ts
+++ b/src/routes/ask/intent_store.ts
@@ -1,0 +1,165 @@
+/**
+ * Backend-owned intent store for /ask system_state mode.
+ *
+ * Purpose: Keep a single active intent as the source of truth for CLI hydration.
+ * Inputs/Outputs: exposes pure read/update helpers for chat and optimistic patch writes.
+ * Edge cases: version mismatches return conflict metadata instead of mutating state.
+ */
+
+export type IntentStatus = 'active' | 'paused' | 'completed';
+export type IntentPhase = 'exploration' | 'execution';
+
+export interface StoredIntent {
+  intentId: string;
+  label: string;
+  status: IntentStatus;
+  phase: IntentPhase;
+  confidence: number;
+  version: number;
+  lastTouchedAt: string;
+}
+
+export interface IntentPatch {
+  label?: string;
+  status?: IntentStatus;
+  phase?: IntentPhase;
+  confidence?: number;
+}
+
+export interface IntentConflict {
+  error: 'INTENT_VERSION_CONFLICT';
+  currentVersion: number;
+}
+
+let activeIntent: StoredIntent | null = null;
+let lastRoutingUsed: 'local' | 'backend' = 'backend';
+
+const DEFAULT_INTENT_CONFIDENCE = 0.5;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function clampConfidence(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function normalizeLabelFromPrompt(prompt: string): string {
+  const compact = prompt.trim().replace(/\s+/g, ' ');
+  if (!compact) {
+    return 'intent_system';
+  }
+  return compact.slice(0, 160);
+}
+
+function createIntentFromPrompt(prompt: string): StoredIntent {
+  const timestamp = Date.now();
+  return {
+    intentId: `int_${timestamp.toString(36)}`,
+    label: normalizeLabelFromPrompt(prompt),
+    status: 'active',
+    phase: 'exploration',
+    confidence: DEFAULT_INTENT_CONFIDENCE,
+    version: 1,
+    lastTouchedAt: nowIso()
+  };
+}
+
+/**
+ * Purpose: Return the current active intent snapshot.
+ * Inputs/Outputs: no input; returns StoredIntent clone or null.
+ * Edge cases: returns null when no chat activity has established intent yet.
+ */
+export function getActiveIntentSnapshot(): StoredIntent | null {
+  //audit Assumption: store must stay immutable to callers; failure risk: external mutation; expected invariant: internal state only changes through helpers; handling strategy: return clone.
+  return activeIntent ? { ...activeIntent } : null;
+}
+
+/**
+ * Purpose: Record chat activity and keep a single active intent.
+ * Inputs/Outputs: chat prompt string; returns updated StoredIntent clone.
+ * Edge cases: empty prompts still refresh timestamps using a stable fallback label.
+ */
+export function recordChatIntent(prompt: string): StoredIntent {
+  //audit Assumption: first chat turn establishes intent; failure risk: null state; expected invariant: active intent always exists after chat record; handling strategy: lazy initialize.
+  if (!activeIntent) {
+    activeIntent = createIntentFromPrompt(prompt);
+    return { ...activeIntent };
+  }
+
+  const nextLabel = normalizeLabelFromPrompt(prompt);
+  activeIntent = {
+    ...activeIntent,
+    label: nextLabel,
+    status: 'active',
+    lastTouchedAt: nowIso(),
+    version: activeIntent.version + 1
+  };
+  return { ...activeIntent };
+}
+
+/**
+ * Purpose: Apply optimistic-lock updates to the active intent.
+ * Inputs/Outputs: expectedVersion and patch object; returns updated intent or conflict.
+ * Edge cases: no active intent returns a version conflict with currentVersion=0.
+ */
+export function updateIntentWithOptimisticLock(
+  expectedVersion: number,
+  patch: IntentPatch
+): { ok: true; intent: StoredIntent } | { ok: false; conflict: IntentConflict } {
+  //audit Assumption: updates require an existing record; failure risk: patching null state; expected invariant: conflict returned when missing; handling strategy: reject with currentVersion=0.
+  if (!activeIntent) {
+    return {
+      ok: false,
+      conflict: { error: 'INTENT_VERSION_CONFLICT', currentVersion: 0 }
+    };
+  }
+
+  //audit Assumption: optimistic lock prevents stale writes; failure risk: lost update; expected invariant: version must match; handling strategy: reject with currentVersion.
+  if (expectedVersion !== activeIntent.version) {
+    return {
+      ok: false,
+      conflict: {
+        error: 'INTENT_VERSION_CONFLICT',
+        currentVersion: activeIntent.version
+      }
+    };
+  }
+
+  const nextConfidence =
+    typeof patch.confidence === 'number'
+      ? clampConfidence(patch.confidence)
+      : activeIntent.confidence;
+
+  const nextIntent: StoredIntent = {
+    ...activeIntent,
+    label: patch.label ?? activeIntent.label,
+    status: patch.status ?? activeIntent.status,
+    phase: patch.phase ?? activeIntent.phase,
+    confidence: nextConfidence,
+    lastTouchedAt: nowIso(),
+    version: activeIntent.version + 1
+  };
+
+  activeIntent = nextIntent;
+  return { ok: true, intent: { ...nextIntent } };
+}
+
+/**
+ * Purpose: Track routing usage for system_state telemetry.
+ * Inputs/Outputs: routing source label; no return value.
+ * Edge cases: invalid inputs are narrowed by TypeScript union at compile time.
+ */
+export function setLastRoutingUsed(route: 'local' | 'backend'): void {
+  lastRoutingUsed = route;
+}
+
+/**
+ * Purpose: Read the last routing source used by /ask chat handling.
+ * Inputs/Outputs: no input; returns routing label.
+ * Edge cases: defaults to "backend" before first write to avoid null handling.
+ */
+export function getLastRoutingUsed(): 'local' | 'backend' {
+  return lastRoutingUsed;
+}
+

--- a/src/routes/ask/types.ts
+++ b/src/routes/ask/types.ts
@@ -4,8 +4,26 @@ import type {
   ClientContextDTO
 } from '../../types/dto.js';
 
+export type AskMode = 'chat' | 'system_review' | 'system_state';
+
+export interface SchemaValidationBypassAuditFlag {
+  auditFlag: 'SCHEMA_VALIDATION_BYPASS';
+  reason: string;
+  timestamp: string;
+}
+
 export type AskRequest = AIRequestDTO & {
-  prompt: string;
+  prompt?: string;
+  message?: string;
+  mode?: AskMode | string;
+  subject?: string;
+  expectedVersion?: number;
+  patch?: {
+    confidence?: number;
+    phase?: 'exploration' | 'execution';
+    status?: 'active' | 'paused' | 'completed';
+    label?: string;
+  };
   sessionId?: string;
   overrideAuditSafe?: string;
   clientContext?: ClientContextDTO;
@@ -31,4 +49,69 @@ export interface AskResponse extends AIResponseDTO {
     logged: boolean;
   };
   clientContext?: ClientContextDTO;
+  auditFlag?: SchemaValidationBypassAuditFlag;
+}
+
+export interface SystemReviewRisk {
+  level: 'low' | 'medium' | 'high';
+  area: string;
+  description: string;
+  mitigation: string;
+}
+
+export interface SystemReviewRecommendation {
+  priority: 'low' | 'medium' | 'high';
+  action: string;
+  rationale: string;
+}
+
+export interface SystemReviewResponse {
+  mode: 'system_review';
+  subject: 'intent_system';
+  verdict: 'approved' | 'approved_with_risks' | 'blocked';
+  summary: string;
+  strengths: string[];
+  risks: SystemReviewRisk[];
+  gaps: string[];
+  recommendations: SystemReviewRecommendation[];
+  assumptions: string[];
+  confidence: number;
+  reviewedAt: string;
+  reviewVersion: 1;
+}
+
+export interface SystemStateIntentDTO {
+  intentId: string | null;
+  label: string | null;
+  status: 'active' | 'paused' | 'completed' | null;
+  phase: 'exploration' | 'execution' | null;
+  confidence: number;
+  version: number;
+  lastTouchedAt: string | null;
+}
+
+export interface SystemStateResponse {
+  mode: 'system_state';
+  intent: SystemStateIntentDTO;
+  routing: {
+    preferred: 'local' | 'backend';
+    lastUsed: 'local' | 'backend';
+    confidenceGate: number;
+  };
+  backend: {
+    connected: true;
+    registryAvailable: true;
+    lastHeartbeatAt: string;
+  };
+  stateFreshness: {
+    intent: 'fresh' | 'stale';
+    backend: 'fresh' | 'degraded';
+    lastValidatedAt: string;
+  };
+  limits: {
+    rateLimited: boolean;
+    remainingRequests: number;
+  };
+  generatedAt: string;
+  confidence: number;
 }

--- a/src/routes/ask/validation.ts
+++ b/src/routes/ask/validation.ts
@@ -2,15 +2,22 @@ import type { Request, Response } from 'express';
 import { validateInput } from '../../utils/security.js';
 import { buildValidationErrorResponse } from '../../lib/errors/index.js';
 
-const ASK_TEXT_FIELDS = ['prompt', 'userInput', 'content', 'text', 'query'] as const;
+const ASK_TEXT_FIELDS = ['prompt', 'message', 'userInput', 'content', 'text', 'query'] as const;
+const SYSTEM_MODES = ['system_review', 'system_state'] as const;
+type SystemMode = (typeof SYSTEM_MODES)[number];
 
 // Enhanced validation schema for ask requests that accepts multiple text field aliases
 const askValidationSchema = {
+  mode: { type: 'string' as const, maxLength: 64, sanitize: true },
   prompt: { type: 'string' as const, minLength: 1, maxLength: 10000, sanitize: true },
+  message: { type: 'string' as const, minLength: 1, maxLength: 10000, sanitize: true },
   userInput: { type: 'string' as const, minLength: 1, maxLength: 10000, sanitize: true },
   content: { type: 'string' as const, minLength: 1, maxLength: 10000, sanitize: true },
   text: { type: 'string' as const, minLength: 1, maxLength: 10000, sanitize: true },
   query: { type: 'string' as const, minLength: 1, maxLength: 10000, sanitize: true },
+  subject: { type: 'string' as const, minLength: 1, maxLength: 200, sanitize: true },
+  expectedVersion: { type: 'number' as const },
+  patch: { type: 'object' as const },
   model: { type: 'string' as const, maxLength: 100, sanitize: true },
   temperature: { type: 'number' as const },
   max_tokens: { type: 'number' as const },
@@ -42,6 +49,41 @@ export const askValidationMiddleware = (req: Request, res: Response, next: () =>
   if (!validation.isValid) {
     //audit Assumption: validation errors are safe to expose; risk: leaking schema expectations; invariant: only validation errors returned; handling: standardized payload.
     return res.status(400).json(buildValidationErrorResponse(validation.errors));
+  }
+
+  const modeValue = validation.sanitized.mode;
+  const normalizedMode = typeof modeValue === 'string' && modeValue.trim().length > 0 ? modeValue.trim() : 'chat';
+
+  //audit Assumption: system mode names are fixed and explicit; risk: accidental fallback to chat; invariant: unknown system mode rejected; handling: strict mode allowlist.
+  if (normalizedMode.startsWith('system_') && !SYSTEM_MODES.includes(normalizedMode as SystemMode)) {
+    return res.status(400).json(
+      buildValidationErrorResponse([`Unsupported mode '${normalizedMode}'. Allowed modes: ${SYSTEM_MODES.join(', ')}`])
+    );
+  }
+
+  if (normalizedMode === 'system_state') {
+    const expectedVersion = validation.sanitized.expectedVersion;
+    const patch = validation.sanitized.patch;
+
+    //audit Assumption: optimistic-lock writes require both expectedVersion and patch; risk: partial state mutation contract; invariant: both fields present together; handling: reject partial update payloads.
+    if ((expectedVersion === undefined) !== (patch === undefined)) {
+      return res.status(400).json(
+        buildValidationErrorResponse([
+          "system_state updates require both 'expectedVersion' and 'patch' fields together"
+        ])
+      );
+    }
+
+    //audit Assumption: expectedVersion must be an integer for deterministic locking; risk: floating-point mismatch; invariant: integer version checks; handling: reject non-integer versions.
+    if (typeof expectedVersion === 'number' && !Number.isInteger(expectedVersion)) {
+      return res.status(400).json(
+        buildValidationErrorResponse(["'expectedVersion' must be an integer when provided"])
+      );
+    }
+
+    req.body = validation.sanitized;
+    next();
+    return;
   }
 
   const hasTextField = ASK_TEXT_FIELDS.some(field => {

--- a/tests/ask-system-governance.test.ts
+++ b/tests/ask-system-governance.test.ts
@@ -1,0 +1,65 @@
+import express, { type Express } from 'express';
+import request from 'supertest';
+import askRouter from '../src/routes/ask.js';
+
+let app: Express;
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test';
+  app = express();
+  app.use(express.json({ limit: '10mb' }));
+  app.use('/', askRouter);
+});
+
+describe('/ask governed system modes', () => {
+  it('returns strict system_state payload', async () => {
+    const res = await request(app).post('/ask').send({
+      mode: 'system_state',
+      metadata: { instanceId: 'jest-instance' }
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.mode).toBe('system_state');
+    expect(res.body.intent).toBeDefined();
+    expect(res.body.routing).toBeDefined();
+    expect(res.body.backend).toBeDefined();
+    expect(res.body.stateFreshness).toBeDefined();
+    expect(res.body.generatedAt).toBeDefined();
+  });
+
+  it('records chat intent and exposes it through system_state', async () => {
+    const chatRes = await request(app).post('/ask').send({
+      prompt: 'Implement governed backend mode dispatch in /ask'
+    });
+
+    expect(chatRes.status).toBe(200);
+
+    const stateRes = await request(app).post('/ask').send({ mode: 'system_state' });
+    expect(stateRes.status).toBe(200);
+    expect(stateRes.body.intent.intentId).toBeTruthy();
+    expect(stateRes.body.intent.label).toContain('Implement governed backend mode dispatch in /ask');
+    expect(stateRes.body.intent.status).toBe('active');
+  });
+
+  it('returns 409 on intent optimistic lock mismatch', async () => {
+    const stateRes = await request(app).post('/ask').send({ mode: 'system_state' });
+    const currentVersion = Number(stateRes.body?.intent?.version || 1);
+
+    const conflictRes = await request(app).post('/ask').send({
+      mode: 'system_state',
+      expectedVersion: currentVersion + 100,
+      patch: { confidence: 0.9, phase: 'execution' }
+    });
+
+    expect(conflictRes.status).toBe(409);
+    expect(conflictRes.body.error).toBe('INTENT_VERSION_CONFLICT');
+    expect(typeof conflictRes.body.currentVersion).toBe('number');
+  });
+
+  it('hard-fails invalid system_review input', async () => {
+    const reviewRes = await request(app).post('/ask').send({ mode: 'system_review' });
+
+    expect(reviewRes.status).toBe(400);
+    expect(reviewRes.body.error).toBe('Validation failed');
+  });
+});

--- a/tests/ask-validation.test.ts
+++ b/tests/ask-validation.test.ts
@@ -18,7 +18,7 @@ describe('ask route validation', () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('Validation failed');
     expect(Array.isArray(res.body.details)).toBe(true);
-    expect(res.body.details.join(' ')).toContain('prompt, userInput, content, text, query');
+    expect(res.body.details.join(' ')).toContain('prompt, message, userInput, content, text, query');
   });
 
   it('accepts alternate prompt field names', async () => {


### PR DESCRIPTION
## Summary
- enforce explicit `/ask` mode dispatch for `system_review`, `system_state`, and `chat`
- add backend-owned single-intent store with optimistic locking (`INTENT_VERSION_CONFLICT`)
- add strict schema handling for `system_*` and lenient chat bypass auditing (`SCHEMA_VALIDATION_BYPASS`)
- wire CLI to reflect backend state via `mode=system_state`, including startup hydration and `arcanos status`
- route working-context recall ("What was I working on?") to backend system state

## Constraints honored
- no new endpoints
- `/ask` remains the only modified route surface for governed mode behavior
- exactly two system modes: `system_review`, `system_state`
- backend is source of record; CLI reflects state and does not invent backend intent

## Validation
- `npm run type-check`
- `npm test -- tests/ask-validation.test.ts tests/ask-system-governance.test.ts`
- `python -m pytest daemon-python/tests -q`
- manual E2E lifecycle run (backend + CLI restart + `arcanos status` + working-context recall)