### PR TITLE
Fix prompts.json missing from dist at runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "dev:inspect": "npm run build && node --loader ./scripts/esm-alias-loader.mjs --inspect dist/start-server.js",
         "dev:watch": "tsc --watch",
         "build": "npm run build:workers && tsc && tsc-alias && npm run dist:check-aliases && npm run build:copy-assets",
-        "build:copy-assets": "node -e \"const fs=require('fs'),p=require('path');const src=p.join('config','prompts.json');const dests=['dist/config','dist/platform/runtime'];dests.forEach(d=>{fs.mkdirSync(d,{recursive:true});fs.copyFileSync(src,p.join(d,'prompts.json'))});console.log('Copied prompts.json to dist/')\"",
+        "build:copy-assets": "node scripts/copy-assets.js",
         "dist:repair-aliases": "node scripts/repair-dist-aliases.js --rewrite",
         "dist:check-aliases": "node scripts/repair-dist-aliases.js --check",
         "clean": "rm -rf dist",


### PR DESCRIPTION
## Summary
- TypeScript compiler doesn't copy `.json` assets to `dist/`, causing `"Prompts configuration file not found in expected locations"` errors at runtime
- Adds a `build:copy-assets` script that copies `config/prompts.json` to `dist/config/` and `dist/platform/runtime/` after compilation
- Hooks the copy step into both `build` and `dev` scripts

## Test plan
- [ ] Run `npm run build` and verify `dist/config/prompts.json` and `dist/platform/runtime/prompts.json` exist
- [ ] Run `npm run dev` and confirm no "Prompts configuration file not found" error in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)