### PR TITLE
Fix prompts.json not found on Railway deploy

### DIFF
--- a/collected-ts/src/config/prompts.ts
+++ b/collected-ts/src/config/prompts.ts
@@ -80,6 +80,8 @@ let promptsConfig: PromptsConfig | null = null;
 const CONFIG_SEARCH_PATHS = [
   join(process.cwd(), 'config', 'prompts.json'),
   join(__dirname, 'prompts.json'),
+  join(__dirname, '..', '..', 'config', 'prompts.json'),
+  join(__dirname, '..', '..', '..', 'config', 'prompts.json'),
   join(process.cwd(), 'src', 'config', 'prompts.json')
 ];
 
@@ -184,7 +186,12 @@ function loadPromptsConfig(): PromptsConfig {
     const configPath = resolvePromptsConfigPath();
 
     if (!configPath) {
-      throw new Error('Prompts configuration file not found in expected locations');
+      const searchedPaths = CONFIG_SEARCH_PATHS.map(p => `  ${p} (exists: ${existsSync(p)})`).join('\n');
+      throw new Error(
+        `Prompts configuration file not found in expected locations.\n` +
+        `cwd: ${process.cwd()}, __dirname: ${__dirname}\n` +
+        `Searched:\n${searchedPaths}`
+      );
     }
 
     const configData = readFileSync(configPath, 'utf-8');

--- a/src/platform/runtime/prompts.ts
+++ b/src/platform/runtime/prompts.ts
@@ -80,6 +80,8 @@ let promptsConfig: PromptsConfig | null = null;
 const CONFIG_SEARCH_PATHS = [
   join(process.cwd(), 'config', 'prompts.json'),
   join(__dirname, 'prompts.json'),
+  join(__dirname, '..', '..', 'config', 'prompts.json'),
+  join(__dirname, '..', '..', '..', 'config', 'prompts.json'),
   join(process.cwd(), 'src', 'config', 'prompts.json')
 ];
 
@@ -184,7 +186,12 @@ function loadPromptsConfig(): PromptsConfig {
     const configPath = resolvePromptsConfigPath();
 
     if (!configPath) {
-      throw new Error('Prompts configuration file not found in expected locations');
+      const searchedPaths = CONFIG_SEARCH_PATHS.map(p => `  ${p} (exists: ${existsSync(p)})`).join('\n');
+      throw new Error(
+        `Prompts configuration file not found in expected locations.\n` +
+        `cwd: ${process.cwd()}, __dirname: ${__dirname}\n` +
+        `Searched:\n${searchedPaths}`
+      );
     }
 
     const configData = readFileSync(configPath, 'utf-8');


### PR DESCRIPTION
## Summary
- Add fallback `__dirname`-relative paths to walk up from `dist/platform/runtime/` to project root `config/`
- Add diagnostic error logging (cwd, __dirname, all searched paths with existence) for faster debugging if it still fails

## Test plan
- [ ] Deploy to Railway and verify no "Prompts configuration file not found" errors in logs
- [ ] If error recurs, logs will show exact paths checked for immediate diagnosis

🤖 Generated with [Claude Code](https://claude.com/claude-code)