### PR TITLE
Enforce schema-constrained Trinity reasoning and unify watchdog deadlines

### DIFF
--- a/src/core/audit/runClearAudit.ts
+++ b/src/core/audit/runClearAudit.ts
@@ -1,7 +1,6 @@
 import type OpenAI from 'openai';
 import { createGPT5Reasoning } from "@services/openai.js";
 import { logger } from "@platform/logging/structuredLogging.js";
-import { safeJsonParse } from "@core/logic/trinityHelpers.js";
 import type { ReasoningLedger } from "@core/logic/trinityTypes.js";
 
 export interface ClearAuditResult {
@@ -61,8 +60,11 @@ export async function runClearAudit(client: OpenAI, ledger: ReasoningLedger): Pr
     return fallback;
   }
 
-  const parsed = safeJsonParse(result.content);
-  if (!parsed || typeof parsed !== 'object') {
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    parsed = JSON.parse(result.content) as Record<string, unknown>;
+  } catch {
+    //audit Assumption: model may return malformed JSON; risk: invalid CLEAR scoring state; invariant: audit result is always numeric and bounded; handling: return deterministic fallback.
     logger.warn('CLEAR audit failed to parse JSON', {
       module: 'audit',
       operation: 'runClearAudit'

--- a/src/core/logic/trinity.ts
+++ b/src/core/logic/trinity.ts
@@ -269,10 +269,10 @@ export async function runThroughBrain(
 
   // --- Concurrency governor + watchdog ---
   const [release] = await acquireTierSlot(tier);
-  const { watchdog, tierSoftCap, effectiveLimit } = createTrinityWatchdog(tier, runtimeBudget, !!internalContext?.escalated);
+  const { watchdog, tierSoftCap, effectiveLimit } = createTrinityWatchdog(tier, runtimeBudget);
   const checkWatchdog = () => {
     assertBudgetAvailable(runtimeBudget);
-    watchdog.check(getSafeRemainingMs(runtimeBudget));
+    watchdog.check();
   };
 
   try {

--- a/src/core/logic/trinityHelpers.ts
+++ b/src/core/logic/trinityHelpers.ts
@@ -9,6 +9,7 @@ import { logger } from "@platform/logging/structuredLogging.js";
  * Computes max and average relevance score from memory entries.
  */
 export function calculateMemoryScoreSummary(relevanceScores: number[]): { maxScore: number; averageScore: number } {
+  //audit Assumption: empty relevance set is valid for prompts with no memory hits; risk: divide-by-zero; invariant: average score is numeric; handling: return zeros.
   if (relevanceScores.length === 0) {
     return { maxScore: 0, averageScore: 0 };
   }
@@ -18,32 +19,9 @@ export function calculateMemoryScoreSummary(relevanceScores: number[]): { maxSco
   return { maxScore, averageScore };
 }
 
-export const STRUCTURED_REASONING_PROMPT = `
-Return JSON only in this format:
-
-{
-  "reasoning_steps": string[],
-  "assumptions": string[],
-  "constraints": string[],
-  "tradeoffs": string[],
-  "alternatives_considered": string[],
-  "chosen_path_justification": string,
-  "final_answer": string
-}
-
-Do not include commentary outside JSON.
-`;
-
-export function safeJsonParse(text: string) {
-  try {
-    // Basic cleanup for markdown code blocks if the model includes them
-    const jsonStr = text.replace(/```json\s?|```/g, '').trim();
-    return JSON.parse(jsonStr);
-  } catch {
-    return null;
-  }
-}
-
+/**
+ * Emits a standardized fallback event for stages that still support model fallback.
+ */
 export function logFallbackEvent(stage: string, requestedModel: string, fallbackModel: string, reason: string): void {
   logger.warn('Trinity fallback invoked', {
     module: 'trinity',

--- a/src/core/logic/trinitySchema.ts
+++ b/src/core/logic/trinitySchema.ts
@@ -1,0 +1,61 @@
+/**
+ * Canonical JSON schema for Trinity structured reasoning responses.
+ * This schema is used with decoding constraints so stage output is deterministic.
+ */
+export interface TrinityStructuredReasoning {
+  reasoning_steps: string[];
+  assumptions: string[];
+  constraints: string[];
+  tradeoffs: string[];
+  alternatives_considered: string[];
+  chosen_path_justification: string;
+  final_answer: string;
+}
+
+export const TRINITY_STRUCTURED_REASONING_SCHEMA = {
+  name: 'trinity_structured_reasoning',
+  strict: true,
+  schema: {
+    type: 'object',
+    additionalProperties: false,
+    required: [
+      'reasoning_steps',
+      'assumptions',
+      'constraints',
+      'tradeoffs',
+      'alternatives_considered',
+      'chosen_path_justification',
+      'final_answer'
+    ],
+    properties: {
+      reasoning_steps: {
+        type: 'array',
+        items: { type: 'string', minLength: 1 }
+      },
+      assumptions: {
+        type: 'array',
+        items: { type: 'string', minLength: 1 }
+      },
+      constraints: {
+        type: 'array',
+        items: { type: 'string', minLength: 1 }
+      },
+      tradeoffs: {
+        type: 'array',
+        items: { type: 'string', minLength: 1 }
+      },
+      alternatives_considered: {
+        type: 'array',
+        items: { type: 'string', minLength: 1 }
+      },
+      chosen_path_justification: {
+        type: 'string',
+        minLength: 1
+      },
+      final_answer: {
+        type: 'string',
+        minLength: 1
+      }
+    }
+  }
+} as const;

--- a/src/runtime/openaiClient.ts
+++ b/src/runtime/openaiClient.ts
@@ -1,0 +1,45 @@
+import OpenAI from 'openai';
+import type { RuntimeBudget } from './runtimeBudget.js';
+import { getSafeRemainingMs } from './runtimeBudget.js';
+import { RuntimeBudgetExceededError } from './runtimeErrors.js';
+import type { TrinityStructuredReasoning } from '../core/logic/trinitySchema.js';
+import { TRINITY_STRUCTURED_REASONING_SCHEMA } from '../core/logic/trinitySchema.js';
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+/**
+ * Runs a schema-constrained reasoning call and returns validated structured output.
+ * Input: user prompt and runtime budget. Output: TrinityStructuredReasoning object.
+ * Edge case: throws RuntimeBudgetExceededError when safe budget is exhausted.
+ */
+export async function runStructuredReasoning(
+  prompt: string,
+  budget: RuntimeBudget
+): Promise<TrinityStructuredReasoning> {
+  const safeRemainingMs = getSafeRemainingMs(budget);
+  //audit Assumption: remaining budget must be positive before network call; risk: timeout after deadline; invariant: no invocation starts without safe window; handling: throw RuntimeBudgetExceededError.
+  if (safeRemainingMs <= 0) {
+    throw new RuntimeBudgetExceededError();
+  }
+
+  const abortController = new AbortController();
+  const timeoutHandle = setTimeout(() => abortController.abort(), safeRemainingMs);
+
+  try {
+    const response = await (client.responses as any).create(
+      {
+        model: 'gpt-5',
+        input: prompt,
+        response_format: {
+          type: 'json_schema',
+          json_schema: TRINITY_STRUCTURED_REASONING_SCHEMA
+        }
+      },
+      { signal: abortController.signal }
+    );
+
+    return response.output_parsed as TrinityStructuredReasoning;
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}

--- a/src/runtime/runtimeBudget.ts
+++ b/src/runtime/runtimeBudget.ts
@@ -1,7 +1,7 @@
 import { RuntimeBudgetExceededError } from './runtimeErrors.js';
 
-export const WORKER_RUNTIME_BUDGET_MS = 45_000;
-export const RUNTIME_SAFETY_BUFFER_MS = 2_000;
+export const WATCHDOG_LIMIT_MS = 45_000;
+export const SAFETY_BUFFER_MS = 2_000;
 
 export interface RuntimeBudget {
   readonly startedAt: number;
@@ -10,43 +10,38 @@ export interface RuntimeBudget {
   readonly safetyBuffer: number;
 }
 
-interface CreateRuntimeBudgetOptions {
-  watchdogLimitMs?: number;
-  safetyBufferMs?: number;
-}
-
-export function createRuntimeBudget(options: CreateRuntimeBudgetOptions = {}): RuntimeBudget {
+/**
+ * Creates a runtime budget anchored to a single hard deadline.
+ * Input: none. Output: RuntimeBudget snapshot with deadline metadata.
+ * Edge case: uses wall-clock now; callers should create only one budget per job.
+ */
+export function createRuntimeBudget(): RuntimeBudget {
   const startedAt = Date.now();
-  const watchdogLimit = options.watchdogLimitMs ?? WORKER_RUNTIME_BUDGET_MS;
-  const safetyBuffer = options.safetyBufferMs ?? RUNTIME_SAFETY_BUFFER_MS;
-
   return {
     startedAt,
-    hardDeadline: startedAt + watchdogLimit,
-    watchdogLimit,
-    safetyBuffer
+    hardDeadline: startedAt + WATCHDOG_LIMIT_MS,
+    watchdogLimit: WATCHDOG_LIMIT_MS,
+    safetyBuffer: SAFETY_BUFFER_MS
   };
 }
 
-export function getElapsedMs(budget: RuntimeBudget): number {
-  return Date.now() - budget.startedAt;
-}
-
-export function getRemainingMs(budget: RuntimeBudget): number {
-  return budget.hardDeadline - Date.now();
-}
-
+/**
+ * Computes safe remaining milliseconds by subtracting safety buffer from remaining time.
+ * Input: RuntimeBudget. Output: remaining time that can be safely consumed.
+ * Edge case: can return zero/negative value after deadline or within safety buffer.
+ */
 export function getSafeRemainingMs(budget: RuntimeBudget): number {
-  return getRemainingMs(budget) - budget.safetyBuffer;
+  return (budget.hardDeadline - Date.now()) - budget.safetyBuffer;
 }
 
-export function hasSufficientBudget(budget: RuntimeBudget, requiredMs: number): boolean {
-  return getSafeRemainingMs(budget) > requiredMs;
-}
-
+/**
+ * Enforces runtime budget availability before critical stage execution.
+ * Input: RuntimeBudget. Output: void or throws RuntimeBudgetExceededError.
+ * Edge case: throws when safe remaining time is not positive.
+ */
 export function assertBudgetAvailable(budget: RuntimeBudget): void {
+  //audit Assumption: non-positive safe window means execution cannot complete safely; risk: partial state and timeout races; invariant: stages start only with positive safe time; handling: hard-fail.
   if (getSafeRemainingMs(budget) <= 0) {
     throw new RuntimeBudgetExceededError();
   }
 }
-


### PR DESCRIPTION
### Motivation
- Ensure the Trinity reasoning stage is deterministic and decoding-constrained by requiring structured JSON output that matches a canonical schema. 
- Centralize runtime deadline enforcement to a single authoritative budget to avoid split/watchdog inconsistencies and accidental fallback paths. 
- Remove legacy ad-hoc JSON parsing and fallback/downgrade paths so the reasoning stage either succeeds under schema constraints or fails deterministically. 

### Description
- Added a canonical schema and type: `TRINITY_STRUCTURED_REASONING_SCHEMA` and `TrinityStructuredReasoning` in `src/core/logic/trinitySchema.ts` for schema-constrained decoding. 
- Introduced `runStructuredReasoning` in `src/runtime/openaiClient.ts` to call the OpenAI Responses API with `response_format: { type: 'json_schema' }`, using the shared `RuntimeBudget` and an abort timer; it returns typed structured output. 
- Reworked the reasoning stage in `src/core/logic/trinityStages.ts` to require a `RuntimeBudget`, call `runStructuredReasoning`, map fields into the `ReasoningLedger`, and remove the previous `safeJsonParse` / raw-output fallback and related warnings. 
- Unified watchdog/budget logic: replaced split escalation multipliers with tier soft caps clamped by the shared runtime budget in `src/core/logic/trinityGuards.ts`, updated `Watchdog.check()` to enforce a single effective limit, and aligned callers in `src/core/logic/trinity.ts`. 
- Removed `safeJsonParse` and `STRUCTURED_REASONING_PROMPT` from helpers and updated CLEAR audit (`src/core/audit/runClearAudit.ts`) to use an explicit `JSON.parse` with deterministic fallback handling. 
- Replaced runtime budget API with a single authoritative clock: `WATCHDOG_LIMIT_MS` and `SAFETY_BUFFER_MS`, and consolidated helpers in `src/runtime/runtimeBudget.ts` to produce one `RuntimeBudget` per job. 

### Testing
- Ran type checking with `npm run type-check`, which completed successfully. 
- Verified removal of legacy `safeJsonParse` reference by scanning the codebase.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a9e73322c832598cfe29cad7172bb)