### PR TITLE
Export normalizeResponsesCreateParams for build fix

### DIFF
--- a/src/core/adapters/openai.adapter.ts
+++ b/src/core/adapters/openai.adapter.ts
@@ -195,7 +195,7 @@ function normalizeUsage(usage: unknown): { promptTokens: number; completionToken
 
 const MIN_RESPONSE_TOKENS = 16;
 
-function normalizeResponsesCreateParams(
+export function normalizeResponsesCreateParams(
   params: ResponseCreateParamsNonStreaming
 ): ResponseCreateParamsNonStreaming {
   const normalized = { ...params } as ResponseCreateParamsNonStreaming & { max_completion_tokens?: number };


### PR DESCRIPTION
## Summary\n- export 
ormalizeResponsesCreateParams from the OpenAI adapter\n- fix TypeScript module export error in gptDomainClassifier and idleManager imports\n\n## Validation\n- npm install --include=dev --no-audit --no-fund\n- npm run build:workers\n- npm run build\n