### PR TITLE
docs: add self-reflections and ARCANOS MCP server documentation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -71,6 +71,14 @@ No API path changes are required for Railway. Ensure liveness (`/healthz`) and r
 - `POST /api/arcanos/ask` (confirmation required)
 - `POST /api/ask-hrc`
 
+### Reinforcement and reflection feedback
+- `POST /reinforce`
+- `POST /audit`
+- `POST /reinforcement/judge`
+- `GET /reinforcement/metrics`
+- `GET /memory/digest`
+- `GET /memory`
+
 ### AI utility and media
 - `POST /write` (confirmation required)
 - `POST /guide` (confirmation required)
@@ -117,6 +125,8 @@ No API path changes are required for Railway. Ensure liveness (`/healthz`) and r
 - `POST /rag/query`
 
 ### Daemon, debug, and registry paths
+- `POST /mcp` (MCP Streamable HTTP, bearer token required, origin-restricted when configured)
+- `GET /mcp` (always `405 Method Not Allowed`)
 - `POST /api/daemon/heartbeat` (daemon auth required)
 - `GET /api/daemon/commands` (daemon auth required)
 - `POST /api/daemon/commands/ack` (daemon auth required)

--- a/docs/ARCANOS_MCP_SERVER.md
+++ b/docs/ARCANOS_MCP_SERVER.md
@@ -1,0 +1,121 @@
+# ARCANOS MCP Server
+
+## Overview
+ARCANOS exposes an MCP server with:
+
+1. HTTP transport: `POST /mcp` (`src/routes/mcp.ts`)
+2. Stdio transport: `src/mcp/mcp-stdio.ts`
+
+The server registers ARCANOS/Trinity, plans, agents, RAG, research, memory, module, and ops tools from `src/mcp/server/index.ts`.
+
+## Request Lifecycle (HTTP)
+1. `POST /mcp` enters `mcpAuthMiddleware`.
+2. Request context is built (`requestId`, OpenAI client, runtime budget, optional `sessionId`).
+3. A fresh MCP server + streamable HTTP transport is created per request (prevents cross-request state leakage).
+4. Tool handlers execute with request-local async context.
+5. Response is returned in MCP protocol format.
+
+`GET /mcp` is intentionally rejected with `405 Method Not Allowed`.
+
+## Security Model
+
+### Auth and origin
+- `MCP_BEARER_TOKEN` is required.
+- Request must include `Authorization: Bearer <token>`.
+- Optional origin allowlist via `MCP_ALLOWED_ORIGINS`.
+
+### Confirmation gating
+- Controlled by `MCP_REQUIRE_CONFIRMATION` (default `true`).
+- Gated tools require a server-issued nonce (`confirmationNonce`).
+- Nonce is payload-bound and session-bound, then consumed on success.
+- TTL is `MCP_CONFIRM_TTL_MS` (default `60000` ms).
+
+### Destructive exposure
+- `MCP_EXPOSE_DESTRUCTIVE=false` (default) hides destructive operations.
+- Destructive tools return `ERR_DISABLED` when not exposed.
+
+### Module invocation hardening
+- `modules.invoke` is deny-by-default.
+- Allowlist is `MCP_ALLOW_MODULE_ACTIONS` (CSV, e.g. `rag:*,billing:charge`).
+
+## Tool Catalog
+
+### Core reasoning
+- `trinity.ask`
+- `arcanos.run`
+- `trinity.query_finetune`
+
+### CLEAR and plans
+- `clear.evaluate`
+- `plans.create`
+- `plans.list`
+- `plans.get`
+- `plans.approve`
+- `plans.block` (destructive)
+- `plans.expire` (destructive)
+- `plans.execute` (destructive)
+- `plans.results`
+
+### Agents
+- `agents.register`
+- `agents.list`
+- `agents.get`
+- `agents.heartbeat`
+
+### RAG and research
+- `rag.ingest_url`
+- `rag.ingest_content`
+- `rag.query`
+- `research.run`
+
+### Memory/modules/ops
+- `memory.save`
+- `memory.load`
+- `memory.list`
+- `memory.delete` (destructive)
+- `modules.list`
+- `modules.invoke` (allowlist-gated)
+- `ops.health_report`
+
+## Configuration
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `MCP_BEARER_TOKEN` | none | Required for HTTP MCP auth. |
+| `MCP_ALLOWED_ORIGINS` | empty | Comma-separated browser origin allowlist. |
+| `MCP_HTTP_BODY_LIMIT` | `1mb` | Express JSON body size limit on `/mcp`. |
+| `MCP_REQUIRE_CONFIRMATION` | `true` | Enables nonce confirmation gate. |
+| `MCP_CONFIRM_TTL_MS` | `60000` | Nonce expiry window in milliseconds. |
+| `MCP_EXPOSE_DESTRUCTIVE` | `false` | Enables destructive tools when `true`. |
+| `MCP_ENABLE_SESSIONS` | `false` | Enables generated transport session IDs. |
+| `MCP_ALLOW_MODULE_ACTIONS` | empty | Required to permit `modules.invoke`. |
+
+## Example (HTTP MCP)
+
+### List tools
+```bash
+curl -X POST http://localhost:3000/mcp \
+  -H "Authorization: Bearer $MCP_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}'
+```
+
+### Call `trinity.ask`
+```bash
+curl -X POST http://localhost:3000/mcp \
+  -H "Authorization: Bearer $MCP_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"trinity.ask\",\"arguments\":{\"prompt\":\"Health check\"}}}"
+```
+
+## Stdio Mode Notes
+- Entrypoint: `node dist/mcp/mcp-stdio.js` (after build).
+- Logs are forced to `stderr` to avoid corrupting MCP stdout frames.
+- Optional session id can be passed by CLI arg (`--sessionId`) or env (`MCP_SESSION_ID` / `ARCANOS_SESSION_ID`).
+
+## Troubleshooting
+- `MCP_BEARER_TOKEN not configured`: set the token env var and restart.
+- `401 Unauthorized`: wrong/missing bearer token.
+- `403 Origin not allowed`: `Origin` header not in `MCP_ALLOWED_ORIGINS`.
+- `ERR_CONFIRM_REQUIRED` / `ERR_CONFIRM_INVALID`: re-run tool call with returned `confirmationNonce` before TTL expires.
+- `ERR_DISABLED`: tool is destructive and `MCP_EXPOSE_DESTRUCTIVE=false`.
+- `ERR_GATED` from `modules.invoke`: add explicit `module:action` to `MCP_ALLOW_MODULE_ACTIONS`.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -84,6 +84,29 @@ The OpenAI client resolves keys in this order, skipping placeholders:
 | `ARCANOS_AUTOMATION_SECRET` | empty | Shared secret for automation bypass. |
 | `ARCANOS_AUTOMATION_HEADER` | `x-arcanos-automation` | Header carrying automation secret. |
 
+### Self reflections and judged feedback
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `ARCANOS_CONTEXT_MODE` | `reinforcement` | Enables/disables contextual reinforcement recording (`off` disables storage in memory context window). |
+| `ARCANOS_CONTEXT_WINDOW` | `50` | Maximum in-memory reinforcement entries retained. |
+| `ARCANOS_MEMORY_DIGEST_SIZE` | `8` | Context digest length used in system prompt reinforcement section. |
+| `ARCANOS_CLEAR_MIN_SCORE` | `0.85` | Minimum normalized score threshold for judged acceptance. |
+| `TRINITY_JUDGED_FEEDBACK_ENABLED` | `true` | Enables automatic judged feedback writes from Trinity CLEAR audit output. |
+| `TRINITY_JUDGED_ALLOWED_ENDPOINTS` | `*` | Comma-separated source-endpoint allowlist for auto-judged feedback (`*` allows all). |
+| `JUDGED_FEEDBACK_CACHE_MAX_ENTRIES` | `2000` | Maximum entries retained in judged idempotency cache. |
+
+### MCP server
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `MCP_BEARER_TOKEN` | none | Required bearer token for `POST /mcp`. |
+| `MCP_ALLOWED_ORIGINS` | empty | Comma-separated browser origin allowlist for MCP HTTP requests. |
+| `MCP_HTTP_BODY_LIMIT` | `1mb` | JSON body size limit for MCP transport route. |
+| `MCP_REQUIRE_CONFIRMATION` | `true` | Require nonce confirmation for gated MCP tools. |
+| `MCP_CONFIRM_TTL_MS` | `60000` | Nonce expiration window for MCP confirmation flow. |
+| `MCP_EXPOSE_DESTRUCTIVE` | `false` | Expose destructive MCP tools when set to true. |
+| `MCP_ENABLE_SESSIONS` | `false` | Enable transport session ID generation in MCP HTTP transport. |
+| `MCP_ALLOW_MODULE_ACTIONS` | empty | CSV allowlist controlling `modules.invoke` (`module:action` or `module:*`). |
+
 ### Daemon-specific core variables
 
 | Variable | Default | Purpose |

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,12 +16,14 @@ Recommended reading order:
 5. `docs/API.md`
 6. `docs/OPENAI_RESPONSES_TOOLS.md`
 7. `docs/TRINITY_PIPELINE.md`
-8. `docs/CUSTOM_GPTS.md`
-9. `docs/FINE_TUNING.md`
-10. `docs/CLEAR_METHOD_2_0.md`
-11. `docs/RAILWAY_DEPLOYMENT.md`
-12. `docs/CI_CD.md`
-13. `docs/DOCUMENTATION.md`
+8. `docs/SELF_REFLECTIONS.md`
+9. `docs/ARCANOS_MCP_SERVER.md`
+10. `docs/CUSTOM_GPTS.md`
+11. `docs/FINE_TUNING.md`
+12. `docs/CLEAR_METHOD_2_0.md`
+13. `docs/RAILWAY_DEPLOYMENT.md`
+14. `docs/CI_CD.md`
+15. `docs/DOCUMENTATION.md`
 
 ## Configuration
 Configuration source files:
@@ -47,3 +49,5 @@ Use `docs/TROUBLESHOOTING.md` and include concrete errors, command output, and e
 - `docs/CI_CD.md`
 - `docs/REFERENCES.md`
 - `docs/CLEAR_METHOD_2_0.md`
+- `docs/SELF_REFLECTIONS.md`
+- `docs/ARCANOS_MCP_SERVER.md`

--- a/docs/SELF_REFLECTIONS.md
+++ b/docs/SELF_REFLECTIONS.md
@@ -1,0 +1,97 @@
+# Self Reflections
+
+## Overview
+ARCANOS has two reflection paths:
+
+1. `ai-reflections` (`src/services/ai-reflections.ts`): generates patch/reflection content, optionally persisted.
+2. Judged-response feedback (`src/services/judgedResponseFeedback.ts`): converts response quality signals into reinforcement context and persisted `self_reflections` records.
+
+Both paths are designed to keep user-facing responses non-blocking if persistence fails.
+
+## How It Works
+
+### Reflection generation (`ai-reflections`)
+- Entry point: `buildPatchSet()`.
+- If `useMemory: true`, the generated patch is persisted with `saveSelfReflection()`.
+- If `useMemory: false`, persistence is intentionally skipped (stateless mode).
+- If OpenAI generation fails, a deterministic fallback patch is returned.
+
+### Judged response feedback (`judgedResponseFeedback`)
+- Entry points:
+1. Manual route: `POST /reinforcement/judge`.
+2. Automatic Trinity hook: `runThroughBrain()` calls `recordTrinityJudgedFeedback()` after CLEAR audit.
+- Payload is validated and normalized (`prompt`, `response`, `score`, `scoreScale`).
+- Score is normalized against `ARCANOS_CLEAR_MIN_SCORE` to determine `accepted`.
+- A reinforcement context entry is registered (`source: audit`, positive/negative bias).
+- A `self_reflections` row is attempted with category `judged-response`.
+
+## Persistence Behavior
+- Repository: `src/core/db/repositories/selfReflectionRepository.ts`.
+- Persistence is lazy-bootstrapped:
+1. Checks DB connectivity.
+2. Attempts `initializeDatabase('self-reflections')`.
+3. Ensures tables/indexes exist via `initializeTables()`.
+- Failed bootstrap attempts are cooldown-throttled for 30s to avoid retry storms.
+- If DB is unavailable, writes are skipped with warning and request flow continues.
+
+The common warning:
+`[🧠 Reflections] Database not connected; skipping persistence for self-reflection`
+means response processing continued, but no reflection row was written.
+
+## Startup Hydration
+- On startup (`src/core/startup.ts`), ARCANOS calls `hydrateJudgedResponseFeedbackContext()`.
+- It reloads recent persisted `judged-response` reflections into in-memory reinforcement context.
+- Hydration is one-time per process unless test-reset with `resetJudgedFeedbackHydrationState()`.
+
+## Safety and Guardrails
+- Idempotency window: 5 minutes for judged feedback duplicate suppression.
+- Bounded cache: `JUDGED_FEEDBACK_CACHE_MAX_ENTRIES` (default `2000`).
+- Deep metadata sanitization:
+1. Max depth and item caps.
+2. Dangerous keys dropped (`__proto__`, `prototype`, `constructor`).
+3. Circular references and non-plain objects safely handled.
+4. Common secret/token patterns redacted before persistence.
+
+## Runtime Metrics
+Endpoint: `GET /reinforcement/metrics`
+
+Returns:
+- `judgedFeedback` telemetry (`attempts`, `duplicatesSkipped`, `persistedWrites`, `persistenceFailures`, cache stats).
+- Reinforcement health snapshot (`mode`, `window`, `storedContexts`, `minimumClearScore`, etc.).
+
+Use this endpoint to confirm judged feedback writes are happening and duplicates are being suppressed.
+
+## Configuration
+
+### Reinforcement core
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `ARCANOS_CONTEXT_MODE` | `reinforcement` | Set `off` to disable contextual recording. |
+| `ARCANOS_CONTEXT_WINDOW` | `50` | Max in-memory reinforcement entries. |
+| `ARCANOS_MEMORY_DIGEST_SIZE` | `8` | Digest size in contextual prompt rendering. |
+| `ARCANOS_CLEAR_MIN_SCORE` | `0.85` | Acceptance threshold used in judged feedback normalization. |
+
+### Judged feedback automation
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `TRINITY_JUDGED_FEEDBACK_ENABLED` | `true` | Enables automatic judged persistence from Trinity CLEAR audits. |
+| `TRINITY_JUDGED_ALLOWED_ENDPOINTS` | `*` | Comma-separated allowlist for source endpoints (e.g. `ask,siri,mcp.trinity.ask`). |
+| `JUDGED_FEEDBACK_CACHE_MAX_ENTRIES` | `2000` | In-memory idempotency cache cap. |
+
+## Quick Test
+```bash
+curl -X POST http://localhost:3000/reinforcement/judge \
+  -H "Content-Type: application/json" \
+  -d "{\"prompt\":\"p\",\"response\":\"r\",\"score\":9.2,\"scoreScale\":\"0-10\",\"feedback\":\"good\"}"
+
+curl http://localhost:3000/reinforcement/metrics
+```
+
+## Troubleshooting
+- `Database not connected; skipping persistence...`:
+1. Verify `DATABASE_URL` is set and reachable from runtime.
+2. Restart the service to allow bootstrap and table init.
+3. Confirm writes via `/reinforcement/metrics` (`persistedWrites` increasing, low `persistenceFailures`).
+- Unexpected auto-judge skips:
+1. Check `TRINITY_JUDGED_FEEDBACK_ENABLED`.
+2. Check `TRINITY_JUDGED_ALLOWED_ENDPOINTS` includes the emitting endpoint (`ask`, `brain`, `siri`, `mcp.trinity.ask`, etc.).


### PR DESCRIPTION
## Summary\n- add docs/SELF_REFLECTIONS.md with architecture, flow, safety, metrics, config, and troubleshooting\n- add docs/ARCANOS_MCP_SERVER.md with transport/auth model, tool catalog, config, and troubleshooting\n- update docs index and references in docs/README.md\n- update docs/API.md with reinforcement and MCP endpoints\n- update docs/CONFIGURATION.md with self-reflection/judged-feedback and MCP env vars\n\n## Notes\n- documentation-only change; no runtime code included in this commit