### PR TITLE
feat: add judged feedback persistence and Trinity endpoint wiring

### DIFF
--- a/src/core/db/repositories/selfReflectionRepository.ts
+++ b/src/core/db/repositories/selfReflectionRepository.ts
@@ -4,8 +4,9 @@
  * Persists AI reflection outputs for historical analysis and tooling reuse.
  */
 
-import { isDatabaseConnected } from "@core/db/client.js";
+import { isDatabaseConnected, initializeDatabase } from "@core/db/client.js";
 import { query } from "@core/db/query.js";
+import { initializeTables } from "@core/db/schema.js";
 
 export interface SelfReflectionInsert {
   priority: string;
@@ -15,8 +16,80 @@ export interface SelfReflectionInsert {
   metadata: unknown;
 }
 
+export interface SelfReflectionRecord {
+  id: string;
+  priority: string;
+  category: string;
+  content: string;
+  improvements: string[];
+  metadata: Record<string, unknown>;
+  createdAt: string;
+}
+
+const SELF_REFLECTION_DB_WORKER_ID = 'self-reflections';
+const SELF_REFLECTION_INIT_RETRY_COOLDOWN_MS = 30_000;
+
+let pendingBootstrap: Promise<boolean> | null = null;
+let lastBootstrapFailureAtMs = 0;
+
 /**
- * Store a generated self-reflection in the database when connectivity is available.
+ * Ensure self-reflection persistence can reach PostgreSQL.
+ *
+ * Purpose: lazily bootstrap DB connectivity for standalone script/test flows.
+ * Inputs/outputs: no inputs, returns readiness boolean.
+ * Edge cases: applies cooldown after failed bootstrap to avoid retry storms.
+ */
+async function ensureSelfReflectionPersistenceReady(): Promise<boolean> {
+  //audit Assumption: connected pool means persistence can proceed immediately; risk: stale status flag; invariant: no redundant bootstrap when already connected; handling: fast-path return.
+  if (isDatabaseConnected()) {
+    return true;
+  }
+
+  //audit Assumption: repeated failed bootstraps in tight loops cause noise and overhead; risk: retry storm; invariant: retries are throttled by cooldown; handling: short-circuit until cooldown expires.
+  const nowMs = Date.now();
+  const cooldownActive =
+    lastBootstrapFailureAtMs > 0 &&
+    nowMs - lastBootstrapFailureAtMs < SELF_REFLECTION_INIT_RETRY_COOLDOWN_MS;
+  if (cooldownActive) {
+    return false;
+  }
+
+  //audit Assumption: concurrent save calls should share one bootstrap attempt; risk: duplicate pool initialization and table DDL races; invariant: at most one bootstrap promise in flight; handling: reuse pending promise.
+  if (pendingBootstrap) {
+    return pendingBootstrap;
+  }
+
+  pendingBootstrap = (async () => {
+    try {
+      const connected = await initializeDatabase(SELF_REFLECTION_DB_WORKER_ID);
+      //audit Assumption: initializeDatabase may return false without throwing; risk: hidden connectivity failure; invariant: false response marks bootstrap failure; handling: record cooldown and stop.
+      if (!connected || !isDatabaseConnected()) {
+        lastBootstrapFailureAtMs = Date.now();
+        return false;
+      }
+
+      await initializeTables();
+      lastBootstrapFailureAtMs = 0;
+      return true;
+    } catch (error: unknown) {
+      //audit Assumption: bootstrap exceptions should not break reflection generation path; risk: persistence loss and noisy crashes; invariant: caller gets boolean readiness; handling: warn + cooldown fail-close.
+      lastBootstrapFailureAtMs = Date.now();
+      console.warn('[🧠 Reflections] Failed to initialize database for persistence:', getErrorMessage(error));
+      return false;
+    } finally {
+      pendingBootstrap = null;
+    }
+  })();
+
+  return pendingBootstrap;
+}
+
+/**
+ * Store a generated self-reflection in PostgreSQL.
+ *
+ * Purpose: persist reflection output for historical analysis and tooling reuse.
+ * Inputs/outputs: reflection payload fields -> no return value.
+ * Edge cases: lazily initializes DB when not already connected and safely skips persistence when unavailable.
  */
 export async function saveSelfReflection({
   priority,
@@ -25,11 +98,14 @@ export async function saveSelfReflection({
   improvements,
   metadata
 }: SelfReflectionInsert): Promise<void> {
-  if (!isDatabaseConnected()) {
+  const persistenceReady = await ensureSelfReflectionPersistenceReady();
+  //audit Assumption: persistence is optional for runtime correctness; risk: data loss when DB unavailable; invariant: caller flow continues without throw; handling: warn and skip write.
+  if (!persistenceReady) {
     console.warn('[🧠 Reflections] Database not connected; skipping persistence for self-reflection');
     return;
   }
 
+  //audit Assumption: persistence payload must remain JSON-serializable; risk: malformed values breaking insert; invariant: improvements metadata normalized before write; handling: sanitize arrays + default metadata.
   const sanitizedImprovements = Array.isArray(improvements) ? improvements : [];
   const serializedMetadata = metadata ?? {};
 
@@ -44,4 +120,101 @@ export async function saveSelfReflection({
       JSON.stringify(serializedMetadata)
     ]
   );
+}
+
+/**
+ * Load recent self-reflections filtered by category.
+ *
+ * Purpose: provide persistence-backed learning context for response quality feedback loops.
+ * Inputs/outputs: category + limit -> ordered self-reflection records (newest first).
+ * Edge cases: returns empty array when DB is unavailable or category/limit are invalid.
+ */
+export async function loadRecentSelfReflectionsByCategory(
+  category: string,
+  limit: number = 20
+): Promise<SelfReflectionRecord[]> {
+  //audit Assumption: category must be a non-empty identifier; risk: broad table scans and ambiguous filtering; invariant: query executes with a valid category string; handling: validate and return empty.
+  if (typeof category !== 'string' || category.trim().length === 0) {
+    return [];
+  }
+
+  const sanitizedLimit = Math.max(1, Math.min(100, Math.floor(limit)));
+  const persistenceReady = await ensureSelfReflectionPersistenceReady();
+  //audit Assumption: reads are optional for runtime correctness; risk: stale/empty learning context; invariant: caller receives deterministic array; handling: return empty when DB unavailable.
+  if (!persistenceReady) {
+    return [];
+  }
+
+  const result = await query(
+    `SELECT id, priority, category, content, improvements, metadata, created_at
+     FROM self_reflections
+     WHERE category = $1
+     ORDER BY created_at DESC
+     LIMIT $2`,
+    [category.trim(), sanitizedLimit]
+  );
+
+  return result.rows.map((rowRaw: unknown) => {
+    const row = rowRaw as Record<string, unknown>;
+    //audit Assumption: DB jsonb columns may deserialize as objects or strings depending on driver settings; risk: runtime parsing failures; invariant: record fields remain serializable; handling: resilient normalization helper.
+    const normalizedImprovements = normalizeStringArray(row.improvements);
+    const normalizedMetadata = normalizeObjectRecord(row.metadata);
+    const normalizedCreatedAt = typeof row.created_at === 'string'
+      ? row.created_at
+      : new Date().toISOString();
+
+    return {
+      id: String(row.id ?? ''),
+      priority: String(row.priority ?? 'medium'),
+      category: String(row.category ?? ''),
+      content: String(row.content ?? ''),
+      improvements: normalizedImprovements,
+      metadata: normalizedMetadata,
+      createdAt: normalizedCreatedAt
+    };
+  });
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter(item => typeof item === 'string') as string[];
+  }
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        return parsed.filter(item => typeof item === 'string') as string[];
+      }
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
+function normalizeObjectRecord(value: unknown): Record<string, unknown> {
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  return 'Unknown error';
 }

--- a/src/core/logic/trinity.ts
+++ b/src/core/logic/trinity.ts
@@ -56,6 +56,7 @@ import { runClearAudit, type ClearAuditResult } from '../audit/runClearAudit.js'
 import { trackEscalation } from '@analytics/escalationTracker.js';
 import { getClearMinThreshold, recordRun } from '@analytics/clearAutoTuner.js';
 import { runSelfImproveCycle } from '@services/selfImprove/controller.js';
+import { recordTrinityJudgedFeedback } from './trinityJudgedFeedback.js';
 import type { RuntimeBudget } from '@platform/resilience/runtimeBudget.js';
 import { createRuntimeBudget, assertBudgetAvailable, getSafeRemainingMs } from '@platform/resilience/runtimeBudget.js';
 
@@ -464,6 +465,18 @@ export async function runThroughBrain(
       latencyMs,
       latencyDriftDetected
     };
+
+    result.judgedFeedback = await recordTrinityJudgedFeedback({
+      requestId,
+      prompt: auditSafePrompt,
+      response: finalText,
+      clearAudit,
+      tier,
+      sessionId,
+      sourceEndpoint: options.sourceEndpoint,
+      internalMode,
+      remainingBudgetMs: result.guardInfo.remainingBudgetMs
+    });
 
     return result;
 

--- a/src/core/logic/trinityJudgedFeedback.ts
+++ b/src/core/logic/trinityJudgedFeedback.ts
@@ -1,0 +1,237 @@
+import { getEnv, getEnvBoolean } from "@platform/runtime/env.js";
+import { processJudgedResponseFeedback } from "@services/judgedResponseFeedback.js";
+import type { ClearAuditResult } from "@core/audit/runClearAudit.js";
+import type { ClearScoreScale } from "@shared/types/reinforcement.js";
+import { resolveErrorMessage } from "@core/lib/errors/index.js";
+import { logger } from "@platform/logging/structuredLogging.js";
+
+export interface TrinityJudgedFeedbackInput {
+  requestId: string;
+  prompt: string;
+  response: string;
+  clearAudit?: ClearAuditResult;
+  tier: 'simple' | 'complex' | 'critical';
+  sessionId?: string;
+  sourceEndpoint?: string;
+  internalMode?: boolean;
+  remainingBudgetMs?: number;
+}
+
+export interface TrinityJudgedFeedbackSummary {
+  enabled: boolean;
+  attempted: boolean;
+  source: 'clear_audit';
+  reason?: string;
+  traceId?: string;
+  accepted?: boolean;
+  score?: number;
+  scoreScale?: ClearScoreScale;
+  normalizedScore?: number;
+  persisted?: boolean;
+}
+
+const MINIMUM_JUDGED_FEEDBACK_BUDGET_MS = 2_000;
+const DEFAULT_ALLOWED_TRINITY_JUDGED_ENDPOINTS = '*';
+
+/**
+ * Persist Trinity response quality judgment from CLEAR audit output.
+ *
+ * Purpose: convert CLEAR scores into judged-response feedback entries that improve future responses.
+ * Inputs/outputs: Trinity response context + CLEAR score -> persistence summary metadata.
+ * Edge cases: returns non-throwing skip reasons when disabled, budget-constrained, or CLEAR data is unavailable.
+ */
+export async function recordTrinityJudgedFeedback(
+  input: TrinityJudgedFeedbackInput
+): Promise<TrinityJudgedFeedbackSummary> {
+  const enabled = getEnvBoolean('TRINITY_JUDGED_FEEDBACK_ENABLED', true);
+  const allowedSourceEndpoints = parseAllowedSourceEndpoints(
+    getEnv('TRINITY_JUDGED_ALLOWED_ENDPOINTS', DEFAULT_ALLOWED_TRINITY_JUDGED_ENDPOINTS)
+  );
+  //audit Assumption: operators may disable auto judged feedback during incidents; risk: unintended persistence load; invariant: disabled mode performs no writes; handling: explicit early-return skip summary.
+  if (!enabled) {
+    return {
+      enabled: false,
+      attempted: false,
+      source: 'clear_audit',
+      reason: 'disabled_by_env'
+    };
+  }
+
+  //audit Assumption: budget-constrained requests should prioritize user response over persistence side-effects; risk: timeout regressions; invariant: judged persistence only runs with sufficient remaining budget; handling: skip when budget below threshold.
+  if (
+    typeof input.remainingBudgetMs === 'number' &&
+    Number.isFinite(input.remainingBudgetMs) &&
+    input.remainingBudgetMs < MINIMUM_JUDGED_FEEDBACK_BUDGET_MS
+  ) {
+    return {
+      enabled: true,
+      attempted: false,
+      source: 'clear_audit',
+      reason: 'insufficient_runtime_budget'
+    };
+  }
+
+  //audit Assumption: CLEAR audit drives automated quality judgments; risk: low-signal records without score context; invariant: auto-judged persistence requires CLEAR audit data; handling: skip when unavailable.
+  if (!input.clearAudit) {
+    return {
+      enabled: true,
+      attempted: false,
+      source: 'clear_audit',
+      reason: 'clear_audit_unavailable'
+    };
+  }
+
+  //audit Assumption: endpoint allowlisting should gate automated judged persistence to approved entrypoints; risk: unbounded writes from non-chat routes; invariant: only configured endpoints can persist auto judgments; handling: skip with explicit reason when disallowed.
+  if (!isSourceEndpointAllowed(input.sourceEndpoint, allowedSourceEndpoints)) {
+    const sourceEndpoint = input.sourceEndpoint ?? 'unknown';
+    logger.warn(
+      '[🧠 Trinity] Auto judged feedback skipped for disallowed source endpoint',
+      {
+        module: 'trinity',
+        operation: 'judged-feedback-source-gate',
+        requestId: input.requestId
+      },
+      {
+        sourceEndpoint,
+        allowedSourceEndpoints: allowedSourceEndpoints.wildcard
+          ? '*'
+          : Array.from(allowedSourceEndpoints.entries.values())
+      }
+    );
+    return {
+      enabled: true,
+      attempted: false,
+      source: 'clear_audit',
+      reason: `source_endpoint_not_allowed:${sourceEndpoint}`
+    };
+  }
+
+  const scoreScale: ClearScoreScale = '0-10';
+  const score = Number((input.clearAudit.overall * 2).toFixed(3));
+  const feedbackText =
+    `Automated Trinity CLEAR audit overall=${input.clearAudit.overall.toFixed(2)}/5 for tier=${input.tier}.`;
+  const improvementHints = buildImprovementHintsFromClearAudit(input.clearAudit);
+
+  try {
+    const judgedResult = await processJudgedResponseFeedback(
+      {
+        requestId: input.requestId,
+        prompt: input.prompt,
+        response: input.response,
+        score,
+        scoreScale,
+        feedback: feedbackText,
+        judge: 'trinity-clear-audit',
+        improvements: improvementHints,
+        metadata: {
+          source: 'trinity_auto_judged_feedback',
+          tier: input.tier,
+          sessionId: input.sessionId,
+          sourceEndpoint: input.sourceEndpoint,
+          internalMode: input.internalMode ?? false,
+          clearAudit: input.clearAudit
+        }
+      },
+      input.requestId
+    );
+
+    return {
+      enabled: true,
+      attempted: true,
+      source: 'clear_audit',
+      traceId: judgedResult.traceId,
+      accepted: judgedResult.accepted,
+      score: judgedResult.score,
+      scoreScale: judgedResult.scoreScale,
+      normalizedScore: judgedResult.normalizedScore,
+      persisted: judgedResult.persisted
+    };
+  } catch (error: unknown) {
+    //audit Assumption: judged persistence failures should never fail user-facing response flow; risk: partial request failure due side-effect write path; invariant: function always returns summary object; handling: warn and return failure summary.
+    const errorMessage = resolveErrorMessage(error);
+    logger.warn(
+      '[🧠 Trinity] Auto judged feedback persistence failed',
+      {
+        module: 'trinity',
+        operation: 'judged-feedback-persist-failure',
+        requestId: input.requestId
+      },
+      {
+        errorMessage,
+        sourceEndpoint: input.sourceEndpoint
+      }
+    );
+    return {
+      enabled: true,
+      attempted: true,
+      source: 'clear_audit',
+      reason: `persist_failed:${errorMessage}`
+    };
+  }
+}
+
+/**
+ * Derive concise improvement hints from CLEAR audit dimension scores.
+ *
+ * Purpose: convert low CLEAR dimensions into actionable feedback guidance for future responses.
+ * Inputs/outputs: CLEAR audit scores -> deduplicated improvement hint list.
+ * Edge cases: returns at least one generic hint when all dimensions are above threshold.
+ */
+export function buildImprovementHintsFromClearAudit(clearAudit: ClearAuditResult): string[] {
+  const hints: string[] = [];
+  const LOW_SCORE_THRESHOLD = 3;
+
+  //audit Assumption: low clarity indicates missing structure and explicitness; risk: repeated ambiguity; invariant: hint emitted when clarity below threshold; handling: append targeted clarity guidance.
+  if (clearAudit.clarity < LOW_SCORE_THRESHOLD) {
+    hints.push('Increase structure clarity and make assumptions explicit.');
+  }
+  if (clearAudit.leverage < LOW_SCORE_THRESHOLD) {
+    hints.push('Use more relevant context and prior memory evidence.');
+  }
+  if (clearAudit.efficiency < LOW_SCORE_THRESHOLD) {
+    hints.push('Reduce unnecessary verbosity and prioritize direct execution steps.');
+  }
+  if (clearAudit.alignment < LOW_SCORE_THRESHOLD) {
+    hints.push('Align output more tightly with user goals and stated constraints.');
+  }
+  if (clearAudit.resilience < LOW_SCORE_THRESHOLD) {
+    hints.push('Call out edge cases and failure handling strategies explicitly.');
+  }
+
+  //audit Assumption: high-scoring outputs still benefit from reinforcement artifacts; risk: empty improvement arrays reduce downstream context usefulness; invariant: non-empty hint list; handling: add generic reinforcement hint.
+  if (hints.length === 0) {
+    hints.push('Maintain current response quality while preserving deterministic structure.');
+  }
+
+  return hints;
+}
+
+interface AllowedSourceEndpointsPolicy {
+  wildcard: boolean;
+  entries: Set<string>;
+}
+
+function parseAllowedSourceEndpoints(rawValue: string): AllowedSourceEndpointsPolicy {
+  const parsedValues = rawValue
+    .split(',')
+    .map(value => value.trim().toLowerCase())
+    .filter(value => value.length > 0);
+  const wildcard = parsedValues.includes('*');
+  return {
+    wildcard,
+    entries: new Set(parsedValues.filter(value => value !== '*'))
+  };
+}
+
+function isSourceEndpointAllowed(
+  sourceEndpoint: string | undefined,
+  policy: AllowedSourceEndpointsPolicy
+): boolean {
+  if (policy.wildcard) {
+    return true;
+  }
+  if (!sourceEndpoint || sourceEndpoint.trim().length === 0) {
+    return false;
+  }
+  return policy.entries.has(sourceEndpoint.trim().toLowerCase());
+}

--- a/src/core/logic/trinityTypes.ts
+++ b/src/core/logic/trinityTypes.ts
@@ -97,6 +97,18 @@ export interface TrinityResult {
     resilience: number;
     overall: number;
   };
+  judgedFeedback?: {
+    enabled: boolean;
+    attempted: boolean;
+    source: 'clear_audit';
+    reason?: string;
+    traceId?: string;
+    accepted?: boolean;
+    score?: number;
+    scoreScale?: import('@shared/types/reinforcement.js').ClearScoreScale;
+    normalizedScore?: number;
+    persisted?: boolean;
+  };
   confidence?: number;
 }
 
@@ -105,6 +117,7 @@ export interface TrinityRunOptions {
   dryRunReason?: string;
   cognitiveDomain?: import('@shared/types/cognitiveDomain.js').CognitiveDomain;
   internalMode?: boolean;
+  sourceEndpoint?: string;
 }
 
 export interface TrinityDryRunPreview {

--- a/src/core/startup.ts
+++ b/src/core/startup.ts
@@ -11,6 +11,7 @@ import { resolveErrorMessage } from "@core/lib/errors/index.js";
 import { verifyIntegrityManifestConfiguration } from "@services/safety/configIntegrity.js";
 import { activateUnsafeCondition } from "@services/safety/runtimeState.js";
 import { emitSafetyAuditEvent } from "@services/safety/auditEvents.js";
+import { hydrateJudgedResponseFeedbackContext } from "@services/judgedResponseFeedback.js";
 
 /**
  * Runs startup checks including environment validation, database init,
@@ -78,6 +79,16 @@ export async function performStartup(): Promise<void> {
     const dbConnected = await initializeDatabase('server');
     if (!dbConnected) {
       logger.warn('⚠️ DB CHECK - Database not available - continuing with in-memory fallback');
+    } else {
+      try {
+        const hydratedEntries = await hydrateJudgedResponseFeedbackContext();
+        //audit Assumption: judged feedback hydration is best-effort and should not block startup; risk: missing historical context after restart; invariant: startup continues even when hydration fails; handling: informational logging with fallback catch below.
+        logger.info('🧠 Reinforcement judged feedback hydrated', { hydratedEntries });
+      } catch (hydrationError: unknown) {
+        logger.warn('⚠️ Reinforcement judged feedback hydration failed - continuing without persisted judgment context', {
+          error: resolveErrorMessage(hydrationError)
+        });
+      }
     }
   } catch (err: unknown) {
     //audit Assumption: DB init errors should log and fallback

--- a/src/mcp/server/index.ts
+++ b/src/mcp/server/index.ts
@@ -102,7 +102,7 @@ export async function createMcpServer(ctx: McpRequestContext): Promise<AnyMcpSer
         prompt,
         sessionId,
         args.overrideAuditSafe,
-        {},
+        { sourceEndpoint: 'mcp.trinity.ask' },
         ctx.runtimeBudget
       );
       return mcpText(result);
@@ -690,5 +690,4 @@ export async function buildMcpServer(ctx: McpRequestContext): Promise<{ server: 
   await server.connect(transport);
   return { server, transport };
 }
-
 

--- a/src/platform/runtime/workerContext.ts
+++ b/src/platform/runtime/workerContext.ts
@@ -72,7 +72,14 @@ export function createWorkerContext(workerId: string): WorkerContext {
 
           // Use the trinity brain system for AI processing (pass adapter's client)
           const runtimeBudget = createRuntimeBudget();
-          const result = await runThroughBrain(client, prompt, undefined, undefined, {}, runtimeBudget);
+          const result = await runThroughBrain(
+            client,
+            prompt,
+            undefined,
+            undefined,
+            { sourceEndpoint: `worker:${workerId}` },
+            runtimeBudget
+          );
           return result.result;
         } catch (error: unknown) {
           //audit Assumption: AI failures should propagate with safe message

--- a/src/routes/ask/index.ts
+++ b/src/routes/ask/index.ts
@@ -533,7 +533,17 @@ export const handleAIRequest = async (
     }
 
     const runtimeBudget = createRuntimeBudget();
-    const output = await runThroughBrain(openai, prompt, sessionId, overrideAuditSafe, { cognitiveDomain: finalDomain }, runtimeBudget);
+    const output = await runThroughBrain(
+      openai,
+      prompt,
+      sessionId,
+      overrideAuditSafe,
+      {
+        cognitiveDomain: finalDomain,
+        sourceEndpoint: endpointName
+      },
+      runtimeBudget
+    );
     return res.json({
       ...(output as AskResponse),
       clientContext: req.body.clientContext,

--- a/src/routes/mcp.ts
+++ b/src/routes/mcp.ts
@@ -13,27 +13,24 @@ const router = express.Router();
 // The MCP transport handler needs raw JSON body.
 router.use(express.json({ limit: process.env.MCP_HTTP_BODY_LIMIT ?? '1mb' }));
 
-let sharedMcpServerPromise: Promise<{ server: any; transport: any }> | null = null;
-
-async function getSharedMcpServer() {
-  if (!sharedMcpServerPromise) {
-    sharedMcpServerPromise = (async () => {
-      const proxyContext = createMcpRequestContextProxy();
-      const { buildMcpServer } = await import('../mcp/server.js');
-      return buildMcpServer(proxyContext);
-    })().catch((error) => {
-      sharedMcpServerPromise = null;
-      throw error;
-    });
-  }
-
-  return sharedMcpServerPromise;
+/**
+ * Build an isolated MCP server/transport pair for a single HTTP request.
+ *
+ * Purpose: avoid cross-request transport state leakage in streamable HTTP mode.
+ * Inputs/outputs: no inputs; returns a new MCP server + transport pair.
+ * Edge cases: throws import/build errors to caller for standardized error handling.
+ */
+async function buildMcpServerForRequest() {
+  const proxyContext = createMcpRequestContextProxy();
+  const { buildMcpServer } = await import('../mcp/server.js');
+  return buildMcpServer(proxyContext);
 }
 
 router.post('/mcp', mcpAuthMiddleware, async (req: Request, res: Response) => {
   try {
     const ctx = buildMcpRequestContext(req);
-    const { transport } = await getSharedMcpServer();
+    //audit Assumption: streamable transport instances are request-scoped; risk: shared transport state causes subsequent MCP calls to fail; invariant: each request gets a fresh transport; handling: build isolated server/transport pair per request.
+    const { transport } = await buildMcpServerForRequest();
 
     await runWithMcpRequestContext(ctx, async () => {
       await transport.handleRequest(req, res, req.body);

--- a/src/routes/reinforcement.ts
+++ b/src/routes/reinforcement.ts
@@ -3,7 +3,11 @@ import { auditTrace } from "@transport/http/middleware/auditTrace.js";
 import { registerContextEntry, getReinforcementHealth } from "@services/contextualReinforcement.js";
 import { getMemoryDigest } from "@services/memoryDigest.js";
 import { processClearFeedback } from "@services/audit.js";
-import type { ClearFeedbackPayload } from "@shared/types/reinforcement.js";
+import {
+  getJudgedFeedbackRuntimeTelemetry,
+  processJudgedResponseFeedback
+} from "@services/judgedResponseFeedback.js";
+import type { ClearFeedbackPayload, JudgedResponsePayload } from "@shared/types/reinforcement.js";
 import { resolveErrorMessage } from "@core/lib/errors/index.js";
 import { sendBadRequest } from '@shared/http/index.js';
 
@@ -56,6 +60,26 @@ router.post('/audit', auditTrace, async (req: Request, res: Response) => {
   }
 });
 
+router.post('/reinforcement/judge', auditTrace, async (req: Request, res: Response) => {
+  const payload = req.body as JudgedResponsePayload;
+
+  try {
+    //audit Assumption: route-level trace id is always available from auditTrace middleware; risk: missing identifier breaks feedback traceability; invariant: every judged record has a trace id; handling: use middleware id fallback.
+    const result = await processJudgedResponseFeedback(payload, res.locals.auditTraceId);
+    return res.status(200).json({
+      status: 'ok',
+      traceId: result.traceId,
+      accepted: result.accepted,
+      score: result.score,
+      scoreScale: result.scoreScale,
+      normalizedScore: result.normalizedScore,
+      persisted: result.persisted
+    });
+  } catch (error) {
+    return sendBadRequest(res, resolveErrorMessage(error));
+  }
+});
+
 router.get('/memory/digest', (_: Request, res: Response) => {
   res.json(getMemoryDigest());
 });
@@ -66,6 +90,15 @@ router.get('/memory', (_: Request, res: Response) => {
 
 router.get('/health', (_: Request, res: Response) => {
   res.json(getReinforcementHealth());
+});
+
+router.get('/reinforcement/metrics', (_: Request, res: Response) => {
+  //audit Assumption: runtime telemetry is non-sensitive operational metadata; risk: overexposing internals; invariant: response contains aggregate counters only; handling: expose sanitized aggregate snapshot.
+  res.json({
+    status: 'ok',
+    judgedFeedback: getJudgedFeedbackRuntimeTelemetry(),
+    reinforcement: getReinforcementHealth()
+  });
 });
 
 export default router;

--- a/src/routes/siri.ts
+++ b/src/routes/siri.ts
@@ -32,7 +32,14 @@ const handleSiriRequest = async (
 
   try {
     const runtimeBudget = createRuntimeBudget();
-    const output = await runThroughBrain(openai, input, sessionId, overrideAuditSafe, {}, runtimeBudget);
+    const output = await runThroughBrain(
+      openai,
+      input,
+      sessionId,
+      overrideAuditSafe,
+      { sourceEndpoint: 'siri' },
+      runtimeBudget
+    );
     return res.json({ ...output, content: output.result } as SiriResponse);
   } catch (err) {
     handleAIError(err, input, 'siri', res);

--- a/src/services/ai-reflections.ts
+++ b/src/services/ai-reflections.ts
@@ -89,6 +89,7 @@ export async function buildPatchSet(options: PatchSetOptions = {}): Promise<Patc
     category = 'general',
     systemAnalysis = true
   } = options;
+  const shouldPersistReflection = useMemory;
 
   // Use config layer for env access (adapter boundary pattern)
   const reflectionModel = options.model || getEnv('AI_REFLECTION_MODEL') || getDefaultModel();
@@ -194,7 +195,10 @@ export async function buildPatchSet(options: PatchSetOptions = {}): Promise<Patc
       }
     };
 
-    await persistSelfReflection(patch);
+    //audit Assumption: stateless runs are transient and should avoid DB dependency; risk: losing historical traces for stateless calls; invariant: stateful runs continue persisting; handling: gate persistence on memory mode.
+    if (shouldPersistReflection) {
+      await persistSelfReflection(patch);
+    }
 
     return patch;
 
@@ -240,7 +244,10 @@ export async function buildPatchSet(options: PatchSetOptions = {}): Promise<Patc
       }
     };
 
-    await persistSelfReflection(fallbackPatch);
+    //audit Assumption: fallback should match persistence gating of primary path; risk: inconsistent behavior between success/failure; invariant: stateless mode remains DB-independent; handling: reuse same gate.
+    if (shouldPersistReflection) {
+      await persistSelfReflection(fallbackPatch);
+    }
 
     return fallbackPatch;
   }

--- a/src/services/arcanosPrompt.ts
+++ b/src/services/arcanosPrompt.ts
@@ -29,7 +29,14 @@ export async function handleArcanosPrompt(prompt: string) {
   try {
     // Route the prompt through the main Trinity brain processing
     const runtimeBudget = createRuntimeBudget();
-    const output = await runThroughBrain(client, prompt, undefined, undefined, {}, runtimeBudget);
+    const output = await runThroughBrain(
+      client,
+      prompt,
+      undefined,
+      undefined,
+      { sourceEndpoint: 'arcanosPrompt' },
+      runtimeBudget
+    );
     return output;
   } catch (error: unknown) {
     //audit Assumption: map errors to friendly message when possible

--- a/src/services/judgedResponseFeedback.ts
+++ b/src/services/judgedResponseFeedback.ts
@@ -1,0 +1,609 @@
+import crypto from 'node:crypto';
+
+import {
+  loadRecentSelfReflectionsByCategory,
+  saveSelfReflection,
+  type SelfReflectionRecord
+} from "@core/db/repositories/selfReflectionRepository.js";
+import { getReinforcementConfig, registerContextEntry } from "@services/contextualReinforcement.js";
+import { logger } from "@platform/logging/structuredLogging.js";
+import { getEnvNumber } from "@platform/runtime/env.js";
+import type {
+  ClearScoreScale,
+  JudgedResponsePayload,
+  JudgedResponseResult
+} from "@shared/types/reinforcement.js";
+
+const JUDGED_RESPONSE_REFLECTION_CATEGORY = 'judged-response';
+const MAX_PROMPT_LENGTH = 10_000;
+const MAX_RESPONSE_LENGTH = 20_000;
+const MAX_FEEDBACK_LENGTH = 2_000;
+const MAX_IMPROVEMENTS = 25;
+const DEFAULT_HYDRATION_LIMIT = 20;
+const JUDGED_IDEMPOTENCY_WINDOW_MS = 5 * 60 * 1_000;
+const IDENTITY_HASH_LENGTH = 16;
+const DEFAULT_JUDGED_CACHE_MAX_ENTRIES = 2_000;
+const JUDGED_CACHE_MAX_ENTRIES = Math.max(
+  1,
+  Math.floor(getEnvNumber('JUDGED_FEEDBACK_CACHE_MAX_ENTRIES', DEFAULT_JUDGED_CACHE_MAX_ENTRIES))
+);
+const MAX_METADATA_DEPTH = 8;
+const MAX_METADATA_KEYS_PER_OBJECT = 200;
+const MAX_METADATA_ARRAY_ITEMS = 200;
+const DANGEROUS_METADATA_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
+let hasHydratedJudgedFeedbackContext = false;
+
+export interface JudgedFeedbackRuntimeTelemetry {
+  attempts: number;
+  duplicatesSkipped: number;
+  persistedWrites: number;
+  persistenceFailures: number;
+  cacheEvictions: number;
+  cacheSize: number;
+  cacheMaxEntries: number;
+  idempotencyWindowMs: number;
+  lastEventAt: string | null;
+}
+
+interface CachedJudgedResult {
+  storedAtMs: number;
+  result: JudgedResponseResult;
+}
+
+const recentJudgedResultByIdempotencyKey = new Map<string, CachedJudgedResult>();
+const judgedFeedbackRuntimeTelemetry: JudgedFeedbackRuntimeTelemetry = {
+  attempts: 0,
+  duplicatesSkipped: 0,
+  persistedWrites: 0,
+  persistenceFailures: 0,
+  cacheEvictions: 0,
+  cacheSize: 0,
+  cacheMaxEntries: JUDGED_CACHE_MAX_ENTRIES,
+  idempotencyWindowMs: JUDGED_IDEMPOTENCY_WINDOW_MS,
+  lastEventAt: null
+};
+
+interface NormalizedJudgedPayload {
+  requestId: string;
+  prompt: string;
+  response: string;
+  feedback?: string;
+  judge?: string;
+  score: number;
+  scoreScale: ClearScoreScale;
+  normalizedScore: number;
+  accepted: boolean;
+  improvements: string[];
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Process judged response feedback, store it, and feed it back into prompt reinforcement.
+ *
+ * Purpose: turn explicit human/system judgments into reusable context for better response quality.
+ * Inputs/outputs: judged payload + fallback trace id -> normalized persisted judgment result.
+ * Edge cases: throws on invalid payload fields and still returns `persisted=false` if DB write fails.
+ */
+export async function processJudgedResponseFeedback(
+  payload: JudgedResponsePayload,
+  fallbackTraceId: string
+): Promise<JudgedResponseResult> {
+  const normalizedPayload = normalizeJudgedResponsePayload(payload, fallbackTraceId);
+  const sourceEndpoint = extractSourceEndpoint(normalizedPayload.metadata);
+  const idempotencyKey = buildJudgedFeedbackIdempotencyKey(normalizedPayload);
+  const nowMs = Date.now();
+
+  judgedFeedbackRuntimeTelemetry.attempts += 1;
+  judgedFeedbackRuntimeTelemetry.lastEventAt = new Date(nowMs).toISOString();
+
+  const duplicateResult = getCachedJudgedResult(idempotencyKey, nowMs);
+  //audit Assumption: repeated judged writes for the same content within a short window are accidental loops; risk: duplicate persistence and reinforcement drift; invariant: idempotency key collapses duplicates; handling: return cached result and skip side effects.
+  if (duplicateResult) {
+    judgedFeedbackRuntimeTelemetry.duplicatesSkipped += 1;
+    logger.info(
+      '[🧠 Reinforcement] Skipping duplicate judged-response persistence',
+      {
+        module: 'judged-feedback',
+        operation: 'idempotency-skip',
+        requestId: normalizedPayload.requestId
+      },
+      {
+        idempotencyKey,
+        sourceEndpoint
+      }
+    );
+    judgedFeedbackRuntimeTelemetry.cacheSize = recentJudgedResultByIdempotencyKey.size;
+    return duplicateResult;
+  }
+
+  const contextSummary = buildJudgedContextSummary(normalizedPayload);
+
+  registerContextEntry({
+    source: 'audit',
+    summary: contextSummary,
+    requestId: normalizedPayload.requestId,
+    metadata: {
+      kind: JUDGED_RESPONSE_REFLECTION_CATEGORY,
+      accepted: normalizedPayload.accepted,
+      score: normalizedPayload.score,
+      scoreScale: normalizedPayload.scoreScale,
+      normalizedScore: normalizedPayload.normalizedScore
+    },
+    //audit Assumption: accepted judgments should bias future output positively and rejected judgments negatively; risk: inverted learning signal; invariant: bias aligns with acceptance state; handling: deterministic accepted->positive mapping.
+    bias: normalizedPayload.accepted ? 'positive' : 'negative',
+    score: normalizedPayload.normalizedScore
+  });
+
+  let persisted = true;
+  try {
+    await saveSelfReflection({
+      priority: mapNormalizedScoreToPriority(normalizedPayload.normalizedScore),
+      category: JUDGED_RESPONSE_REFLECTION_CATEGORY,
+      content: normalizedPayload.response,
+      improvements: normalizedPayload.improvements,
+      metadata: {
+        kind: JUDGED_RESPONSE_REFLECTION_CATEGORY,
+        requestId: normalizedPayload.requestId,
+        prompt: sanitizeJudgedText(normalizedPayload.prompt),
+        response: sanitizeJudgedText(normalizedPayload.response),
+        feedback: normalizedPayload.feedback,
+        judge: normalizedPayload.judge,
+        score: normalizedPayload.score,
+        scoreScale: normalizedPayload.scoreScale,
+        normalizedScore: normalizedPayload.normalizedScore,
+        accepted: normalizedPayload.accepted,
+        ...normalizedPayload.metadata
+      }
+    });
+    judgedFeedbackRuntimeTelemetry.persistedWrites += 1;
+  } catch (error) {
+    //audit Assumption: persistence failure should not drop in-memory reinforcement for this process; risk: historical judgment loss across restarts; invariant: caller still receives accepted/scoring result; handling: report persisted=false.
+    persisted = false;
+    judgedFeedbackRuntimeTelemetry.persistenceFailures += 1;
+    console.warn('[🧠 Reinforcement] Failed to persist judged response feedback:', resolveErrorMessage(error));
+  }
+
+  const result: JudgedResponseResult = {
+    traceId: normalizedPayload.requestId,
+    accepted: normalizedPayload.accepted,
+    score: normalizedPayload.score,
+    scoreScale: normalizedPayload.scoreScale,
+    normalizedScore: normalizedPayload.normalizedScore,
+    persisted
+  };
+
+  cacheJudgedResult(idempotencyKey, result, nowMs);
+  judgedFeedbackRuntimeTelemetry.cacheSize = recentJudgedResultByIdempotencyKey.size;
+  return result;
+}
+
+/**
+ * Hydrate reinforcement context from recent persisted judged responses.
+ *
+ * Purpose: restore response-quality learning signals after process restarts.
+ * Inputs/outputs: optional max entry count -> count of hydrated entries.
+ * Edge cases: idempotent by default and returns zero when no persisted judgments are available.
+ */
+export async function hydrateJudgedResponseFeedbackContext(limit: number = DEFAULT_HYDRATION_LIMIT): Promise<number> {
+  //audit Assumption: startup hydration should run once per process by default; risk: duplicate context entries degrade prompt quality; invariant: repeated calls without explicit reset do nothing; handling: guard with module-level flag.
+  if (hasHydratedJudgedFeedbackContext) {
+    return 0;
+  }
+
+  const sanitizedLimit = Math.max(1, Math.min(100, Math.floor(limit)));
+  const reflections = await loadRecentSelfReflectionsByCategory(
+    JUDGED_RESPONSE_REFLECTION_CATEGORY,
+    sanitizedLimit
+  );
+
+  let hydratedCount = 0;
+  for (const reflection of reflections.reverse()) {
+    const hydrated = hydrateContextFromPersistedReflection(reflection);
+    if (hydrated) {
+      hydratedCount += 1;
+    }
+  }
+
+  hasHydratedJudgedFeedbackContext = true;
+  return hydratedCount;
+}
+
+/**
+ * Reset judged feedback hydration guard (test utility).
+ *
+ * Purpose: allow isolated tests to re-run hydration logic deterministically.
+ * Inputs/outputs: no inputs and no output.
+ * Edge cases: only affects in-process module state.
+ */
+export function resetJudgedFeedbackHydrationState(): void {
+  hasHydratedJudgedFeedbackContext = false;
+}
+
+/**
+ * Read judged-feedback runtime telemetry snapshot.
+ *
+ * Purpose: expose lightweight counters for duplicate suppression and persistence outcomes.
+ * Inputs/outputs: no inputs -> immutable telemetry snapshot object.
+ * Edge cases: counters are process-local and reset on restart.
+ */
+export function getJudgedFeedbackRuntimeTelemetry(): JudgedFeedbackRuntimeTelemetry {
+  return {
+    ...judgedFeedbackRuntimeTelemetry,
+    cacheSize: recentJudgedResultByIdempotencyKey.size,
+    cacheMaxEntries: JUDGED_CACHE_MAX_ENTRIES,
+    idempotencyWindowMs: JUDGED_IDEMPOTENCY_WINDOW_MS
+  };
+}
+
+function hydrateContextFromPersistedReflection(reflection: SelfReflectionRecord): boolean {
+  const metadata = reflection.metadata ?? {};
+  const accepted = Boolean(metadata.accepted);
+  const score = typeof metadata.normalizedScore === 'number' ? metadata.normalizedScore : undefined;
+  const requestId = typeof metadata.requestId === 'string' && metadata.requestId.trim().length > 0
+    ? metadata.requestId
+    : reflection.id;
+
+  //audit Assumption: persisted judged reflections include enough metadata for meaningful summaries; risk: malformed legacy records creating noisy context; invariant: malformed records are skipped; handling: validate summary inputs and return false when unusable.
+  const summary = buildHydratedContextSummary(reflection, accepted, score);
+  if (!summary) {
+    return false;
+  }
+
+  registerContextEntry({
+    source: 'audit',
+    summary,
+    requestId,
+    metadata: {
+      kind: JUDGED_RESPONSE_REFLECTION_CATEGORY,
+      accepted,
+      loadedFromPersistence: true,
+      reflectionId: reflection.id
+    },
+    bias: accepted ? 'positive' : 'negative',
+    score,
+    patternId: reflection.id
+  });
+  return true;
+}
+
+function buildHydratedContextSummary(
+  reflection: SelfReflectionRecord,
+  accepted: boolean,
+  score: number | undefined
+): string | null {
+  const feedbackValue = reflection.metadata?.feedback;
+  const feedback = typeof feedbackValue === 'string' ? feedbackValue.trim() : '';
+  const normalizedScoreText = typeof score === 'number' ? score.toFixed(2) : 'n/a';
+  const baseSummary =
+    `Judged response (${accepted ? 'accepted' : 'rejected'}) normalized score=${normalizedScoreText}.`;
+
+  if (!feedback && reflection.improvements.length === 0) {
+    return baseSummary;
+  }
+
+  const improvementSummary = reflection.improvements.length > 0
+    ? `Improvements: ${reflection.improvements.slice(0, 5).join(' | ')}.`
+    : '';
+  const feedbackSummary = feedback ? `Feedback: ${truncateText(feedback, MAX_FEEDBACK_LENGTH)}.` : '';
+  const combined = [baseSummary, feedbackSummary, improvementSummary].filter(Boolean).join(' ');
+  return combined.trim().length > 0 ? combined : null;
+}
+
+function normalizeJudgedResponsePayload(
+  payload: JudgedResponsePayload,
+  fallbackTraceId: string
+): NormalizedJudgedPayload {
+  //audit Assumption: endpoint receives object payloads; risk: null/primitive payloads bypass validation; invariant: payload object required; handling: throw explicit error.
+  if (typeof payload !== 'object' || payload === null) {
+    throw new Error('Judged response payload must be an object');
+  }
+
+  const requestId =
+    typeof payload.requestId === 'string' && payload.requestId.trim().length > 0
+      ? payload.requestId.trim()
+      : fallbackTraceId;
+  const prompt = requireNonEmptyText(payload.prompt, 'prompt', MAX_PROMPT_LENGTH);
+  const response = requireNonEmptyText(payload.response, 'response', MAX_RESPONSE_LENGTH);
+  const score = normalizeFiniteNumber(payload.score, 'score');
+  const scoreScale = resolveClearScoreScale(score, payload.scoreScale);
+  const normalizedScore = normalizeClearScoreForThreshold(score, scoreScale, getReinforcementConfig().minimumClearScore);
+  const accepted = normalizedScore >= getReinforcementConfig().minimumClearScore;
+  const improvements = normalizeImprovements(payload.improvements);
+
+  //audit Assumption: metadata may contain nested untrusted keys and non-plain objects; risk: prototype pollution and serialization instability; invariant: persisted metadata is deeply sanitized and JSON-safe; handling: recursive sanitization with dangerous-key stripping.
+  const metadata = sanitizeMetadataRecord(payload.metadata);
+
+  const feedback = typeof payload.feedback === 'string' && payload.feedback.trim().length > 0
+    ? truncateText(payload.feedback.trim(), MAX_FEEDBACK_LENGTH)
+    : undefined;
+  const judge = typeof payload.judge === 'string' && payload.judge.trim().length > 0
+    ? payload.judge.trim()
+    : undefined;
+
+  return {
+    requestId,
+    prompt,
+    response,
+    feedback,
+    judge,
+    score,
+    scoreScale,
+    normalizedScore,
+    accepted,
+    improvements,
+    metadata
+  };
+}
+
+function buildJudgedContextSummary(normalizedPayload: NormalizedJudgedPayload): string {
+  const baseSummary =
+    `Judged response score ${normalizedPayload.score.toFixed(2)} (${normalizedPayload.scoreScale}, normalized ${normalizedPayload.normalizedScore.toFixed(2)}) -> ${normalizedPayload.accepted ? 'accepted' : 'rejected'}.`;
+
+  if (!normalizedPayload.feedback && normalizedPayload.improvements.length === 0) {
+    return baseSummary;
+  }
+
+  const feedbackSegment = normalizedPayload.feedback ? `Feedback: ${normalizedPayload.feedback}.` : '';
+  const improvementSegment = normalizedPayload.improvements.length > 0
+    ? `Improvements: ${normalizedPayload.improvements.slice(0, 5).join(' | ')}.`
+    : '';
+  return [baseSummary, feedbackSegment, improvementSegment].filter(Boolean).join(' ').trim();
+}
+
+function requireNonEmptyText(value: unknown, fieldName: string, maxLength: number): string {
+  //audit Assumption: judged payload text fields are required for meaningful learning; risk: empty text creates noisy/low-signal records; invariant: trimmed non-empty string returned; handling: strict validation + truncation.
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`Judged response payload field "${fieldName}" must be a non-empty string`);
+  }
+  return truncateText(value.trim(), maxLength);
+}
+
+function normalizeFiniteNumber(value: unknown, fieldName: string): number {
+  //audit Assumption: score must be numeric; risk: NaN/non-numeric values break acceptance gating; invariant: finite number returned; handling: throw validation error.
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`Judged response payload field "${fieldName}" must be a finite number`);
+  }
+  return value;
+}
+
+function normalizeImprovements(improvements: unknown): string[] {
+  if (!Array.isArray(improvements)) {
+    return [];
+  }
+  return improvements
+    .filter(item => typeof item === 'string')
+    .map(item => item.trim())
+    .filter(item => item.length > 0)
+    .slice(0, MAX_IMPROVEMENTS);
+}
+
+function resolveClearScoreScale(score: number, declaredScale?: ClearScoreScale): ClearScoreScale {
+  if (declaredScale === '0-1' || declaredScale === '0-10') {
+    return declaredScale;
+  }
+
+  //audit Assumption: scores <=1 are normalized scale by default; risk: ambiguous scale for low 0-10 scores; invariant: deterministic inference; handling: use threshold heuristic.
+  if (score <= 1) {
+    return '0-1';
+  }
+  return '0-10';
+}
+
+function normalizeClearScoreForThreshold(
+  score: number,
+  scoreScale: ClearScoreScale,
+  minimumClearScore: number
+): number {
+  const minimumScale: ClearScoreScale = minimumClearScore <= 1 ? '0-1' : '0-10';
+  if (scoreScale === minimumScale) {
+    return score;
+  }
+  if (scoreScale === '0-10' && minimumScale === '0-1') {
+    return score / 10;
+  }
+  return score * 10;
+}
+
+function mapNormalizedScoreToPriority(normalizedScore: number): 'high' | 'medium' | 'low' {
+  //audit Assumption: reinforcement minimum score can be configured in either 0-1 or 0-10 scale; risk: wrong priority mapping if scale misunderstood; invariant: normalized score converted to 0-10 before mapping; handling: explicit conversion branch.
+  const asTenPointScore = normalizedScore <= 1 ? normalizedScore * 10 : normalizedScore;
+  if (asTenPointScore >= 8) {
+    return 'high';
+  }
+  if (asTenPointScore >= 5) {
+    return 'medium';
+  }
+  return 'low';
+}
+
+function buildJudgedFeedbackIdempotencyKey(payload: NormalizedJudgedPayload): string {
+  //audit Assumption: stable hash identity should include request + normalized judgment content; risk: collisions skipping distinct writes; invariant: deterministic key for semantically identical judged records; handling: include request, judge, scores, and content digests.
+  const promptDigest = crypto
+    .createHash('sha256')
+    .update(payload.prompt)
+    .digest('hex')
+    .slice(0, IDENTITY_HASH_LENGTH);
+  const responseDigest = crypto
+    .createHash('sha256')
+    .update(payload.response)
+    .digest('hex')
+    .slice(0, IDENTITY_HASH_LENGTH);
+  const judgeIdentity = payload.judge ?? 'unknown';
+  return [
+    payload.requestId,
+    judgeIdentity,
+    payload.scoreScale,
+    payload.score.toFixed(3),
+    promptDigest,
+    responseDigest
+  ].join('|');
+}
+
+function getCachedJudgedResult(idempotencyKey: string, nowMs: number): JudgedResponseResult | null {
+  purgeExpiredJudgedResults(nowMs);
+  const cached = recentJudgedResultByIdempotencyKey.get(idempotencyKey);
+  if (!cached) {
+    return null;
+  }
+  return cached.result;
+}
+
+function cacheJudgedResult(idempotencyKey: string, result: JudgedResponseResult, nowMs: number): void {
+  purgeExpiredJudgedResults(nowMs);
+  enforceJudgedCacheCapacity();
+  recentJudgedResultByIdempotencyKey.set(idempotencyKey, {
+    storedAtMs: nowMs,
+    result
+  });
+}
+
+function purgeExpiredJudgedResults(nowMs: number): void {
+  for (const [key, cached] of recentJudgedResultByIdempotencyKey.entries()) {
+    //audit Assumption: stale cache entries no longer useful for loop suppression; risk: unbounded memory growth; invariant: cache entries remain within TTL window; handling: periodic purge on read/write.
+    if (nowMs - cached.storedAtMs > JUDGED_IDEMPOTENCY_WINDOW_MS) {
+      recentJudgedResultByIdempotencyKey.delete(key);
+    }
+  }
+}
+
+function enforceJudgedCacheCapacity(): void {
+  //audit Assumption: idempotency cache should stay bounded under high cardinality traffic; risk: unbounded memory growth; invariant: entry count remains below configured max; handling: evict oldest entries before inserts.
+  while (recentJudgedResultByIdempotencyKey.size >= JUDGED_CACHE_MAX_ENTRIES) {
+    const oldestKey = recentJudgedResultByIdempotencyKey.keys().next().value as string | undefined;
+    if (!oldestKey) {
+      break;
+    }
+    recentJudgedResultByIdempotencyKey.delete(oldestKey);
+    judgedFeedbackRuntimeTelemetry.cacheEvictions += 1;
+  }
+}
+
+function extractSourceEndpoint(metadata: Record<string, unknown>): string | undefined {
+  const sourceEndpointValue = metadata.sourceEndpoint;
+  if (typeof sourceEndpointValue !== 'string') {
+    return undefined;
+  }
+  const trimmed = sourceEndpointValue.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function sanitizeJudgedText(value: string): string {
+  //audit Assumption: judged text may include raw secrets from prompt/response traces; risk: sensitive persistence leakage; invariant: known secret patterns are masked before DB write; handling: deterministic regex redaction.
+  return value
+    .replace(/\bsk-[A-Za-z0-9_-]{20,}\b/g, '[REDACTED_OPENAI_KEY]')
+    .replace(/\bBearer\s+[A-Za-z0-9._-]{12,}\b/gi, '[REDACTED_BEARER_TOKEN]')
+    .replace(/\b(api[_-]?key|token|secret|password)\s*[:=]\s*["']?[^"'\s]+/gi, '$1=[REDACTED]');
+}
+
+function sanitizeMetadataRecord(value: unknown): Record<string, unknown> {
+  //audit Assumption: caller metadata can be absent or malformed; risk: unsafe object spread and unstable persistence; invariant: metadata is always a plain object record; handling: fallback to empty record when root is invalid.
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return {};
+  }
+  const seenObjects = new WeakSet<object>();
+  const sanitizedValue = sanitizeMetadataValue(value, 0, seenObjects);
+  if (typeof sanitizedValue === 'object' && sanitizedValue !== null && !Array.isArray(sanitizedValue)) {
+    return sanitizedValue as Record<string, unknown>;
+  }
+  return {};
+}
+
+function sanitizeMetadataValue(
+  value: unknown,
+  depth: number,
+  seenObjects: WeakSet<object>
+): unknown {
+  //audit Assumption: recursive sanitization must terminate predictably; risk: deep/cyclic inputs causing stack or memory pressure; invariant: depth and cycle guards bound traversal; handling: truncate deep/cyclic branches.
+  if (depth > MAX_METADATA_DEPTH) {
+    return '[TRUNCATED_DEPTH]';
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    return truncateText(sanitizeJudgedText(value), MAX_RESPONSE_LENGTH);
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message
+    };
+  }
+  if (typeof value === 'function' || typeof value === 'symbol' || typeof value === 'undefined') {
+    return undefined;
+  }
+  if (typeof value !== 'object') {
+    return String(value);
+  }
+
+  if (seenObjects.has(value)) {
+    return '[CIRCULAR_REFERENCE]';
+  }
+  seenObjects.add(value);
+
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, MAX_METADATA_ARRAY_ITEMS)
+      .map(item => sanitizeMetadataValue(item, depth + 1, seenObjects))
+      .filter(item => item !== undefined);
+  }
+
+  //audit Assumption: non-plain objects may include class instances with hidden behaviors; risk: serializing unsafe internals; invariant: only plain records are traversed as objects; handling: coerce non-plain objects to string descriptors.
+  if (!isPlainRecord(value)) {
+    return Object.prototype.toString.call(value);
+  }
+
+  const sanitizedRecord: Record<string, unknown> = {};
+  const entries = Object.entries(value as Record<string, unknown>).slice(0, MAX_METADATA_KEYS_PER_OBJECT);
+  for (const [rawKey, rawEntryValue] of entries) {
+    if (DANGEROUS_METADATA_KEYS.has(rawKey)) {
+      continue;
+    }
+    const sanitizedEntryValue = sanitizeMetadataValue(rawEntryValue, depth + 1, seenObjects);
+    if (sanitizedEntryValue === undefined) {
+      continue;
+    }
+    sanitizedRecord[rawKey] = sanitizedEntryValue;
+  }
+  return sanitizedRecord;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function truncateText(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return value.slice(0, maxLength);
+}
+
+function resolveErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  return 'Unknown error';
+}

--- a/src/shared/types/reinforcement.ts
+++ b/src/shared/types/reinforcement.ts
@@ -53,6 +53,27 @@ export interface ClearFeedbackPayload {
   };
 }
 
+export interface JudgedResponsePayload {
+  requestId?: string;
+  prompt: string;
+  response: string;
+  score: number;
+  scoreScale?: ClearScoreScale;
+  feedback?: string;
+  judge?: string;
+  improvements?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface JudgedResponseResult {
+  traceId: string;
+  accepted: boolean;
+  score: number;
+  scoreScale: ClearScoreScale;
+  normalizedScore: number;
+  persisted: boolean;
+}
+
 export interface AuditRecord {
   id: string;
   requestId: string;

--- a/src/transport/http/controllers/aiController.ts
+++ b/src/transport/http/controllers/aiController.ts
@@ -46,7 +46,14 @@ export class AIController {
     try {
       // runThroughBrain enforces GPT-5.1 as the primary reasoning stage
       const runtimeBudget = createRuntimeBudget();
-      const output = await runThroughBrain(openai, input, body.sessionId, body.overrideAuditSafe, {}, runtimeBudget);
+      const output = await runThroughBrain(
+        openai,
+        input,
+        body.sessionId,
+        body.overrideAuditSafe,
+        { sourceEndpoint: endpointName },
+        runtimeBudget
+      );
 
       const responsePayload: AIResponse = {
         ...(output as AIResponse),

--- a/src/workers/jobRunner.ts
+++ b/src/workers/jobRunner.ts
@@ -86,7 +86,10 @@ async function run(): Promise<void> {
         prompt,
         sessionId,
         overrideAuditSafe,
-        { cognitiveDomain },
+        {
+          cognitiveDomain,
+          sourceEndpoint: 'worker.jobRunner.ask'
+        },
         runtimeBudget
       );
 

--- a/tests/ai-controller-source-endpoint.test.ts
+++ b/tests/ai-controller-source-endpoint.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+type AIControllerModule = typeof import('../src/transport/http/controllers/aiController.js');
+
+interface AIControllerHarness {
+  module: AIControllerModule;
+  runThroughBrainMock: jest.Mock;
+  validateAIRequestMock: jest.Mock;
+  handleAIErrorMock: jest.Mock;
+}
+
+/**
+ * Load AI controller with isolated Trinity/request-handler mocks.
+ *
+ * Purpose: verify endpoint metadata is forwarded into Trinity run options.
+ * Inputs/outputs: no inputs -> controller module + dependency mocks.
+ * Edge cases: module cache reset prevents mock leakage across tests.
+ */
+async function loadAIControllerHarness(): Promise<AIControllerHarness> {
+  jest.resetModules();
+
+  const runThroughBrainMock = jest.fn(async () => ({
+    result: 'ok',
+    module: 'mock',
+    meta: { id: 'mock-id', created: Date.now() },
+    activeModel: 'mock',
+    fallbackFlag: false,
+    dryRun: false,
+    fallbackSummary: {
+      intakeFallbackUsed: false,
+      gpt5FallbackUsed: false,
+      finalFallbackUsed: false,
+      fallbackReasons: []
+    },
+    auditSafe: {
+      mode: true,
+      overrideUsed: false,
+      auditFlags: [],
+      processedSafely: true
+    },
+    memoryContext: {
+      entriesAccessed: 0,
+      contextSummary: '',
+      memoryEnhanced: false,
+      maxRelevanceScore: 0,
+      averageRelevanceScore: 0
+    },
+    taskLineage: {
+      requestId: 'mock-request',
+      logged: true
+    }
+  }));
+  const validateAIRequestMock = jest.fn(() => ({
+    client: {} as unknown,
+    input: 'test prompt',
+    body: {
+      sessionId: 'session-123',
+      overrideAuditSafe: 'override-token'
+    }
+  }));
+  const handleAIErrorMock = jest.fn();
+
+  jest.unstable_mockModule('@core/logic/trinity.js', () => ({
+    runThroughBrain: runThroughBrainMock
+  }));
+  jest.unstable_mockModule('@transport/http/requestHandler.js', () => ({
+    validateAIRequest: validateAIRequestMock,
+    handleAIError: handleAIErrorMock
+  }));
+  jest.unstable_mockModule('@services/datasetHarvester.js', () => ({
+    harvestDatasetsFromAudit: () => []
+  }));
+
+  const module = await import('../src/transport/http/controllers/aiController.js');
+  return {
+    module,
+    runThroughBrainMock,
+    validateAIRequestMock,
+    handleAIErrorMock
+  };
+}
+
+describe('AIController Trinity source endpoint forwarding', () => {
+  it('passes endpointName into Trinity run options', async () => {
+    const harness = await loadAIControllerHarness();
+
+    const req = {} as any;
+    const res = { json: jest.fn() } as any;
+
+    await harness.module.AIController.processAIRequest(req, res, 'write');
+
+    expect(harness.validateAIRequestMock).toHaveBeenCalledTimes(1);
+    expect(harness.runThroughBrainMock).toHaveBeenCalledTimes(1);
+    expect(harness.runThroughBrainMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'test prompt',
+      'session-123',
+      'override-token',
+      { sourceEndpoint: 'write' },
+      expect.anything()
+    );
+    expect(harness.handleAIErrorMock).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/ai-reflections.persistence-mode.test.ts
+++ b/tests/ai-reflections.persistence-mode.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+type AIReflectionsModule = typeof import('../src/services/ai-reflections.js');
+
+interface AIReflectionsHarness {
+  module: AIReflectionsModule;
+  callOpenAIMock: jest.Mock;
+  saveSelfReflectionMock: jest.Mock;
+}
+
+/**
+ * Load ai-reflections module with isolated persistence and OpenAI mocks.
+ *
+ * Purpose: verify persistence gating behavior for stateless vs stateful patch generation.
+ * Inputs/outputs: none -> imported module plus dependency mocks.
+ * Edge cases: resets module cache between tests to avoid shared env/config state.
+ */
+async function loadAIReflectionsHarness(): Promise<AIReflectionsHarness> {
+  jest.resetModules();
+
+  const callOpenAIMock = jest.fn(async () => ({
+    output: 'Mock reflection output',
+    cached: false,
+    model: 'gpt-test-model'
+  }));
+  const saveSelfReflectionMock = jest.fn(async () => undefined);
+
+  jest.unstable_mockModule('../src/services/openai.js', () => ({
+    callOpenAI: callOpenAIMock,
+    getDefaultModel: () => 'gpt-test-model'
+  }));
+  jest.unstable_mockModule('@core/db/repositories/selfReflectionRepository.js', () => ({
+    saveSelfReflection: saveSelfReflectionMock
+  }));
+  jest.unstable_mockModule('@platform/runtime/aiReflectionTemplates.js', () => ({
+    AI_REFLECTION_DEFAULT_SYSTEM_PROMPT: 'test-system-prompt',
+    buildReflectionPrompt: () => 'test-reflection-prompt',
+    buildDefaultPatchContent: () => 'default-fallback-content',
+    buildFallbackPatchContent: () => 'error-fallback-content'
+  }));
+  jest.unstable_mockModule('@platform/runtime/env.js', () => ({
+    getEnv: (_key: string) => undefined,
+    getEnvNumber: (_key: string, fallback: number) => fallback
+  }));
+
+  const module = await import('../src/services/ai-reflections.js');
+  return {
+    module,
+    callOpenAIMock,
+    saveSelfReflectionMock
+  };
+}
+
+describe('ai-reflections persistence mode', () => {
+  it('does not persist reflections in stateless mode', async () => {
+    const harness = await loadAIReflectionsHarness();
+
+    await harness.module.buildPatchSet({
+      useMemory: false,
+      useCache: false,
+      category: 'stateless-test'
+    });
+
+    expect(harness.callOpenAIMock).toHaveBeenCalledTimes(1);
+    expect(harness.saveSelfReflectionMock).not.toHaveBeenCalled();
+  });
+
+  it('persists reflections in stateful mode', async () => {
+    const harness = await loadAIReflectionsHarness();
+
+    await harness.module.buildPatchSet({
+      useMemory: true,
+      useCache: false,
+      category: 'stateful-test'
+    });
+
+    expect(harness.callOpenAIMock).toHaveBeenCalledTimes(1);
+    expect(harness.saveSelfReflectionMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/judgedResponseFeedback.test.ts
+++ b/tests/judgedResponseFeedback.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+type JudgedResponseFeedbackModule = typeof import('../src/services/judgedResponseFeedback.js');
+
+interface JudgedResponseFeedbackHarness {
+  module: JudgedResponseFeedbackModule;
+  registerContextEntryMock: jest.Mock;
+  saveSelfReflectionMock: jest.Mock;
+  loadRecentSelfReflectionsByCategoryMock: jest.Mock;
+}
+
+/**
+ * Load judged response feedback service with isolated persistence/context mocks.
+ *
+ * Purpose: verify judgment processing and hydration behavior without touching external services.
+ * Inputs/outputs: optional persisted reflections -> module and dependency mocks.
+ * Edge cases: resets module cache to avoid shared hydration state between tests.
+ */
+async function loadJudgedFeedbackHarness(options?: {
+  persistedReflections?: Array<Record<string, unknown>>;
+  cacheMaxEntries?: number;
+}): Promise<JudgedResponseFeedbackHarness> {
+  jest.resetModules();
+
+  const registerContextEntryMock = jest.fn();
+  const saveSelfReflectionMock = jest.fn(async () => undefined);
+  const loadRecentSelfReflectionsByCategoryMock = jest.fn(async () => options?.persistedReflections ?? []);
+
+  jest.unstable_mockModule('@services/contextualReinforcement.js', () => ({
+    getReinforcementConfig: () => ({
+      mode: 'reinforcement',
+      window: 50,
+      digestSize: 8,
+      minimumClearScore: 0.85
+    }),
+    registerContextEntry: registerContextEntryMock
+  }));
+
+  jest.unstable_mockModule('@core/db/repositories/selfReflectionRepository.js', () => ({
+    saveSelfReflection: saveSelfReflectionMock,
+    loadRecentSelfReflectionsByCategory: loadRecentSelfReflectionsByCategoryMock
+  }));
+  jest.unstable_mockModule('@platform/runtime/env.js', () => ({
+    getEnv: (_key: string, defaultValue?: string) => defaultValue,
+    getEnvNumber: (key: string, defaultValue: number) => {
+      if (key === 'JUDGED_FEEDBACK_CACHE_MAX_ENTRIES') {
+        return options?.cacheMaxEntries ?? defaultValue;
+      }
+      return defaultValue;
+    },
+    getEnvBoolean: (_key: string, defaultValue: boolean) => defaultValue
+  }));
+
+  const module = await import('../src/services/judgedResponseFeedback.js');
+  return {
+    module,
+    registerContextEntryMock,
+    saveSelfReflectionMock,
+    loadRecentSelfReflectionsByCategoryMock
+  };
+}
+
+describe('judgedResponseFeedback', () => {
+  it('stores judged feedback and registers positive context for accepted scores', async () => {
+    const harness = await loadJudgedFeedbackHarness();
+
+    const result = await harness.module.processJudgedResponseFeedback(
+      {
+        prompt: 'How do I configure retries?',
+        response: 'You can configure retries using exponential backoff.',
+        score: 0.92,
+        scoreScale: '0-1',
+        feedback: 'Great clarity',
+        improvements: ['Keep concrete examples']
+      },
+      'trace-001'
+    );
+
+    expect(result.accepted).toBe(true);
+    expect(result.persisted).toBe(true);
+    expect(result.traceId).toBe('trace-001');
+    expect(harness.registerContextEntryMock).toHaveBeenCalledTimes(1);
+    expect(harness.saveSelfReflectionMock).toHaveBeenCalledTimes(1);
+    expect(harness.saveSelfReflectionMock.mock.calls[0][0]).toMatchObject({
+      category: 'judged-response'
+    });
+  });
+
+  it('rejects invalid payloads before persistence', async () => {
+    const harness = await loadJudgedFeedbackHarness();
+
+    await expect(
+      harness.module.processJudgedResponseFeedback(
+        {
+          prompt: '',
+          response: 'response text',
+          score: 0.7
+        },
+        'trace-002'
+      )
+    ).rejects.toThrow('prompt');
+
+    expect(harness.saveSelfReflectionMock).not.toHaveBeenCalled();
+    expect(harness.registerContextEntryMock).not.toHaveBeenCalled();
+  });
+
+  it('suppresses duplicate judged writes within idempotency window', async () => {
+    const harness = await loadJudgedFeedbackHarness();
+    const untrustedMetadata = JSON.parse(
+      '{"sourceEndpoint":"ask","nested":{"apiKey":"safe-value","__proto__":{"polluted":true},"constructor":{"nestedDanger":true},"safe":"value"}}'
+    ) as Record<string, unknown>;
+    const payload = {
+      requestId: 'dup-req-1',
+      prompt: 'Token sample sk-123456789012345678901234567890123456',
+      response: 'Use retries with backoff.',
+      score: 9.1,
+      scoreScale: '0-10' as const,
+      feedback: 'Concise response',
+      judge: 'trinity-clear-audit',
+      metadata: untrustedMetadata
+    };
+
+    const first = await harness.module.processJudgedResponseFeedback(payload, 'dup-req-1');
+    const second = await harness.module.processJudgedResponseFeedback(payload, 'dup-req-1');
+
+    expect(first).toEqual(second);
+    expect(harness.saveSelfReflectionMock).toHaveBeenCalledTimes(1);
+    expect(harness.registerContextEntryMock).toHaveBeenCalledTimes(1);
+
+    const persistedMetadata = harness.saveSelfReflectionMock.mock.calls[0][0].metadata as Record<string, unknown>;
+    expect(String(persistedMetadata.prompt)).toContain('[REDACTED_OPENAI_KEY]');
+    const nestedMetadata = persistedMetadata.nested as Record<string, unknown>;
+    expect(nestedMetadata).toBeDefined();
+    expect(Object.prototype.hasOwnProperty.call(nestedMetadata, '__proto__')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(nestedMetadata, 'constructor')).toBe(false);
+    expect(String(nestedMetadata.apiKey)).toBe('safe-value');
+  });
+
+  it('enforces idempotency cache max entries and tracks evictions', async () => {
+    const harness = await loadJudgedFeedbackHarness({ cacheMaxEntries: 2 });
+
+    await harness.module.processJudgedResponseFeedback(
+      { requestId: 'cache-1', prompt: 'p1', response: 'r1', score: 9.1, scoreScale: '0-10' },
+      'cache-1'
+    );
+    await harness.module.processJudgedResponseFeedback(
+      { requestId: 'cache-2', prompt: 'p2', response: 'r2', score: 9.2, scoreScale: '0-10' },
+      'cache-2'
+    );
+    await harness.module.processJudgedResponseFeedback(
+      { requestId: 'cache-3', prompt: 'p3', response: 'r3', score: 9.3, scoreScale: '0-10' },
+      'cache-3'
+    );
+
+    const telemetry = harness.module.getJudgedFeedbackRuntimeTelemetry();
+    expect(telemetry.cacheMaxEntries).toBe(2);
+    expect(telemetry.cacheSize).toBe(2);
+    expect(telemetry.cacheEvictions).toBe(1);
+    expect(telemetry.attempts).toBe(3);
+  });
+
+  it('hydrates context from persisted judged reflections only once per process', async () => {
+    const harness = await loadJudgedFeedbackHarness({
+      persistedReflections: [
+        {
+          id: 'reflection-1',
+          priority: 'high',
+          category: 'judged-response',
+          content: 'Stored response one',
+          improvements: ['Use stricter examples'],
+          metadata: {
+            accepted: true,
+            normalizedScore: 0.93,
+            requestId: 'req-1',
+            feedback: 'Useful and direct'
+          },
+          createdAt: new Date().toISOString()
+        },
+        {
+          id: 'reflection-2',
+          priority: 'low',
+          category: 'judged-response',
+          content: 'Stored response two',
+          improvements: [],
+          metadata: {
+            accepted: false,
+            normalizedScore: 0.42,
+            requestId: 'req-2',
+            feedback: 'Too generic'
+          },
+          createdAt: new Date().toISOString()
+        }
+      ]
+    });
+
+    harness.module.resetJudgedFeedbackHydrationState();
+    const hydratedFirst = await harness.module.hydrateJudgedResponseFeedbackContext(10);
+    const hydratedSecond = await harness.module.hydrateJudgedResponseFeedbackContext(10);
+
+    expect(hydratedFirst).toBe(2);
+    expect(hydratedSecond).toBe(0);
+    expect(harness.loadRecentSelfReflectionsByCategoryMock).toHaveBeenCalledTimes(1);
+    expect(harness.registerContextEntryMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/reinforcement.metrics-route.test.ts
+++ b/tests/reinforcement.metrics-route.test.ts
@@ -1,0 +1,82 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it, jest } from '@jest/globals';
+
+/**
+ * Build reinforcement router with isolated dependency mocks.
+ *
+ * Purpose: verify metrics export endpoint wiring without DB/network side effects.
+ * Inputs/outputs: no inputs -> supertest-compatible express app.
+ * Edge cases: audit middleware is bypassed in test mode to simplify route assertions.
+ */
+async function buildReinforcementTestApp() {
+  jest.resetModules();
+
+  const judgedTelemetry = {
+    attempts: 5,
+    duplicatesSkipped: 2,
+    persistedWrites: 3,
+    persistenceFailures: 0,
+    cacheEvictions: 1,
+    cacheSize: 7,
+    cacheMaxEntries: 200,
+    idempotencyWindowMs: 300000,
+    lastEventAt: '2026-03-05T00:00:00.000Z'
+  };
+
+  const reinforcementHealth = {
+    status: 'ok',
+    mode: 'reinforcement',
+    window: 50,
+    digestSize: 8,
+    storedContexts: 10,
+    audits: 3,
+    minimumClearScore: 0.85
+  };
+
+  jest.unstable_mockModule('@transport/http/middleware/auditTrace.js', () => ({
+    auditTrace: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next()
+  }));
+  jest.unstable_mockModule('@services/contextualReinforcement.js', () => ({
+    registerContextEntry: jest.fn(),
+    getReinforcementHealth: () => reinforcementHealth
+  }));
+  jest.unstable_mockModule('@services/memoryDigest.js', () => ({
+    getMemoryDigest: () => ({ mode: 'reinforcement', window: 50, digest: [], entries: [] })
+  }));
+  jest.unstable_mockModule('@services/audit.js', () => ({
+    processClearFeedback: jest.fn()
+  }));
+  jest.unstable_mockModule('@services/judgedResponseFeedback.js', () => ({
+    processJudgedResponseFeedback: jest.fn(),
+    getJudgedFeedbackRuntimeTelemetry: () => judgedTelemetry
+  }));
+  jest.unstable_mockModule('@core/lib/errors/index.js', () => ({
+    resolveErrorMessage: (error: unknown) => String(error)
+  }));
+  jest.unstable_mockModule('@shared/http/index.js', () => ({
+    sendBadRequest: (res: express.Response, code: string) => res.status(400).json({ error: code })
+  }));
+
+  const { default: reinforcementRouter } = await import('../src/routes/reinforcement.js');
+  const app = express();
+  app.use(express.json());
+  app.use('/', reinforcementRouter);
+  return { app, judgedTelemetry, reinforcementHealth };
+}
+
+describe('reinforcement metrics route', () => {
+  it('returns judged-feedback runtime telemetry snapshot', async () => {
+    const { app, judgedTelemetry, reinforcementHealth } = await buildReinforcementTestApp();
+
+    const response = await request(app).get('/reinforcement/metrics');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      status: 'ok',
+      judgedFeedback: judgedTelemetry,
+      reinforcement: reinforcementHealth
+    });
+  });
+});
+

--- a/tests/selfReflectionRepository.persistence.test.ts
+++ b/tests/selfReflectionRepository.persistence.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+type SelfReflectionRepositoryModule = typeof import('../src/core/db/repositories/selfReflectionRepository.js');
+
+interface RepositoryHarness {
+  module: SelfReflectionRepositoryModule;
+  isDatabaseConnectedMock: jest.Mock<() => boolean>;
+  initializeDatabaseMock: jest.Mock<(workerId: string) => Promise<boolean>>;
+  initializeTablesMock: jest.Mock<() => Promise<void>>;
+  queryMock: jest.Mock;
+  dbState: { connected: boolean };
+}
+
+/**
+ * Load self-reflection repository with isolated DB dependency mocks.
+ *
+ * Purpose: provide deterministic branch coverage for DB bootstrap/persistence behavior.
+ * Inputs/outputs: initial connection state and init implementation -> imported module + mocks.
+ * Edge cases: each call resets module cache to avoid sharing bootstrap cooldown state.
+ */
+async function loadRepositoryHarness(options?: {
+  connectedInitially?: boolean;
+  initializeDatabaseImpl?: (dbState: { connected: boolean }) => Promise<boolean>;
+}): Promise<RepositoryHarness> {
+  jest.resetModules();
+
+  const dbState = { connected: options?.connectedInitially ?? false };
+  const isDatabaseConnectedMock = jest.fn<() => boolean>(() => dbState.connected);
+  const initializeDatabaseMock = jest.fn<(workerId: string) => Promise<boolean>>(async () => {
+    if (!options?.initializeDatabaseImpl) {
+      return false;
+    }
+    return options.initializeDatabaseImpl(dbState);
+  });
+  const initializeTablesMock = jest.fn<() => Promise<void>>(async () => undefined);
+  const queryMock = jest.fn(async () => ({ rows: [], rowCount: 1 }));
+
+  jest.unstable_mockModule('@core/db/client.js', () => ({
+    isDatabaseConnected: isDatabaseConnectedMock,
+    initializeDatabase: initializeDatabaseMock
+  }));
+  jest.unstable_mockModule('@core/db/schema.js', () => ({
+    initializeTables: initializeTablesMock
+  }));
+  jest.unstable_mockModule('@core/db/query.js', () => ({
+    query: queryMock
+  }));
+
+  const module = await import('../src/core/db/repositories/selfReflectionRepository.js');
+  return {
+    module,
+    isDatabaseConnectedMock,
+    initializeDatabaseMock,
+    initializeTablesMock,
+    queryMock,
+    dbState
+  };
+}
+
+describe('selfReflectionRepository persistence bootstrap', () => {
+  it('bootstraps DB connectivity and persists reflection when not yet connected', async () => {
+    const harness = await loadRepositoryHarness({
+      connectedInitially: false,
+      initializeDatabaseImpl: async dbState => {
+        dbState.connected = true;
+        return true;
+      }
+    });
+
+    await harness.module.saveSelfReflection({
+      priority: 'high',
+      category: 'test',
+      content: 'reflection content',
+      improvements: ['one', 'two'],
+      metadata: { source: 'unit-test' }
+    });
+
+    expect(harness.initializeDatabaseMock).toHaveBeenCalledTimes(1);
+    expect(harness.initializeDatabaseMock).toHaveBeenCalledWith('self-reflections');
+    expect(harness.initializeTablesMock).toHaveBeenCalledTimes(1);
+    expect(harness.queryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists directly when DB is already connected', async () => {
+    const harness = await loadRepositoryHarness({
+      connectedInitially: true
+    });
+
+    await harness.module.saveSelfReflection({
+      priority: 'medium',
+      category: 'test',
+      content: 'existing connection',
+      improvements: [],
+      metadata: {}
+    });
+
+    expect(harness.initializeDatabaseMock).not.toHaveBeenCalled();
+    expect(harness.initializeTablesMock).not.toHaveBeenCalled();
+    expect(harness.queryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throttles repeated bootstrap attempts after a failed initialization', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const harness = await loadRepositoryHarness({
+      connectedInitially: false,
+      initializeDatabaseImpl: async () => false
+    });
+
+    try {
+      await harness.module.saveSelfReflection({
+        priority: 'low',
+        category: 'failure-test',
+        content: 'first attempt',
+        improvements: [],
+        metadata: {}
+      });
+      await harness.module.saveSelfReflection({
+        priority: 'low',
+        category: 'failure-test',
+        content: 'second attempt',
+        improvements: [],
+        metadata: {}
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    expect(harness.initializeDatabaseMock).toHaveBeenCalledTimes(1);
+    expect(harness.queryMock).not.toHaveBeenCalled();
+  });
+
+  it('loads recent reflections by category with normalized JSON fields', async () => {
+    const harness = await loadRepositoryHarness({
+      connectedInitially: true
+    });
+
+    harness.queryMock.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'r-1',
+          priority: 'high',
+          category: 'judged-response',
+          content: 'response text',
+          improvements: '["improve clarity","add examples"]',
+          metadata: '{"accepted":true,"normalizedScore":0.91}',
+          created_at: '2026-03-05T00:00:00.000Z'
+        }
+      ],
+      rowCount: 1
+    });
+
+    const rows = await harness.module.loadRecentSelfReflectionsByCategory('judged-response', 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: 'r-1',
+      category: 'judged-response',
+      improvements: ['improve clarity', 'add examples'],
+      metadata: { accepted: true, normalizedScore: 0.91 }
+    });
+  });
+});

--- a/tests/trinityJudgedFeedback.test.ts
+++ b/tests/trinityJudgedFeedback.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+type TrinityJudgedFeedbackModule = typeof import('../src/core/logic/trinityJudgedFeedback.js');
+
+interface TrinityJudgedFeedbackHarness {
+  module: TrinityJudgedFeedbackModule;
+  getEnvBooleanMock: jest.Mock;
+  processJudgedResponseFeedbackMock: jest.Mock;
+}
+
+/**
+ * Load Trinity judged-feedback module with isolated env/persistence mocks.
+ *
+ * Purpose: verify deterministic gating and mapping logic without DB/network side effects.
+ * Inputs/outputs: optional enabled flag + process result override -> module and mocks.
+ * Edge cases: resets module state between tests to avoid stale environment behavior.
+ */
+async function loadTrinityJudgedFeedbackHarness(options?: {
+  enabled?: boolean;
+  allowedSourceEndpoints?: string;
+  processResult?: Record<string, unknown>;
+  processThrows?: boolean;
+}): Promise<TrinityJudgedFeedbackHarness> {
+  jest.resetModules();
+
+  const getEnvBooleanMock = jest.fn((_key: string, defaultValue: boolean) => {
+    if (typeof options?.enabled === 'boolean') {
+      return options.enabled;
+    }
+    return defaultValue;
+  });
+
+  const processJudgedResponseFeedbackMock = jest.fn(async () => {
+    if (options?.processThrows) {
+      throw new Error('persist failure');
+    }
+    return options?.processResult ?? {
+      traceId: 'trace-default',
+      accepted: true,
+      score: 8.4,
+      scoreScale: '0-10',
+      normalizedScore: 0.84,
+      persisted: true
+    };
+  });
+
+  jest.unstable_mockModule('@platform/runtime/env.js', () => ({
+    getEnvBoolean: getEnvBooleanMock,
+    getEnvNumber: (_key: string, fallback: number) => fallback,
+    getEnv: (key: string, fallback?: string) => {
+      if (key === 'TRINITY_JUDGED_ALLOWED_ENDPOINTS') {
+        return options?.allowedSourceEndpoints ?? fallback;
+      }
+      return fallback;
+    }
+  }));
+  jest.unstable_mockModule('@services/judgedResponseFeedback.js', () => ({
+    processJudgedResponseFeedback: processJudgedResponseFeedbackMock
+  }));
+
+  const module = await import('../src/core/logic/trinityJudgedFeedback.js');
+  return {
+    module,
+    getEnvBooleanMock,
+    processJudgedResponseFeedbackMock
+  };
+}
+
+describe('trinityJudgedFeedback', () => {
+  it('skips persistence when feature is disabled', async () => {
+    const harness = await loadTrinityJudgedFeedbackHarness({ enabled: false });
+
+    const summary = await harness.module.recordTrinityJudgedFeedback({
+      requestId: 'req-1',
+      prompt: 'prompt',
+      response: 'response',
+      clearAudit: {
+        clarity: 4,
+        leverage: 4,
+        efficiency: 4,
+        alignment: 4,
+        resilience: 4,
+        overall: 4
+      },
+      tier: 'simple'
+    });
+
+    expect(summary).toMatchObject({
+      enabled: false,
+      attempted: false,
+      reason: 'disabled_by_env'
+    });
+    expect(harness.processJudgedResponseFeedbackMock).not.toHaveBeenCalled();
+  });
+
+  it('skips when CLEAR audit is unavailable', async () => {
+    const harness = await loadTrinityJudgedFeedbackHarness({ enabled: true });
+
+    const summary = await harness.module.recordTrinityJudgedFeedback({
+      requestId: 'req-2',
+      prompt: 'prompt',
+      response: 'response',
+      tier: 'complex'
+    });
+
+    expect(summary).toMatchObject({
+      enabled: true,
+      attempted: false,
+      reason: 'clear_audit_unavailable'
+    });
+    expect(harness.processJudgedResponseFeedbackMock).not.toHaveBeenCalled();
+  });
+
+  it('maps CLEAR score into judged feedback payload', async () => {
+    const harness = await loadTrinityJudgedFeedbackHarness({
+      enabled: true,
+      processResult: {
+        traceId: 'trace-3',
+        accepted: true,
+        score: 8.2,
+        scoreScale: '0-10',
+        normalizedScore: 0.82,
+        persisted: true
+      }
+    });
+
+    const summary = await harness.module.recordTrinityJudgedFeedback({
+      requestId: 'req-3',
+      prompt: 'what should I do?',
+      response: 'do this first',
+      clearAudit: {
+        clarity: 4,
+        leverage: 4.5,
+        efficiency: 4.1,
+        alignment: 3.8,
+        resilience: 4.2,
+        overall: 4.1
+      },
+      tier: 'critical',
+      sourceEndpoint: 'ask',
+      sessionId: 'session-3',
+      internalMode: false,
+      remainingBudgetMs: 8000
+    });
+
+    expect(summary).toMatchObject({
+      enabled: true,
+      attempted: true,
+      traceId: 'trace-3',
+      accepted: true,
+      scoreScale: '0-10'
+    });
+    expect(harness.processJudgedResponseFeedbackMock).toHaveBeenCalledTimes(1);
+    const firstCallPayload = harness.processJudgedResponseFeedbackMock.mock.calls[0][0];
+    expect(firstCallPayload).toMatchObject({
+      requestId: 'req-3',
+      prompt: 'what should I do?',
+      response: 'do this first',
+      scoreScale: '0-10',
+      judge: 'trinity-clear-audit'
+    });
+    expect(firstCallPayload.score).toBeCloseTo(8.2, 3);
+  });
+
+  it('skips persistence when source endpoint is not allowlisted', async () => {
+    const harness = await loadTrinityJudgedFeedbackHarness({
+      enabled: true,
+      allowedSourceEndpoints: 'ask,siri'
+    });
+
+    const summary = await harness.module.recordTrinityJudgedFeedback({
+      requestId: 'req-allowlist-1',
+      prompt: 'prompt',
+      response: 'response',
+      clearAudit: {
+        clarity: 4,
+        leverage: 4,
+        efficiency: 4,
+        alignment: 4,
+        resilience: 4,
+        overall: 4
+      },
+      tier: 'simple',
+      sourceEndpoint: 'mcp.trinity.ask'
+    });
+
+    expect(summary).toMatchObject({
+      enabled: true,
+      attempted: false,
+      reason: 'source_endpoint_not_allowed:mcp.trinity.ask'
+    });
+    expect(harness.processJudgedResponseFeedbackMock).not.toHaveBeenCalled();
+  });
+
+  it('returns non-throwing summary when persistence fails', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const harness = await loadTrinityJudgedFeedbackHarness({
+      enabled: true,
+      processThrows: true
+    });
+
+    try {
+      const summary = await harness.module.recordTrinityJudgedFeedback({
+        requestId: 'req-4',
+        prompt: 'prompt',
+        response: 'response',
+        clearAudit: {
+          clarity: 2,
+          leverage: 2,
+          efficiency: 2,
+          alignment: 2,
+          resilience: 2,
+          overall: 2
+        },
+        tier: 'simple'
+      });
+
+      expect(summary.enabled).toBe(true);
+      expect(summary.attempted).toBe(true);
+      expect(summary.reason).toContain('persist_failed:');
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary\n- add judged-response feedback processing service with idempotency and telemetry\n- persist Trinity CLEAR-derived judged feedback with endpoint allowlist gating\n- hydrate judged feedback context at startup\n- expose reinforcement metrics endpoint\n- propagate sourceEndpoint through ask/siri/controller/worker and MCP trinity.ask\n- add tests for judged feedback, metrics route, Trinity judged gating, and persistence bootstrap\n\n## Notes\n- includes runtime hardening updates for reflection persistence bootstrap and MCP request-scoped transport