### PR TITLE
Add internal MCP dispatch and production smoke checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,12 @@ ARCANOS_OWNER_EMAIL=you@example.com
 
 # Storage
 # DATABASE_URL=postgresql://user:password@host:5432/database
+# For local access to Railway Postgres, use the TCP proxy host/port and sslmode=no-verify.
+# PGHOST=your-public-proxy.rlwy.net
+# PGPORT=12345
+# PGDATABASE=railway
+# PGUSER=postgres
+# PGPASSWORD=replace-me
 ARC_LOG_PATH=/tmp/arc/log
 ARC_MEMORY_PATH=/tmp/arc/memory
 

--- a/.railwayignore
+++ b/.railwayignore
@@ -13,12 +13,19 @@ logs/
 npm_logs/
 tmp/
 temp/
+coverage/
 *.log
 *.tmp
 
 # Version control and CI files
 .git/
 .github/
+.codex/
+.codex-pr-*/
+.deploy-pr-*/
+.claude/
+.workspace/
+.tmp-locktest/
 
 # IDE and OS files
 .vscode/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1139,6 +1139,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://codeload.github.com/honojs/node-server/tar.gz/refs/tags/v1.19.11",
+      "integrity": "sha512-xEUhGuY1KxqJb/lkmzmSTpuyRM2sNgvLD+nbqDgt5sy8IpgSSV1UIEOQApjGG1Bm6UCHYkOtS13DVV9kQ7K5pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "daily-summary": "node --import ./scripts/register-esm-loader.mjs dist/commands/runDailySummary.js",
     "worker:helper": "node scripts/worker-helper.mjs",
     "validate:railway": "node scripts/validate-railway-compatibility.js",
+    "railway:smoke:production": "node scripts/railway-production-smoke-check.js --environment production",
     "railway:alert:timeouts": "node scripts/check-railway-timeout-regressions.js",
     "railway:alert:budget-abort": "node scripts/check-railway-timeout-regressions.js --since 15m --lines 500 --fail-on-budget-abort",
     "audit": "node scripts/continuous-audit.js",

--- a/scripts/railway-production-smoke-check.js
+++ b/scripts/railway-production-smoke-check.js
@@ -1,0 +1,1053 @@
+#!/usr/bin/env node
+/**
+ * Purpose: Run a repeatable Railway smoke check against the production app, worker, Postgres, and Redis services.
+ * Inputs/Outputs: Reads Railway CLI output plus the public health endpoint, prints PASS/WARN/FAIL lines to stdout, and exits non-zero when any critical check fails.
+ * Edge cases: Handles missing Railway CLI binaries, malformed JSON payloads, quiet service logs, and noisy platform log lines without silently reporting a healthy system.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+export const RESULT_STATUS = Object.freeze({
+  PASS: 'PASS',
+  WARN: 'WARN',
+  FAIL: 'FAIL'
+});
+
+const DEFAULTS = Object.freeze({
+  environment: 'production',
+  appService: 'ARCANOS V2',
+  workerService: 'ARCANOS Worker',
+  databaseService: '',
+  redisService: '',
+  appUrl: '',
+  healthPath: '/healthz',
+  appLogLines: 300,
+  workerLogLines: 300,
+  databaseLogLines: 500,
+  redisLogLines: 200,
+  requestTimeoutMs: 15000
+});
+
+/**
+ * Purpose: Parse CLI arguments for the smoke check.
+ * Inputs/Outputs: `argv` string array -> normalized configuration object.
+ * Edge cases: Invalid numeric flags fall back to defaults so a typo cannot silently disable checks.
+ *
+ * @param {string[]} argv - Raw process arguments after the script path.
+ * @returns {typeof DEFAULTS} Parsed configuration.
+ */
+export function parseArgs(argv) {
+  const config = { ...DEFAULTS };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argFlag = argv[index];
+    const next = argv[index + 1];
+
+    //audit assumption: only explicit, recognized flags should mutate smoke-check behavior; failure risk: mistyped arguments weaken coverage; expected invariant: unknown flags leave defaults intact; handling strategy: ignore tokens that do not match a known flag.
+    if (argFlag === '--environment' && typeof next === 'string' && next.trim().length > 0) {
+      config.environment = next.trim();
+      index += 1;
+      continue;
+    }
+
+    if (argFlag === '--app-service' && typeof next === 'string' && next.trim().length > 0) {
+      config.appService = next.trim();
+      index += 1;
+      continue;
+    }
+
+    if (argFlag === '--worker-service' && typeof next === 'string' && next.trim().length > 0) {
+      config.workerService = next.trim();
+      index += 1;
+      continue;
+    }
+
+    if (argFlag === '--database-service' && typeof next === 'string' && next.trim().length > 0) {
+      config.databaseService = next.trim();
+      index += 1;
+      continue;
+    }
+
+    if (argFlag === '--redis-service' && typeof next === 'string' && next.trim().length > 0) {
+      config.redisService = next.trim();
+      index += 1;
+      continue;
+    }
+
+    if (argFlag === '--app-url' && typeof next === 'string' && next.trim().length > 0) {
+      config.appUrl = next.trim();
+      index += 1;
+      continue;
+    }
+
+    if (argFlag === '--health-path' && typeof next === 'string' && next.trim().length > 0) {
+      config.healthPath = next.trim();
+      index += 1;
+      continue;
+    }
+
+    //audit assumption: line limits must stay positive integers to bound CLI output and preserve determinism; failure risk: zero/negative values hide recent logs; expected invariant: each line limit > 0; handling strategy: parse-or-default on invalid input.
+    if (
+      (argFlag === '--app-log-lines' || argFlag === '--worker-log-lines' || argFlag === '--database-log-lines' || argFlag === '--redis-log-lines') &&
+      typeof next === 'string' &&
+      next.trim().length > 0
+    ) {
+      const parsed = Number(next);
+      const normalized = Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : null;
+
+      if (normalized !== null) {
+        if (argFlag === '--app-log-lines') {
+          config.appLogLines = normalized;
+        } else if (argFlag === '--worker-log-lines') {
+          config.workerLogLines = normalized;
+        } else if (argFlag === '--database-log-lines') {
+          config.databaseLogLines = normalized;
+        } else {
+          config.redisLogLines = normalized;
+        }
+      }
+
+      index += 1;
+      continue;
+    }
+
+    if (argFlag === '--request-timeout-ms' && typeof next === 'string' && next.trim().length > 0) {
+      const parsed = Number(next);
+      config.requestTimeoutMs = Number.isFinite(parsed) && parsed > 0
+        ? Math.floor(parsed)
+        : DEFAULTS.requestTimeoutMs;
+      index += 1;
+    }
+  }
+
+  return config;
+}
+
+/**
+ * Purpose: Create a normalized smoke-check result entry.
+ * Inputs/Outputs: Check name + status + detail -> serializable result object.
+ * Edge cases: Trims detail strings so multiline command output does not pollute summaries.
+ *
+ * @param {string} name - Human-readable check name.
+ * @param {'PASS'|'WARN'|'FAIL'} status - Result status.
+ * @param {string} detail - Short explanation.
+ * @returns {{ name: string; status: 'PASS'|'WARN'|'FAIL'; detail: string }}
+ */
+export function createResult(name, status, detail) {
+  return {
+    name,
+    status,
+    detail: detail.trim()
+  };
+}
+
+/**
+ * Purpose: Parse newline-delimited JSON log output from the Railway CLI.
+ * Inputs/Outputs: Raw CLI string -> array of parsed entry objects.
+ * Edge cases: Malformed or non-object log lines are dropped instead of crashing the smoke check.
+ *
+ * @param {string} rawOutput - Raw stdout from a `railway logs --json` command.
+ * @returns {Array<Record<string, unknown>>} Parsed log entry objects.
+ */
+export function parseJsonLines(rawOutput) {
+  const lines = rawOutput
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  /** @type {Array<Record<string, unknown>>} */
+  const parsedEntries = [];
+
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line);
+
+      //audit assumption: Railway JSON output is one object per line; failure risk: arrays or scalar values break downstream field access; expected invariant: parsed entries are plain objects; handling strategy: retain only object payloads.
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        parsedEntries.push(parsed);
+      }
+    } catch {
+      //audit assumption: intermittent non-JSON lines should not invalidate otherwise usable logs; failure risk: one malformed line aborts the whole smoke check; expected invariant: valid lines remain processable; handling strategy: skip malformed lines.
+    }
+  }
+
+  return parsedEntries;
+}
+
+/**
+ * Purpose: Normalize a Railway service/environment snapshot for one target environment.
+ * Inputs/Outputs: Parsed `railway status --json` payload + environment name -> lightweight topology snapshot.
+ * Edge cases: Missing environment nodes or unexpected payload shapes throw hard errors because all later checks depend on the topology.
+ *
+ * @param {Record<string, any>} statusPayload - Parsed Railway status payload.
+ * @param {string} environmentName - Target environment name.
+ * @returns {{ projectName: string; workspaceName: string; environmentName: string; serviceInstances: Array<{ serviceId: string; name: string; latestDeploymentStatus: string; latestDeploymentCreatedAt: string | null; activeDeploymentStatuses: string[]; serviceDomains: string[]; customDomains: string[] }> }}
+ */
+export function extractEnvironmentSnapshot(statusPayload, environmentName) {
+  const serviceNameMap = new Map(
+    Array.isArray(statusPayload?.services?.edges)
+      ? statusPayload.services.edges.map((edge) => [String(edge?.node?.id ?? ''), String(edge?.node?.name ?? '')])
+      : []
+  );
+
+  const environments = Array.isArray(statusPayload?.environments?.edges)
+    ? statusPayload.environments.edges
+    : [];
+
+  const environmentNode = environments.find((edge) => edge?.node?.name === environmentName)?.node;
+
+  //audit assumption: smoke checks must target one concrete environment node; failure risk: querying the wrong environment produces false health conclusions; expected invariant: requested environment exists in Railway status output; handling strategy: throw a descriptive error when absent.
+  if (!environmentNode) {
+    throw new Error(`Environment "${environmentName}" was not found in Railway status output.`);
+  }
+
+  const serviceInstances = Array.isArray(environmentNode?.serviceInstances?.edges)
+    ? environmentNode.serviceInstances.edges.map((edge) => {
+        const node = edge?.node ?? {};
+        const normalizedName = typeof node.serviceName === 'string' && node.serviceName.length > 0
+          ? node.serviceName
+          : serviceNameMap.get(String(node.serviceId ?? '')) || 'unknown-service';
+
+        return {
+          serviceId: String(node.serviceId ?? ''),
+          name: normalizedName,
+          latestDeploymentStatus: String(node.latestDeployment?.status ?? 'UNKNOWN'),
+          latestDeploymentCreatedAt: typeof node.latestDeployment?.createdAt === 'string'
+            ? node.latestDeployment.createdAt
+            : null,
+          activeDeploymentStatuses: Array.isArray(node.activeDeployments)
+            ? node.activeDeployments
+              .map((deployment) => String(deployment?.status ?? 'UNKNOWN'))
+              .filter((status) => status.length > 0)
+            : [],
+          serviceDomains: Array.isArray(node.domains?.serviceDomains)
+            ? node.domains.serviceDomains
+              .map((domain) => String(domain?.domain ?? ''))
+              .filter((domain) => domain.length > 0)
+            : [],
+          customDomains: Array.isArray(node.domains?.customDomains)
+            ? node.domains.customDomains
+              .map((domain) => String(domain?.domain ?? ''))
+              .filter((domain) => domain.length > 0)
+            : []
+        };
+      })
+    : [];
+
+  return {
+    projectName: String(statusPayload?.name ?? 'unknown-project'),
+    workspaceName: String(statusPayload?.workspace?.name ?? 'unknown-workspace'),
+    environmentName,
+    serviceInstances
+  };
+}
+
+/**
+ * Purpose: Resolve the app, worker, Postgres, and Redis services from the normalized environment snapshot.
+ * Inputs/Outputs: Service instance list + optional explicit service names -> named role map.
+ * Edge cases: Ambiguous heuristic matches fail loudly so the operator can pin service names explicitly.
+ *
+ * @param {Array<{ name: string; latestDeploymentStatus: string; latestDeploymentCreatedAt: string | null; activeDeploymentStatuses: string[]; serviceDomains: string[]; customDomains: string[] }>} serviceInstances - Normalized environment service instances.
+ * @param {typeof DEFAULTS} config - Smoke-check configuration.
+ * @returns {{ app: any; worker: any; database: any; redis: any }}
+ */
+export function findRoleServices(serviceInstances, config) {
+  /**
+   * Purpose: Resolve one service role from explicit naming or a heuristic predicate.
+   * Inputs/Outputs: Role label + optional explicit name + heuristic predicate -> one normalized service object.
+   * Edge cases: Multiple heuristic candidates throw to prevent silently checking the wrong service.
+   *
+   * @param {string} roleLabel - Human-readable role label.
+   * @param {string} explicitName - Optional exact service name.
+   * @param {(service: any) => boolean} predicate - Heuristic candidate matcher.
+   * @returns {any}
+   */
+  function resolveRole(roleLabel, explicitName, predicate) {
+    if (explicitName.trim().length > 0) {
+      const exactMatch = serviceInstances.find((service) => service.name === explicitName);
+
+      //audit assumption: explicit service names should win over heuristics when provided; failure risk: renamed services go unchecked; expected invariant: exact match exists for explicit names; handling strategy: fail immediately when an explicit service cannot be found.
+      if (!exactMatch) {
+        throw new Error(`Expected ${roleLabel} service "${explicitName}" was not found in Railway status output.`);
+      }
+
+      return exactMatch;
+    }
+
+    const candidates = serviceInstances.filter(predicate);
+
+    //audit assumption: heuristics are safe only when they resolve to a single service; failure risk: multiple similarly named services produce false checks; expected invariant: zero or one candidate per role; handling strategy: throw on ambiguity and ask the operator to pin the role explicitly.
+    if (candidates.length !== 1) {
+      const candidateNames = candidates.map((service) => service.name).join(', ') || 'none';
+      throw new Error(`Unable to resolve ${roleLabel} service unambiguously. Candidates: ${candidateNames}.`);
+    }
+
+    return candidates[0];
+  }
+
+  return {
+    app: resolveRole('app', config.appService, (service) => /arcanos/i.test(service.name) && !/worker/i.test(service.name)),
+    worker: resolveRole('worker', config.workerService, (service) => /worker/i.test(service.name)),
+    database: resolveRole('database', config.databaseService, (service) => /^postgres/i.test(service.name)),
+    redis: resolveRole('redis', config.redisService, (service) => /^redis/i.test(service.name))
+  };
+}
+
+/**
+ * Purpose: Evaluate app and worker environment-variable wiring against the expected production topology.
+ * Inputs/Outputs: Resolved app/worker variable maps + environment name -> result list.
+ * Edge cases: Missing URLs or mismatched hosts are treated as failures because the runtime cannot safely recover from broken backend wiring.
+ *
+ * @param {Record<string, string>} appVariables - Parsed `railway variables --json` map for the app service.
+ * @param {Record<string, string>} workerVariables - Parsed `railway variables --json` map for the worker service.
+ * @param {string} environmentName - Expected runtime environment.
+ * @returns {Array<{ name: string; status: 'PASS'|'WARN'|'FAIL'; detail: string }>}
+ */
+export function evaluateRuntimeWiring(appVariables, workerVariables, environmentName) {
+  const results = [];
+  const requiredSharedKeys = ['PGHOST', 'PGPORT', 'PGDATABASE', 'PGUSER', 'REDISHOST', 'REDISPORT', 'DATABASE_URL', 'REDIS_URL', 'NODE_ENV'];
+
+  const missingAppKeys = requiredSharedKeys.filter((key) => !isNonEmptyString(appVariables[key]));
+  const missingWorkerKeys = requiredSharedKeys.filter((key) => !isNonEmptyString(workerVariables[key]));
+
+  //audit assumption: app and worker must expose the same core backend variables to operate against the same topology; failure risk: split-brain app/worker behavior; expected invariant: all required keys are present in both services; handling strategy: fail when required keys are missing.
+  if (missingAppKeys.length > 0 || missingWorkerKeys.length > 0) {
+    results.push(
+      createResult(
+        'Runtime variable completeness',
+        RESULT_STATUS.FAIL,
+        `Missing app keys=[${missingAppKeys.join(', ') || 'none'}], missing worker keys=[${missingWorkerKeys.join(', ') || 'none'}].`
+      )
+    );
+  } else {
+    results.push(
+      createResult(
+        'Runtime variable completeness',
+        RESULT_STATUS.PASS,
+        'App and worker both expose the expected Postgres and Redis connection variables.'
+      )
+    );
+  }
+
+  //audit assumption: production services should self-identify as production to avoid cross-environment confusion; failure risk: accidental staging config in production; expected invariant: both NODE_ENV values match the requested environment; handling strategy: fail on mismatch.
+  if (appVariables.NODE_ENV !== environmentName || workerVariables.NODE_ENV !== environmentName) {
+    results.push(
+      createResult(
+        'Runtime environment identity',
+        RESULT_STATUS.FAIL,
+        `Expected NODE_ENV=${environmentName} for app and worker but saw app=${String(appVariables.NODE_ENV ?? '')}, worker=${String(workerVariables.NODE_ENV ?? '')}.`
+      )
+    );
+  } else {
+    results.push(
+      createResult(
+        'Runtime environment identity',
+        RESULT_STATUS.PASS,
+        `App and worker both report NODE_ENV=${environmentName}.`
+      )
+    );
+  }
+
+  //audit assumption: app and worker must point at the same backing Postgres and Redis hosts to share state safely; failure risk: divergent data planes; expected invariant: PGHOST and REDISHOST match across services; handling strategy: fail on any mismatch.
+  if (appVariables.PGHOST !== workerVariables.PGHOST || appVariables.REDISHOST !== workerVariables.REDISHOST) {
+    results.push(
+      createResult(
+        'Shared backend wiring',
+        RESULT_STATUS.FAIL,
+        `App and worker backend hosts do not match (app PGHOST=${String(appVariables.PGHOST ?? '')}, worker PGHOST=${String(workerVariables.PGHOST ?? '')}, app REDISHOST=${String(appVariables.REDISHOST ?? '')}, worker REDISHOST=${String(workerVariables.REDISHOST ?? '')}).`
+      )
+    );
+  } else {
+    results.push(
+      createResult(
+        'Shared backend wiring',
+        RESULT_STATUS.PASS,
+        `App and worker share PGHOST=${appVariables.PGHOST} and REDISHOST=${appVariables.REDISHOST}.`
+      )
+    );
+  }
+
+  //audit assumption: Railway private-network hosts should use the internal domain suffix for in-platform service-to-service traffic; failure risk: production traffic routed over public ingress unexpectedly; expected invariant: internal hostnames end with .railway.internal; handling strategy: warn so the operator can decide whether a public host is intentional.
+  if (!String(appVariables.PGHOST || '').endsWith('.railway.internal') || !String(appVariables.REDISHOST || '').endsWith('.railway.internal')) {
+    results.push(
+      createResult(
+        'Private-network host naming',
+        RESULT_STATUS.WARN,
+        `Expected internal Railway hostnames but saw PGHOST=${String(appVariables.PGHOST ?? '')}, REDISHOST=${String(appVariables.REDISHOST ?? '')}.`
+      )
+    );
+  } else {
+    results.push(
+      createResult(
+        'Private-network host naming',
+        RESULT_STATUS.PASS,
+        'App backend hosts use Railway internal networking.'
+      )
+    );
+  }
+
+  return results;
+}
+
+/**
+ * Purpose: Evaluate recent application logs for positive health signals and unexpected runtime errors.
+ * Inputs/Outputs: Parsed app log entries -> one result object.
+ * Edge cases: Quiet but otherwise clean logs downgrade to WARN instead of FAIL because low traffic is not itself an outage.
+ *
+ * @param {Array<Record<string, unknown>>} entries - Parsed log entries.
+ * @returns {{ name: string; status: 'PASS'|'WARN'|'FAIL'; detail: string }}
+ */
+export function evaluateAppLogEntries(entries) {
+  if (entries.length === 0) {
+    return createResult('App runtime logs', RESULT_STATUS.WARN, 'No recent app log entries were returned by Railway.');
+  }
+
+  const errorMessages = [];
+  let hasHealthSignal = false;
+  let hasTrafficSignal = false;
+
+  for (const entry of entries) {
+    const level = normalizeString(entry.level).toLowerCase();
+    const message = normalizeString(entry.message);
+    const event = normalizeString(entry.event);
+    const path = normalizeString(entry.path);
+    const statusCode = readStatusCode(entry);
+
+    //audit assumption: app-level error logs should be rare during a healthy smoke-check window; failure risk: user-facing regressions go unnoticed; expected invariant: no recent `level=error` app entries; handling strategy: fail when explicit error logs are present.
+    if (level === 'error') {
+      errorMessages.push(message || `${event || 'event'} ${path || 'path'}`.trim());
+    }
+
+    if (message.includes('ARCANOS:HEALTH') || (event === 'request.completed' && path === '/healthz' && statusCode === 200)) {
+      hasHealthSignal = true;
+    }
+
+    if (event === 'request.completed' && statusCode === 200) {
+      hasTrafficSignal = true;
+    }
+  }
+
+  if (errorMessages.length > 0) {
+    return createResult(
+      'App runtime logs',
+      RESULT_STATUS.FAIL,
+      `Detected recent app error logs. Example: ${errorMessages[0]}`
+    );
+  }
+
+  if (hasHealthSignal || hasTrafficSignal) {
+    return createResult(
+      'App runtime logs',
+      RESULT_STATUS.PASS,
+      'Recent app logs contain healthy diagnostics and/or successful request completions.'
+    );
+  }
+
+  return createResult(
+    'App runtime logs',
+    RESULT_STATUS.WARN,
+    'App logs were readable but did not contain a recent health or request-completion signal.'
+  );
+}
+
+/**
+ * Purpose: Evaluate recent worker logs for successful activity and obvious runtime failures.
+ * Inputs/Outputs: Parsed worker log entries -> one result object.
+ * Edge cases: Quiet worker periods degrade to WARN instead of FAIL when no error signal is present.
+ *
+ * @param {Array<Record<string, unknown>>} entries - Parsed worker log entries.
+ * @returns {{ name: string; status: 'PASS'|'WARN'|'FAIL'; detail: string }}
+ */
+export function evaluateWorkerLogEntries(entries) {
+  if (entries.length === 0) {
+    return createResult('Worker runtime logs', RESULT_STATUS.WARN, 'No recent worker log entries were returned by Railway.');
+  }
+
+  const errorMessages = [];
+  let hasPositiveSignal = false;
+  let hasDegradedBootstrap = false;
+
+  for (const entry of entries) {
+    const level = normalizeString(entry.level).toLowerCase();
+    const message = normalizeString(entry.message);
+
+    //audit assumption: explicit worker errors should fail the smoke check because job processing correctness is uncertain after an unhandled runtime fault; failure risk: queue work silently stalls; expected invariant: no recent worker `level=error` lines; handling strategy: fail immediately on error logs.
+    if (level === 'error') {
+      errorMessages.push(message || 'worker emitted an error log without a message');
+    }
+
+    if (/bootstrap status=degraded/i.test(message)) {
+      hasDegradedBootstrap = true;
+    }
+
+    if (/query executed/i.test(message) || /bootstrap status=/i.test(message) || /jobrunner/i.test(message)) {
+      hasPositiveSignal = true;
+    }
+  }
+
+  if (errorMessages.length > 0) {
+    return createResult(
+      'Worker runtime logs',
+      RESULT_STATUS.FAIL,
+      `Detected recent worker error logs. Example: ${errorMessages[0]}`
+    );
+  }
+
+  if (hasDegradedBootstrap) {
+    return createResult(
+      'Worker runtime logs',
+      RESULT_STATUS.WARN,
+      'Worker logs were readable but include a degraded bootstrap marker in the recent window.'
+    );
+  }
+
+  if (hasPositiveSignal) {
+    return createResult(
+      'Worker runtime logs',
+      RESULT_STATUS.PASS,
+      'Recent worker logs show activity such as DB queries or bootstrap markers without explicit errors.'
+    );
+  }
+
+  return createResult(
+    'Worker runtime logs',
+    RESULT_STATUS.WARN,
+    'Worker logs were readable but did not contain a recent activity marker.'
+  );
+}
+
+/**
+ * Purpose: Evaluate recent Postgres logs for active fatal conditions while ignoring routine checkpoint noise.
+ * Inputs/Outputs: Parsed database log entries -> one result object.
+ * Edge cases: Railway may map Postgres `LOG:` lines to higher-severity shells, so message content is used instead of the wrapper severity field.
+ *
+ * @param {Array<Record<string, unknown>>} entries - Parsed Postgres log entries.
+ * @returns {{ name: string; status: 'PASS'|'WARN'|'FAIL'; detail: string }}
+ */
+export function evaluateDatabaseLogEntries(entries) {
+  if (entries.length === 0) {
+    return createResult('Database runtime logs', RESULT_STATUS.WARN, 'No recent Postgres log entries were returned by Railway.');
+  }
+
+  const fatalMessages = [];
+  let hasRoutineSignal = false;
+
+  for (const entry of entries) {
+    const message = normalizeString(entry.message);
+
+    //audit assumption: schema-mismatch or fatal database messages represent active production risk even if the service process is still alive; failure risk: the app appears healthy while queries fail; expected invariant: no recent FATAL/PANIC/schema-missing markers; handling strategy: fail when those markers appear.
+    if (/\sFATAL:/i.test(message) || /\sPANIC:/i.test(message) || /relation "User" does not exist/i.test(message)) {
+      fatalMessages.push(message);
+    }
+
+    if (/checkpoint complete/i.test(message) || /database system is ready to accept connections/i.test(message) || /\sLOG:/i.test(message)) {
+      hasRoutineSignal = true;
+    }
+  }
+
+  if (fatalMessages.length > 0) {
+    return createResult(
+      'Database runtime logs',
+      RESULT_STATUS.FAIL,
+      `Detected recent Postgres failure markers. Example: ${fatalMessages[0]}`
+    );
+  }
+
+  if (hasRoutineSignal) {
+    return createResult(
+      'Database runtime logs',
+      RESULT_STATUS.PASS,
+      'Recent Postgres logs show routine activity without fatal or schema-mismatch markers.'
+    );
+  }
+
+  return createResult(
+    'Database runtime logs',
+    RESULT_STATUS.WARN,
+    'Postgres logs were readable but did not contain a routine checkpoint or readiness signal.'
+  );
+}
+
+/**
+ * Purpose: Evaluate recent Redis logs for readiness and actionable warnings.
+ * Inputs/Outputs: Parsed Redis log entries -> one result object.
+ * Edge cases: The standard kernel overcommit warning is surfaced as WARN because it is advisory on Railway but worth keeping visible.
+ *
+ * @param {Array<Record<string, unknown>>} entries - Parsed Redis log entries.
+ * @returns {{ name: string; status: 'PASS'|'WARN'|'FAIL'; detail: string }}
+ */
+export function evaluateRedisLogEntries(entries) {
+  if (entries.length === 0) {
+    return createResult('Redis runtime logs', RESULT_STATUS.WARN, 'No recent Redis log entries were returned by Railway.');
+  }
+
+  let hasReadySignal = false;
+  let hasOvercommitWarning = false;
+  const fatalMessages = [];
+
+  for (const entry of entries) {
+    const message = normalizeString(entry.message);
+
+    //audit assumption: Redis fatal startup or persistence failures invalidate queue/cache health even if the deployment record says SUCCESS; failure risk: app can connect intermittently to a broken cache; expected invariant: no fatal Redis messages in the scanned window; handling strategy: fail on known fatal markers.
+    if (/fatal/i.test(message) || /oom command not allowed/i.test(message) || /background save may fail/i.test(message) && !/Memory overcommit must be enabled/i.test(message)) {
+      fatalMessages.push(message);
+    }
+
+    if (/Memory overcommit must be enabled/i.test(message)) {
+      hasOvercommitWarning = true;
+    }
+
+    if (/Ready to accept connections/i.test(message)) {
+      hasReadySignal = true;
+    }
+  }
+
+  if (fatalMessages.length > 0) {
+    return createResult(
+      'Redis runtime logs',
+      RESULT_STATUS.FAIL,
+      `Detected recent Redis failure markers. Example: ${fatalMessages[0]}`
+    );
+  }
+
+  if (hasReadySignal && hasOvercommitWarning) {
+    return createResult(
+      'Redis runtime logs',
+      RESULT_STATUS.WARN,
+      'Redis reports ready-to-accept-connections, but the standard vm.overcommit_memory advisory is still present.'
+    );
+  }
+
+  if (hasReadySignal) {
+    return createResult(
+      'Redis runtime logs',
+      RESULT_STATUS.PASS,
+      'Redis reports ready-to-accept-connections in the scanned window.'
+    );
+  }
+
+  if (hasOvercommitWarning) {
+    return createResult(
+      'Redis runtime logs',
+      RESULT_STATUS.WARN,
+      'Redis logs are readable but only the vm.overcommit_memory advisory was found in the scanned window.'
+    );
+  }
+
+  return createResult(
+    'Redis runtime logs',
+    RESULT_STATUS.WARN,
+    'Redis logs were readable but did not contain a recent readiness marker.'
+  );
+}
+
+/**
+ * Purpose: Execute the end-to-end smoke check workflow.
+ * Inputs/Outputs: Normalized configuration -> ordered result list.
+ * Edge cases: Critical Railway CLI failures are captured as FAIL results and short-circuit dependent checks.
+ *
+ * @param {typeof DEFAULTS} config - Smoke-check configuration.
+ * @returns {Promise<Array<{ name: string; status: 'PASS'|'WARN'|'FAIL'; detail: string }>>}
+ */
+export async function runSmokeCheck(config) {
+  /** @type {Array<{ name: string; status: 'PASS'|'WARN'|'FAIL'; detail: string }>} */
+  const results = [];
+
+  try {
+    const railwayVersion = executeRailwayCommand(['--version']).trim();
+    results.push(createResult('Railway CLI', RESULT_STATUS.PASS, railwayVersion));
+  } catch (error) {
+    results.push(createResult('Railway CLI', RESULT_STATUS.FAIL, formatCommandError(error)));
+    return results;
+  }
+
+  try {
+    const activationMessage = executeRailwayCommand(['environment', config.environment]).trim();
+    results.push(createResult('Railway environment activation', RESULT_STATUS.PASS, activationMessage || `Activated ${config.environment}.`));
+  } catch (error) {
+    results.push(createResult('Railway environment activation', RESULT_STATUS.FAIL, formatCommandError(error)));
+    return results;
+  }
+
+  let environmentSnapshot;
+  let roleServices;
+  try {
+    const statusPayload = readJsonCommand(['status', '--json']);
+    environmentSnapshot = extractEnvironmentSnapshot(statusPayload, config.environment);
+    roleServices = findRoleServices(environmentSnapshot.serviceInstances, config);
+    results.push(
+      createResult(
+        'Topology discovery',
+        RESULT_STATUS.PASS,
+        `Project=${environmentSnapshot.projectName}, workspace=${environmentSnapshot.workspaceName}, app=${roleServices.app.name}, worker=${roleServices.worker.name}, database=${roleServices.database.name}, redis=${roleServices.redis.name}.`
+      )
+    );
+  } catch (error) {
+    results.push(createResult('Topology discovery', RESULT_STATUS.FAIL, formatCommandError(error)));
+    return results;
+  }
+
+  for (const [roleLabel, service] of Object.entries(roleServices)) {
+    //audit assumption: successful latest deployments are the minimum baseline for a healthy smoke-check role; failure risk: stale or failed deploys hide broken services; expected invariant: latest deployment status is SUCCESS; handling strategy: fail role checks when the latest deployment is not successful.
+    if (service.latestDeploymentStatus !== 'SUCCESS') {
+      results.push(
+        createResult(
+          `${capitalize(roleLabel)} deployment state`,
+          RESULT_STATUS.FAIL,
+          `${service.name} latest deployment status is ${service.latestDeploymentStatus}.`
+        )
+      );
+    } else {
+      results.push(
+        createResult(
+          `${capitalize(roleLabel)} deployment state`,
+          RESULT_STATUS.PASS,
+          `${service.name} latest deployment is SUCCESS${service.latestDeploymentCreatedAt ? ` at ${service.latestDeploymentCreatedAt}` : ''}.`
+        )
+      );
+    }
+  }
+
+  let appVariables;
+  let workerVariables;
+  try {
+    appVariables = readJsonCommand(['variables', '--service', roleServices.app.name, '--json']);
+    workerVariables = readJsonCommand(['variables', '--service', roleServices.worker.name, '--json']);
+    results.push(...evaluateRuntimeWiring(appVariables, workerVariables, config.environment));
+  } catch (error) {
+    results.push(createResult('Runtime wiring', RESULT_STATUS.FAIL, formatCommandError(error)));
+    return results;
+  }
+
+  try {
+    const healthUrl = resolveHealthUrl(appVariables, roleServices.app, config);
+    const healthResult = await requestHealthCheck(healthUrl, config);
+    results.push(healthResult);
+  } catch (error) {
+    results.push(createResult('App public health endpoint', RESULT_STATUS.FAIL, formatCommandError(error)));
+  }
+
+  results.push(readAndEvaluateLogs(roleServices.app.name, config.environment, config.appLogLines, evaluateAppLogEntries));
+  results.push(readAndEvaluateLogs(roleServices.worker.name, config.environment, config.workerLogLines, evaluateWorkerLogEntries));
+  results.push(readAndEvaluateLogs(roleServices.database.name, config.environment, config.databaseLogLines, evaluateDatabaseLogEntries));
+  results.push(readAndEvaluateLogs(roleServices.redis.name, config.environment, config.redisLogLines, evaluateRedisLogEntries));
+
+  return results;
+}
+
+/**
+ * Purpose: Print the ordered result list in a compact operator-friendly format.
+ * Inputs/Outputs: Result array -> stdout lines.
+ * Edge cases: Long details remain on one line so copy/paste into incident notes stays simple.
+ *
+ * @param {Array<{ name: string; status: 'PASS'|'WARN'|'FAIL'; detail: string }>} results - Smoke-check result list.
+ * @returns {void}
+ */
+export function printResults(results) {
+  for (const result of results) {
+    process.stdout.write(`[${result.status}] ${result.name}: ${result.detail}\n`);
+  }
+
+  const failCount = results.filter((result) => result.status === RESULT_STATUS.FAIL).length;
+  const warnCount = results.filter((result) => result.status === RESULT_STATUS.WARN).length;
+  const passCount = results.filter((result) => result.status === RESULT_STATUS.PASS).length;
+  const overall = failCount > 0 ? RESULT_STATUS.FAIL : warnCount > 0 ? RESULT_STATUS.WARN : RESULT_STATUS.PASS;
+
+  process.stdout.write(`Summary: overall=${overall} pass=${passCount} warn=${warnCount} fail=${failCount}\n`);
+}
+
+/**
+ * Purpose: Read one Railway log stream and evaluate it with a role-specific analyzer.
+ * Inputs/Outputs: Service name + environment + line limit + evaluator -> result object.
+ * Edge cases: CLI failures are converted into FAIL results so the smoke check does not silently skip a role.
+ *
+ * @param {string} serviceName - Railway service name.
+ * @param {string} environmentName - Railway environment name.
+ * @param {number} lineLimit - Maximum number of log lines to request.
+ * @param {(entries: Array<Record<string, unknown>>) => { name: string; status: 'PASS'|'WARN'|'FAIL'; detail: string }} evaluator - Role-specific log evaluator.
+ * @returns {{ name: string; status: 'PASS'|'WARN'|'FAIL'; detail: string }}
+ */
+function readAndEvaluateLogs(serviceName, environmentName, lineLimit, evaluator) {
+  try {
+    const rawLogs = executeRailwayCommand([
+      'logs',
+      '--deployment',
+      '--json',
+      '--lines',
+      String(lineLimit),
+      '--service',
+      serviceName,
+      '--environment',
+      environmentName
+    ]);
+
+    return evaluator(parseJsonLines(rawLogs));
+  } catch (error) {
+    return createResult(`${serviceName} logs`, RESULT_STATUS.FAIL, formatCommandError(error));
+  }
+}
+
+/**
+ * Purpose: Resolve the public health-check URL for the app service.
+ * Inputs/Outputs: App variable map + normalized app service object + config -> absolute URL string.
+ * Edge cases: Missing public domains throw because the smoke check cannot validate app ingress without one.
+ *
+ * @param {Record<string, string>} appVariables - Parsed app variables.
+ * @param {{ serviceDomains: string[]; customDomains: string[] }} appService - Normalized app service.
+ * @param {typeof DEFAULTS} config - Smoke-check configuration.
+ * @returns {string}
+ */
+function resolveHealthUrl(appVariables, appService, config) {
+  const rawDomain = config.appUrl
+    || normalizeString(appVariables.RAILWAY_STATIC_URL)
+    || appService.customDomains[0]
+    || appService.serviceDomains[0];
+
+  //audit assumption: the public ingress check requires one resolvable app domain; failure risk: smoke check validates only private wiring and misses ingress breakage; expected invariant: app URL or domain is configured; handling strategy: throw when no public target can be derived.
+  if (!isNonEmptyString(rawDomain)) {
+    throw new Error('Unable to resolve a public app URL for the health check.');
+  }
+
+  const normalizedBase = /^https?:\/\//i.test(rawDomain) ? rawDomain : `https://${rawDomain}`;
+  return `${normalizedBase.replace(/\/+$/, '')}${config.healthPath.startsWith('/') ? config.healthPath : `/${config.healthPath}`}`;
+}
+
+/**
+ * Purpose: Fetch and validate the app health endpoint.
+ * Inputs/Outputs: Health URL + config -> one result object.
+ * Edge cases: Non-JSON bodies or mismatched environments fail because the endpoint contract is part of the smoke check.
+ *
+ * @param {string} healthUrl - Absolute health endpoint URL.
+ * @param {typeof DEFAULTS} config - Smoke-check configuration.
+ * @returns {Promise<{ name: string; status: 'PASS'|'WARN'|'FAIL'; detail: string }>}
+ */
+async function requestHealthCheck(healthUrl, config) {
+  const abortController = new AbortController();
+  const timeoutHandle = setTimeout(() => abortController.abort(), config.requestTimeoutMs);
+
+  try {
+    const response = await fetch(healthUrl, {
+      headers: {
+        'user-agent': 'arcanos-railway-production-smoke-check/1.0'
+      },
+      signal: abortController.signal
+    });
+
+    const bodyText = await response.text();
+    let parsedBody = null;
+
+    try {
+      parsedBody = JSON.parse(bodyText);
+    } catch {
+      //audit assumption: ARCANOS health endpoint should return JSON, but parse failures should still report the HTTP status; failure risk: endpoint regressions are hidden behind generic request failures; expected invariant: JSON body when healthy; handling strategy: continue with null parsedBody and fail with body preview if needed.
+    }
+
+    //audit assumption: the public health endpoint must return HTTP 200 plus `{ ok: true }` in the target environment; failure risk: ingress returns a generic page while the service is unhealthy; expected invariant: status 200, JSON body, body.ok===true, body.env matches target; handling strategy: fail on any contract violation.
+    if (!response.ok || !parsedBody || parsedBody.ok !== true || parsedBody.env !== config.environment) {
+      return createResult(
+        'App public health endpoint',
+        RESULT_STATUS.FAIL,
+        `Health check failed for ${healthUrl} with status=${response.status}, body=${truncate(bodyText, 220)}`
+      );
+    }
+
+    return createResult(
+      'App public health endpoint',
+      RESULT_STATUS.PASS,
+      `GET ${healthUrl} returned ${response.status} with ok=true and env=${parsedBody.env}.`
+    );
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+}
+
+/**
+ * Purpose: Execute one Railway CLI command with Windows-friendly fallbacks.
+ * Inputs/Outputs: Railway argument vector -> raw stdout string.
+ * Edge cases: Retries with `.exe`, shell mode, and the PowerShell shim to tolerate Windows PATH aliasing.
+ *
+ * @param {string[]} args - Railway CLI argument vector.
+ * @returns {string}
+ */
+function executeRailwayCommand(args) {
+  const execOptions = {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  };
+
+  const candidates = process.platform === 'win32'
+    ? [
+        { file: 'railway', args, options: execOptions },
+        { file: 'railway.exe', args, options: execOptions }
+      ]
+    : [{ file: 'railway', args, options: execOptions }];
+
+  let lastError = null;
+
+  for (const candidate of candidates) {
+    try {
+      return execFileSync(candidate.file, candidate.args, candidate.options);
+    } catch (error) {
+      lastError = error;
+
+      //audit assumption: ENOENT on Windows can mean the shell alias path was not resolved rather than a truly missing CLI; failure risk: false-negative tool detection; expected invariant: non-ENOENT execution failures should surface immediately; handling strategy: continue only for ENOENT candidates.
+      if (!(error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT')) {
+        throw error;
+      }
+    }
+  }
+
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA || '';
+    const railwayShimPath = join(appData, 'npm', 'railway.ps1');
+
+    //audit assumption: npm global installs place the PowerShell shim under %APPDATA%\npm; failure risk: the CLI exists but direct spawn misses it; expected invariant: shim path exists when Railway was installed through npm; handling strategy: invoke the shim with PowerShell bypass as a final fallback.
+    if (existsSync(railwayShimPath)) {
+      return execFileSync(
+        'powershell.exe',
+        ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', railwayShimPath, ...args],
+        execOptions
+      );
+    }
+  }
+
+  throw lastError || new Error('Failed to execute the Railway CLI.');
+}
+
+/**
+ * Purpose: Execute a Railway command that returns one JSON document.
+ * Inputs/Outputs: Railway argument vector -> parsed JSON object.
+ * Edge cases: Invalid JSON throws a descriptive error instead of returning partial data.
+ *
+ * @param {string[]} args - Railway CLI argument vector.
+ * @returns {Record<string, any>}
+ */
+function readJsonCommand(args) {
+  const rawOutput = executeRailwayCommand(args).trim();
+
+  //audit assumption: the targeted Railway commands return one complete JSON payload when `--json` is supplied; failure risk: malformed payloads lead to partial health conclusions; expected invariant: JSON.parse succeeds for the full payload; handling strategy: throw with command context on parse failure.
+  try {
+    return JSON.parse(rawOutput);
+  } catch (error) {
+    throw new Error(`Failed to parse JSON from Railway command "${args.join(' ')}": ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+/**
+ * Purpose: Read a normalized HTTP status code from a parsed log entry.
+ * Inputs/Outputs: Log entry object -> number or null.
+ * Edge cases: String status codes are parsed numerically; missing values return null.
+ *
+ * @param {Record<string, unknown>} entry - Parsed log entry.
+ * @returns {number | null}
+ */
+function readStatusCode(entry) {
+  const rawData = entry.data && typeof entry.data === 'object' && !Array.isArray(entry.data)
+    ? entry.data
+    : {};
+  const statusCodeCandidate = rawData.statusCode;
+
+  if (typeof statusCodeCandidate === 'number') {
+    return statusCodeCandidate;
+  }
+
+  const parsed = Number(statusCodeCandidate);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Purpose: Normalize unknown input values into safe strings.
+ * Inputs/Outputs: unknown value -> trimmed string.
+ * Edge cases: Nullish values normalize to the empty string.
+ *
+ * @param {unknown} value - Any runtime value.
+ * @returns {string}
+ */
+function normalizeString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+/**
+ * Purpose: Check whether a value is a non-empty string after trimming.
+ * Inputs/Outputs: unknown value -> boolean.
+ * Edge cases: Nullish values always return false.
+ *
+ * @param {unknown} value - Any runtime value.
+ * @returns {boolean}
+ */
+function isNonEmptyString(value) {
+  return normalizeString(value).length > 0;
+}
+
+/**
+ * Purpose: Convert command failures into compact operator-facing error text.
+ * Inputs/Outputs: thrown command error -> short string.
+ * Edge cases: Prefers stderr when present because Railway CLI failures often hide the useful message there.
+ *
+ * @param {unknown} error - Thrown error.
+ * @returns {string}
+ */
+function formatCommandError(error) {
+  if (error && typeof error === 'object' && 'stderr' in error && typeof error.stderr === 'string' && error.stderr.trim().length > 0) {
+    return truncate(error.stderr.trim(), 240);
+  }
+
+  if (error instanceof Error) {
+    return truncate(error.message, 240);
+  }
+
+  return truncate(String(error), 240);
+}
+
+/**
+ * Purpose: Truncate long strings for one-line console output.
+ * Inputs/Outputs: raw string + limit -> truncated string.
+ * Edge cases: Values shorter than the limit are returned unchanged.
+ *
+ * @param {string} value - Raw string.
+ * @param {number} limit - Maximum output length.
+ * @returns {string}
+ */
+function truncate(value, limit) {
+  return value.length <= limit ? value : `${value.slice(0, limit - 3)}...`;
+}
+
+/**
+ * Purpose: Capitalize the first letter of a role label for console output.
+ * Inputs/Outputs: lower-case label -> title-cased label.
+ * Edge cases: Empty strings return unchanged.
+ *
+ * @param {string} value - Raw label.
+ * @returns {string}
+ */
+function capitalize(value) {
+  return value.length === 0 ? value : `${value[0].toUpperCase()}${value.slice(1)}`;
+}
+
+/**
+ * Purpose: Main CLI entrypoint.
+ * Inputs/Outputs: process args -> stdout summary and exit code.
+ * Edge cases: Unexpected promise rejections are converted into one failure line rather than a stack trace wall.
+ *
+ * @returns {Promise<void>}
+ */
+async function main() {
+  const config = parseArgs(process.argv.slice(2));
+  const results = await runSmokeCheck(config);
+  printResults(results);
+
+  const hasFailures = results.some((result) => result.status === RESULT_STATUS.FAIL);
+  process.exitCode = hasFailures ? 1 : 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    const failure = createResult('Smoke-check execution', RESULT_STATUS.FAIL, formatCommandError(error));
+    printResults([failure]);
+    process.exitCode = 1;
+  });
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import errorHandler from "@transport/http/middleware/errorHandler.js";
 import { requestContext, sendNotFound } from '@shared/http/index.js';
 import getGptModuleMap from '@platform/runtime/gptRouterConfig.js';
 import { getEnv } from '@platform/runtime/env.js';
+import { arcanosMcpService } from '@services/arcanosMcp.js';
 
 function hasConfiguredOpenAIKey(): boolean {
   const key = getEnv('OPENAI_API_KEY');
@@ -33,6 +34,12 @@ export function createApp(): Express {
   Object.defineProperty(app.locals, 'openai', {
     writable: false,
     configurable: false,
+  });
+  Object.defineProperty(app.locals, 'arcanosMcp', {
+    value: arcanosMcpService,
+    writable: false,
+    configurable: false,
+    enumerable: true,
   });
 
   app.get('/healthz', async (_req: Request, res: Response, next: NextFunction) => {

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -72,16 +72,26 @@ export function buildMcpRequestContext(req: Request): McpRequestContext {
 }
 
 /**
- * Build context for stdio-based MCP (no Express Request available).
+ * Build context for detached MCP transports that run without an Express Request.
+ *
+ * Purpose:
+ * - Reuse one context constructor for stdio and in-process backend MCP execution.
+ *
+ * Inputs/outputs:
+ * - Input: optional session id plus a transport label for logging.
+ * - Output: MCP request context with OpenAI client, runtime budget, and detached logger metadata.
+ *
+ * Edge case behavior:
+ * - Throws when the OpenAI adapter is unavailable because detached transports cannot proceed without it.
  */
-export function buildMcpStdioContext(sessionId?: string): McpRequestContext {
+function buildDetachedMcpContext(sessionId: string | undefined, transport: 'internal' | 'stdio'): McpRequestContext {
   const { client } = getOpenAIClientOrAdapter();
   if (!client) {
     throw new Error('OpenAI client unavailable (adapter not initialized)');
   }
 
   const requestId = generateRequestId('mcp');
-  const logger = createMcpLogger({ requestId, sessionId, transport: 'stdio' });
+  const logger = createMcpLogger({ requestId, sessionId, transport });
 
   return {
     requestId,
@@ -92,4 +102,38 @@ export function buildMcpStdioContext(sessionId?: string): McpRequestContext {
     req: {} as any,
     logger,
   };
+}
+
+/**
+ * Build context for stdio-based MCP (no Express Request available).
+ *
+ * Purpose:
+ * - Support desktop MCP clients that communicate over stdio.
+ *
+ * Inputs/outputs:
+ * - Input: optional session identifier supplied by the stdio client.
+ * - Output: detached MCP request context tagged with `stdio` transport metadata.
+ *
+ * Edge case behavior:
+ * - Throws when the OpenAI adapter is unavailable.
+ */
+export function buildMcpStdioContext(sessionId?: string): McpRequestContext {
+  return buildDetachedMcpContext(sessionId, 'stdio');
+}
+
+/**
+ * Build context for in-process backend MCP calls (no Express Request available).
+ *
+ * Purpose:
+ * - Let backend services and workers reuse the ARCANOS MCP registry without routing through HTTP.
+ *
+ * Inputs/outputs:
+ * - Input: optional backend-managed session identifier.
+ * - Output: detached MCP request context tagged with `internal` transport metadata.
+ *
+ * Edge case behavior:
+ * - Throws when the OpenAI adapter is unavailable.
+ */
+export function buildMcpInternalContext(sessionId?: string): McpRequestContext {
+  return buildDetachedMcpContext(sessionId, 'internal');
 }

--- a/src/platform/runtime/env.ts
+++ b/src/platform/runtime/env.ts
@@ -12,6 +12,7 @@
 
 import { APPLICATION_CONSTANTS } from "@shared/constants.js";
 import { resolveErrorMessage } from "@shared/errorUtils.js";
+import dotenv from "dotenv";
 
 export interface EnvConfig {
   // Required for Railway deployment
@@ -39,6 +40,29 @@ const SYSTEM_ENV_ALLOWLIST = new Set([
   'CI',
   'GITHUB_ACTIONS'
 ]);
+
+let hasLoadedDotenv = false;
+
+/**
+ * Load local `.env` values before any runtime env reads.
+ *
+ * Purpose: make runtime config deterministic for local execution paths that do
+ * not import other modules which happen to call `dotenv.config()`.
+ * Inputs/outputs: none.
+ * Edge cases: missing `.env` is acceptable because hosted environments inject
+ * variables directly into `process.env`.
+ */
+function ensureRuntimeDotenvLoaded(): void {
+  //audit Assumption: local runtime config should not depend on unrelated import order; failure risk: DATABASE_URL and other local secrets appear unset even when present in .env; expected invariant: dotenv bootstrap runs once before env access; handling strategy: guard repeated loads with a module-local flag.
+  if (hasLoadedDotenv) {
+    return;
+  }
+
+  dotenv.config();
+  hasLoadedDotenv = true;
+}
+
+ensureRuntimeDotenvLoaded();
 
 /**
  * Read runtime environment variables for application configuration.

--- a/src/platform/runtime/workerBoot.ts
+++ b/src/platform/runtime/workerBoot.ts
@@ -211,20 +211,22 @@ async function initializeWorkers(): Promise<WorkerInitResult> {
                   return;
                 }
 
-                const cycleId = interpreterSupervisor.beginCycle(`worker:${workerId}`, {
-                  category: 'worker',
-                  metadata: {
-                    schedule: workerModule.schedule
-                  }
-                });
                 try {
-                  interpreterSupervisor.heartbeat(cycleId);
-                  await context.log(`Running scheduled worker: ${workerModule.name}`);
-                  await workerModule.run(context);
-                  interpreterSupervisor.completeCycle(cycleId);
+                  await interpreterSupervisor.runSupervisedCycle(
+                    `worker:${workerId}`,
+                    async () => {
+                      await context.log(`Running scheduled worker: ${workerModule.name}`);
+                      await workerModule.run(context);
+                    },
+                    {
+                      category: 'worker',
+                      metadata: {
+                        schedule: workerModule.schedule
+                      }
+                    }
+                  );
                 } catch (error) {
                   const errorMsg = resolveErrorMessage(error);
-                  interpreterSupervisor.failCycle(cycleId, errorMsg);
                   await context.error(`Scheduled execution failed: ${errorMsg}`);
                 } finally {
                   await cycleLock.release();

--- a/src/platform/runtime/workerConfig.ts
+++ b/src/platform/runtime/workerConfig.ts
@@ -233,36 +233,32 @@ export interface WorkerBootstrapSummary {
 
 function createWorkerHandler(workerId: string) {
   return async (request: WorkerDispatchRequest): Promise<WorkerResult> => {
-    const cycleId = interpreterSupervisor.beginCycle(`worker:${workerId}`, {
-      category: 'worker',
-      metadata: {
-        source: 'worker-task-queue'
-      }
-    });
     logger.info('[WORKER] Dispatching task', {
       workerId,
       inputPreview: request.input.slice(0, 120),
       sourceEndpoint: request.sourceEndpoint || 'worker.dispatch'
     });
 
-    try {
-      interpreterSupervisor.heartbeat(cycleId);
-      const result = await workerTask(request);
-      interpreterSupervisor.heartbeat(cycleId);
-      interpreterSupervisor.completeCycle(cycleId);
+    const result = await interpreterSupervisor.runSupervisedCycle(
+      `worker:${workerId}`,
+      async () => {
+        return workerTask(request);
+      },
+      {
+        category: 'worker',
+        metadata: {
+          source: 'worker-task-queue'
+        }
+      }
+    );
 
-      logger.info('[WORKER] Task processed', {
-        workerId,
-        activeModel: result.activeModel,
-        error: result.error
-      });
+    logger.info('[WORKER] Task processed', {
+      workerId,
+      activeModel: result.activeModel,
+      error: result.error
+    });
 
-      return { ...result, workerId };
-    } catch (error) {
-      const message = resolveErrorMessage(error);
-      interpreterSupervisor.failCycle(cycleId, message);
-      throw error;
-    }
+    return { ...result, workerId };
   };
 }
 

--- a/src/platform/runtime/workerContext.ts
+++ b/src/platform/runtime/workerContext.ts
@@ -9,6 +9,12 @@ import type { QueryResult } from 'pg';
 import { getOpenAIClientOrAdapter } from "@services/openai/clientBridge.js";
 import { resolveErrorMessage } from "@core/lib/errors/index.js";
 import { runWorkerTrinityPrompt } from '../../workers/trinityWorkerPipeline.js';
+import {
+  invokeArcanosMcpTool,
+  listArcanosMcpTools,
+  type ArcanosMcpToolCallResult,
+  type ArcanosMcpToolListResult
+} from '@services/arcanosMcp.js';
 
 export interface WorkerContext {
   log: (message: string) => Promise<void>;
@@ -18,6 +24,10 @@ export interface WorkerContext {
   };
   ai: {
     ask: (prompt: string) => Promise<string>;
+  };
+  mcp: {
+    invokeTool: (toolName: string, toolArguments?: Record<string, unknown>) => Promise<ArcanosMcpToolCallResult>;
+    listTools: () => Promise<ArcanosMcpToolListResult>;
   };
 }
 
@@ -78,6 +88,22 @@ export function createWorkerContext(workerId: string): WorkerContext {
           //audit Assumption: AI failures should propagate with safe message
           throw new Error(`AI request failed: ${resolveErrorMessage(error)}`);
         }
+      }
+    },
+
+    mcp: {
+      invokeTool: async (toolName: string, toolArguments: Record<string, unknown> = {}) => {
+        return invokeArcanosMcpTool({
+          toolName,
+          toolArguments,
+          sessionId: `worker:${workerId}`
+        });
+      },
+
+      listTools: async () => {
+        return listArcanosMcpTools({
+          sessionId: `worker:${workerId}`
+        });
       }
     }
   };

--- a/src/routes/_core/gptDispatch.ts
+++ b/src/routes/_core/gptDispatch.ts
@@ -2,11 +2,13 @@ import getGptModuleMap from "@platform/runtime/gptRouterConfig.js";
 import { dispatchModuleAction, getModuleMetadata } from "../modules.js";
 import type { GptMatchMethod } from "@platform/logging/gptLogger.js";
 import { persistModuleConversation } from "@services/moduleConversationPersistence.js";
+import { arcanosMcpService, type ArcanosMcpService, type ArcanosMcpToolCallResult, type ArcanosMcpToolListResult } from "@services/arcanosMcp.js";
 import {
   executeNaturalLanguageMemoryCommand,
   parseNaturalLanguageMemoryCommand
 } from "@services/naturalLanguageMemory.js";
 import { isRecord } from "@shared/typeGuards.js";
+import type { Request } from "express";
 
 export type AskEnvelope =
   | { ok: true; result: unknown; _route: RouteMeta }
@@ -29,6 +31,7 @@ export type RouteGptRequestInput = {
   body: any;
   requestId?: string;
   logger?: any;
+  request?: Request;
 };
 
 function extractPrompt(body: any): string | null {
@@ -99,6 +102,251 @@ function resolveSessionId(body: unknown, payload: unknown): string | undefined {
   }
 
   return undefined;
+}
+
+type McpDispatchIntent =
+  | {
+      action: 'mcp.invoke';
+      toolName: string;
+      toolArguments: Record<string, unknown>;
+      dispatchMode: 'automatic' | 'explicit';
+      reason: string;
+    }
+  | {
+      action: 'mcp.list_tools';
+      dispatchMode: 'automatic' | 'explicit';
+      reason: string;
+    };
+
+function getRecordString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function getRecordObject(record: Record<string, unknown>, key: string): Record<string, unknown> | undefined {
+  const value = record[key];
+  return isRecord(value) ? value : undefined;
+}
+
+function normalizeMcpDispatchAction(rawAction: string | undefined): 'mcp.invoke' | 'mcp.list_tools' | null {
+  if (!rawAction) {
+    return null;
+  }
+
+  const normalizedAction = normalize(rawAction);
+  if (normalizedAction === 'mcp.invoke' || normalizedAction === 'mcp.run') {
+    return 'mcp.invoke';
+  }
+  if (
+    normalizedAction === 'mcp.list_tools' ||
+    normalizedAction === 'mcp.listtools' ||
+    normalizedAction === 'mcp.list-tools'
+  ) {
+    return 'mcp.list_tools';
+  }
+
+  return null;
+}
+
+/**
+ * Resolve explicit dispatcher requests for the internal ARCANOS MCP service.
+ * Inputs/Outputs: requested action plus normalized payload; returns MCP intent, validation error, or null.
+ * Edge cases: ignores payload.mcp when a non-MCP action was explicitly requested.
+ */
+function parseMcpDispatchIntent(
+  requestedAction: string | undefined,
+  payload: unknown
+): { intent: McpDispatchIntent | null; error?: string } {
+  const normalizedRequestedAction = normalizeMcpDispatchAction(requestedAction);
+
+  //audit Assumption: explicit non-MCP actions must keep existing dispatcher semantics; failure risk: payload fields accidentally reroute normal module calls into MCP; expected invariant: MCP branch only activates for explicit MCP actions or when no action was requested and payload.mcp is present; handling strategy: short-circuit on non-MCP requested actions.
+  if (requestedAction && !normalizedRequestedAction) {
+    return { intent: null };
+  }
+
+  const payloadRecord = isRecord(payload) ? payload : null;
+  const embeddedEnvelope = payloadRecord ? getRecordObject(payloadRecord, 'mcp') : undefined;
+  const envelope = embeddedEnvelope ?? payloadRecord;
+
+  if (!envelope) {
+    return { intent: null };
+  }
+
+  const normalizedEnvelopeAction =
+    normalizedRequestedAction ??
+    normalizeMcpDispatchAction(getRecordString(envelope, 'action') ?? getRecordString(envelope, 'operation'));
+
+  if (!normalizedEnvelopeAction) {
+    return { intent: null };
+  }
+
+  if (normalizedEnvelopeAction === 'mcp.list_tools') {
+    return {
+      intent: {
+        action: 'mcp.list_tools',
+        dispatchMode: 'explicit',
+        reason: 'payload_mcp_list_tools',
+      }
+    };
+  }
+
+  const toolName =
+    getRecordString(envelope, 'toolName') ??
+    getRecordString(envelope, 'name');
+
+  //audit Assumption: MCP invoke dispatch requires a concrete tool identifier; failure risk: opening a dispatcher MCP session with an empty target creates opaque downstream errors; expected invariant: every MCP invoke request names one tool; handling strategy: reject malformed requests at dispatcher boundary.
+  if (!toolName) {
+    return { intent: null, error: 'MCP invoke dispatch requires payload.toolName (or payload.mcp.toolName).' };
+  }
+
+  const toolArguments =
+    getRecordObject(envelope, 'toolArguments') ??
+    getRecordObject(envelope, 'arguments') ??
+    {};
+
+  return {
+    intent: {
+      action: 'mcp.invoke',
+      toolName,
+      toolArguments,
+      dispatchMode: 'explicit',
+      reason: 'payload_mcp_invoke',
+    }
+  };
+}
+
+const automaticMcpListToolsPattern =
+  /\b(?:list|show|get|what(?:\s+are)?)\b[^.!?\n]{0,24}\b(?:mcp\s+)?tools?\b|\bmcp\s+tools?\b/i;
+const automaticMcpModulesListPattern =
+  /\b(?:list|show|get)\b[^.!?\n]{0,20}\bmodules?\b|\bmodules?\b[^.!?\n]{0,20}\b(?:list|show|get)\b/i;
+const automaticMcpHealthReportPattern =
+  /\b(?:ops|system|backend|service|deployment|railway)\b[^.!?\n]{0,28}\bhealth\b|\bhealth\b[^.!?\n]{0,28}\b(?:ops|system|backend|service|deployment|railway)\b|\bhealth\s+report\b/i;
+const automaticMcpStrongCuePattern = /\b(?:use|via|through)\s+mcp\b|\bmcp\s+(?:server|tools?|tooling)\b/i;
+const automaticMcpOpsVerbPattern =
+  /\b(?:diagnose|debug|inspect|audit|analyze|check|report|trace|verify|investigate|orchestrate|manage)\b/i;
+const automaticMcpBackendNounPattern =
+  /\b(?:backend|system|deployment|service|worker|queue|database|postgres|redis|railway|dag|workflow|plan|plans|agent|agents|module|modules|research|memory)\b/i;
+
+/**
+ * Infer conservative automatic MCP dispatch for query-like operational prompts.
+ * Inputs/Outputs: module, action context, prompt text, and session id; returns MCP intent or null.
+ * Edge cases: only auto-routes generic tutor-like query flows so domain-specific modules keep their existing handlers.
+ */
+function inferAutomaticMcpDispatchIntent(params: {
+  moduleName: string;
+  prompt: string | null;
+  requestedAction: string | undefined;
+  actionCandidate: string | null;
+  sessionId: string | undefined;
+}): McpDispatchIntent | null {
+  const { moduleName, prompt, requestedAction, actionCandidate, sessionId } = params;
+
+  //audit Assumption: automatic MCP selection should never override explicit non-query actions; failure risk: dispatcher bypasses strict module contracts; expected invariant: auto MCP only applies to query-like traffic; handling strategy: gate on absent/`query` action intent.
+  if (requestedAction && requestedAction !== 'query') {
+    return null;
+  }
+
+  //audit Assumption: auto MCP routing is safest on the generic ARCANOS tutor path; failure risk: domain-specific modules lose specialized behavior; expected invariant: gaming/booker/etc. keep existing module dispatch unless MCP was explicit; handling strategy: restrict automatic inference to the tutor module.
+  if (moduleName !== 'ARCANOS:TUTOR') {
+    return null;
+  }
+
+  //audit Assumption: only query/default-query routes can be safely upgraded to MCP automatically; failure risk: ambiguous modules or non-query actions get rerouted unexpectedly; expected invariant: automatic MCP stays within generic query execution; handling strategy: require null-or-query action candidate.
+  if (actionCandidate && actionCandidate !== 'query') {
+    return null;
+  }
+
+  if (!prompt) {
+    return null;
+  }
+
+  if (automaticMcpListToolsPattern.test(prompt)) {
+    return {
+      action: 'mcp.list_tools',
+      dispatchMode: 'automatic',
+      reason: 'prompt_requests_mcp_tools',
+    };
+  }
+
+  if (automaticMcpModulesListPattern.test(prompt)) {
+    return {
+      action: 'mcp.invoke',
+      toolName: 'modules.list',
+      toolArguments: {},
+      dispatchMode: 'automatic',
+      reason: 'prompt_requests_module_inventory',
+    };
+  }
+
+  if (automaticMcpHealthReportPattern.test(prompt)) {
+    return {
+      action: 'mcp.invoke',
+      toolName: 'ops.health_report',
+      toolArguments: {},
+      dispatchMode: 'automatic',
+      reason: 'prompt_requests_ops_health',
+    };
+  }
+
+  //audit Assumption: broad operational prompts benefit from the generic Trinity MCP tool when they mention backend state or explicitly ask to use MCP; failure risk: normal tutoring prompts are over-routed into MCP; expected invariant: fallback only triggers on strong MCP cues or combined ops-verb/backend-noun prompts; handling strategy: require explicit regex evidence before delegating to `trinity.ask`.
+  if (
+    automaticMcpStrongCuePattern.test(prompt) ||
+    (automaticMcpOpsVerbPattern.test(prompt) && automaticMcpBackendNounPattern.test(prompt))
+  ) {
+    return {
+      action: 'mcp.invoke',
+      toolName: 'trinity.ask',
+      toolArguments: {
+        prompt,
+        sessionId,
+      },
+      dispatchMode: 'automatic',
+      reason: automaticMcpStrongCuePattern.test(prompt)
+        ? 'prompt_requests_mcp_routing'
+        : 'prompt_requests_backend_operations',
+    };
+  }
+
+  return null;
+}
+
+function getDispatcherMcpService(request: Request | undefined): ArcanosMcpService {
+  const requestScopedService = request?.app?.locals?.arcanosMcp;
+  //audit Assumption: app.locals may expose a request-scoped MCP facade; failure risk: missing app-local wiring breaks HTTP context reuse; expected invariant: fallback singleton remains available when locals are absent; handling strategy: validate shape and fall back to the shared service instance.
+  if (
+    requestScopedService &&
+    typeof requestScopedService.invokeTool === 'function' &&
+    typeof requestScopedService.listTools === 'function'
+  ) {
+    return requestScopedService as ArcanosMcpService;
+  }
+
+  return arcanosMcpService;
+}
+
+function extractMcpToolError(result: ArcanosMcpToolCallResult | ArcanosMcpToolListResult): {
+  code: string;
+  message: string;
+  details?: unknown;
+} | null {
+  if (!('isError' in result) || result.isError !== true) {
+    return null;
+  }
+
+  const structuredContent = isRecord(result.structuredContent) ? result.structuredContent : null;
+  const errorBody = structuredContent && isRecord(structuredContent.error) ? structuredContent.error : null;
+  if (!errorBody) {
+    return {
+      code: 'MCP_TOOL_ERROR',
+      message: 'ARCANOS MCP tool returned an error result.',
+    };
+  }
+
+  return {
+    code: typeof errorBody.code === 'string' ? errorBody.code : 'MCP_TOOL_ERROR',
+    message: typeof errorBody.message === 'string' ? errorBody.message : 'ARCANOS MCP tool returned an error result.',
+    details: errorBody.details,
+  };
 }
 
 const UNIVERSAL_MEMORY_SESSION_ID = "global";
@@ -284,7 +532,7 @@ export async function resolveGptRouting(gptId: string, requestId?: string): Prom
   };
 }
 export async function routeGptRequest(input: RouteGptRequestInput): Promise<AskEnvelope> {
-  const { gptId, body, requestId, logger } = input;
+  const { gptId, body, requestId, logger, request } = input;
   const trimmedGptId = (gptId ?? "").trim();
 
   const baseRoute: RouteMeta = {
@@ -316,10 +564,27 @@ export async function routeGptRequest(input: RouteGptRequestInput): Promise<AskE
   const requestedAction = typeof body?.action === "string" ? body.action.trim() : undefined;
   const payload = buildDispatchPayload(body);
   const prompt = extractPrompt(payload);
+  const mcpDispatch = parseMcpDispatchIntent(requestedAction, payload);
+  if (mcpDispatch.error) {
+    return {
+      ok: false,
+      error: { code: "BAD_REQUEST", message: mcpDispatch.error },
+      _route: {
+        ...baseRoute,
+        module: entry.module,
+        action: requestedAction ?? 'mcp.invoke',
+        matchMethod,
+        route: entry.route,
+        availableActions,
+        moduleVersion: (moduleMetadata as any)?.version ?? null,
+      },
+    };
+  }
   const parsedMemoryCommand =
     typeof prompt === "string" ? parseNaturalLanguageMemoryCommand(prompt) : { intent: "unknown" };
   const actionCandidate = pickAction(availableActions, requestedAction);
   const hasNoRoutableAction = !actionCandidate;
+  const sessionId = resolveSessionId(body, payload);
 
   const shouldInterceptMemoryInDispatcher =
     typeof prompt === "string" &&
@@ -396,6 +661,169 @@ export async function routeGptRequest(input: RouteGptRequestInput): Promise<AskE
           availableActions,
           moduleVersion: (moduleMetadata as any)?.version ?? null
         }
+      };
+    }
+  }
+
+  const automaticMcpDispatchIntent = mcpDispatch.intent
+    ? null
+    : inferAutomaticMcpDispatchIntent({
+        moduleName: entry.module,
+        prompt,
+        requestedAction,
+        actionCandidate,
+        sessionId,
+      });
+  const resolvedMcpDispatchIntent = mcpDispatch.intent ?? automaticMcpDispatchIntent;
+
+  if (resolvedMcpDispatchIntent) {
+    const dispatcherMcpService = getDispatcherMcpService(request);
+    const dispatcherAction = resolvedMcpDispatchIntent.action;
+    const dispatcherRouteAction =
+      resolvedMcpDispatchIntent.dispatchMode === 'automatic'
+        ? `mcp.auto.${dispatcherAction === 'mcp.invoke' ? 'invoke' : 'list_tools'}`
+        : dispatcherAction;
+
+    if (resolvedMcpDispatchIntent.dispatchMode === 'automatic') {
+      logger?.info?.("gpt.dispatch.mcp.auto_selected", {
+        requestId,
+        gptId: trimmedGptId,
+        module: entry.module,
+        action: dispatcherAction,
+        matchMethod,
+        reason: resolvedMcpDispatchIntent.reason,
+        toolName: resolvedMcpDispatchIntent.action === 'mcp.invoke' ? resolvedMcpDispatchIntent.toolName : undefined,
+      });
+    }
+
+    logger?.info?.("gpt.dispatch.mcp.plan", {
+      requestId,
+      gptId: trimmedGptId,
+      module: entry.module,
+      action: dispatcherAction,
+      matchMethod,
+      dispatchMode: resolvedMcpDispatchIntent.dispatchMode,
+      reason: resolvedMcpDispatchIntent.reason,
+      toolName: resolvedMcpDispatchIntent.action === 'mcp.invoke' ? resolvedMcpDispatchIntent.toolName : undefined,
+    });
+
+    try {
+      const mcpResult =
+        resolvedMcpDispatchIntent.action === 'mcp.invoke'
+          ? await dispatcherMcpService.invokeTool({
+              toolName: resolvedMcpDispatchIntent.toolName,
+              toolArguments: resolvedMcpDispatchIntent.toolArguments,
+              request,
+              sessionId,
+            })
+          : await dispatcherMcpService.listTools({
+              request,
+              sessionId,
+            });
+
+      const mcpToolError = extractMcpToolError(mcpResult);
+      if (mcpToolError) {
+        return {
+          ok: false,
+          error: mcpToolError,
+          _route: {
+            ...baseRoute,
+            module: entry.module,
+            action: dispatcherRouteAction,
+            matchMethod,
+            route: entry.route,
+            availableActions,
+            moduleVersion: (moduleMetadata as any)?.version ?? null
+          }
+        };
+      }
+
+      const routedMcpResult = {
+        handledBy: "mcp-dispatcher",
+        mcp:
+          resolvedMcpDispatchIntent.action === 'mcp.invoke'
+            ? {
+                action: 'invoke',
+                toolName: resolvedMcpDispatchIntent.toolName,
+                dispatchMode: resolvedMcpDispatchIntent.dispatchMode,
+                reason: resolvedMcpDispatchIntent.reason,
+                result: mcpResult,
+              }
+            : {
+                action: 'list_tools',
+                dispatchMode: resolvedMcpDispatchIntent.dispatchMode,
+                reason: resolvedMcpDispatchIntent.reason,
+                result: mcpResult,
+              }
+      };
+
+      await persistModuleConversation({
+        moduleName: entry.module,
+        route: entry.route,
+        action: dispatcherRouteAction,
+        gptId: trimmedGptId,
+        sessionId,
+        requestId,
+        requestPayload: payload,
+        responsePayload: routedMcpResult
+      }).catch((error: unknown) => {
+        //audit Assumption: MCP dispatch persistence failures should not hide successful dispatcher output; failure risk: conversation history gaps; expected invariant: MCP result still returns to caller; handling strategy: warn and continue.
+        logger?.warn?.("gpt.dispatch.mcp.persistence_failed", {
+          requestId,
+          gptId: trimmedGptId,
+          module: entry.module,
+          action: dispatcherRouteAction,
+          error: String((error as Error)?.message ?? error),
+        });
+      });
+
+      logger?.info?.("gpt.dispatch.mcp.ok", {
+        requestId,
+        gptId: trimmedGptId,
+        module: entry.module,
+        action: dispatcherAction,
+        dispatchMode: resolvedMcpDispatchIntent.dispatchMode,
+        reason: resolvedMcpDispatchIntent.reason,
+        toolName: resolvedMcpDispatchIntent.action === 'mcp.invoke' ? resolvedMcpDispatchIntent.toolName : undefined,
+      });
+
+      return {
+        ok: true,
+        result: routedMcpResult,
+        _route: {
+          ...baseRoute,
+          module: entry.module,
+          action: dispatcherRouteAction,
+          matchMethod,
+          route: entry.route,
+          availableActions,
+          moduleVersion: (moduleMetadata as any)?.version ?? null
+        },
+      };
+    } catch (err: any) {
+      logger?.error?.("gpt.dispatch.mcp.error", {
+        requestId,
+        gptId: trimmedGptId,
+        module: entry.module,
+        action: dispatcherAction,
+        matchMethod,
+        dispatchMode: resolvedMcpDispatchIntent.dispatchMode,
+        reason: resolvedMcpDispatchIntent.reason,
+        error: String(err?.message ?? err),
+      });
+
+      return {
+        ok: false,
+        error: { code: "MODULE_ERROR", message: err?.message ?? "MCP dispatch failed" },
+        _route: {
+          ...baseRoute,
+          module: entry.module,
+          action: dispatcherRouteAction,
+          matchMethod,
+          route: entry.route,
+          availableActions,
+          moduleVersion: (moduleMetadata as any)?.version ?? null
+        },
       };
     }
   }

--- a/src/routes/api-ask.ts
+++ b/src/routes/api-ask.ts
@@ -171,6 +171,7 @@ router.post(
         body: req.body,
         requestId: (req as any).requestId,
         logger: (req as any).logger,
+        request: req,
       });
 
       if (!envelope.ok) {

--- a/src/routes/ask/daemonTools.ts
+++ b/src/routes/ask/daemonTools.ts
@@ -14,6 +14,11 @@ import type { AskResponse } from './types.js';
 import { parseToolArgumentsWithSchema } from '@services/safety/aiOutputBoundary.js';
 import { emitSafetyAuditEvent } from '@services/safety/auditEvents.js';
 import { extractResponseOutputText } from '@arcanos/openai/responseParsing';
+import {
+  buildInitialToolLoopTranscript,
+  buildToolLoopContinuationRequest,
+  type ToolLoopFunctionCallOutput
+} from './toolLoop.js';
 
 type DaemonMetadata = {
   source?: string;
@@ -308,12 +313,14 @@ export async function tryDispatchDaemonTools(
   // Tool-calling loop: keep executing function calls until the model returns a text response
   // or we reach a hard cap. This enables "tool output continuation".
   const MAX_TURNS = 8;
+  const storeOpenAIResponses = shouldStoreOpenAIResponses();
+  let toolLoopTranscript = buildInitialToolLoopTranscript(prompt);
 
   let response: any = await responsesApi.create({
     model,
-    store: shouldStoreOpenAIResponses(),
+    store: storeOpenAIResponses,
     instructions: DAEMON_TOOL_SYSTEM_PROMPT,
-    input: [{ role: 'user', content: prompt }],
+    input: toolLoopTranscript,
     tools: daemonResponsesTools,
     tool_choice: 'auto',
     max_output_tokens: maxOutputTokens
@@ -336,7 +343,7 @@ export async function tryDispatchDaemonTools(
     }
 
     const pendingActions: PendingDaemonAction[] = [];
-    const functionCallOutputs: Array<{ type: 'function_call_output'; call_id: string; output: string }> = [];
+    const functionCallOutputs: ToolLoopFunctionCallOutput[] = [];
 
     for (const call of toolCalls) {
       const toolName = typeof call?.name === 'string' ? call.name : '';
@@ -483,16 +490,18 @@ export async function tryDispatchDaemonTools(
       };
     }
 
-    response = await responsesApi.create({
-      model,
-      store: shouldStoreOpenAIResponses(),
-      previous_response_id: response.id,
+    const continuationRequest = buildToolLoopContinuationRequest({
       instructions: DAEMON_TOOL_SYSTEM_PROMPT,
-      input: functionCallOutputs,
+      maxOutputTokens,
+      model,
+      previousResponse: response,
+      storeResponses: storeOpenAIResponses,
       tools: daemonResponsesTools,
-      tool_choice: 'auto',
-      max_output_tokens: maxOutputTokens
+      transcript: toolLoopTranscript,
+      functionCallOutputs
     });
+    toolLoopTranscript = continuationRequest.nextTranscript;
+    response = await responsesApi.create(continuationRequest.request);
 
     lastText = extractResponseOutputText(response, lastText);
   }

--- a/src/routes/ask/dagTools.ts
+++ b/src/routes/ask/dagTools.ts
@@ -10,6 +10,11 @@ import { arcanosDagRunService } from '@services/arcanosDagRunService.js';
 import { TRINITY_CORE_DAG_TEMPLATE_NAME } from '../../dag/templates.js';
 import { generateRequestId } from '@shared/idGenerator.js';
 import type { AskResponse } from './types.js';
+import {
+  buildInitialToolLoopTranscript,
+  buildToolLoopContinuationRequest,
+  type ToolLoopFunctionCallOutput
+} from './toolLoop.js';
 
 const DAG_TOOL_SYSTEM_PROMPT = [
   'You are ARCANOS in DAG orchestration mode.',
@@ -803,11 +808,13 @@ export async function tryDispatchDagTools(
   }
 
   const MAX_TURNS = 8;
+  const storeOpenAIResponses = shouldStoreOpenAIResponses();
+  let toolLoopTranscript = buildInitialToolLoopTranscript(prompt);
   let response: any = await responsesApi.create({
     model,
-    store: shouldStoreOpenAIResponses(),
+    store: storeOpenAIResponses,
     instructions: DAG_TOOL_SYSTEM_PROMPT,
-    input: [{ role: 'user', content: prompt }],
+    input: toolLoopTranscript,
     tools: dagControlResponsesTools,
     tool_choice: 'auto',
     max_output_tokens: maxOutputTokens
@@ -829,7 +836,7 @@ export async function tryDispatchDagTools(
       return buildDagToolResponse(response, lastText);
     }
 
-    const functionCallOutputs: Array<{ type: 'function_call_output'; call_id: string; output: string }> = [];
+    const functionCallOutputs: ToolLoopFunctionCallOutput[] = [];
 
     for (const toolCall of toolCalls) {
       const toolName = typeof toolCall.name === 'string' ? toolCall.name : '';
@@ -862,16 +869,18 @@ export async function tryDispatchDagTools(
       }
     }
 
-    response = await responsesApi.create({
-      model,
-      store: shouldStoreOpenAIResponses(),
-      previous_response_id: response.id,
+    const continuationRequest = buildToolLoopContinuationRequest({
       instructions: DAG_TOOL_SYSTEM_PROMPT,
-      input: functionCallOutputs,
+      maxOutputTokens,
+      model,
+      previousResponse: response,
+      storeResponses: storeOpenAIResponses,
       tools: dagControlResponsesTools,
-      tool_choice: 'auto',
-      max_output_tokens: maxOutputTokens
+      transcript: toolLoopTranscript,
+      functionCallOutputs
     });
+    toolLoopTranscript = continuationRequest.nextTranscript;
+    response = await responsesApi.create(continuationRequest.request);
     lastText = extractResponseOutputText(response, lastText);
   }
 

--- a/src/routes/ask/toolLoop.ts
+++ b/src/routes/ask/toolLoop.ts
@@ -1,0 +1,119 @@
+import type {
+  ResponseCreateParamsNonStreaming,
+  ResponseInputItem
+} from 'openai/resources/responses/responses';
+
+export type ToolLoopFunctionCallOutput = {
+  type: 'function_call_output';
+  call_id: string;
+  output: string;
+};
+
+type ToolLoopContinuationParams = {
+  instructions: string;
+  maxOutputTokens: number;
+  model: string;
+  previousResponse: {
+    id?: string | null;
+    output?: unknown;
+  };
+  storeResponses: boolean;
+  tools: Array<Record<string, unknown>>;
+  transcript: ResponseInputItem[];
+  functionCallOutputs: ToolLoopFunctionCallOutput[];
+};
+
+type ToolLoopContinuationRequest = {
+  nextTranscript: ResponseInputItem[];
+  request: ResponseCreateParamsNonStreaming;
+};
+
+/**
+ * Build the initial local transcript for a stateless-capable tool loop.
+ *
+ * Inputs: the user prompt for the tool-enabled ask path.
+ * Outputs: a transcript array that can be reused on later stateless follow-up turns.
+ * Edge cases: empty prompts are preserved so the caller can keep one consistent input shape.
+ */
+export function buildInitialToolLoopTranscript(prompt: string): ResponseInputItem[] {
+  return [{ role: 'user', content: prompt }];
+}
+
+/**
+ * Build the next Responses API request for a tool loop.
+ *
+ * Inputs: model settings, the prior response, the current transcript, and tool outputs.
+ * Outputs: the next request payload plus the next local transcript snapshot.
+ * Edge cases: when response storage is disabled or the prior response id is missing, the function falls back to a fully stateless transcript replay.
+ */
+export function buildToolLoopContinuationRequest(
+  params: ToolLoopContinuationParams
+): ToolLoopContinuationRequest {
+  const {
+    instructions,
+    maxOutputTokens,
+    model,
+    previousResponse,
+    storeResponses,
+    tools,
+    transcript,
+    functionCallOutputs
+  } = params;
+  const reusableResponseItems = extractReusableResponseOutputItems(previousResponse.output);
+  const nextTranscript = [...transcript, ...reusableResponseItems, ...functionCallOutputs];
+
+  const baseRequest: ResponseCreateParamsNonStreaming = {
+    model,
+    store: storeResponses,
+    instructions,
+    input: functionCallOutputs,
+    tools: tools as unknown as ResponseCreateParamsNonStreaming['tools'],
+    tool_choice: 'auto',
+    max_output_tokens: maxOutputTokens
+  };
+
+  if (storeResponses && typeof previousResponse.id === 'string' && previousResponse.id.trim().length > 0) {
+    //audit Assumption: a stored response id is only safe when storage is enabled and the id is present; failure risk: OpenAI rejects follow-up turns with a missing or non-persisted id; expected invariant: stateful chaining only occurs for persisted responses; handling strategy: gate previous_response_id behind the storage contract.
+    return {
+      nextTranscript,
+      request: {
+        ...baseRequest,
+        previous_response_id: previousResponse.id,
+        input: functionCallOutputs
+      }
+    };
+  }
+
+  //audit Assumption: stateless follow-up turns must replay local transcript state; failure risk: the model loses tool-call context or references a missing previous response; expected invariant: every follow-up call is self-contained when storage is off; handling strategy: append prior response items plus function outputs into the next input payload.
+  return {
+    nextTranscript,
+    request: {
+      ...baseRequest,
+      store: false,
+      input: nextTranscript
+    }
+  };
+}
+
+/**
+ * Filter prior response items down to replay-safe input items.
+ *
+ * Inputs: arbitrary response output payload from the Responses API.
+ * Outputs: reusable response items that can be sent back as stateless input.
+ * Edge cases: invalid or non-array output payloads are discarded instead of poisoning the next request.
+ */
+export function extractReusableResponseOutputItems(output: unknown): ResponseInputItem[] {
+  if (!Array.isArray(output)) {
+    //audit Assumption: only array output payloads can be replayed into the next request; failure risk: malformed output corrupts the transcript; expected invariant: replay input is an array of response items; handling strategy: drop invalid output payloads.
+    return [];
+  }
+
+  return output.filter((item): item is ResponseInputItem => {
+    if (!item || typeof item !== 'object') {
+      return false;
+    }
+
+    //audit Assumption: replayable output items must retain an explicit type tag; failure risk: untyped objects cause invalid Responses API input; expected invariant: each replay item declares a valid item type; handling strategy: keep only object items with a string type field.
+    return typeof (item as { type?: unknown }).type === 'string';
+  });
+}

--- a/src/routes/ask/workerTools.ts
+++ b/src/routes/ask/workerTools.ts
@@ -8,6 +8,11 @@ import type { AskResponse } from './types.js';
 import { parseToolArgumentsWithSchema } from '@services/safety/aiOutputBoundary.js';
 import { extractResponseOutputText } from '@arcanos/openai/responseParsing';
 import {
+  buildInitialToolLoopTranscript,
+  buildToolLoopContinuationRequest,
+  type ToolLoopFunctionCallOutput
+} from './toolLoop.js';
+import {
   dispatchWorkerInput,
   getWorkerControlHealth,
   getLatestWorkerJobDetail,
@@ -626,11 +631,13 @@ export async function tryDispatchWorkerTools(
   }
 
   const MAX_TURNS = 8;
+  const storeOpenAIResponses = shouldStoreOpenAIResponses();
+  let toolLoopTranscript = buildInitialToolLoopTranscript(prompt);
   let response: any = await responsesApi.create({
     model,
-    store: shouldStoreOpenAIResponses(),
+    store: storeOpenAIResponses,
     instructions: WORKER_TOOL_SYSTEM_PROMPT,
-    input: [{ role: 'user', content: prompt }],
+    input: toolLoopTranscript,
     tools: workerControlResponsesTools,
     tool_choice: 'auto',
     max_output_tokens: maxOutputTokens
@@ -652,7 +659,7 @@ export async function tryDispatchWorkerTools(
       return buildWorkerToolResponse(response, lastText);
     }
 
-    const functionCallOutputs: Array<{ type: 'function_call_output'; call_id: string; output: string }> = [];
+    const functionCallOutputs: ToolLoopFunctionCallOutput[] = [];
 
     for (const toolCall of toolCalls) {
       const toolName = typeof toolCall.name === 'string' ? toolCall.name : '';
@@ -684,16 +691,18 @@ export async function tryDispatchWorkerTools(
       }
     }
 
-    response = await responsesApi.create({
-      model,
-      store: shouldStoreOpenAIResponses(),
-      previous_response_id: response.id,
+    const continuationRequest = buildToolLoopContinuationRequest({
       instructions: WORKER_TOOL_SYSTEM_PROMPT,
-      input: functionCallOutputs,
+      maxOutputTokens,
+      model,
+      previousResponse: response,
+      storeResponses: storeOpenAIResponses,
       tools: workerControlResponsesTools,
-      tool_choice: 'auto',
-      max_output_tokens: maxOutputTokens
+      transcript: toolLoopTranscript,
+      functionCallOutputs
     });
+    toolLoopTranscript = continuationRequest.nextTranscript;
+    response = await responsesApi.create(continuationRequest.request);
     lastText = extractResponseOutputText(response, lastText);
   }
 

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -18,6 +18,7 @@ router.post("/:gptId", async (req, res, next) => {
       body: req.body,
       requestId: (req as any).requestId,
       logger: (req as any).logger,
+      request: req,
     });
 
     if (!envelope.ok) {

--- a/src/services/arcanosMcp.ts
+++ b/src/services/arcanosMcp.ts
@@ -1,0 +1,229 @@
+import type { Request } from 'express';
+
+import { resolveErrorMessage } from '@core/lib/errors/index.js';
+
+import type { McpRequestContext } from '../mcp/context.js';
+
+type JsonObject = Record<string, unknown>;
+
+export interface ArcanosMcpInvokeOptions {
+  toolName: string;
+  toolArguments?: JsonObject;
+  request?: Request;
+  sessionId?: string;
+}
+
+export interface ArcanosMcpListToolsOptions {
+  request?: Request;
+  sessionId?: string;
+}
+
+export interface ArcanosMcpToolCallResult extends JsonObject {
+  content?: JsonObject[];
+  structuredContent?: JsonObject;
+  isError?: boolean;
+}
+
+export interface ArcanosMcpToolDefinition extends JsonObject {
+  name: string;
+}
+
+export interface ArcanosMcpToolListResult extends JsonObject {
+  tools: ArcanosMcpToolDefinition[];
+}
+
+export interface ArcanosMcpService {
+  invokeTool: (options: ArcanosMcpInvokeOptions) => Promise<ArcanosMcpToolCallResult>;
+  listTools: (options?: ArcanosMcpListToolsOptions) => Promise<ArcanosMcpToolListResult>;
+}
+
+type InternalMcpClient = {
+  connect: (transport: unknown) => Promise<void>;
+  callTool: (params: { name: string; arguments?: JsonObject }) => Promise<ArcanosMcpToolCallResult>;
+  listTools: (params?: JsonObject) => Promise<ArcanosMcpToolListResult>;
+  close: () => Promise<void>;
+};
+
+type InternalMcpServer = {
+  connect: (transport: unknown) => Promise<void>;
+  close?: () => Promise<void>;
+};
+
+type InternalMcpTransport = {
+  close?: () => Promise<void>;
+};
+
+type InternalMcpConnection = {
+  client: InternalMcpClient;
+  clientTransport: InternalMcpTransport;
+  server: InternalMcpServer;
+  serverTransport: InternalMcpTransport;
+};
+
+type InternalMcpSdk = {
+  Client: new (
+    implementation: { name: string; version: string },
+    options?: { capabilities?: Record<string, unknown> }
+  ) => InternalMcpClient;
+  InMemoryTransport: {
+    createLinkedPair: () => [InternalMcpTransport, InternalMcpTransport];
+  };
+};
+
+async function loadInternalMcpSdk(): Promise<InternalMcpSdk> {
+  try {
+    const [clientModule, inMemoryModule] = await Promise.all([
+      import('@modelcontextprotocol/sdk/client/index.js'),
+      import('@modelcontextprotocol/sdk/inMemory.js'),
+    ]);
+
+    return {
+      Client: clientModule.Client as InternalMcpSdk['Client'],
+      InMemoryTransport: inMemoryModule.InMemoryTransport as InternalMcpSdk['InMemoryTransport'],
+    };
+  } catch (error) {
+    const message = resolveErrorMessage(error);
+    throw new Error(`ARCANOS internal MCP client is unavailable because @modelcontextprotocol/sdk failed to load: ${message}`);
+  }
+}
+
+function normalizeToolName(toolName: string): string {
+  const normalizedToolName = toolName.trim();
+  //audit Assumption: backend callers must provide an explicit MCP tool name; failure risk: empty tool names produce misleading transport errors; expected invariant: each invocation targets one named tool; handling strategy: fail fast before opening the MCP connection.
+  if (!normalizedToolName) {
+    throw new Error('ARCANOS MCP tool name is required');
+  }
+
+  return normalizedToolName;
+}
+
+async function buildInvocationContext(
+  options: Pick<ArcanosMcpInvokeOptions, 'request' | 'sessionId'> | ArcanosMcpListToolsOptions
+): Promise<McpRequestContext> {
+  const contextModule = await import('../mcp/context.js');
+
+  //audit Assumption: an Express request should win when available so MCP calls inherit request-scoped session and request id data; failure risk: detached context loses auth-adjacent telemetry or wrong session linkage; expected invariant: HTTP callers reuse HTTP context, background callers use internal context; handling strategy: branch on request presence.
+  if (options.request) {
+    return contextModule.buildMcpRequestContext(options.request);
+  }
+
+  return contextModule.buildMcpInternalContext(options.sessionId);
+}
+
+async function closeInternalMcpConnection(connection: InternalMcpConnection, ctx: McpRequestContext): Promise<void> {
+  const closeFailures: Array<{ target: string; error: string }> = [];
+
+  for (const [target, closeable] of [
+    ['client', connection.client],
+    ['server', connection.server],
+    ['clientTransport', connection.clientTransport],
+    ['serverTransport', connection.serverTransport],
+  ] as const) {
+    if (typeof closeable.close !== 'function') {
+      continue;
+    }
+
+    try {
+      await closeable.close();
+    } catch (error) {
+      //audit Assumption: cleanup failures should not hide the primary tool result; failure risk: transport leaks or masked root-cause errors; expected invariant: every close attempt is made and any cleanup error is emitted; handling strategy: collect and log structured cleanup failures after all close attempts.
+      closeFailures.push({ target, error: resolveErrorMessage(error) });
+    }
+  }
+
+  if (closeFailures.length > 0) {
+    ctx.logger.error('internal_mcp_cleanup_failed', { closeFailures });
+  }
+}
+
+async function openInternalMcpConnection(ctx: McpRequestContext): Promise<InternalMcpConnection> {
+  const [{ createMcpServer }, { Client, InMemoryTransport }] = await Promise.all([
+    import('../mcp/server.js'),
+    loadInternalMcpSdk(),
+  ]);
+
+  const server = await createMcpServer(ctx) as InternalMcpServer;
+  const client = new Client({ name: 'arcanos-backend', version: '1.0.0' }, { capabilities: {} });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const connection: InternalMcpConnection = {
+    client,
+    clientTransport,
+    server,
+    serverTransport,
+  };
+
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    return connection;
+  } catch (error) {
+    //audit Assumption: partially-open MCP transports must always be torn down on connection failure; failure risk: orphaned transports leak resources and poison later retries; expected invariant: failed connection attempts leave no live in-memory transport; handling strategy: close the partial connection before surfacing a structured failure.
+    await closeInternalMcpConnection(connection, ctx);
+    throw new Error(`Failed to open ARCANOS internal MCP connection: ${resolveErrorMessage(error)}`);
+  }
+}
+
+/**
+ * Invoke one ARCANOS MCP tool from backend code without routing through `/mcp`.
+ *
+ * Purpose:
+ * - Let app routes, services, and workers reuse the canonical ARCANOS MCP tool registry in-process.
+ *
+ * Inputs/outputs:
+ * - Input: tool name, optional JSON arguments, plus optional request or session context.
+ * - Output: raw MCP `callTool` result returned by the in-process client.
+ *
+ * Edge case behavior:
+ * - Throws on empty tool names, MCP transport startup failures, or tool execution failures.
+ */
+export async function invokeArcanosMcpTool(options: ArcanosMcpInvokeOptions): Promise<ArcanosMcpToolCallResult> {
+  const normalizedToolName = normalizeToolName(options.toolName);
+  const context = await buildInvocationContext(options);
+  const connection = await openInternalMcpConnection(context);
+
+  try {
+    return await connection.client.callTool({
+      name: normalizedToolName,
+      arguments: options.toolArguments ?? {},
+    });
+  } catch (error) {
+    //audit Assumption: backend callers need a tool-specific failure message rather than a transport-generic exception; failure risk: opaque errors slow debugging and retry strategy; expected invariant: the thrown error names the MCP tool that failed; handling strategy: wrap the SDK error with the tool name while preserving cleanup in `finally`.
+    throw new Error(`ARCANOS MCP tool "${normalizedToolName}" failed: ${resolveErrorMessage(error)}`);
+  } finally {
+    await closeInternalMcpConnection(connection, context);
+  }
+}
+
+/**
+ * List ARCANOS MCP tools from backend code without routing through `/mcp`.
+ *
+ * Purpose:
+ * - Give backend services a discovery path for the canonical ARCANOS MCP registry.
+ *
+ * Inputs/outputs:
+ * - Input: optional request or session context.
+ * - Output: raw MCP `listTools` result from the in-process client.
+ *
+ * Edge case behavior:
+ * - Throws when the in-process MCP connection cannot be opened or tool discovery fails.
+ */
+export async function listArcanosMcpTools(
+  options: ArcanosMcpListToolsOptions = {}
+): Promise<ArcanosMcpToolListResult> {
+  const context = await buildInvocationContext(options);
+  const connection = await openInternalMcpConnection(context);
+
+  try {
+    return await connection.client.listTools();
+  } catch (error) {
+    //audit Assumption: discovery failures should surface as explicit MCP list failures; failure risk: callers misread a transport error as "no tools"; expected invariant: list failure remains distinct from an empty tool list; handling strategy: wrap and rethrow the SDK error with list-specific context.
+    throw new Error(`ARCANOS MCP tool discovery failed: ${resolveErrorMessage(error)}`);
+  } finally {
+    await closeInternalMcpConnection(connection, context);
+  }
+}
+
+export const arcanosMcpService: ArcanosMcpService = Object.freeze({
+  invokeTool: invokeArcanosMcpTool,
+  listTools: listArcanosMcpTools,
+});

--- a/src/services/safety/interpreterSupervisor.ts
+++ b/src/services/safety/interpreterSupervisor.ts
@@ -27,6 +27,7 @@ interface InterpreterCycleRecord {
 interface CycleOptions {
   category?: SupervisorCategory;
   metadata?: Record<string, unknown>;
+  keepAliveIntervalMs?: number;
 }
 
 interface InterpreterSupervisor {
@@ -65,6 +66,19 @@ export function createInterpreterSupervisor(): InterpreterSupervisor {
       clearTimeout(cycle.timer);
       cycle.timer = undefined;
     }
+  };
+
+  const resolveKeepAliveIntervalMs = (options: CycleOptions): number => {
+    const configuredIntervalMs = options.keepAliveIntervalMs;
+    //audit Assumption: explicit keepalive values are authoritative when finite; failure risk: caller-provided NaN or negative values break timer behavior; expected invariant: keepalive interval is a non-negative integer; handling strategy: clamp invalid values to zero and normalize valid values.
+    if (typeof configuredIntervalMs === 'number' && Number.isFinite(configuredIntervalMs)) {
+      return Math.max(0, Math.floor(configuredIntervalMs));
+    }
+    //audit Assumption: worker cycles can legitimately spend longer than the heartbeat timeout awaiting external I/O; failure risk: healthy long-running worker tasks get quarantined; expected invariant: worker supervision emits progress heartbeats before timeout elapses; handling strategy: default worker keepalive to one-third of the timeout with a 1s floor.
+    if (options.category === 'worker') {
+      return Math.max(1000, Math.floor(heartbeatTimeoutMs / 3));
+    }
+    return 0;
   };
 
   const removeCycle = (cycle: InterpreterCycleRecord): void => {
@@ -288,19 +302,46 @@ export function createInterpreterSupervisor(): InterpreterSupervisor {
     options: CycleOptions = {}
   ): Promise<T> => {
     const cycleId = beginCycle(entityId, options);
+    const keepAliveIntervalMs = resolveKeepAliveIntervalMs(options);
     const heartbeatRunner = (): void => {
       heartbeat(cycleId);
+    };
+    let keepAliveTimer: NodeJS.Timeout | undefined;
+
+    const stopKeepAliveTimer = (): void => {
+      if (keepAliveTimer) {
+        clearInterval(keepAliveTimer);
+        keepAliveTimer = undefined;
+      }
+    };
+
+    const startKeepAliveTimer = (): void => {
+      //audit Assumption: zero keepalive means caller accepts manual heartbeat responsibility; failure risk: unnecessary interval churn for short-lived cycles; expected invariant: only positive intervals schedule autonomous heartbeats; handling strategy: no-op when interval is zero.
+      if (keepAliveIntervalMs <= 0) {
+        return;
+      }
+      keepAliveTimer = setInterval(() => {
+        heartbeatRunner();
+      }, keepAliveIntervalMs);
+      if (typeof keepAliveTimer.unref === 'function') {
+        keepAliveTimer.unref();
+      }
     };
 
     try {
       heartbeatRunner();
+      startKeepAliveTimer();
       const result = await work(heartbeatRunner);
+      stopKeepAliveTimer();
       heartbeatRunner();
       completeCycle(cycleId);
       return result;
     } catch (error) {
+      stopKeepAliveTimer();
       failCycle(cycleId, error instanceof Error ? error.message : String(error));
       throw error;
+    } finally {
+      stopKeepAliveTimer();
     }
   };
 

--- a/src/services/safety/runtimeState/index.ts
+++ b/src/services/safety/runtimeState/index.ts
@@ -89,6 +89,7 @@ const SAFETY_STATE_FILE = path.join(process.cwd(), 'memory', 'safety-runtime-sta
 const SAVE_DEBOUNCE_MS = 100;
 const MAX_ENTITY_KEYS = 1000;
 const IS_TEST_ENV = process.env.NODE_ENV === 'test';
+const PROCESS_STARTED_AT_ISO = new Date().toISOString();
 
 let pendingSaveTimeout: NodeJS.Timeout | null = null;
 
@@ -293,6 +294,7 @@ function readStateFromDisk(): SafetyRuntimeSnapshot {
 }
 
 let runtimeSnapshot: SafetyRuntimeSnapshot = readStateFromDisk();
+reconcileAutoRecoverableQuarantinesForProcessStart(PROCESS_STARTED_AT_ISO);
 
 async function flushStateToDisk(reason?: string): Promise<void> {
   try {
@@ -425,6 +427,79 @@ export function getActiveQuarantines(kind?: QuarantineKind): SafetyQuarantineRec
     }
     return kind ? record.kind === kind : true;
   });
+}
+
+/**
+ * Purpose: Release stale auto-recoverable quarantines that were persisted by a previous process.
+ * Inputs/Outputs: Optional process start timestamp and actor label; returns released quarantine IDs plus reset entities.
+ * Edge cases: Integrity quarantines and quarantines created by the current process are preserved.
+ */
+export function reconcileAutoRecoverableQuarantinesForProcessStart(
+  processStartedAtIso: string = PROCESS_STARTED_AT_ISO,
+  actor = 'runtime:auto-recovery:process-start'
+): {
+  releasedQuarantineIds: string[];
+  resetEntityIds: string[];
+} {
+  const processStartedAtMs = Date.parse(processStartedAtIso);
+  //audit Assumption: reconciliation must only run with a valid process-start timestamp; failure risk: malformed timestamps clear active safeguards; expected invariant: process start time is parseable before stale quarantine release; handling strategy: no-op on invalid timestamps.
+  if (!Number.isFinite(processStartedAtMs)) {
+    return {
+      releasedQuarantineIds: [],
+      resetEntityIds: []
+    };
+  }
+
+  const releasedQuarantineIds: string[] = [];
+  const resetEntityIds = new Set<string>();
+  const releasableQuarantines = getActiveQuarantines().filter(record => {
+    //audit Assumption: integrity and explicitly non-recoverable quarantines must survive process restarts; failure risk: restart bypasses hard safety blocks; expected invariant: only non-integrity auto-recoverable quarantines are candidates; handling strategy: strict filter on quarantine flags.
+    if (record.integrityFailure || record.autoRecoverable === false) {
+      return false;
+    }
+    const createdAtMs = Date.parse(record.createdAt);
+    //audit Assumption: only quarantines older than the current process are stale; failure risk: newly-created runtime quarantine released immediately after activation; expected invariant: current-process quarantines remain active; handling strategy: require a valid older createdAt timestamp.
+    if (!Number.isFinite(createdAtMs)) {
+      return false;
+    }
+    return createdAtMs < processStartedAtMs;
+  });
+
+  for (const quarantine of releasableQuarantines) {
+    const releaseResult = releaseQuarantine(quarantine.quarantineId, {
+      actor,
+      releaseNote: 'Released stale auto-recoverable quarantine after process restart',
+      integrityOnly: false
+    });
+    if (!releaseResult.released) {
+      continue;
+    }
+    releasedQuarantineIds.push(quarantine.quarantineId);
+    const entityId = typeof quarantine.metadata?.entityId === 'string' ? quarantine.metadata.entityId : undefined;
+    //audit Assumption: worker heartbeat counters from a prior process should not count against the restarted runtime; failure risk: stale counters trigger immediate re-quarantine after restart; expected invariant: prior-process entities restart with clean failure signals; handling strategy: reset counters when entity metadata is available.
+    if (entityId) {
+      resetEntitySignalsForProcessRecovery(entityId);
+      resetEntityIds.add(entityId);
+    }
+  }
+
+  if (releasedQuarantineIds.length > 0) {
+    emitSafetyAuditEvent({
+      event: 'process_restart_auto_recovery',
+      severity: 'info',
+      details: {
+        actor,
+        processStartedAtIso,
+        releasedQuarantineIds,
+        resetEntityIds: Array.from(resetEntityIds)
+      }
+    });
+  }
+
+  return {
+    releasedQuarantineIds,
+    resetEntityIds: Array.from(resetEntityIds)
+  };
 }
 
 /**
@@ -699,6 +774,10 @@ export function resetFailureSignals(entityId: string): void {
   delete runtimeSnapshot.counters.heartbeatMisses[key];
   runtimeSnapshot.counters.healthyCycles[key] = 0;
   saveState('resetFailureSignals');
+}
+
+function resetEntitySignalsForProcessRecovery(entityId: string): void {
+  resetFailureSignals(entityId);
 }
 
 /**

--- a/tests/arcanos-mcp.service.test.ts
+++ b/tests/arcanos-mcp.service.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockBuildMcpRequestContext = jest.fn();
+const mockBuildMcpInternalContext = jest.fn();
+const mockCreateMcpServer = jest.fn();
+const mockClientConnect = jest.fn();
+const mockClientCallTool = jest.fn();
+const mockClientListTools = jest.fn();
+const mockClientClose = jest.fn();
+const mockServerConnect = jest.fn();
+const mockServerClose = jest.fn();
+const mockClientTransportClose = jest.fn();
+const mockServerTransportClose = jest.fn();
+const mockCreateLinkedPair = jest.fn();
+
+class FakeClient {
+  constructor(_implementation: { name: string; version: string }, _options?: { capabilities?: Record<string, unknown> }) {}
+
+  connect(transport: unknown) {
+    return mockClientConnect(transport);
+  }
+
+  callTool(params: { name: string; arguments?: Record<string, unknown> }) {
+    return mockClientCallTool(params);
+  }
+
+  listTools(params?: Record<string, unknown>) {
+    return mockClientListTools(params);
+  }
+
+  close() {
+    return mockClientClose();
+  }
+}
+
+jest.unstable_mockModule('../src/mcp/context.js', () => ({
+  buildMcpRequestContext: mockBuildMcpRequestContext,
+  buildMcpInternalContext: mockBuildMcpInternalContext,
+}));
+
+jest.unstable_mockModule('../src/mcp/server.js', () => ({
+  createMcpServer: mockCreateMcpServer,
+}));
+
+jest.unstable_mockModule('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: FakeClient,
+}));
+
+jest.unstable_mockModule('@modelcontextprotocol/sdk/inMemory.js', () => ({
+  InMemoryTransport: {
+    createLinkedPair: mockCreateLinkedPair,
+  },
+}));
+
+const {
+  arcanosMcpService,
+  invokeArcanosMcpTool,
+  listArcanosMcpTools,
+} = await import('../src/services/arcanosMcp.js');
+
+function buildMockContext() {
+  return {
+    requestId: 'mcp-req-1',
+    sessionId: 'session-1',
+    runtimeBudget: {},
+    req: {},
+    logger: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  } as any;
+}
+
+describe('arcanosMcpService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockBuildMcpRequestContext.mockReturnValue(buildMockContext());
+    mockBuildMcpInternalContext.mockReturnValue(buildMockContext());
+    mockCreateMcpServer.mockResolvedValue({
+      connect: mockServerConnect,
+      close: mockServerClose,
+    });
+    mockClientConnect.mockResolvedValue(undefined);
+    mockClientCallTool.mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+      structuredContent: { ok: true },
+    });
+    mockClientListTools.mockResolvedValue({
+      tools: [{ name: 'modules.list' }],
+    });
+    mockClientClose.mockResolvedValue(undefined);
+    mockServerConnect.mockResolvedValue(undefined);
+    mockServerClose.mockResolvedValue(undefined);
+    mockClientTransportClose.mockResolvedValue(undefined);
+    mockServerTransportClose.mockResolvedValue(undefined);
+    mockCreateLinkedPair.mockReturnValue([
+      { close: mockClientTransportClose },
+      { close: mockServerTransportClose },
+    ]);
+  });
+
+  it('invokes an ARCANOS MCP tool with detached backend context', async () => {
+    const result = await invokeArcanosMcpTool({
+      toolName: 'modules.list',
+      toolArguments: { scope: 'all' },
+      sessionId: 'worker:planner',
+    });
+
+    expect(mockBuildMcpInternalContext).toHaveBeenCalledWith('worker:planner');
+    expect(mockBuildMcpRequestContext).not.toHaveBeenCalled();
+    expect(mockClientCallTool).toHaveBeenCalledWith({
+      name: 'modules.list',
+      arguments: { scope: 'all' },
+    });
+    expect(mockClientClose).toHaveBeenCalledTimes(1);
+    expect(mockServerClose).toHaveBeenCalledTimes(1);
+    expect(mockClientTransportClose).toHaveBeenCalledTimes(1);
+    expect(mockServerTransportClose).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(
+      expect.objectContaining({
+        structuredContent: { ok: true },
+      })
+    );
+  });
+
+  it('uses request-scoped context when listing tools from the app runtime', async () => {
+    const request = { header: jest.fn() } as any;
+
+    const result = await arcanosMcpService.listTools({ request });
+
+    expect(mockBuildMcpRequestContext).toHaveBeenCalledWith(request);
+    expect(mockBuildMcpInternalContext).not.toHaveBeenCalled();
+    expect(mockClientListTools).toHaveBeenCalledWith(undefined);
+    expect(result).toEqual({
+      tools: [{ name: 'modules.list' }],
+    });
+  });
+
+  it('fails fast on blank tool names before opening an MCP connection', async () => {
+    await expect(
+      invokeArcanosMcpTool({
+        toolName: '   ',
+      })
+    ).rejects.toThrow('ARCANOS MCP tool name is required');
+
+    expect(mockBuildMcpInternalContext).not.toHaveBeenCalled();
+    expect(mockCreateMcpServer).not.toHaveBeenCalled();
+  });
+
+  it('cleans up transports when an MCP tool call fails', async () => {
+    mockClientCallTool.mockRejectedValue(new Error('tool exploded'));
+
+    await expect(
+      invokeArcanosMcpTool({
+        toolName: 'dag.run.get',
+        toolArguments: { runId: 'dagrun_1' },
+        sessionId: 'worker:planner',
+      })
+    ).rejects.toThrow('ARCANOS MCP tool "dag.run.get" failed: tool exploded');
+
+    expect(mockClientClose).toHaveBeenCalledTimes(1);
+    expect(mockServerClose).toHaveBeenCalledTimes(1);
+    expect(mockClientTransportClose).toHaveBeenCalledTimes(1);
+    expect(mockServerTransportClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/ask-tool-loop.test.ts
+++ b/tests/ask-tool-loop.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from '@jest/globals';
+
+const { buildInitialToolLoopTranscript, buildToolLoopContinuationRequest, extractReusableResponseOutputItems } =
+  await import('../src/routes/ask/toolLoop.js');
+
+describe('ask tool loop continuation', () => {
+  it('uses previous_response_id only when response storage is available', () => {
+    const transcript = buildInitialToolLoopTranscript('inspect dag status');
+    const functionCall = {
+      type: 'function_call',
+      name: 'get_dag_run',
+      call_id: 'call-1',
+      arguments: '{"runId":"dagrun_1"}'
+    };
+    const functionCallOutput = {
+      type: 'function_call_output' as const,
+      call_id: 'call-1',
+      output: '{"ok":true}'
+    };
+
+    const continuation = buildToolLoopContinuationRequest({
+      instructions: 'use dag tools',
+      maxOutputTokens: 256,
+      model: 'gpt-4.1-mini',
+      previousResponse: {
+        id: 'resp-1',
+        output: [functionCall]
+      },
+      storeResponses: true,
+      tools: [],
+      transcript,
+      functionCallOutputs: [functionCallOutput]
+    });
+
+    expect(continuation.request.previous_response_id).toBe('resp-1');
+    expect(continuation.request.input).toEqual([functionCallOutput]);
+    expect(continuation.nextTranscript).toEqual([...transcript, functionCall, functionCallOutput]);
+  });
+
+  it('replays the local transcript when response storage is disabled', () => {
+    const transcript = buildInitialToolLoopTranscript('inspect worker state');
+    const assistantMessage = {
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: 'Calling the worker status tool.' }]
+    };
+    const functionCall = {
+      type: 'function_call',
+      name: 'get_worker_status',
+      call_id: 'call-2',
+      arguments: '{}'
+    };
+    const functionCallOutput = {
+      type: 'function_call_output' as const,
+      call_id: 'call-2',
+      output: '{"ok":true}'
+    };
+
+    const continuation = buildToolLoopContinuationRequest({
+      instructions: 'use worker tools',
+      maxOutputTokens: 256,
+      model: 'gpt-4.1-mini',
+      previousResponse: {
+        id: 'resp-2',
+        output: [assistantMessage, functionCall]
+      },
+      storeResponses: false,
+      tools: [],
+      transcript,
+      functionCallOutputs: [functionCallOutput]
+    });
+
+    expect(continuation.request.previous_response_id).toBeUndefined();
+    expect(continuation.request.store).toBe(false);
+    expect(continuation.request.input).toEqual([
+      ...transcript,
+      assistantMessage,
+      functionCall,
+      functionCallOutput
+    ]);
+    expect(continuation.nextTranscript).toEqual([
+      ...transcript,
+      assistantMessage,
+      functionCall,
+      functionCallOutput
+    ]);
+  });
+
+  it('drops malformed response items instead of replaying them', () => {
+    const reusableItems = extractReusableResponseOutputItems([
+      null,
+      'bad-item',
+      { noType: true },
+      { type: 'function_call', name: 'get_dag_capabilities', call_id: 'call-3', arguments: '{}' }
+    ]);
+
+    expect(reusableItems).toEqual([
+      { type: 'function_call', name: 'get_dag_capabilities', call_id: 'call-3', arguments: '{}' }
+    ]);
+  });
+});

--- a/tests/daemon-tools-response-loop.test.ts
+++ b/tests/daemon-tools-response-loop.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const queueDaemonCommandForInstanceMock = jest.fn();
+const getDaemonCommandResultForInstanceMock = jest.fn();
+const createPendingDaemonActionsMock = jest.fn();
+
+jest.unstable_mockModule('@services/openai.js', () => ({
+  getDefaultModel: jest.fn(() => 'gpt-4.1-mini')
+}));
+
+jest.unstable_mockModule('@shared/tokenParameterHelper.js', () => ({
+  getTokenParameter: jest.fn(() => ({ max_output_tokens: 256 }))
+}));
+
+jest.unstable_mockModule('@config/openaiStore.js', () => ({
+  shouldStoreOpenAIResponses: jest.fn(() => false)
+}));
+
+jest.unstable_mockModule('@platform/runtime/env.js', () => ({
+  getEnv: jest.fn((name: string, fallback: string) => fallback)
+}));
+
+jest.unstable_mockModule('@routes/api-daemon.js', () => ({
+  createPendingDaemonActions: createPendingDaemonActionsMock,
+  getDaemonCommandResultForInstance: getDaemonCommandResultForInstanceMock,
+  queueDaemonCommandForInstance: queueDaemonCommandForInstanceMock
+}));
+
+jest.unstable_mockModule('@services/safety/auditEvents.js', () => ({
+  emitSafetyAuditEvent: jest.fn()
+}));
+
+jest.unstable_mockModule('@arcanos/openai/responseParsing', () => ({
+  extractResponseOutputText: jest.fn((response: { output_text?: string }, fallback: string) => response.output_text || fallback)
+}));
+
+const { tryDispatchDaemonTools } = await import('../src/routes/ask/daemonTools.js');
+
+describe('daemon tool responses loop', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queueDaemonCommandForInstanceMock.mockReturnValue('cmd-1');
+    getDaemonCommandResultForInstanceMock.mockReturnValue({
+      ok: true,
+      summary: 'screen captured'
+    });
+  });
+
+  it('replays local transcript state for stateless responses follow-up turns', async () => {
+    const createMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'resp-1',
+        model: 'gpt-4.1-mini',
+        output: [
+          {
+            type: 'function_call',
+            name: 'capture_screen',
+            call_id: 'call-1',
+            arguments: '{}'
+          }
+        ]
+      })
+      .mockResolvedValueOnce({
+        id: 'resp-2',
+        model: 'gpt-4.1-mini',
+        output: [],
+        output_text: 'Screen captured successfully.'
+      });
+
+    const response = await tryDispatchDaemonTools(
+      {
+        responses: {
+          create: createMock
+        }
+      } as any,
+      'look at my screen',
+      {
+        source: 'daemon',
+        instanceId: 'daemon-instance-1'
+      }
+    );
+
+    expect(queueDaemonCommandForInstanceMock).toHaveBeenCalledTimes(1);
+    expect(createMock.mock.calls[1]?.[0]?.previous_response_id).toBeUndefined();
+    expect(createMock.mock.calls[1]?.[0]?.input).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'user',
+          content: 'look at my screen'
+        }),
+        expect.objectContaining({
+          type: 'function_call',
+          name: 'capture_screen',
+          call_id: 'call-1'
+        }),
+        expect.objectContaining({
+          type: 'function_call_output',
+          call_id: 'call-1'
+        })
+      ])
+    );
+    expect(response).toEqual(
+      expect.objectContaining({
+        module: 'daemon-tools',
+        result: 'Screen captured successfully.'
+      })
+    );
+  });
+});

--- a/tests/dag-tools.test.ts
+++ b/tests/dag-tools.test.ts
@@ -192,6 +192,24 @@ describe('tryDispatchDagTools', () => {
         ])
       })
     );
+    expect(createMock.mock.calls[1]?.[0]?.previous_response_id).toBeUndefined();
+    expect(createMock.mock.calls[1]?.[0]?.input).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'user',
+          content: 'inspect the orchestration workflow and decide which DAG control tool to use'
+        }),
+        expect.objectContaining({
+          type: 'function_call',
+          name: 'get_dag_capabilities',
+          call_id: 'call-1'
+        }),
+        expect.objectContaining({
+          type: 'function_call_output',
+          call_id: 'call-1'
+        })
+      ])
+    );
     expect(response).toEqual(
       expect.objectContaining({
         module: 'dag-tools',

--- a/tests/db-client-sanitization.test.ts
+++ b/tests/db-client-sanitization.test.ts
@@ -6,10 +6,18 @@ const poolSpy = jest.fn(() => ({
   end: jest.fn().mockResolvedValue(undefined)
 }));
 
+const mockDotenvConfig = jest.fn();
+
 jest.mock('pg', () => ({
   __esModule: true,
   default: { Pool: poolSpy },
   Pool: poolSpy
+}));
+
+jest.mock('dotenv', () => ({
+  __esModule: true,
+  config: mockDotenvConfig,
+  default: { config: mockDotenvConfig }
 }));
 
 const deleteEnvKeys = () => {
@@ -21,6 +29,7 @@ describe('initializeDatabase env handling', () => {
   beforeEach(() => {
     jest.resetModules();
     poolSpy.mockClear();
+    mockDotenvConfig.mockClear();
     deleteEnvKeys();
   });
 

--- a/tests/gpt-dispatch.mcp.test.ts
+++ b/tests/gpt-dispatch.mcp.test.ts
@@ -1,0 +1,354 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockGetGptModuleMap = jest.fn();
+const mockDispatchModuleAction = jest.fn();
+const mockGetModuleMetadata = jest.fn();
+const mockPersistModuleConversation = jest.fn();
+const mockExecuteNaturalLanguageMemoryCommand = jest.fn();
+const mockParseNaturalLanguageMemoryCommand = jest.fn();
+
+jest.unstable_mockModule('../src/platform/runtime/gptRouterConfig.js', () => ({
+  default: mockGetGptModuleMap,
+}));
+
+jest.unstable_mockModule('../src/routes/modules.js', () => ({
+  dispatchModuleAction: mockDispatchModuleAction,
+  getModuleMetadata: mockGetModuleMetadata,
+}));
+
+jest.unstable_mockModule('../src/services/moduleConversationPersistence.js', () => ({
+  persistModuleConversation: mockPersistModuleConversation,
+}));
+
+jest.unstable_mockModule('../src/services/naturalLanguageMemory.js', () => ({
+  executeNaturalLanguageMemoryCommand: mockExecuteNaturalLanguageMemoryCommand,
+  parseNaturalLanguageMemoryCommand: mockParseNaturalLanguageMemoryCommand,
+}));
+
+jest.unstable_mockModule('../src/services/arcanosMcp.js', () => ({
+  arcanosMcpService: {
+    invokeTool: jest.fn(),
+    listTools: jest.fn(),
+  },
+}));
+
+jest.unstable_mockModule('../src/shared/typeGuards.js', () => ({
+  isRecord(value: unknown) {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  },
+}));
+
+const { routeGptRequest } = await import('../src/routes/_core/gptDispatch.js');
+
+describe('routeGptRequest MCP dispatch branch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetGptModuleMap.mockResolvedValue({
+      tutor: { route: 'tutor', module: 'ARCANOS:TUTOR' },
+    });
+    mockGetModuleMetadata.mockReturnValue({
+      name: 'ARCANOS:TUTOR',
+      actions: ['query'],
+      route: 'tutor',
+    });
+    mockPersistModuleConversation.mockResolvedValue(undefined);
+    mockParseNaturalLanguageMemoryCommand.mockReturnValue({ intent: 'unknown' });
+    mockExecuteNaturalLanguageMemoryCommand.mockResolvedValue({ operation: 'noop' });
+  });
+
+  it('uses the request-scoped ARCANOS MCP service for explicit mcp.invoke actions', async () => {
+    const invokeTool = jest.fn().mockResolvedValue({
+      structuredContent: { ok: true },
+    });
+    const listTools = jest.fn();
+    const request = {
+      app: {
+        locals: {
+          arcanosMcp: {
+            invokeTool,
+            listTools,
+          },
+        },
+      },
+    } as any;
+
+    const envelope = await routeGptRequest({
+      gptId: 'tutor',
+      body: {
+        action: 'mcp.invoke',
+        payload: {
+          toolName: 'modules.list',
+          toolArguments: { scope: 'all' },
+        },
+        sessionId: 'sess-1',
+      },
+      requestId: 'req-1',
+      request,
+    });
+
+    expect(invokeTool).toHaveBeenCalledWith({
+      toolName: 'modules.list',
+      toolArguments: { scope: 'all' },
+      request,
+      sessionId: 'sess-1',
+    });
+    expect(mockDispatchModuleAction).not.toHaveBeenCalled();
+    expect(mockPersistModuleConversation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'mcp.invoke',
+        gptId: 'tutor',
+        moduleName: 'ARCANOS:TUTOR',
+        sessionId: 'sess-1',
+      })
+    );
+    expect(envelope).toEqual(
+      expect.objectContaining({
+        ok: true,
+        result: expect.objectContaining({
+          handledBy: 'mcp-dispatcher',
+          mcp: expect.objectContaining({
+            action: 'invoke',
+            toolName: 'modules.list',
+          }),
+        }),
+      })
+    );
+  });
+
+  it('allows payload.mcp to trigger list tools dispatch when no action was requested', async () => {
+    const request = {
+      app: {
+        locals: {
+          arcanosMcp: {
+            invokeTool: jest.fn(),
+            listTools: jest.fn().mockResolvedValue({
+              tools: [{ name: 'modules.list' }],
+            }),
+          },
+        },
+      },
+    } as any;
+
+    const envelope = await routeGptRequest({
+      gptId: 'tutor',
+      body: {
+        payload: {
+          mcp: {
+            action: 'mcp.listTools',
+          },
+        },
+      },
+      requestId: 'req-2',
+      request,
+    });
+
+    expect(request.app.locals.arcanosMcp.listTools).toHaveBeenCalledWith({
+      request,
+      sessionId: undefined,
+    });
+    expect(envelope).toEqual(
+      expect.objectContaining({
+        ok: true,
+        result: expect.objectContaining({
+          handledBy: 'mcp-dispatcher',
+          mcp: expect.objectContaining({
+            action: 'list_tools',
+          }),
+        }),
+      })
+    );
+  });
+
+  it('surfaces MCP tool errors as dispatcher failures', async () => {
+    const request = {
+      app: {
+        locals: {
+          arcanosMcp: {
+            invokeTool: jest.fn().mockResolvedValue({
+              isError: true,
+              structuredContent: {
+                error: {
+                  code: 'ERR_BAD_REQUEST',
+                  message: 'Unknown MCP tool',
+                  details: { tool: 'missing.tool' },
+                },
+              },
+            }),
+            listTools: jest.fn(),
+          },
+        },
+      },
+    } as any;
+
+    const envelope = await routeGptRequest({
+      gptId: 'tutor',
+      body: {
+        action: 'mcp.invoke',
+        payload: {
+          toolName: 'missing.tool',
+        },
+      },
+      requestId: 'req-3',
+      request,
+    });
+
+    expect(mockDispatchModuleAction).not.toHaveBeenCalled();
+    expect(mockPersistModuleConversation).not.toHaveBeenCalled();
+    expect(envelope).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: {
+          code: 'ERR_BAD_REQUEST',
+          message: 'Unknown MCP tool',
+          details: { tool: 'missing.tool' },
+        },
+      })
+    );
+  });
+
+  it('automatically routes tutor prompts asking for MCP tools into listTools', async () => {
+    const request = {
+      app: {
+        locals: {
+          arcanosMcp: {
+            invokeTool: jest.fn(),
+            listTools: jest.fn().mockResolvedValue({
+              tools: [{ name: 'modules.list' }],
+            }),
+          },
+        },
+      },
+    } as any;
+
+    const envelope = await routeGptRequest({
+      gptId: 'tutor',
+      body: {
+        message: 'Show me the MCP tools available right now.',
+      },
+      requestId: 'req-4',
+      request,
+    });
+
+    expect(request.app.locals.arcanosMcp.listTools).toHaveBeenCalledWith({
+      request,
+      sessionId: undefined,
+    });
+    expect(mockDispatchModuleAction).not.toHaveBeenCalled();
+    expect(envelope).toEqual(
+      expect.objectContaining({
+        ok: true,
+        result: expect.objectContaining({
+          handledBy: 'mcp-dispatcher',
+          mcp: expect.objectContaining({
+            action: 'list_tools',
+            dispatchMode: 'automatic',
+            reason: 'prompt_requests_mcp_tools',
+          }),
+        }),
+        _route: expect.objectContaining({
+          action: 'mcp.auto.list_tools',
+        }),
+      })
+    );
+  });
+
+  it('automatically routes tutor health prompts into ops.health_report', async () => {
+    const invokeTool = jest.fn().mockResolvedValue({
+      structuredContent: { ok: true, status: 'healthy' },
+    });
+    const request = {
+      app: {
+        locals: {
+          arcanosMcp: {
+            invokeTool,
+            listTools: jest.fn(),
+          },
+        },
+      },
+    } as any;
+
+    const envelope = await routeGptRequest({
+      gptId: 'tutor',
+      body: {
+        message: 'Give me a backend health report.',
+      },
+      requestId: 'req-5',
+      request,
+    });
+
+    expect(invokeTool).toHaveBeenCalledWith({
+      toolName: 'ops.health_report',
+      toolArguments: {},
+      request,
+      sessionId: undefined,
+    });
+    expect(envelope).toEqual(
+      expect.objectContaining({
+        ok: true,
+        result: expect.objectContaining({
+          handledBy: 'mcp-dispatcher',
+          mcp: expect.objectContaining({
+            action: 'invoke',
+            toolName: 'ops.health_report',
+            dispatchMode: 'automatic',
+            reason: 'prompt_requests_ops_health',
+          }),
+        }),
+      })
+    );
+  });
+
+  it('automatically routes broad backend operations prompts into trinity.ask', async () => {
+    const invokeTool = jest.fn().mockResolvedValue({
+      structuredContent: { ok: true, result: 'dispatched through trinity' },
+    });
+    const request = {
+      app: {
+        locals: {
+          arcanosMcp: {
+            invokeTool,
+            listTools: jest.fn(),
+          },
+        },
+      },
+    } as any;
+
+    const prompt = 'Inspect the backend worker, postgres, and redis state and report what is wrong.';
+    const envelope = await routeGptRequest({
+      gptId: 'tutor',
+      body: {
+        message: prompt,
+        sessionId: 'sess-auto-1',
+      },
+      requestId: 'req-6',
+      request,
+    });
+
+    expect(invokeTool).toHaveBeenCalledWith({
+      toolName: 'trinity.ask',
+      toolArguments: {
+        prompt,
+        sessionId: 'sess-auto-1',
+      },
+      request,
+      sessionId: 'sess-auto-1',
+    });
+    expect(envelope).toEqual(
+      expect.objectContaining({
+        ok: true,
+        result: expect.objectContaining({
+          handledBy: 'mcp-dispatcher',
+          mcp: expect.objectContaining({
+            action: 'invoke',
+            toolName: 'trinity.ask',
+            dispatchMode: 'automatic',
+            reason: 'prompt_requests_backend_operations',
+          }),
+        }),
+        _route: expect.objectContaining({
+          action: 'mcp.auto.invoke',
+        }),
+      })
+    );
+  });
+});

--- a/tests/interpreter-supervisor.test.ts
+++ b/tests/interpreter-supervisor.test.ts
@@ -45,6 +45,32 @@ describe('interpreter supervisor safety escalation', () => {
     expect(thresholdConditions[0]?.metadata?.entityId).toBe(entityId);
   });
 
+  it('keeps worker supervised cycles alive while async work is still running', async () => {
+    const supervisor = createInterpreterSupervisor();
+    const entityId = 'worker:test-keepalive';
+    const longRunningTaskPromise = supervisor.runSupervisedCycle(
+      entityId,
+      async () => {
+        await new Promise<void>(resolve => {
+          const timeout = setTimeout(resolve, config.safety.heartbeatTimeoutMs * 2);
+          if (typeof timeout.unref === 'function') {
+            timeout.unref();
+          }
+        });
+        return 'ok';
+      },
+      { category: 'worker' }
+    );
+
+    await jest.advanceTimersByTimeAsync(config.safety.heartbeatTimeoutMs * 2 + 5);
+
+    await expect(longRunningTaskPromise).resolves.toBe('ok');
+    expect(getActiveUnsafeConditions('INTERPRETER_HEARTBEAT_LOSS')).toHaveLength(0);
+    expect(
+      getActiveQuarantines('worker').filter(record => record.metadata?.entityId === entityId)
+    ).toHaveLength(0);
+  });
+
   it('auto-recovers non-integrity quarantine after cooldown and healthy cycles', async () => {
     const originalCooldownMs = config.safety.quarantineCooldownMs;
     config.safety.quarantineCooldownMs = 0;

--- a/tests/mcp-context.test.ts
+++ b/tests/mcp-context.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockGetOpenAIClientOrAdapter = jest.fn();
+const mockCreateRuntimeBudget = jest.fn();
+const mockGenerateRequestId = jest.fn();
+const mockCreateMcpLogger = jest.fn();
+
+jest.unstable_mockModule('../src/services/openai/clientBridge.js', () => ({
+  getOpenAIClientOrAdapter: mockGetOpenAIClientOrAdapter,
+}));
+
+jest.unstable_mockModule('../src/platform/resilience/runtimeBudget.js', () => ({
+  createRuntimeBudget: mockCreateRuntimeBudget,
+}));
+
+jest.unstable_mockModule('../src/lib/requestId.js', () => ({
+  generateRequestId: mockGenerateRequestId,
+}));
+
+jest.unstable_mockModule('../src/mcp/log.js', () => ({
+  createMcpLogger: mockCreateMcpLogger,
+}));
+
+const { buildMcpInternalContext, buildMcpStdioContext } = await import('../src/mcp/context.js');
+
+describe('MCP detached context builders', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetOpenAIClientOrAdapter.mockReturnValue({ client: { responses: {} } });
+    mockCreateRuntimeBudget.mockReturnValue({ budgetId: 'budget-1' });
+    mockGenerateRequestId.mockReturnValue('mcp_1');
+    mockCreateMcpLogger.mockImplementation((meta: Record<string, unknown>) => ({
+      meta,
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }));
+  });
+
+  it('tags in-process MCP contexts with the internal transport label', () => {
+    const context = buildMcpInternalContext('worker:planner');
+
+    expect(mockCreateMcpLogger).toHaveBeenCalledWith({
+      requestId: 'mcp_1',
+      sessionId: 'worker:planner',
+      transport: 'internal',
+    });
+    expect(context.logger).toEqual(
+      expect.objectContaining({
+        meta: expect.objectContaining({
+          transport: 'internal',
+        }),
+      })
+    );
+  });
+
+  it('keeps stdio MCP contexts labeled as stdio', () => {
+    buildMcpStdioContext('stdio-session');
+
+    expect(mockCreateMcpLogger).toHaveBeenCalledWith({
+      requestId: 'mcp_1',
+      sessionId: 'stdio-session',
+      transport: 'stdio',
+    });
+  });
+});

--- a/tests/railway-production-smoke-check.test.js
+++ b/tests/railway-production-smoke-check.test.js
@@ -1,0 +1,167 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  RESULT_STATUS,
+  evaluateDatabaseLogEntries,
+  evaluateRedisLogEntries,
+  evaluateRuntimeWiring,
+  extractEnvironmentSnapshot,
+  findRoleServices,
+  parseJsonLines
+} from '../scripts/railway-production-smoke-check.js';
+
+describe('railway-production-smoke-check', () => {
+  it('extracts the production topology and resolves all four service roles', () => {
+    const snapshot = extractEnvironmentSnapshot(
+      {
+        name: 'Arcanos',
+        workspace: { name: "pbjustin's Projects" },
+        services: {
+          edges: [
+            { node: { id: 'app', name: 'ARCANOS V2' } },
+            { node: { id: 'worker', name: 'ARCANOS Worker' } },
+            { node: { id: 'db', name: 'Postgres-BTrN' } },
+            { node: { id: 'redis', name: 'Redis-lQbV' } }
+          ]
+        },
+        environments: {
+          edges: [
+            {
+              node: {
+                name: 'production',
+                serviceInstances: {
+                  edges: [
+                    {
+                      node: {
+                        serviceId: 'app',
+                        serviceName: 'ARCANOS V2',
+                        latestDeployment: { status: 'SUCCESS', createdAt: '2026-03-08T04:12:59.062Z' },
+                        activeDeployments: [{ status: 'SUCCESS' }],
+                        domains: {
+                          serviceDomains: [{ domain: 'acranos-production.up.railway.app' }],
+                          customDomains: []
+                        }
+                      }
+                    },
+                    {
+                      node: {
+                        serviceId: 'worker',
+                        serviceName: 'ARCANOS Worker',
+                        latestDeployment: { status: 'SUCCESS', createdAt: '2026-03-08T02:37:35.855Z' },
+                        activeDeployments: [{ status: 'SUCCESS' }],
+                        domains: {
+                          serviceDomains: [],
+                          customDomains: []
+                        }
+                      }
+                    },
+                    {
+                      node: {
+                        serviceId: 'db',
+                        serviceName: 'Postgres-BTrN',
+                        latestDeployment: { status: 'SUCCESS', createdAt: '2026-02-03T07:30:06.462Z' },
+                        activeDeployments: [{ status: 'SUCCESS' }],
+                        domains: {
+                          serviceDomains: [],
+                          customDomains: []
+                        }
+                      }
+                    },
+                    {
+                      node: {
+                        serviceId: 'redis',
+                        serviceName: 'Redis-lQbV',
+                        latestDeployment: { status: 'SUCCESS', createdAt: '2026-02-24T06:38:37.033Z' },
+                        activeDeployments: [{ status: 'SUCCESS' }],
+                        domains: {
+                          serviceDomains: [],
+                          customDomains: []
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      'production'
+    );
+
+    const roles = findRoleServices(snapshot.serviceInstances, {
+      environment: 'production',
+      appService: 'ARCANOS V2',
+      workerService: 'ARCANOS Worker',
+      databaseService: '',
+      redisService: '',
+      appUrl: '',
+      healthPath: '/healthz',
+      appLogLines: 300,
+      workerLogLines: 300,
+      databaseLogLines: 500,
+      redisLogLines: 200,
+      requestTimeoutMs: 15000
+    });
+
+    expect(snapshot.projectName).toBe('Arcanos');
+    expect(roles.app.name).toBe('ARCANOS V2');
+    expect(roles.worker.name).toBe('ARCANOS Worker');
+    expect(roles.database.name).toBe('Postgres-BTrN');
+    expect(roles.redis.name).toBe('Redis-lQbV');
+  });
+
+  it('passes runtime wiring when app and worker share production Postgres and Redis settings', () => {
+    const results = evaluateRuntimeWiring(
+      {
+        NODE_ENV: 'production',
+        PGHOST: 'postgres-btrn.railway.internal',
+        PGPORT: '5432',
+        PGDATABASE: 'railway',
+        PGUSER: 'postgres',
+        REDISHOST: 'redis-lqbv.railway.internal',
+        REDISPORT: '6379',
+        DATABASE_URL: 'postgres://masked',
+        REDIS_URL: 'redis://masked'
+      },
+      {
+        NODE_ENV: 'production',
+        PGHOST: 'postgres-btrn.railway.internal',
+        PGPORT: '5432',
+        PGDATABASE: 'railway',
+        PGUSER: 'postgres',
+        REDISHOST: 'redis-lqbv.railway.internal',
+        REDISPORT: '6379',
+        DATABASE_URL: 'postgres://masked',
+        REDIS_URL: 'redis://masked'
+      },
+      'production'
+    );
+
+    expect(results.every((result) => result.status !== RESULT_STATUS.FAIL)).toBe(true);
+    expect(results.find((result) => result.name === 'Shared backend wiring')?.status).toBe(RESULT_STATUS.PASS);
+  });
+
+  it('fails database log evaluation when the missing User table error appears', () => {
+    const result = evaluateDatabaseLogEntries(
+      parseJsonLines([
+        JSON.stringify({ level: 'error', message: '2026-03-06 02:42:01.855 UTC [25385] ERROR:  relation "User" does not exist' }),
+        JSON.stringify({ level: 'error', message: '2026-03-08 02:42:11.892 UTC [28] LOG:  checkpoint complete: wrote 36 buffers' })
+      ].join('\n'))
+    );
+
+    expect(result.status).toBe(RESULT_STATUS.FAIL);
+    expect(result.detail).toMatch(/relation "User" does not exist/i);
+  });
+
+  it('warns for the standard Redis overcommit advisory while preserving the readiness signal', () => {
+    const result = evaluateRedisLogEntries(
+      parseJsonLines([
+        JSON.stringify({ level: 'info', message: '1:C 24 Feb 2026 06:38:47.711 # WARNING Memory overcommit must be enabled!' }),
+        JSON.stringify({ level: 'info', message: '1:M 24 Feb 2026 06:38:47.721 * Ready to accept connections tcp' })
+      ].join('\n'))
+    );
+
+    expect(result.status).toBe(RESULT_STATUS.WARN);
+    expect(result.detail).toMatch(/ready-to-accept-connections/i);
+  });
+});

--- a/tests/runtime-env-dotenv.test.ts
+++ b/tests/runtime-env-dotenv.test.ts
@@ -1,0 +1,42 @@
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const originalDatabaseUrl = process.env.DATABASE_URL;
+const mockDotenvConfig = jest.fn(() => {
+  process.env.DATABASE_URL = 'postgresql://dotenv.example/arcanos';
+  return {
+    parsed: {
+      DATABASE_URL: process.env.DATABASE_URL
+    }
+  };
+});
+
+jest.unstable_mockModule('dotenv', () => ({
+  __esModule: true,
+  default: {
+    config: mockDotenvConfig
+  }
+}));
+
+describe('runtime env bootstrap', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockDotenvConfig.mockClear();
+    delete process.env.DATABASE_URL;
+  });
+
+  afterAll(() => {
+    if (originalDatabaseUrl === undefined) {
+      delete process.env.DATABASE_URL;
+      return;
+    }
+
+    process.env.DATABASE_URL = originalDatabaseUrl;
+  });
+
+  it('loads dotenv before serving runtime env reads', async () => {
+    const { getEnv } = await import('../src/platform/runtime/env.js');
+
+    expect(mockDotenvConfig).toHaveBeenCalledTimes(1);
+    expect(getEnv('DATABASE_URL')).toBe('postgresql://dotenv.example/arcanos');
+  });
+});

--- a/tests/unsafe-execution-gate.test.ts
+++ b/tests/unsafe-execution-gate.test.ts
@@ -5,6 +5,7 @@ import safetyRouter from '../src/routes/safety.js';
 import unsafeExecutionGate from '../src/middleware/unsafeExecutionGate.js';
 import {
   activateUnsafeCondition,
+  reconcileAutoRecoverableQuarantinesForProcessStart,
   registerQuarantine,
   resetSafetyRuntimeStateForTests
 } from '../src/services/safety/runtimeState.js';
@@ -103,6 +104,42 @@ describe('unsafeExecutionGate', () => {
       });
     expect(releaseResponse.status).toBe(200);
     expect(releaseResponse.body.released).toBe(true);
+
+    const unblockedResponse = await request(app).post('/mutate').send({ action: 'write' });
+    expect(unblockedResponse.status).toBe(200);
+    expect(unblockedResponse.body.ok).toBe(true);
+  });
+
+  it('releases stale auto-recoverable worker quarantines after process restart reconciliation', async () => {
+    const app = createUnsafeApp();
+    const quarantine = registerQuarantine({
+      kind: 'worker',
+      reason: 'test heartbeat loss',
+      integrityFailure: false,
+      autoRecoverable: true,
+      metadata: {
+        entityId: 'worker:test-restart-recovery'
+      }
+    });
+
+    activateUnsafeCondition({
+      code: 'INTERPRETER_HEARTBEAT_LOSS',
+      message: 'Heartbeat loss during test',
+      quarantineId: quarantine.quarantineId,
+      metadata: {
+        entityId: 'worker:test-restart-recovery'
+      }
+    });
+
+    const blockedResponse = await request(app).post('/mutate').send({ action: 'write' });
+    expect(blockedResponse.status).toBe(503);
+
+    const recoveryResult = reconcileAutoRecoverableQuarantinesForProcessStart(
+      new Date(Date.now() + 1000).toISOString(),
+      'operator:test-process-restart'
+    );
+    expect(recoveryResult.releasedQuarantineIds).toContain(quarantine.quarantineId);
+    expect(recoveryResult.resetEntityIds).toContain('worker:test-restart-recovery');
 
     const unblockedResponse = await request(app).post('/mutate').send({ action: 'write' });
     expect(unblockedResponse.status).toBe(200);

--- a/tests/worker-context.mcp.test.ts
+++ b/tests/worker-context.mcp.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockDbQuery = jest.fn();
+const mockLogExecution = jest.fn();
+const mockGenerateMockResponse = jest.fn();
+const mockGetOpenAIClientOrAdapter = jest.fn();
+const mockRunWorkerTrinityPrompt = jest.fn();
+const mockInvokeArcanosMcpTool = jest.fn();
+const mockListArcanosMcpTools = jest.fn();
+
+jest.unstable_mockModule('../src/core/db/index.js', () => ({
+  query: mockDbQuery,
+  logExecution: mockLogExecution,
+}));
+
+jest.unstable_mockModule('../src/services/openai.js', () => ({
+  generateMockResponse: mockGenerateMockResponse,
+}));
+
+jest.unstable_mockModule('../src/services/openai/clientBridge.js', () => ({
+  getOpenAIClientOrAdapter: mockGetOpenAIClientOrAdapter,
+}));
+
+jest.unstable_mockModule('../src/workers/trinityWorkerPipeline.js', () => ({
+  runWorkerTrinityPrompt: mockRunWorkerTrinityPrompt,
+}));
+
+jest.unstable_mockModule('../src/services/arcanosMcp.js', () => ({
+  invokeArcanosMcpTool: mockInvokeArcanosMcpTool,
+  listArcanosMcpTools: mockListArcanosMcpTools,
+}));
+
+const { createWorkerContext } = await import('../src/platform/runtime/workerContext.js');
+
+describe('createWorkerContext MCP facade', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetOpenAIClientOrAdapter.mockReturnValue({ client: null });
+    mockInvokeArcanosMcpTool.mockResolvedValue({ structuredContent: { ok: true } });
+    mockListArcanosMcpTools.mockResolvedValue({ tools: [{ name: 'modules.list' }] });
+  });
+
+  it('routes worker MCP tool calls through the internal ARCANOS MCP service', async () => {
+    const context = createWorkerContext('planner-1');
+
+    const result = await context.mcp.invokeTool('modules.list', { scope: 'all' });
+
+    expect(mockInvokeArcanosMcpTool).toHaveBeenCalledWith({
+      toolName: 'modules.list',
+      toolArguments: { scope: 'all' },
+      sessionId: 'worker:planner-1',
+    });
+    expect(result).toEqual({ structuredContent: { ok: true } });
+  });
+
+  it('lists ARCANOS MCP tools with the worker-scoped session id', async () => {
+    const context = createWorkerContext('planner-1');
+
+    const result = await context.mcp.listTools();
+
+    expect(mockListArcanosMcpTools).toHaveBeenCalledWith({
+      sessionId: 'worker:planner-1',
+    });
+    expect(result).toEqual({ tools: [{ name: 'modules.list' }] });
+  });
+});

--- a/tests/worker-tools.test.ts
+++ b/tests/worker-tools.test.ts
@@ -185,6 +185,24 @@ describe('tryDispatchWorkerTools', () => {
         ])
       })
     );
+    expect(createMock.mock.calls[1]?.[0]?.previous_response_id).toBeUndefined();
+    expect(createMock.mock.calls[1]?.[0]?.input).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'user',
+          content: 'inspect worker operations and decide what tool to call'
+        }),
+        expect.objectContaining({
+          type: 'function_call',
+          name: 'get_worker_status',
+          call_id: 'call-1'
+        }),
+        expect.objectContaining({
+          type: 'function_call_output',
+          call_id: 'call-1'
+        })
+      ])
+    );
     expect(response).toEqual(
       expect.objectContaining({
         module: 'worker-tools',

--- a/workers/src/workerTypes.ts
+++ b/workers/src/workerTypes.ts
@@ -10,4 +10,11 @@ export interface WorkerContext {
   ai: {
     ask: (prompt: string) => Promise<string>;
   };
+  mcp: {
+    invokeTool: (
+      toolName: string,
+      toolArguments?: Record<string, unknown>
+    ) => Promise<Record<string, unknown>>;
+    listTools: () => Promise<Record<string, unknown>>;
+  };
 }


### PR DESCRIPTION
## Summary
- add an internal ARCANOS MCP service and wire it into the app, worker context, and dispatcher
- add automatic dispatcher MCP routing plus ask-tool response loop coverage
- add a repeatable Railway production smoke check and fix local DATABASE_URL runtime loading

## Validation
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/arcanos-mcp.service.test.ts tests/ask-tool-loop.test.ts tests/daemon-tools-response-loop.test.ts tests/dag-tools.test.ts tests/db-client-sanitization.test.ts tests/gpt-dispatch.mcp.test.ts tests/interpreter-supervisor.test.ts tests/mcp-context.test.ts tests/railway-production-smoke-check.test.js tests/runtime-env-dotenv.test.ts tests/unsafe-execution-gate.test.ts tests/worker-context.mcp.test.ts tests/worker-tools.test.ts tests/unified-config.runtime.test.ts tests/unified-config-self-improve.test.ts tests/trinity-status-service.test.ts`
- `npm run build`
- `node scripts/railway-production-smoke-check.js --environment production`