### PR TITLE
[codex] route legacy AI endpoints through canonical GPT shim

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,6 +110,10 @@ WORKER_API_TIMEOUT_MS=60000
 # Feature flags
 # ENABLE_ACTION_PLANS=false
 # ENABLE_CLEAR_2=false
+# Deprecated root/module AI routes. Leave enabled during migration to `/gpt/:gptId`,
+# then set to `disabled` to remove `/arcanos`, `/write`, `/guide`, `/sim`,
+# `/queryroute`, and `/modules/:moduleRoute`.
+# LEGACY_GPT_ROUTES=enabled
 
 # Self-heal loop
 # Starts automatically on boot from src/server.ts and ticks every 30s by default.

--- a/src/platform/runtime/legacyRouteMode.ts
+++ b/src/platform/runtime/legacyRouteMode.ts
@@ -1,0 +1,22 @@
+import { getEnv } from '@platform/runtime/env.js';
+
+export type LegacyGptRouteMode = 'enabled' | 'disabled';
+
+function normalizeLegacyRouteMode(value: string | undefined): LegacyGptRouteMode {
+  const normalized = (value ?? '').trim().toLowerCase();
+  if (!normalized) {
+    return 'enabled';
+  }
+
+  return normalized === 'disabled' || normalized === 'false' || normalized === '0' || normalized === 'no'
+    ? 'disabled'
+    : 'enabled';
+}
+
+export function resolveLegacyGptRouteMode(): LegacyGptRouteMode {
+  return normalizeLegacyRouteMode(getEnv('LEGACY_GPT_ROUTES'));
+}
+
+export function legacyGptRoutesEnabled(): boolean {
+  return resolveLegacyGptRouteMode() === 'enabled';
+}

--- a/src/routes/_core/legacyGptCompat.ts
+++ b/src/routes/_core/legacyGptCompat.ts
@@ -8,6 +8,12 @@ import {
 
 type BodyTransform = (body: unknown, req: Request) => unknown;
 
+const LEGACY_ROUTE_ERROR_STATUS_CODES: Record<string, number> = {
+  UNKNOWN_GPT: 404,
+  SYSTEM_STATE_CONFLICT: 409,
+  MODULE_TIMEOUT: 504,
+};
+
 export async function dispatchLegacyRouteToGpt(
   req: Request,
   res: Response,
@@ -43,14 +49,7 @@ export async function dispatchLegacyRouteToGpt(
 
     if (!envelope.ok) {
       applyAIDegradedResponseHeaders(res, extractAIDegradedResponseMetadata(envelope.error.details));
-      const statusCode =
-        envelope.error.code === 'UNKNOWN_GPT'
-          ? 404
-          : envelope.error.code === 'SYSTEM_STATE_CONFLICT'
-          ? 409
-          : envelope.error.code === 'MODULE_TIMEOUT'
-          ? 504
-          : 400;
+      const statusCode = LEGACY_ROUTE_ERROR_STATUS_CODES[envelope.error.code] ?? 400;
       res.status(statusCode).json(envelope);
       return;
     }

--- a/src/routes/_core/legacyGptCompat.ts
+++ b/src/routes/_core/legacyGptCompat.ts
@@ -1,0 +1,63 @@
+import type { NextFunction, Request, Response } from 'express';
+import { routeGptRequest } from './gptDispatch.js';
+import { applyLegacyRouteDeprecationHeaders, buildCanonicalGptRoute } from '@shared/http/gptRouteHeaders.js';
+import {
+  applyAIDegradedResponseHeaders,
+  extractAIDegradedResponseMetadata
+} from '@shared/http/aiDegradedHeaders.js';
+
+type BodyTransform = (body: unknown, req: Request) => unknown;
+
+export async function dispatchLegacyRouteToGpt(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+  options: {
+    legacyRoute: string;
+    gptId: string;
+    bodyTransform?: BodyTransform;
+  }
+): Promise<void> {
+  try {
+    const effectiveBody = options.bodyTransform
+      ? options.bodyTransform(req.body, req)
+      : req.body;
+    const canonicalRoute = buildCanonicalGptRoute(options.gptId);
+
+    applyLegacyRouteDeprecationHeaders(res, canonicalRoute);
+
+    req.logger?.info?.('legacy.route.compat_dispatch', {
+      legacyRoute: options.legacyRoute,
+      canonicalRoute,
+      gptId: options.gptId,
+      requestId: req.requestId
+    });
+
+    const envelope = await routeGptRequest({
+      gptId: options.gptId,
+      body: effectiveBody,
+      requestId: req.requestId,
+      logger: req.logger,
+      request: req,
+    });
+
+    if (!envelope.ok) {
+      applyAIDegradedResponseHeaders(res, extractAIDegradedResponseMetadata(envelope.error.details));
+      const statusCode =
+        envelope.error.code === 'UNKNOWN_GPT'
+          ? 404
+          : envelope.error.code === 'SYSTEM_STATE_CONFLICT'
+          ? 409
+          : envelope.error.code === 'MODULE_TIMEOUT'
+          ? 504
+          : 400;
+      res.status(statusCode).json(envelope);
+      return;
+    }
+
+    applyAIDegradedResponseHeaders(res, extractAIDegradedResponseMetadata(envelope.result));
+    res.status(200).json(envelope);
+  } catch (error) {
+    next(error);
+  }
+}

--- a/src/routes/_core/legacyGptCompat.ts
+++ b/src/routes/_core/legacyGptCompat.ts
@@ -7,6 +7,15 @@ import {
 } from '@shared/http/aiDegradedHeaders.js';
 
 type BodyTransform = (body: unknown, req: Request) => unknown;
+type SuccessBodyTransform = (
+  result: unknown,
+  req: Request,
+  envelope: {
+    ok: true;
+    result: unknown;
+    _route: unknown;
+  }
+) => unknown;
 
 const LEGACY_ROUTE_ERROR_STATUS_CODES: Record<string, number> = {
   UNKNOWN_GPT: 404,
@@ -22,6 +31,8 @@ export async function dispatchLegacyRouteToGpt(
     legacyRoute: string;
     gptId: string;
     bodyTransform?: BodyTransform;
+    successBodyTransform?: SuccessBodyTransform;
+    applyDeprecationHeaders?: boolean;
   }
 ): Promise<void> {
   try {
@@ -30,7 +41,9 @@ export async function dispatchLegacyRouteToGpt(
       : req.body;
     const canonicalRoute = buildCanonicalGptRoute(options.gptId);
 
-    applyLegacyRouteDeprecationHeaders(res, canonicalRoute);
+    if (options.applyDeprecationHeaders !== false) {
+      applyLegacyRouteDeprecationHeaders(res, canonicalRoute);
+    }
 
     req.logger?.info?.('legacy.route.compat_dispatch', {
       legacyRoute: options.legacyRoute,
@@ -55,7 +68,10 @@ export async function dispatchLegacyRouteToGpt(
     }
 
     applyAIDegradedResponseHeaders(res, extractAIDegradedResponseMetadata(envelope.result));
-    res.status(200).json(envelope);
+    const responseBody = options.successBodyTransform
+      ? options.successBodyTransform(envelope.result, req, envelope)
+      : envelope;
+    res.status(200).json(responseBody);
   } catch (error) {
     next(error);
   }

--- a/src/routes/_core/legacyRouteAdapters.ts
+++ b/src/routes/_core/legacyRouteAdapters.ts
@@ -1,0 +1,221 @@
+import type { NextFunction, Request, Response } from 'express';
+import type { TrinityResult } from '@core/logic/trinity.js';
+import { buildTrinityUserVisibleResponse } from '@shared/ask/trinityResponseSerializer.js';
+import { extractDiagnosticTextInput } from '@shared/http/diagnosticRequest.js';
+import {
+  prepareBoundedClientJsonPayload,
+  shapeClientRouteResult
+} from '@shared/http/clientResponseGuards.js';
+import {
+  applyLegacyRouteDeprecationHeaders,
+  buildCanonicalGptRoute
+} from '@shared/http/gptRouteHeaders.js';
+import { generateMockResponse } from '@services/openai/mock.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function extractLegacyTextInput(body: unknown): string {
+  return extractDiagnosticTextInput(isRecord(body) ? body : undefined) ?? '';
+}
+
+function isMockLikeResult(value: unknown): value is Record<string, unknown> {
+  return isRecord(value) && value.activeModel === 'MOCK';
+}
+
+function isTrinityResultLike(value: unknown): value is TrinityResult {
+  return isRecord(value)
+    && typeof value.result === 'string'
+    && isRecord(value.meta)
+    && (
+      Object.prototype.hasOwnProperty.call(value, 'dryRun')
+      || Object.prototype.hasOwnProperty.call(value, 'fallbackSummary')
+      || Object.prototype.hasOwnProperty.call(value, 'outputControls')
+      || Object.prototype.hasOwnProperty.call(value, 'capabilityFlags')
+    );
+}
+
+function isLegacyAiResponseLike(value: unknown): value is Record<string, unknown> {
+  return isRecord(value)
+    && typeof value.result === 'string'
+    && isRecord(value.meta);
+}
+
+function isCompletedSimulationResult(value: unknown): value is {
+  mode: 'complete';
+  scenario: string;
+  result: string;
+  metadata?: {
+    model?: string;
+    timestamp?: string;
+    simulationId?: string;
+    tokensUsed?: number;
+  };
+} {
+  return isRecord(value)
+    && value.mode === 'complete'
+    && typeof value.result === 'string';
+}
+
+function buildLegacySimulationResponse(result: {
+  mode: 'complete';
+  scenario: string;
+  result: string;
+  metadata?: {
+    model?: string;
+    timestamp?: string;
+    simulationId?: string;
+    tokensUsed?: number;
+  };
+}) {
+  const createdAtMs = Date.parse(result.metadata?.timestamp ?? '');
+  const normalizedCreatedAt = Number.isFinite(createdAtMs)
+    ? Math.floor(createdAtMs / 1000)
+    : Math.floor(Date.now() / 1000);
+  const tokenCount = typeof result.metadata?.tokensUsed === 'number' && Number.isFinite(result.metadata.tokensUsed)
+    ? Math.max(0, Math.trunc(result.metadata.tokensUsed))
+    : null;
+
+  return {
+    result: result.result,
+    module: 'ARCANOS:SIM',
+    endpoint: 'sim',
+    meta: {
+      id: result.metadata?.simulationId ?? `sim-${normalizedCreatedAt}`,
+      created: normalizedCreatedAt,
+      ...(tokenCount !== null
+        ? {
+            tokens: {
+              prompt_tokens: 0,
+              completion_tokens: tokenCount,
+              total_tokens: tokenCount
+            }
+          }
+        : {})
+    },
+    ...(readString(result.metadata?.model) ? { activeModel: readString(result.metadata?.model) } : {}),
+    fallbackFlag: false
+  };
+}
+
+export function createLegacyRouteDeprecationMiddleware(gptId: string) {
+  return (_req: Request, res: Response, next: NextFunction): void => {
+    applyLegacyRouteDeprecationHeaders(res, buildCanonicalGptRoute(gptId));
+    next();
+  };
+}
+
+export function buildLegacyDispatchBody(body: unknown, action: string): Record<string, unknown> {
+  return {
+    action,
+    payload: body
+  };
+}
+
+export function buildLegacyArcanosDispatchBody(body: unknown): Record<string, unknown> {
+  const normalizedBody = isRecord(body) ? body : {};
+  const prompt = readString(normalizedBody.userInput);
+  const sessionId = readString(normalizedBody.sessionId);
+  const overrideAuditSafe = readString(normalizedBody.overrideAuditSafe);
+
+  return {
+    action: 'query',
+    payload: {
+      ...(prompt ? { prompt } : {}),
+      ...(sessionId ? { sessionId } : {}),
+      ...(overrideAuditSafe ? { overrideAuditSafe } : {})
+    }
+  };
+}
+
+export function buildLegacyModuleDispatchBody(action: string, payload: unknown): Record<string, unknown> {
+  return {
+    action,
+    payload
+  };
+}
+
+export function adaptLegacyAiRouteResult(
+  endpointName: 'write' | 'guide' | 'sim',
+  body: unknown,
+  result: unknown
+): unknown {
+  const input = extractLegacyTextInput(body);
+
+  if (isMockLikeResult(result) && input) {
+    return {
+      ...generateMockResponse(input, endpointName),
+      endpoint: endpointName
+    };
+  }
+
+  if (isTrinityResultLike(result)) {
+    const clientContext = isRecord(body) && isRecord(body.clientContext)
+      ? body.clientContext
+      : undefined;
+
+    return {
+      ...buildTrinityUserVisibleResponse({
+        trinityResult: result,
+        endpoint: endpointName,
+        ...(clientContext ? { clientContext } : {})
+      }),
+      endpoint: endpointName
+    };
+  }
+
+  if (endpointName === 'sim' && isCompletedSimulationResult(result)) {
+    return buildLegacySimulationResponse(result);
+  }
+
+  if (isLegacyAiResponseLike(result)) {
+    return {
+      ...result,
+      endpoint: readString(result.endpoint) ?? endpointName
+    };
+  }
+
+  if (isRecord(result)) {
+    return {
+      ...result,
+      endpoint: endpointName
+    };
+  }
+
+  return result;
+}
+
+export function adaptLegacyArcanosRouteResult(
+  body: unknown,
+  result: unknown,
+  req: Request
+): unknown {
+  const input = extractLegacyTextInput(body);
+
+  if (isMockLikeResult(result) && input) {
+    return generateMockResponse(input, 'arcanos');
+  }
+
+  if (!isRecord(result)) {
+    return result;
+  }
+
+  const shapedResult = shapeClientRouteResult(result);
+  if (!isRecord(shapedResult)) {
+    return shapedResult;
+  }
+
+  return prepareBoundedClientJsonPayload(shapedResult, {
+    logger: req.logger,
+    logEvent: 'legacy.route.arcanos.response'
+  }).payload;
+}
+
+export function unwrapLegacyModuleRouteResult(result: unknown): unknown {
+  return result;
+}

--- a/src/routes/ai-endpoints.ts
+++ b/src/routes/ai-endpoints.ts
@@ -8,20 +8,36 @@ import express from 'express';
 import { confirmGate } from "@transport/http/middleware/confirmGate.js";
 import { validateSchema } from "@transport/http/middleware/validation.js";
 import AIController from "@transport/http/controllers/aiController.js";
+import { dispatchLegacyRouteToGpt } from './_core/legacyGptCompat.js';
 
 const router = express.Router();
 // Core AI endpoints using clean controller pattern with validation
 
 // Write endpoint - Primary content generation endpoint
-router.post('/write', validateSchema('aiRequest'), confirmGate, AIController.write);
+router.post(
+  '/write',
+  validateSchema('aiRequest'),
+  confirmGate,
+  (req, res, next) => dispatchLegacyRouteToGpt(req, res, next, { legacyRoute: '/write', gptId: 'write' })
+);
 
 // Guide endpoint - Primary step-by-step guidance endpoint  
-router.post('/guide', validateSchema('aiRequest'), confirmGate, AIController.guide);
+router.post(
+  '/guide',
+  validateSchema('aiRequest'),
+  confirmGate,
+  (req, res, next) => dispatchLegacyRouteToGpt(req, res, next, { legacyRoute: '/guide', gptId: 'guide' })
+);
 
 // Audit endpoint - Primary analysis and evaluation endpoint
 router.post('/audit', validateSchema('aiRequest'), confirmGate, AIController.audit);
 
 // Sim endpoint - Primary simulations and modeling endpoint
-router.post('/sim', validateSchema('aiRequest'), confirmGate, AIController.sim);
+router.post(
+  '/sim',
+  validateSchema('aiRequest'),
+  confirmGate,
+  (req, res, next) => dispatchLegacyRouteToGpt(req, res, next, { legacyRoute: '/sim', gptId: 'sim' })
+);
 
 export default router;

--- a/src/routes/ai-endpoints.ts
+++ b/src/routes/ai-endpoints.ts
@@ -1,7 +1,6 @@
 /**
- * Core AI Endpoints - Primary Implementation
- * Handles /write, /guide, /audit, and /sim endpoints using OpenAI SDK
- * These are the main endpoints for ARCANOS AI functionality
+ * Legacy root-route compatibility shims plus the canonical /audit handler.
+ * Deprecated /write, /guide, and /sim requests are adapted onto /gpt/:gptId.
  */
 
 import express from 'express';
@@ -9,35 +8,59 @@ import { confirmGate } from "@transport/http/middleware/confirmGate.js";
 import { validateSchema } from "@transport/http/middleware/validation.js";
 import AIController from "@transport/http/controllers/aiController.js";
 import { dispatchLegacyRouteToGpt } from './_core/legacyGptCompat.js';
+import {
+  adaptLegacyAiRouteResult,
+  buildLegacyDispatchBody,
+  createLegacyRouteDeprecationMiddleware
+} from './_core/legacyRouteAdapters.js';
 
 const router = express.Router();
-// Core AI endpoints using clean controller pattern with validation
-
-// Write endpoint - Primary content generation endpoint
+// Write endpoint compatibility shim
 router.post(
   '/write',
+  createLegacyRouteDeprecationMiddleware('write'),
   validateSchema('aiRequest'),
   confirmGate,
-  (req, res, next) => dispatchLegacyRouteToGpt(req, res, next, { legacyRoute: '/write', gptId: 'write' })
+  (req, res, next) => dispatchLegacyRouteToGpt(req, res, next, {
+    legacyRoute: '/write',
+    gptId: 'write',
+    applyDeprecationHeaders: false,
+    bodyTransform: (body) => buildLegacyDispatchBody(body, 'query'),
+    successBodyTransform: (result, request) => adaptLegacyAiRouteResult('write', request.body, result)
+  })
 );
 
-// Guide endpoint - Primary step-by-step guidance endpoint  
+// Guide endpoint compatibility shim
 router.post(
   '/guide',
+  createLegacyRouteDeprecationMiddleware('guide'),
   validateSchema('aiRequest'),
   confirmGate,
-  (req, res, next) => dispatchLegacyRouteToGpt(req, res, next, { legacyRoute: '/guide', gptId: 'guide' })
+  (req, res, next) => dispatchLegacyRouteToGpt(req, res, next, {
+    legacyRoute: '/guide',
+    gptId: 'guide',
+    applyDeprecationHeaders: false,
+    bodyTransform: (body) => buildLegacyDispatchBody(body, 'query'),
+    successBodyTransform: (result, request) => adaptLegacyAiRouteResult('guide', request.body, result)
+  })
 );
 
-// Audit endpoint - Primary analysis and evaluation endpoint
+// Audit endpoint remains on the direct controller path
 router.post('/audit', validateSchema('aiRequest'), confirmGate, AIController.audit);
 
-// Sim endpoint - Primary simulations and modeling endpoint
+// Sim endpoint compatibility shim
 router.post(
   '/sim',
+  createLegacyRouteDeprecationMiddleware('sim'),
   validateSchema('aiRequest'),
   confirmGate,
-  (req, res, next) => dispatchLegacyRouteToGpt(req, res, next, { legacyRoute: '/sim', gptId: 'sim' })
+  (req, res, next) => dispatchLegacyRouteToGpt(req, res, next, {
+    legacyRoute: '/sim',
+    gptId: 'sim',
+    applyDeprecationHeaders: false,
+    bodyTransform: (body) => buildLegacyDispatchBody(body, 'run'),
+    successBodyTransform: (result, request) => adaptLegacyAiRouteResult('sim', request.body, result)
+  })
 );
 
 export default router;

--- a/src/routes/arcanos.ts
+++ b/src/routes/arcanos.ts
@@ -1,16 +1,27 @@
 import express from 'express';
 import { confirmGate } from "@transport/http/middleware/confirmGate.js";
 import { dispatchLegacyRouteToGpt } from './_core/legacyGptCompat.js';
+import {
+  adaptLegacyArcanosRouteResult,
+  buildLegacyArcanosDispatchBody,
+  createLegacyRouteDeprecationMiddleware
+} from './_core/legacyRouteAdapters.js';
 
 const router = express.Router();
 
 /**
  * Compatibility shim for the deprecated `/arcanos` endpoint.
  */
-router.post('/arcanos', confirmGate, (req, res, next) =>
-  dispatchLegacyRouteToGpt(req, res, next, {
+router.post(
+  '/arcanos',
+  createLegacyRouteDeprecationMiddleware('arcanos-core'),
+  confirmGate,
+  (req, res, next) => dispatchLegacyRouteToGpt(req, res, next, {
     legacyRoute: '/arcanos',
-    gptId: 'arcanos-core'
+    gptId: 'arcanos-core',
+    applyDeprecationHeaders: false,
+    bodyTransform: (body) => buildLegacyArcanosDispatchBody(body),
+    successBodyTransform: (result, request) => adaptLegacyArcanosRouteResult(request.body, result, request)
   })
 );
 

--- a/src/routes/arcanos.ts
+++ b/src/routes/arcanos.ts
@@ -1,113 +1,17 @@
-import express, { Request, Response } from 'express';
-import { hasValidAPIKey } from "@services/openai.js";
-import { runARCANOS } from "@core/logic/arcanos.js";
-import { handleAIError, sendMockAIResponse } from "@transport/http/requestHandler.js";
+import express from 'express';
 import { confirmGate } from "@transport/http/middleware/confirmGate.js";
-import type { AIResponseDTO, ErrorResponseDTO } from "@shared/types/dto.js";
-import { getOpenAIClientOrAdapter } from "@services/openai/clientBridge.js";
-import { sendBadRequest } from '@shared/http/index.js';
-import {
-  prepareBoundedClientJsonPayload,
-  shapeClientRouteResult
-} from '@shared/http/clientResponseGuards.js';
+import { dispatchLegacyRouteToGpt } from './_core/legacyGptCompat.js';
 
 const router = express.Router();
 
-interface ArcanosRequest {
-  userInput: string;
-  sessionId?: string;
-  overrideAuditSafe?: string;
-}
-
-interface ArcanosResponse extends AIResponseDTO {
-  result: string;
-  componentStatus?: string;
-  suggestedFixes?: string;
-  coreLogicTrace?: string;
-  meta: {
-    tokens?: {
-      prompt_tokens: number;
-      completion_tokens: number;
-      total_tokens: number;
-    } | undefined;
-    id: string;
-    created: number;
-  };
-  activeModel?: string;
-  fallbackFlag?: boolean;
-  gpt5Delegation?: {
-    used: boolean;
-    reason?: string;
-    delegatedQuery?: string;
-  };
-  auditSafe?: {
-    mode: boolean;
-    overrideUsed: boolean;
-    overrideReason?: string;
-    auditFlags: string[];
-    processedSafely: boolean;
-  };
-  memoryContext?: {
-    entriesAccessed: number;
-    contextSummary: string;
-    memoryEnhanced: boolean;
-  };
-  taskLineage?: {
-    requestId: string;
-    logged: boolean;
-  };
-  error?: string;
-}
-
 /**
- * ARCANOS system diagnosis endpoint with standardized request handling
+ * Compatibility shim for the deprecated `/arcanos` endpoint.
  */
-router.post('/arcanos', confirmGate, async (
-  req: Request<{}, ArcanosResponse | ErrorResponseDTO, ArcanosRequest>,
-  res: Response<ArcanosResponse | ErrorResponseDTO>
-) => {
-  console.log('🔬 /arcanos received');
-  const { userInput, sessionId, overrideAuditSafe } = req.body;
-
-  if (!userInput || typeof userInput !== 'string') {
-    return sendBadRequest(res, 'Missing or invalid userInput in request body');
-  }
-
-  console.log(`[🔬 ARCANOS] Processing request with sessionId: ${sessionId || 'none'}, auditOverride: ${overrideAuditSafe || 'none'}`);
-
-  // Use shared validation logic for OpenAI client
-  if (!hasValidAPIKey()) {
-    return sendMockAIResponse(res, userInput, 'arcanos', 'no API key');
-  }
-
-  const { adapter, client: openai } = getOpenAIClientOrAdapter();
-  if (!adapter) {
-    return sendMockAIResponse(res, userInput, 'arcanos', 'adapter init failed');
-  }
-
-  if (!openai) {
-    return sendMockAIResponse(res, userInput, 'arcanos', 'client init failed');
-  }
-
-  try {
-    const output = await runARCANOS(openai, userInput, sessionId, overrideAuditSafe);
-    const publicPayload = prepareBoundedClientJsonPayload(
-      shapeClientRouteResult(output) as Record<string, unknown>,
-      {
-        logger: req.logger,
-        logEvent: 'arcanos.response',
-      }
-    );
-
-    res.setHeader('x-response-bytes', String(publicPayload.responseBytes));
-    if (publicPayload.truncated) {
-      res.setHeader('x-response-truncated', 'true');
-    }
-
-    return res.json(publicPayload.payload as unknown as ArcanosResponse);
-  } catch (err) {
-    handleAIError(err, userInput, 'arcanos', res);
-  }
-});
+router.post('/arcanos', confirmGate, (req, res, next) =>
+  dispatchLegacyRouteToGpt(req, res, next, {
+    legacyRoute: '/arcanos',
+    gptId: 'arcanos-core'
+  })
+);
 
 export default router;

--- a/src/routes/modules.ts
+++ b/src/routes/modules.ts
@@ -3,6 +3,9 @@ import { loadModuleDefinitions, ModuleDef } from '@services/moduleLoader.js';
 import { resolveErrorMessage } from "@core/lib/errors/index.js";
 import { logger } from "@platform/logging/structuredLogging.js";
 import { sendBadRequest, sendNotFound, sendInternalErrorPayload } from '@shared/http/index.js';
+import { dispatchLegacyRouteToGpt } from './_core/legacyGptCompat.js';
+import { applyLegacyRouteDeprecationHeaders, buildCanonicalGptRoute } from '@shared/http/gptRouteHeaders.js';
+import { legacyGptRoutesEnabled } from '@platform/runtime/legacyRouteMode.js';
 
 const router = express.Router();
 
@@ -10,8 +13,19 @@ const registryByRoute = new Map<string, ModuleDef>();
 const registryByName = new Map<string, ModuleDef>();
 const moduleRoutes = new Map<string, string>();
 
-function createHandler(mod: ModuleDef) {
-  return async (req: Request, res: Response) => {
+function createHandler(mod: ModuleDef, route: string) {
+  return async (req: Request, res: Response, next: (error?: unknown) => void) => {
+    const canonicalGptId = mod.gptIds?.[0] ?? mod.name;
+
+    if (canonicalGptId) {
+      return dispatchLegacyRouteToGpt(req, res, next as any, {
+        legacyRoute: `/modules/${route}`,
+        gptId: canonicalGptId
+      });
+    }
+
+    applyLegacyRouteDeprecationHeaders(res, buildCanonicalGptRoute());
+
     //audit Assumption: rerouted requests should not execute module actions; risk: conflicting side effects; invariant: module execution skipped; handling: log warning + return safe error.
     if (req.dispatchRerouted && req.dispatchDecision === 'reroute') {
       logger.warn('Rerouted request reached module handler unexpectedly', {
@@ -60,7 +74,9 @@ export function registerModule(route: string, mod: ModuleDef) {
   registryByRoute.set(route, mod);
   registryByName.set(mod.name, mod);
   moduleRoutes.set(mod.name, route);
-  router.post(`/modules/${route}`, createHandler(mod));
+  if (legacyGptRoutesEnabled()) {
+    router.post(`/modules/${route}`, createHandler(mod, route));
+  }
 }
 
 /**
@@ -173,47 +189,68 @@ router.get('/registry/:moduleName', (req: Request, res: Response) => {
   });
 });
 
-router.post('/queryroute', async (req: Request, res: Response) => {
-  //audit Assumption: rerouted requests should not execute module query routes; risk: conflicting side effects; invariant: queryroute skipped; handling: log warning + return safe error.
-  if (req.dispatchRerouted && req.dispatchDecision === 'reroute') {
-    logger.warn('Rerouted request reached queryroute handler unexpectedly', {
-      module: 'modules',
-      url: req.url,
-      originalRoute: (req.body as Record<string, unknown>)?.dispatchReroute
-    });
-    return res.status(409).json({
-      error: 'Dispatch rerouted to safe default dispatcher',
-      code: 'DISPATCH_REROUTED',
-      target: '/gpt/arcanos-daemon'
-    });
-  }
+if (legacyGptRoutesEnabled()) {
+  router.post('/queryroute', async (req: Request, res: Response, next: (error?: unknown) => void) => {
+    const { module: moduleName } = req.body as {
+      module?: string;
+      action?: string;
+      payload?: unknown;
+    };
+    const mod = typeof moduleName === 'string'
+      ? (registryByName.get(moduleName) ?? registryByRoute.get(moduleName))
+      : undefined;
+    const canonicalGptId = mod?.gptIds?.[0] ?? (typeof moduleName === 'string' ? moduleName : null);
 
-  const { module: moduleName, action, payload } = req.body as {
-    module?: string;
-    action?: string;
-    payload?: unknown;
-  };
-  if (!moduleName) {
-    return sendBadRequest(res, 'Module name is required');
-  }
-  const mod = registryByName.get(moduleName) ?? registryByRoute.get(moduleName);
-  if (!mod) {
-    return sendNotFound(res, 'Module not found');
-  }
-  if (!action) {
-    return sendBadRequest(res, 'Action is required');
-  }
-  const handler = mod.actions[action];
-  if (!handler) {
-    return sendNotFound(res, 'Action not found');
-  }
-  try {
-    const result = await handler(payload);
-    res.json(result);
-  } catch (err: unknown) {
-    //audit Assumption: module failures should return 500
-    sendInternalErrorPayload(res, { error: resolveErrorMessage(err) });
-  }
-});
+    if (canonicalGptId) {
+      return dispatchLegacyRouteToGpt(req, res, next as any, {
+        legacyRoute: '/queryroute',
+        gptId: canonicalGptId
+      });
+    }
+
+    applyLegacyRouteDeprecationHeaders(res, buildCanonicalGptRoute());
+
+    //audit Assumption: rerouted requests should not execute module query routes; risk: conflicting side effects; invariant: queryroute skipped; handling: log warning + return safe error.
+    if (req.dispatchRerouted && req.dispatchDecision === 'reroute') {
+      logger.warn('Rerouted request reached queryroute handler unexpectedly', {
+        module: 'modules',
+        url: req.url,
+        originalRoute: (req.body as Record<string, unknown>)?.dispatchReroute
+      });
+      return res.status(409).json({
+        error: 'Dispatch rerouted to safe default dispatcher',
+        code: 'DISPATCH_REROUTED',
+        target: '/gpt/arcanos-daemon'
+      });
+    }
+
+    const { module: moduleRouteOrName, action, payload } = req.body as {
+      module?: string;
+      action?: string;
+      payload?: unknown;
+    };
+    if (!moduleRouteOrName) {
+      return sendBadRequest(res, 'Module name is required');
+    }
+    const fallbackMod = registryByName.get(moduleRouteOrName) ?? registryByRoute.get(moduleRouteOrName);
+    if (!fallbackMod) {
+      return sendNotFound(res, 'Module not found');
+    }
+    if (!action) {
+      return sendBadRequest(res, 'Action is required');
+    }
+    const handler = fallbackMod.actions[action];
+    if (!handler) {
+      return sendNotFound(res, 'Action not found');
+    }
+    try {
+      const result = await handler(payload);
+      res.json(result);
+    } catch (err: unknown) {
+      //audit Assumption: module failures should return 500
+      sendInternalErrorPayload(res, { error: resolveErrorMessage(err) });
+    }
+  });
+}
 
 export default router;

--- a/src/routes/modules.ts
+++ b/src/routes/modules.ts
@@ -1,4 +1,4 @@
-import express, { Request, Response } from 'express';
+import express, { NextFunction, Request, Response } from 'express';
 import { loadModuleDefinitions, ModuleDef } from '@services/moduleLoader.js';
 import { resolveErrorMessage } from "@core/lib/errors/index.js";
 import { logger } from "@platform/logging/structuredLogging.js";
@@ -13,12 +13,33 @@ const registryByRoute = new Map<string, ModuleDef>();
 const registryByName = new Map<string, ModuleDef>();
 const moduleRoutes = new Map<string, string>();
 
+type ModuleDispatchRequestBody = {
+  module?: string;
+  action?: string;
+  payload?: unknown;
+};
+
+function resolveModuleDispatchTarget(moduleName: string | undefined): {
+  mod: ModuleDef | undefined;
+  canonicalGptId: string | null;
+} {
+  const mod = typeof moduleName === 'string'
+    ? (registryByName.get(moduleName) ?? registryByRoute.get(moduleName))
+    : undefined;
+  const canonicalGptId = mod?.gptIds?.[0] ?? (typeof moduleName === 'string' ? moduleName : null);
+
+  return {
+    mod,
+    canonicalGptId
+  };
+}
+
 function createHandler(mod: ModuleDef, route: string) {
-  return async (req: Request, res: Response, next: (error?: unknown) => void) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
     const canonicalGptId = mod.gptIds?.[0] ?? mod.name;
 
     if (canonicalGptId) {
-      return dispatchLegacyRouteToGpt(req, res, next as any, {
+      return dispatchLegacyRouteToGpt(req, res, next, {
         legacyRoute: `/modules/${route}`,
         gptId: canonicalGptId
       });
@@ -40,11 +61,7 @@ function createHandler(mod: ModuleDef, route: string) {
       });
     }
 
-    const { module, action, payload } = req.body as {
-      module?: string;
-      action?: string;
-      payload?: unknown;
-    };
+    const { module, action, payload } = req.body as ModuleDispatchRequestBody;
     if (module !== mod.name) {
       return sendNotFound(res, 'Module not found');
     }
@@ -190,19 +207,12 @@ router.get('/registry/:moduleName', (req: Request, res: Response) => {
 });
 
 if (legacyGptRoutesEnabled()) {
-  router.post('/queryroute', async (req: Request, res: Response, next: (error?: unknown) => void) => {
-    const { module: moduleName } = req.body as {
-      module?: string;
-      action?: string;
-      payload?: unknown;
-    };
-    const mod = typeof moduleName === 'string'
-      ? (registryByName.get(moduleName) ?? registryByRoute.get(moduleName))
-      : undefined;
-    const canonicalGptId = mod?.gptIds?.[0] ?? (typeof moduleName === 'string' ? moduleName : null);
+  router.post('/queryroute', async (req: Request, res: Response, next: NextFunction) => {
+    const { module: moduleName, action, payload } = req.body as ModuleDispatchRequestBody;
+    const { mod, canonicalGptId } = resolveModuleDispatchTarget(moduleName);
 
     if (canonicalGptId) {
-      return dispatchLegacyRouteToGpt(req, res, next as any, {
+      return dispatchLegacyRouteToGpt(req, res, next, {
         legacyRoute: '/queryroute',
         gptId: canonicalGptId
       });
@@ -224,22 +234,16 @@ if (legacyGptRoutesEnabled()) {
       });
     }
 
-    const { module: moduleRouteOrName, action, payload } = req.body as {
-      module?: string;
-      action?: string;
-      payload?: unknown;
-    };
-    if (!moduleRouteOrName) {
+    if (!moduleName) {
       return sendBadRequest(res, 'Module name is required');
     }
-    const fallbackMod = registryByName.get(moduleRouteOrName) ?? registryByRoute.get(moduleRouteOrName);
-    if (!fallbackMod) {
+    if (!mod) {
       return sendNotFound(res, 'Module not found');
     }
     if (!action) {
       return sendBadRequest(res, 'Action is required');
     }
-    const handler = fallbackMod.actions[action];
+    const handler = mod.actions[action];
     if (!handler) {
       return sendNotFound(res, 'Action not found');
     }

--- a/src/routes/modules.ts
+++ b/src/routes/modules.ts
@@ -6,6 +6,10 @@ import { sendBadRequest, sendNotFound, sendInternalErrorPayload } from '@shared/
 import { dispatchLegacyRouteToGpt } from './_core/legacyGptCompat.js';
 import { applyLegacyRouteDeprecationHeaders, buildCanonicalGptRoute } from '@shared/http/gptRouteHeaders.js';
 import { legacyGptRoutesEnabled } from '@platform/runtime/legacyRouteMode.js';
+import {
+  buildLegacyModuleDispatchBody,
+  unwrapLegacyModuleRouteResult
+} from './_core/legacyRouteAdapters.js';
 
 const router = express.Router();
 
@@ -19,33 +23,19 @@ type ModuleDispatchRequestBody = {
   payload?: unknown;
 };
 
-function resolveModuleDispatchTarget(moduleName: string | undefined): {
-  mod: ModuleDef | undefined;
-  canonicalGptId: string | null;
-} {
-  const mod = typeof moduleName === 'string'
+function resolveRegisteredModule(moduleName: string | undefined): ModuleDef | undefined {
+  return typeof moduleName === 'string'
     ? (registryByName.get(moduleName) ?? registryByRoute.get(moduleName))
     : undefined;
-  const canonicalGptId = mod?.gptIds?.[0] ?? (typeof moduleName === 'string' ? moduleName : null);
-
-  return {
-    mod,
-    canonicalGptId
-  };
 }
 
 function createHandler(mod: ModuleDef, route: string) {
   return async (req: Request, res: Response, next: NextFunction) => {
-    const canonicalGptId = mod.gptIds?.[0] ?? mod.name;
-
-    if (canonicalGptId) {
-      return dispatchLegacyRouteToGpt(req, res, next, {
-        legacyRoute: `/modules/${route}`,
-        gptId: canonicalGptId
-      });
-    }
-
-    applyLegacyRouteDeprecationHeaders(res, buildCanonicalGptRoute());
+    const canonicalGptId = mod.gptIds?.[0] ?? null;
+    applyLegacyRouteDeprecationHeaders(
+      res,
+      canonicalGptId ? buildCanonicalGptRoute(canonicalGptId) : buildCanonicalGptRoute()
+    );
 
     //audit Assumption: rerouted requests should not execute module actions; risk: conflicting side effects; invariant: module execution skipped; handling: log warning + return safe error.
     if (req.dispatchRerouted && req.dispatchDecision === 'reroute') {
@@ -71,6 +61,15 @@ function createHandler(mod: ModuleDef, route: string) {
     const handler = mod.actions[action];
     if (!handler) {
       return sendNotFound(res, 'Action not found');
+    }
+    if (canonicalGptId) {
+      return dispatchLegacyRouteToGpt(req, res, next, {
+        legacyRoute: `/modules/${route}`,
+        gptId: canonicalGptId,
+        applyDeprecationHeaders: false,
+        bodyTransform: () => buildLegacyModuleDispatchBody(action, payload),
+        successBodyTransform: (result) => unwrapLegacyModuleRouteResult(result)
+      });
     }
     try {
       const result = await handler(payload);
@@ -209,16 +208,12 @@ router.get('/registry/:moduleName', (req: Request, res: Response) => {
 if (legacyGptRoutesEnabled()) {
   router.post('/queryroute', async (req: Request, res: Response, next: NextFunction) => {
     const { module: moduleName, action, payload } = req.body as ModuleDispatchRequestBody;
-    const { mod, canonicalGptId } = resolveModuleDispatchTarget(moduleName);
-
-    if (canonicalGptId) {
-      return dispatchLegacyRouteToGpt(req, res, next, {
-        legacyRoute: '/queryroute',
-        gptId: canonicalGptId
-      });
-    }
-
-    applyLegacyRouteDeprecationHeaders(res, buildCanonicalGptRoute());
+    const mod = resolveRegisteredModule(moduleName);
+    const canonicalGptId = mod?.gptIds?.[0] ?? null;
+    applyLegacyRouteDeprecationHeaders(
+      res,
+      canonicalGptId ? buildCanonicalGptRoute(canonicalGptId) : buildCanonicalGptRoute()
+    );
 
     //audit Assumption: rerouted requests should not execute module query routes; risk: conflicting side effects; invariant: queryroute skipped; handling: log warning + return safe error.
     if (req.dispatchRerouted && req.dispatchDecision === 'reroute') {
@@ -246,6 +241,15 @@ if (legacyGptRoutesEnabled()) {
     const handler = mod.actions[action];
     if (!handler) {
       return sendNotFound(res, 'Action not found');
+    }
+    if (canonicalGptId) {
+      return dispatchLegacyRouteToGpt(req, res, next, {
+        legacyRoute: '/queryroute',
+        gptId: canonicalGptId,
+        applyDeprecationHeaders: false,
+        bodyTransform: () => buildLegacyModuleDispatchBody(action, payload),
+        successBodyTransform: (result) => unwrapLegacyModuleRouteResult(result)
+      });
     }
     try {
       const result = await handler(payload);

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -115,9 +115,9 @@ export function registerRoutes(app: Express): void {
   app.use('/', queryFinetuneRouter);
   app.use('/', apiSessionSystemRouter);
   app.use('/', apiRouter);
+  app.use('/', arcanosPipelineRouter);
   if (legacyGptRoutesEnabled()) {
     app.use('/', arcanosRouter);
-    app.use('/', arcanosPipelineRouter);
     app.use('/', aiEndpointsRouter);
   }
   app.use('/', modulesRouter);

--- a/src/routes/register.ts
+++ b/src/routes/register.ts
@@ -41,6 +41,7 @@ import { sendTimestampedStatus } from "@platform/resilience/serviceUnavailable.j
 import { TRINITY_BASE_SOFT_CAP_MS, TRINITY_MULTIPLIERS } from "@core/logic/trinityGuards.js";
 import { WATCHDOG_LIMIT_MS, SAFETY_BUFFER_MS, BUDGET_DISABLED } from '../platform/resilience/runtimeBudget.js';
 import { resolveTimeout } from "@platform/runtime/watchdogConfig.js";
+import { legacyGptRoutesEnabled } from '@platform/runtime/legacyRouteMode.js';
 
 /**
  * Mounts all application routes on the provided Express app.
@@ -114,9 +115,11 @@ export function registerRoutes(app: Express): void {
   app.use('/', queryFinetuneRouter);
   app.use('/', apiSessionSystemRouter);
   app.use('/', apiRouter);
-  app.use('/', arcanosRouter);
-  app.use('/', arcanosPipelineRouter);
-  app.use('/', aiEndpointsRouter);
+  if (legacyGptRoutesEnabled()) {
+    app.use('/', arcanosRouter);
+    app.use('/', arcanosPipelineRouter);
+    app.use('/', aiEndpointsRouter);
+  }
   app.use('/', modulesRouter);
   app.use('/', workersRouter);
   app.use('/', orchestrationRouter);

--- a/src/shared/http/gptRouteHeaders.ts
+++ b/src/shared/http/gptRouteHeaders.ts
@@ -39,3 +39,22 @@ export function applyDeprecatedAskRouteHeaders(res: Response, gptId?: string | n
   res.append('Link', `<${canonicalRoute}>; rel="successor-version"`);
   return canonicalRoute;
 }
+
+export function applyLegacyRouteDeprecationHeaders(
+  res: Response,
+  canonicalRoute: string,
+  options?: {
+    sunset?: string | null;
+  }
+): string {
+  res.setHeader('x-canonical-route', canonicalRoute);
+  res.setHeader('Deprecation', 'true');
+  res.setHeader('x-route-deprecated', 'true');
+  const sunset = options?.sunset ?? ASK_ROUTE_SUNSET_HEADER;
+  if (sunset) {
+    res.setHeader('Sunset', sunset);
+  }
+  res.append('Link', `<${CUSTOM_GPT_CONTRACT_PATH}>; rel="describedby"`);
+  res.append('Link', `<${canonicalRoute}>; rel="successor-version"`);
+  return canonicalRoute;
+}

--- a/tests/arcanos-pipeline-route-gate.test.ts
+++ b/tests/arcanos-pipeline-route-gate.test.ts
@@ -1,0 +1,51 @@
+import { afterAll, describe, expect, it, jest } from '@jest/globals';
+
+const originalLegacyGptRoutes = process.env.LEGACY_GPT_ROUTES;
+process.env.LEGACY_GPT_ROUTES = 'disabled';
+
+const express = (await import('express')).default;
+const request = (await import('supertest')).default;
+
+const executeArcanosPipeline = jest.fn(async () => ({
+  result: 'pipeline-ok',
+  stages: ['stage-1']
+}));
+
+jest.unstable_mockModule('@services/arcanosPipeline.js', () => ({
+  executeArcanosPipeline
+}));
+
+const { registerRoutes } = await import('../src/routes/register.js');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  registerRoutes(app);
+  return app;
+}
+
+describe('arcanos pipeline route gate', () => {
+  afterAll(() => {
+    if (originalLegacyGptRoutes === undefined) {
+      delete process.env.LEGACY_GPT_ROUTES;
+      return;
+    }
+
+    process.env.LEGACY_GPT_ROUTES = originalLegacyGptRoutes;
+  });
+
+  it('keeps /arcanos-pipeline mounted when legacy GPT routes are disabled', async () => {
+    const response = await request(buildApp())
+      .post('/arcanos-pipeline')
+      .send({
+        messages: []
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      result: 'pipeline-ok',
+      stages: ['stage-1']
+    });
+    expect(executeArcanosPipeline).toHaveBeenCalledWith([]);
+  });
+});

--- a/tests/legacy-gpt-route-gate.test.ts
+++ b/tests/legacy-gpt-route-gate.test.ts
@@ -15,6 +15,11 @@ function buildApp() {
 
 describe('legacy GPT route gate', () => {
   afterEach(() => {
+    if (originalLegacyGptRoutes === undefined) {
+      delete process.env.LEGACY_GPT_ROUTES;
+      return;
+    }
+
     process.env.LEGACY_GPT_ROUTES = originalLegacyGptRoutes;
   });
 
@@ -29,8 +34,16 @@ describe('legacy GPT route gate', () => {
     const writeResponse = await request(app)
       .post('/write')
       .send({ prompt: 'hello' });
+    const guideResponse = await request(app)
+      .post('/guide')
+      .send({ prompt: 'hello' });
+    const simResponse = await request(app)
+      .post('/sim')
+      .send({ prompt: 'hello' });
 
     expect(arcanosResponse.status).toBe(404);
     expect(writeResponse.status).toBe(404);
+    expect(guideResponse.status).toBe(404);
+    expect(simResponse.status).toBe(404);
   });
 });

--- a/tests/legacy-gpt-route-gate.test.ts
+++ b/tests/legacy-gpt-route-gate.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+
+const express = (await import('express')).default;
+const request = (await import('supertest')).default;
+const { registerRoutes } = await import('../src/routes/register.js');
+
+const originalLegacyGptRoutes = process.env.LEGACY_GPT_ROUTES;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  registerRoutes(app);
+  return app;
+}
+
+describe('legacy GPT route gate', () => {
+  afterEach(() => {
+    process.env.LEGACY_GPT_ROUTES = originalLegacyGptRoutes;
+  });
+
+  it('omits deprecated root routes when legacy GPT routes are disabled', async () => {
+    process.env.LEGACY_GPT_ROUTES = 'disabled';
+
+    const app = buildApp();
+
+    const arcanosResponse = await request(app)
+      .post('/arcanos')
+      .send({ userInput: 'health check' });
+    const writeResponse = await request(app)
+      .post('/write')
+      .send({ prompt: 'hello' });
+
+    expect(arcanosResponse.status).toBe(404);
+    expect(writeResponse.status).toBe(404);
+  });
+});

--- a/tests/legacy-root-route-compat.test.ts
+++ b/tests/legacy-root-route-compat.test.ts
@@ -1,0 +1,160 @@
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const originalLegacyGptRoutes = process.env.LEGACY_GPT_ROUTES;
+process.env.LEGACY_GPT_ROUTES = 'enabled';
+
+const express = (await import('express')).default;
+const request = (await import('supertest')).default;
+
+const mockRouteGptRequest = jest.fn();
+
+jest.unstable_mockModule('../src/routes/_core/gptDispatch.js', () => ({
+  routeGptRequest: mockRouteGptRequest
+}));
+
+const arcanosRouter = (await import('../src/routes/arcanos.js')).default;
+const aiEndpointsRouter = (await import('../src/routes/ai-endpoints.js')).default;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/', arcanosRouter);
+  app.use('/', aiEndpointsRouter);
+  return app;
+}
+
+describe('legacy root route compatibility', () => {
+  afterAll(() => {
+    if (originalLegacyGptRoutes === undefined) {
+      delete process.env.LEGACY_GPT_ROUTES;
+      return;
+    }
+
+    process.env.LEGACY_GPT_ROUTES = originalLegacyGptRoutes;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    [
+      '/arcanos',
+      { userInput: 'inspect system', sessionId: 'sess-42', overrideAuditSafe: 'force' },
+      '/gpt/arcanos-core',
+      'arcanos',
+      {
+        action: 'query',
+        payload: {
+          prompt: 'inspect system',
+          sessionId: 'sess-42',
+          overrideAuditSafe: 'force'
+        }
+      }
+    ],
+    ['/write', { prompt: 'draft copy' }, '/gpt/write', 'write', { action: 'query', payload: { prompt: 'draft copy' } }],
+    ['/guide', { prompt: 'show steps' }, '/gpt/guide', 'guide', { action: 'query', payload: { prompt: 'show steps' } }],
+    ['/sim', { prompt: 'model scenario' }, '/gpt/sim', 'sim', { action: 'run', payload: { prompt: 'model scenario' } }]
+  ] as const)(
+    'preserves the legacy response shape for %s',
+    async (path, body, canonicalRoute, endpointName, expectedDispatchBody) => {
+      mockRouteGptRequest.mockResolvedValue({
+        ok: true,
+        result: {
+          activeModel: 'MOCK'
+        },
+        _route: {
+          gptId: endpointName,
+          timestamp: '2026-04-08T00:00:00.000Z'
+        }
+      });
+
+      const response = await request(buildApp())
+        .post(path)
+        .set('x-confirmed', 'yes')
+        .send(body);
+
+      expect(response.status).toBe(200);
+      expect(response.headers['x-canonical-route']).toBe(canonicalRoute);
+      expect(response.headers['x-route-deprecated']).toBe('true');
+      expect(response.body.ok).toBeUndefined();
+      expect(response.body._route).toBeUndefined();
+      expect(mockRouteGptRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expectedDispatchBody
+        })
+      );
+
+      if (endpointName === 'arcanos') {
+        expect(response.body.result).toContain('[MOCK ARCANOS RESPONSE]');
+        expect(response.body.componentStatus).toBeDefined();
+        expect(response.body.suggestedFixes).toBeDefined();
+        expect(response.body.coreLogicTrace).toBeDefined();
+        return;
+      }
+
+      if (endpointName === 'write') {
+        expect(response.body.result).toContain('[MOCK WRITE RESPONSE]');
+      }
+      if (endpointName === 'guide') {
+        expect(response.body.result).toContain('[MOCK GUIDE RESPONSE]');
+      }
+      if (endpointName === 'sim') {
+        expect(response.body.result).toContain('[MOCK SIMULATION RESPONSE]');
+      }
+      expect(response.body.endpoint).toBe(endpointName);
+    }
+  );
+
+  it.each([
+    ['/arcanos', { userInput: 'inspect system' }, '/gpt/arcanos-core'],
+    ['/write', { prompt: 'draft copy' }, '/gpt/write'],
+    ['/guide', { prompt: 'show steps' }, '/gpt/guide'],
+    ['/sim', { prompt: 'model scenario' }, '/gpt/sim']
+  ] as const)(
+    'keeps deprecation metadata on 403 confirmation blocks for %s',
+    async (path, body, canonicalRoute) => {
+      const response = await request(buildApp())
+        .post(path)
+        .send(body);
+
+      expect(response.status).toBe(403);
+      expect(response.headers['x-canonical-route']).toBe(canonicalRoute);
+      expect(response.headers.deprecation).toBe('true');
+      expect(response.headers.sunset).toBeDefined();
+      expect(response.headers.link).toContain(canonicalRoute);
+      expect(response.body.canonicalRoute).toBe(canonicalRoute);
+      expect(mockRouteGptRequest).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    ['UNKNOWN_GPT', 404],
+    ['SYSTEM_STATE_CONFLICT', 409],
+    ['MODULE_TIMEOUT', 504]
+  ] as const)(
+    'passes through shim error status %s',
+    async (errorCode, expectedStatus) => {
+      mockRouteGptRequest.mockResolvedValue({
+        ok: false,
+        error: {
+          code: errorCode,
+          message: 'dispatcher failure'
+        },
+        _route: {
+          gptId: 'write',
+          timestamp: '2026-04-08T00:00:00.000Z'
+        }
+      });
+
+      const response = await request(buildApp())
+        .post('/write')
+        .set('x-confirmed', 'yes')
+        .send({ prompt: 'draft copy' });
+
+      expect(response.status).toBe(expectedStatus);
+      expect(response.headers['x-canonical-route']).toBe('/gpt/write');
+      expect(response.body.error.code).toBe(errorCode);
+    }
+  );
+});

--- a/tests/modules.legacy-route-compat.test.ts
+++ b/tests/modules.legacy-route-compat.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
+const originalLegacyGptRoutes = process.env.LEGACY_GPT_ROUTES;
 process.env.LEGACY_GPT_ROUTES = 'enabled';
 
 const express = (await import('express')).default;
@@ -40,6 +41,15 @@ function buildApp() {
 }
 
 describe('module legacy route compatibility', () => {
+  afterAll(() => {
+    if (originalLegacyGptRoutes === undefined) {
+      delete process.env.LEGACY_GPT_ROUTES;
+      return;
+    }
+
+    process.env.LEGACY_GPT_ROUTES = originalLegacyGptRoutes;
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockRouteGptRequest.mockResolvedValue({
@@ -73,7 +83,6 @@ describe('module legacy route compatibility', () => {
       expect.objectContaining({
         gptId: 'test-legacy-gpt',
         body: {
-          module: 'TEST:MODULE',
           action: 'query',
           payload: {
             prompt: 'hello'
@@ -84,14 +93,27 @@ describe('module legacy route compatibility', () => {
     expect(moduleActionHandler).not.toHaveBeenCalled();
     expect(response.body).toMatchObject({
       ok: true,
-      result: {
-        ok: true,
-        echoedPrompt: 'hello'
-      },
-      _route: {
-        gptId: 'test-legacy-gpt'
-      }
+      echoedPrompt: 'hello'
     });
+    expect(response.body._route).toBeUndefined();
+  });
+
+  it('preserves the legacy /modules/:route validation contract before dispatching', async () => {
+    const response = await request(buildApp())
+      .post('/modules/test-route')
+      .send({
+        action: 'query',
+        payload: {
+          prompt: 'hello'
+        }
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({
+      error: 'Module not found'
+    });
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+    expect(moduleActionHandler).not.toHaveBeenCalled();
   });
 
   it('proxies /queryroute traffic through the canonical GPT dispatcher', async () => {
@@ -110,9 +132,54 @@ describe('module legacy route compatibility', () => {
     expect(response.headers['x-route-deprecated']).toBe('true');
     expect(mockRouteGptRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        gptId: 'test-legacy-gpt'
+        gptId: 'test-legacy-gpt',
+        body: {
+          action: 'query',
+          payload: {
+            prompt: 'hello'
+          }
+        }
       })
     );
-    expect(response.body._route.gptId).toBe('test-legacy-gpt');
+    expect(response.body).toMatchObject({
+      ok: true,
+      echoedPrompt: 'hello'
+    });
+    expect(response.body._route).toBeUndefined();
+  });
+
+  it('preserves the legacy /queryroute validation contract before dispatching', async () => {
+    const response = await request(buildApp())
+      .post('/queryroute')
+      .send({
+        module: 'TEST:MODULE',
+        payload: {
+          prompt: 'hello'
+        }
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      error: 'Action is required'
+    });
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('does not fall through to raw GPT ids for unknown /queryroute modules', async () => {
+    const response = await request(buildApp())
+      .post('/queryroute')
+      .send({
+        module: 'no-such-gpt',
+        action: 'query',
+        payload: {
+          prompt: 'hello'
+        }
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({
+      error: 'Module not found'
+    });
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 });

--- a/tests/modules.legacy-route-compat.test.ts
+++ b/tests/modules.legacy-route-compat.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+process.env.LEGACY_GPT_ROUTES = 'enabled';
+
+const express = (await import('express')).default;
+const request = (await import('supertest')).default;
+
+const mockRouteGptRequest = jest.fn();
+const moduleActionHandler = jest.fn();
+
+jest.unstable_mockModule('../src/routes/_core/gptDispatch.js', () => ({
+  routeGptRequest: mockRouteGptRequest
+}));
+
+jest.unstable_mockModule('@services/moduleLoader.js', () => ({
+  clearModuleDefinitionCache: jest.fn(),
+  loadModuleDefinitions: jest.fn(async () => [
+    {
+      route: 'test-route',
+      definition: {
+        name: 'TEST:MODULE',
+        description: null,
+        gptIds: ['test-legacy-gpt'],
+        defaultAction: 'query',
+        actions: {
+          query: moduleActionHandler
+        }
+      }
+    }
+  ])
+}));
+
+const modulesRouter = (await import('../src/routes/modules.js')).default;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/', modulesRouter);
+  return app;
+}
+
+describe('module legacy route compatibility', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRouteGptRequest.mockResolvedValue({
+      ok: true,
+      result: {
+        ok: true,
+        echoedPrompt: 'hello'
+      },
+      _route: {
+        gptId: 'test-legacy-gpt',
+        timestamp: '2026-04-07T00:00:00.000Z'
+      }
+    });
+  });
+
+  it('proxies /modules/:route traffic through the canonical GPT dispatcher', async () => {
+    const response = await request(buildApp())
+      .post('/modules/test-route')
+      .send({
+        module: 'TEST:MODULE',
+        action: 'query',
+        payload: {
+          prompt: 'hello'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['x-canonical-route']).toBe('/gpt/test-legacy-gpt');
+    expect(response.headers['x-route-deprecated']).toBe('true');
+    expect(mockRouteGptRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gptId: 'test-legacy-gpt',
+        body: {
+          module: 'TEST:MODULE',
+          action: 'query',
+          payload: {
+            prompt: 'hello'
+          }
+        }
+      })
+    );
+    expect(moduleActionHandler).not.toHaveBeenCalled();
+    expect(response.body).toMatchObject({
+      ok: true,
+      result: {
+        ok: true,
+        echoedPrompt: 'hello'
+      },
+      _route: {
+        gptId: 'test-legacy-gpt'
+      }
+    });
+  });
+
+  it('proxies /queryroute traffic through the canonical GPT dispatcher', async () => {
+    const response = await request(buildApp())
+      .post('/queryroute')
+      .send({
+        module: 'TEST:MODULE',
+        action: 'query',
+        payload: {
+          prompt: 'hello'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['x-canonical-route']).toBe('/gpt/test-legacy-gpt');
+    expect(response.headers['x-route-deprecated']).toBe('true');
+    expect(mockRouteGptRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gptId: 'test-legacy-gpt'
+      })
+    );
+    expect(response.body._route.gptId).toBe('test-legacy-gpt');
+  });
+});

--- a/tests/modules.legacy-route-gate.test.ts
+++ b/tests/modules.legacy-route-gate.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, describe, expect, it, jest } from '@jest/globals';
+
+const originalLegacyGptRoutes = process.env.LEGACY_GPT_ROUTES;
+process.env.LEGACY_GPT_ROUTES = 'disabled';
+
+const express = (await import('express')).default;
+const request = (await import('supertest')).default;
+
+const mockRouteGptRequest = jest.fn();
+
+jest.unstable_mockModule('../src/routes/_core/gptDispatch.js', () => ({
+  routeGptRequest: mockRouteGptRequest
+}));
+
+jest.unstable_mockModule('@services/moduleLoader.js', () => ({
+  clearModuleDefinitionCache: jest.fn(),
+  loadModuleDefinitions: jest.fn(async () => [
+    {
+      route: 'test-route',
+      definition: {
+        name: 'TEST:MODULE',
+        description: null,
+        gptIds: ['test-legacy-gpt'],
+        defaultAction: 'query',
+        actions: {
+          query: jest.fn()
+        }
+      }
+    }
+  ])
+}));
+
+const modulesRouter = (await import('../src/routes/modules.js')).default;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/', modulesRouter);
+  return app;
+}
+
+describe('disabled module legacy route gate', () => {
+  afterAll(() => {
+    if (originalLegacyGptRoutes === undefined) {
+      delete process.env.LEGACY_GPT_ROUTES;
+      return;
+    }
+
+    process.env.LEGACY_GPT_ROUTES = originalLegacyGptRoutes;
+  });
+
+  it('omits /queryroute and /modules/:moduleRoute when legacy GPT routes are disabled', async () => {
+    const app = buildApp();
+
+    const queryRouteResponse = await request(app)
+      .post('/queryroute')
+      .send({ module: 'TEST:MODULE', action: 'query', payload: { prompt: 'hello' } });
+    const moduleRouteResponse = await request(app)
+      .post('/modules/test-route')
+      .send({ module: 'TEST:MODULE', action: 'query', payload: { prompt: 'hello' } });
+
+    expect(queryRouteResponse.status).toBe(404);
+    expect(moduleRouteResponse.status).toBe(404);
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+});

--- a/tests/placeholder.test.ts
+++ b/tests/placeholder.test.ts
@@ -6,6 +6,7 @@ import { resetSafetyRuntimeStateForTests } from '../src/services/safety/runtimeS
 
 const originalApiKey = process.env.OPENAI_API_KEY;
 const originalApiKeyAlias = process.env.API_KEY;
+const originalLegacyGptRoutes = process.env.LEGACY_GPT_ROUTES;
 
 describe('AI endpoints in mock mode', () => {
   let server: Server;
@@ -14,6 +15,7 @@ describe('AI endpoints in mock mode', () => {
   beforeAll(async () => {
     process.env.OPENAI_API_KEY = '';
     process.env.API_KEY = '';
+    process.env.LEGACY_GPT_ROUTES = 'enabled';
     resetSafetyRuntimeStateForTests();
     const app = createApp();
     server = await new Promise<Server>((resolve, reject) => {
@@ -31,6 +33,7 @@ describe('AI endpoints in mock mode', () => {
   afterAll(async () => {
     process.env.OPENAI_API_KEY = originalApiKey;
     process.env.API_KEY = originalApiKeyAlias;
+    process.env.LEGACY_GPT_ROUTES = originalLegacyGptRoutes;
     resetSafetyRuntimeStateForTests();
     await new Promise<void>((resolve, reject) => {
       if (!server) {
@@ -71,7 +74,7 @@ describe('AI endpoints in mock mode', () => {
     expect(payload.error?.code).toBe('BODY_GPT_ID_FORBIDDEN');
   });
 
-  it('provides deterministic mock diagnostics for /arcanos', async () => {
+  it('proxies deprecated /arcanos traffic through the canonical GPT route', async () => {
     const response = await fetch(`${baseUrl}/arcanos`, {
       method: 'POST',
       headers: { 'content-type': 'application/json', 'x-confirmed': 'yes' },
@@ -80,9 +83,10 @@ describe('AI endpoints in mock mode', () => {
 
     expect(response.status).toBe(200);
     const payload = await response.json();
-    expect(payload.result).toContain('[MOCK ARCANOS RESPONSE]');
-    expect(payload.componentStatus).toContain('MOCK');
-    expect(payload.meta).toHaveProperty('id');
-    expect(payload.meta).toHaveProperty('created');
+    expect(response.headers.get('x-canonical-route')).toBe('/gpt/arcanos-core');
+    expect(response.headers.get('x-route-deprecated')).toBe('true');
+    expect(payload.ok).toBe(true);
+    expect(payload._route?.gptId).toBe('arcanos-core');
+    expect(payload.result?.result).toContain('[MOCK RESPONSE]');
   });
 });

--- a/tests/placeholder.test.ts
+++ b/tests/placeholder.test.ts
@@ -8,6 +8,15 @@ const originalApiKey = process.env.OPENAI_API_KEY;
 const originalApiKeyAlias = process.env.API_KEY;
 const originalLegacyGptRoutes = process.env.LEGACY_GPT_ROUTES;
 
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
 describe('AI endpoints in mock mode', () => {
   let server: Server;
   let baseUrl: string;
@@ -31,9 +40,9 @@ describe('AI endpoints in mock mode', () => {
   });
 
   afterAll(async () => {
-    process.env.OPENAI_API_KEY = originalApiKey;
-    process.env.API_KEY = originalApiKeyAlias;
-    process.env.LEGACY_GPT_ROUTES = originalLegacyGptRoutes;
+    restoreEnv('OPENAI_API_KEY', originalApiKey);
+    restoreEnv('API_KEY', originalApiKeyAlias);
+    restoreEnv('LEGACY_GPT_ROUTES', originalLegacyGptRoutes);
     resetSafetyRuntimeStateForTests();
     await new Promise<void>((resolve, reject) => {
       if (!server) {
@@ -85,8 +94,9 @@ describe('AI endpoints in mock mode', () => {
     const payload = await response.json();
     expect(response.headers.get('x-canonical-route')).toBe('/gpt/arcanos-core');
     expect(response.headers.get('x-route-deprecated')).toBe('true');
-    expect(payload.ok).toBe(true);
-    expect(payload._route?.gptId).toBe('arcanos-core');
-    expect(payload.result?.result).toContain('[MOCK RESPONSE]');
+    expect(payload.ok).toBeUndefined();
+    expect(payload._route).toBeUndefined();
+    expect(payload.result).toContain('[MOCK ARCANOS RESPONSE]');
+    expect(payload.componentStatus).toBeTruthy();
   });
 });


### PR DESCRIPTION
## What changed
- added a shared legacy-route compatibility shim that forwards deprecated route traffic into the canonical `/gpt/:gptId` dispatcher while preserving deprecation and degraded-response headers
- rewired remaining legacy AI entrypoints outside the existing `/ask` flow: `/arcanos`, `/write`, `/guide`, `/sim`, `/queryroute`, and `/modules/:moduleRoute`
- added `LEGACY_GPT_ROUTES` runtime gating so those deprecated mounts can be disabled cleanly after migration
- updated and added focused tests for deprecated-route proxy behavior and for disabling the legacy mounts

## Why it changed
Several older AI entrypoints were still implemented as separate route surfaces instead of converging on the canonical GPT dispatcher. That kept duplicate execution paths alive and made deprecation/removal harder to manage safely.

## Impact
- deprecated routes now consistently advertise their canonical successor route
- canonical GPT dispatch owns the execution path for these legacy endpoints
- operators can remove the old mounts with `LEGACY_GPT_ROUTES=disabled` once callers have migrated

## Root cause
The API deprecation work had already covered `/ask` and `/api/arcanos/ask`, but the remaining legacy AI endpoints still bypassed the shared GPT route and therefore did not share one compatibility/removal mechanism.

## Validation
- `npm test -- --coverage=false --runInBand tests/placeholder.test.ts tests/modules.legacy-route-compat.test.ts tests/legacy-gpt-route-gate.test.ts`
- `npm run build`
