### PR TITLE
[codex] fix async GPT job result retrieval

### DIFF
--- a/contracts/custom_gpt_route.openapi.v1.json
+++ b/contracts/custom_gpt_route.openapi.v1.json
@@ -10,7 +10,7 @@
       "post": {
         "operationId": "invokeGptRoute",
         "summary": "Invoke a GPT-routed module request",
-        "description": "Send a prompt to any GPT/module binding using the path-bound GPT identifier. `action` is optional and should only be sent when the caller explicitly selects a backend-supported action.",
+        "description": "Send a prompt to any GPT/module binding using the path-bound GPT identifier. `action` is optional and should only be sent when the caller explicitly selects a backend-supported action. Use `action: \"get_result\"` with `payload.jobId` to read a stored async GPT job result without enqueueing new work.",
         "parameters": [
           {
             "name": "gptId",
@@ -54,6 +54,15 @@
                     "action": "system_state",
                     "payload": {
                       "sessionId": "cli-123"
+                    }
+                  }
+                },
+                "getResult": {
+                  "summary": "Read a stored async GPT job result",
+                  "value": {
+                    "action": "get_result",
+                    "payload": {
+                      "jobId": "job_123"
                     }
                   }
                 }
@@ -124,7 +133,7 @@
           },
           "action": {
             "type": "string",
-            "description": "Optional explicit backend action. Omit by default so the backend can infer intent. Do not inject unsupported defaults such as \"ask\"."
+            "description": "Optional explicit backend action. Omit by default so the backend can infer intent. Supported explicit actions include module-specific actions, `system_state`, and `get_result`. Do not inject unsupported defaults such as \"ask\"."
           },
           "payload": {
             "type": "object",

--- a/daemon-python/arcanos/backend_client/__init__.py
+++ b/daemon-python/arcanos/backend_client/__init__.py
@@ -13,6 +13,7 @@ import requests
 from ..backend_auth_client import normalize_backend_url
 from .chat import request_ask_with_domain as _request_ask_with_domain
 from .chat import request_chat_completion as _request_chat_completion
+from .chat import request_job_result as _request_job_result
 from .chat import request_system_state as _request_system_state
 from .daemon import request_confirm_daemon_actions as _request_confirm_daemon_actions
 from .plans import fetch_plan as _fetch_plan
@@ -488,6 +489,18 @@ class BackendApiClient:
         Edge cases: returns structured validation errors for partial update payloads.
         """
         return _request_system_state(self, metadata, expected_version, patch, gpt_id)
+
+    def request_job_result(
+        self,
+        job_id: str,
+        gpt_id: Optional[str] = None,
+    ) -> BackendResponse[dict[str, Any]]:
+        """
+        Purpose: Fetch one stored async GPT job result through the canonical GPT route.
+        Inputs/Outputs: required job_id plus optional GPT override; returns raw job-result payload.
+        Edge cases: blank ids fail fast as validation errors.
+        """
+        return _request_job_result(self, job_id, gpt_id)
 
     def request_vision_analysis(
         self,

--- a/daemon-python/arcanos/backend_client/chat.py
+++ b/daemon-python/arcanos/backend_client/chat.py
@@ -181,3 +181,35 @@ def request_system_state(
         return BackendResponse(ok=False, error=response.error)
 
     return BackendResponse(ok=True, value=response.value)
+
+
+def request_job_result(
+    client: "BackendApiClient",
+    job_id: str,
+    gpt_id: Optional[str] = None,
+) -> BackendResponse[dict[str, Any]]:
+    """
+    Purpose: Fetch a stored async GPT job result through the canonical GPT route.
+    Inputs/Outputs: required job_id plus optional gpt_id override; returns raw job-result JSON.
+    Edge cases: blank job ids fail locally so retrieval never degrades into a prompt query.
+    """
+    normalized_job_id = job_id.strip()
+    if not normalized_job_id:
+        return BackendResponse(
+            ok=False,
+            error=BackendRequestError(
+                kind="validation",
+                message="job_id is required for get_result",
+            ),
+        )
+
+    route = resolve_backend_chat_route(gpt_id)
+    payload = _build_backend_payload(
+        action="get_result",
+        payload={"jobId": normalized_job_id},
+    )
+    response = client._request_json("post", route.endpoint, payload)
+    if not response.ok or not response.value:
+        return BackendResponse(ok=False, error=response.error)
+
+    return BackendResponse(ok=True, value=response.value)

--- a/daemon-python/tests/test_backend_client_chat.py
+++ b/daemon-python/tests/test_backend_client_chat.py
@@ -9,6 +9,7 @@ from arcanos.backend_client.chat import (
     resolve_backend_chat_route,
     request_ask_with_domain,
     request_chat_completion,
+    request_job_result,
     request_system_state,
 )
 from arcanos.backend_client import BackendApiClient
@@ -151,6 +152,37 @@ def test_request_system_state_honors_explicit_gpt_id_on_canonical_route() -> Non
     assert path == "/gpt/arcanos-gaming"
     assert "gptId" not in payload
     assert payload["action"] == "system_state"
+
+
+def test_request_job_result_uses_explicit_action_without_prompt() -> None:
+    client = SimpleNamespace()
+    client._request_json = MagicMock(
+        return_value=BackendResponse(ok=True, value={"ok": True, "result": {"status": "complete"}})
+    )
+
+    response = request_job_result(client, "job-123")
+
+    assert response.ok is True
+    _, path, payload = client._request_json.call_args.args
+    assert path == "/gpt/arcanos-daemon"
+    assert payload == {
+        "action": "get_result",
+        "payload": {
+            "jobId": "job-123"
+        }
+    }
+
+
+def test_request_job_result_rejects_blank_job_ids() -> None:
+    client = SimpleNamespace()
+    client._request_json = MagicMock()
+
+    response = request_job_result(client, "   ")
+
+    assert response.ok is False
+    assert response.error is not None
+    assert response.error.kind == "validation"
+    client._request_json.assert_not_called()
 
 
 def test_backend_api_client_parses_gpt_envelope_chat_response() -> None:

--- a/docs/API.md
+++ b/docs/API.md
@@ -65,6 +65,7 @@ Job-backed `POST /gpt/:gptId` response shapes:
 - `202 Accepted`: `{ ok, status:"pending", jobId, poll, stream, jobStatus, lifecycleStatus, deduped?, idempotencyKey, idempotencySource, _route }`
 - `200 OK` after bounded inline completion: standard GPT envelope plus `{ jobId, status, lifecycleStatus, poll, stream, deduped?, idempotencyKey, idempotencySource }`
 - Duplicate submissions set `deduped: true` and return the canonical `jobId`.
+- `200 OK` result retrieval: `POST /gpt/:gptId` with `{ "action": "get_result", "payload": { "jobId": "..." } }` returns `{ ok, result: { jobId, status:"pending|complete|failed|not_found", jobStatus, lifecycleStatus, createdAt, updatedAt, completedAt, poll, stream, result, error }, _route }` and never enqueues new work.
 
 Job status routes:
 - `GET /jobs/:id`: returns `{ id, job_type, status, lifecycle_status, created_at, updated_at, completed_at, cancel_requested_at, cancel_reason, retention_until, idempotency_until, expires_at, error_message, output, result }`
@@ -88,6 +89,7 @@ Retention defaults:
 Client retry guidance:
 - Reuse the same `Idempotency-Key` for safe client retries of the same GPT request body.
 - Poll `GET /jobs/:id` or subscribe to `GET /jobs/:id/stream` after any `202`.
+- If you need to fetch a stored result through the GPT route, call `action: "get_result"` with `payload.jobId` instead of sending a prompt that asks the model to fetch it.
 - Treat `cancelled` and `expired` as terminal and submit a fresh request if more work is needed.
 
 ## Active Endpoint Groups

--- a/docs/CUSTOM_GPTS.md
+++ b/docs/CUSTOM_GPTS.md
@@ -11,9 +11,10 @@ Custom GPTs let Arcanos ship specialized assistants (Backstage Booker, Arcanos G
 
 ## How Custom GPT Routing Works
 1. The GPT calls `POST /gpt/:gptId` with a request body that contains `prompt` and optional `gptVersion`, `action`, `payload`, and `context`.
-2. The GPT router resolves the incoming GPT ID to a module route using the module map and fuzzy matching strategy if needed.
-3. The request is forwarded to `/modules/:route`, and the response is wrapped with a `_gptAck` metadata block.
-4. The module handler calls the action implementation and returns the result as JSON.【F:src/routes/gptRouter.ts†L16-L159】【F:src/routes/modules.ts†L1-L83】
+2. Async job results must be fetched explicitly, either through `GET /jobs/:id` or through `POST /gpt/:gptId` with `action: "get_result"` and `payload.jobId`.
+3. The GPT router resolves the incoming GPT ID to a module route using the module map and fuzzy matching strategy if needed.
+4. The request is forwarded to `/modules/:route`, and the response is wrapped with a `_gptAck` metadata block.
+5. The module handler calls the action implementation and returns the result as JSON.【F:src/routes/gptRouter.ts†L16-L159】【F:src/routes/modules.ts†L1-L83】
 
 ## Setup: Connect a Custom GPT to the Backend
 
@@ -54,6 +55,7 @@ Use a single HTTP action in your Custom GPT definition:
 Rules:
 - `gptId` belongs in the path, not the JSON body.
 - Omit `action` by default so the backend can infer intent from the GPT/module binding.
+- Use `action: "get_result"` with `payload.jobId` when you need to fetch a stored async GPT job result without creating new work.
 - Do **not** inject a default action like `"ask"`; only send `action` when the caller explicitly selects a supported backend action.
 
 The router injects the module name server-side, so your Custom GPT does not need to specify `module` in the payload.【F:src/routes/gptRouter.ts†L16-L159】

--- a/packages/cli/__tests__/gpt-client.test.ts
+++ b/packages/cli/__tests__/gpt-client.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import { jest } from "@jest/globals";
 
-import { invokeGptRoute } from "../src/client/backend.js";
+import { fetchGptJobResult, invokeGptRoute } from "../src/client/backend.js";
 
 function createJsonResponse(payload: Record<string, unknown>, init?: ResponseInit): Response {
   return new Response(JSON.stringify(payload), {
@@ -82,6 +82,28 @@ describe("GPT route OpenAPI contract and client", () => {
     expect(body.action).not.toBe("ask");
   });
 
+  it("supports action-only job result retrieval without requiring a prompt", async () => {
+    const fetchMock = jest.spyOn(globalThis, "fetch").mockResolvedValue(
+      createJsonResponse({ ok: true, result: { status: "complete" } })
+    );
+
+    await fetchGptJobResult({
+      baseUrl: "http://127.0.0.1:3000",
+      gptId: "arcanos-core",
+      jobId: "job-123",
+    });
+
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(requestInit.body));
+
+    expect(body).toEqual({
+      action: "get_result",
+      payload: {
+        jobId: "job-123"
+      }
+    });
+  });
+
   it("defines the OpenAPI contract on POST /gpt/{gptId} with path-bound gptId only", () => {
     const specPath = path.resolve(process.cwd(), "contracts", "custom_gpt_route.openapi.v1.json");
     const spec = JSON.parse(readFileSync(specPath, "utf-8")) as Record<string, any>;
@@ -110,6 +132,14 @@ describe("GPT route OpenAPI contract and client", () => {
     expect(requestSchema?.required ?? []).not.toContain("action");
     expect(requestSchema?.properties?.gptId).toBeUndefined();
     expect(requestSchema?.not?.required).toContain("gptId");
+    expect(
+      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.getResult?.value
+    ).toEqual({
+      action: "get_result",
+      payload: {
+        jobId: "job_123"
+      }
+    });
   });
 
   it("preserves backend HTTP status details when the error body is plain text", async () => {

--- a/packages/cli/src/client/backend.ts
+++ b/packages/cli/src/client/backend.ts
@@ -36,7 +36,7 @@ export interface BackendRecentLogsSnapshot {
 }
 
 export interface GptRouteRequestBody {
-  prompt: string;
+  prompt?: string;
   gptVersion?: string;
   action?: string;
   payload?: Record<string, unknown>;
@@ -46,11 +46,18 @@ export interface GptRouteRequestBody {
 export interface InvokeGptRouteOptions {
   baseUrl: string;
   gptId: string;
-  prompt: string;
+  prompt?: string;
   gptVersion?: string;
   action?: string;
   payload?: Record<string, unknown>;
   context?: Record<string, unknown>;
+  headers?: Record<string, string>;
+}
+
+export interface FetchGptJobResultOptions {
+  baseUrl: string;
+  gptId: string;
+  jobId: string;
   headers?: Record<string, string>;
 }
 
@@ -209,21 +216,23 @@ export function validateToolInvokeResponse(
  * Edge cases: blank `action` values are omitted so clients do not silently inject unsupported defaults such as `"ask"`.
  */
 export function buildGptRouteRequestBody(options: Omit<InvokeGptRouteOptions, "baseUrl" | "gptId" | "headers">): GptRouteRequestBody {
-  const prompt = options.prompt.trim();
-  if (!prompt) {
-    throw new Error("GPT route prompt is required.");
+  const prompt = options.prompt?.trim();
+  const action = options.action?.trim();
+  if (!prompt && !action) {
+    throw new Error("GPT route prompt is required when action is not supplied.");
   }
 
-  const body: GptRouteRequestBody = {
-    prompt
-  };
+  const body: GptRouteRequestBody = {};
+
+  if (prompt) {
+    body.prompt = prompt;
+  }
 
   const gptVersion = options.gptVersion?.trim();
   if (gptVersion) {
     body.gptVersion = gptVersion;
   }
 
-  const action = options.action?.trim();
   // Keep the route generic: only include action when the caller explicitly requested one.
   if (action) {
     body.action = action;
@@ -258,6 +267,20 @@ export async function invokeGptRoute(options: InvokeGptRouteOptions): Promise<Re
     body,
     options.headers
   );
+}
+
+export async function fetchGptJobResult(
+  options: FetchGptJobResultOptions
+): Promise<Record<string, unknown>> {
+  return invokeGptRoute({
+    baseUrl: options.baseUrl,
+    gptId: options.gptId,
+    action: "get_result",
+    payload: {
+      jobId: options.jobId
+    },
+    headers: options.headers
+  });
 }
 
 async function postJson(

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -35,6 +35,7 @@ import { shouldTreatPromptAsDagExecution } from '@shared/dag/dagExecutionRouting
 import {
   IdempotencyKeyConflictError,
   JobRepositoryUnavailableError,
+  getJobById,
   findOrCreateGptJob
 } from '@core/db/repositories/jobRepository.js';
 import { planAutonomousWorkerJob } from '@services/workerAutonomyService.js';
@@ -58,6 +59,11 @@ import {
   summarizeGptJobTimings
 } from '@shared/gpt/gptJobLifecycle.js';
 import { getRequestActorKey } from '@platform/runtime/security.js';
+import {
+  GPT_GET_RESULT_ACTION,
+  buildGptJobResultLookupPayload,
+  parseGptJobResultRequest
+} from '@shared/gpt/gptJobResult.js';
 
 const router = express.Router();
 const ARCANOS_CORE_GPT_IDS = new Set(['arcanos-core', 'core', 'arcanos-daemon']);
@@ -638,6 +644,59 @@ router.post("/:gptId", async (req, res, next) => {
           gptId: incomingGptId,
           ...buildGptRequestAuthState(req),
         });
+
+        if (requestedAction === GPT_GET_RESULT_ACTION) {
+          const parsedJobResultRequest = parseGptJobResultRequest(normalizedBody ?? effectiveBody);
+
+          if (!parsedJobResultRequest.ok) {
+            requestLogger?.warn?.('gpt.request.result_lookup_invalid', {
+              endpoint: req.originalUrl,
+              gptId: incomingGptId,
+              requestId,
+              error: parsedJobResultRequest.error
+            });
+            return res.status(400).json({
+              ok: false,
+              error: {
+                code: 'JOB_ID_INVALID',
+                message: `get_result action requires payload.jobId. ${parsedJobResultRequest.error}`
+              },
+              _route: {
+                requestId,
+                gptId: incomingGptId,
+                action: GPT_GET_RESULT_ACTION,
+                route: 'job_result',
+                timestamp: new Date().toISOString()
+              }
+            });
+          }
+
+          const jobLookup = buildGptJobResultLookupPayload(
+            parsedJobResultRequest.jobId,
+            await getJobById(parsedJobResultRequest.jobId)
+          );
+          requestLogger?.info?.('gpt.request.result_lookup', {
+            endpoint: req.originalUrl,
+            gptId: incomingGptId,
+            requestId,
+            jobId: jobLookup.jobId,
+            lookupStatus: jobLookup.status,
+            jobStatus: jobLookup.jobStatus,
+            lifecycleStatus: jobLookup.lifecycleStatus
+          });
+
+          return res.status(200).json({
+            ok: true,
+            result: jobLookup,
+            _route: {
+              requestId,
+              gptId: incomingGptId,
+              action: GPT_GET_RESULT_ACTION,
+              route: 'job_result',
+              timestamp: new Date().toISOString()
+            }
+          });
+        }
 
         const explicitIdempotencyKey = normalizeExplicitIdempotencyKey(
           req.header('Idempotency-Key') ?? req.header('idempotency-key')

--- a/src/routes/jobs.ts
+++ b/src/routes/jobs.ts
@@ -11,9 +11,9 @@ import type { JobData } from '@core/db/schema.js';
 import { sleep } from '@shared/sleep.js';
 import { getRequestActorKey } from '@platform/runtime/security.js';
 import {
-  isGptJobTerminalStatus,
-  resolveGptJobLifecycleStatus
+  isGptJobTerminalStatus
 } from '@shared/gpt/gptJobLifecycle.js';
+import { buildStoredJobStatusPayload } from '@shared/gpt/gptJobResult.js';
 
 const router = express.Router();
 const DEFAULT_JOB_STREAM_POLL_MS = 500;
@@ -25,26 +25,6 @@ const jobIdSchema = z.object({
 
 function isTerminalJobStatus(status: JobData['status']): boolean {
   return isGptJobTerminalStatus(status);
-}
-
-function buildJobStatusPayload(job: JobData) {
-  return {
-    id: job.id,
-    job_type: job.job_type,
-    status: job.status,
-    lifecycle_status: resolveGptJobLifecycleStatus(job.status),
-    created_at: job.created_at,
-    updated_at: job.updated_at,
-    completed_at: job.completed_at ?? null,
-    cancel_requested_at: job.cancel_requested_at ?? null,
-    cancel_reason: job.cancel_reason ?? null,
-    retention_until: job.retention_until ?? null,
-    idempotency_until: job.idempotency_until ?? null,
-    expires_at: job.expires_at ?? null,
-    error_message: job.error_message ?? null,
-    output: job.output ?? null,
-    result: job.output ?? null
-  };
 }
 
 function writeSseEvent(
@@ -81,7 +61,7 @@ router.get(
       return;
     }
 
-    res.json(buildJobStatusPayload(job));
+    res.json(buildStoredJobStatusPayload(job));
   })
 );
 
@@ -163,7 +143,7 @@ router.post(
           code: 'JOB_ALREADY_TERMINAL',
           message: 'Terminal jobs cannot be cancelled.'
         },
-        job: cancellation.job ? buildJobStatusPayload(cancellation.job) : null
+        job: cancellation.job ? buildStoredJobStatusPayload(cancellation.job) : null
       });
       return;
     }
@@ -172,7 +152,7 @@ router.post(
     res.status(statusCode).json({
       ok: true,
       cancellationRequested: cancellation.outcome === 'cancellation_requested',
-      ...buildJobStatusPayload(cancellation.job!)
+      ...buildStoredJobStatusPayload(cancellation.job!)
     });
   })
 );
@@ -220,7 +200,7 @@ router.get(
           return;
         }
 
-        const payload = buildJobStatusPayload(job);
+        const payload = buildStoredJobStatusPayload(job);
         if (job.status !== lastObservedStatus) {
           writeSseEvent(
             res,

--- a/src/shared/gpt/gptJobResult.ts
+++ b/src/shared/gpt/gptJobResult.ts
@@ -1,0 +1,198 @@
+import { z } from 'zod';
+import type { JobData } from '@core/db/schema.js';
+import { resolveGptJobLifecycleStatus } from './gptJobLifecycle.js';
+
+export const GPT_GET_RESULT_ACTION = 'get_result';
+
+const gptJobResultRequestSchema = z.object({
+  action: z.literal(GPT_GET_RESULT_ACTION),
+  payload: z.object({
+    jobId: z.string().trim().min(1)
+  }).passthrough()
+}).passthrough();
+
+export interface GptJobResultLookupPayload {
+  jobId: string;
+  status: 'pending' | 'complete' | 'failed' | 'not_found';
+  jobStatus: string | null;
+  lifecycleStatus: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+  completedAt: string | null;
+  poll: string;
+  stream: string;
+  result: unknown | null;
+  error: {
+    code: string;
+    message: string;
+    details?: Record<string, unknown>;
+  } | null;
+}
+
+export type ParsedGptJobResultRequest =
+  | { ok: true; jobId: string }
+  | { ok: false; error: string };
+
+function serializeJobTimestamp(value: string | Date | null | undefined): string | null {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return null;
+}
+
+function buildJobFailurePayload(
+  code: string,
+  message: string,
+  details?: Record<string, unknown>
+): GptJobResultLookupPayload['error'] {
+  return {
+    code,
+    message,
+    ...(details ? { details } : {})
+  };
+}
+
+function buildPendingJobLookupPayload(job: JobData): GptJobResultLookupPayload {
+  return {
+    jobId: job.id,
+    status: 'pending',
+    jobStatus: job.status,
+    lifecycleStatus: resolveGptJobLifecycleStatus(job.status),
+    createdAt: serializeJobTimestamp(job.created_at),
+    updatedAt: serializeJobTimestamp(job.updated_at),
+    completedAt: serializeJobTimestamp(job.completed_at),
+    poll: `/jobs/${job.id}`,
+    stream: `/jobs/${job.id}/stream`,
+    result: null,
+    error: null
+  };
+}
+
+function buildCompletedJobLookupPayload(job: JobData): GptJobResultLookupPayload {
+  return {
+    jobId: job.id,
+    status: 'complete',
+    jobStatus: job.status,
+    lifecycleStatus: resolveGptJobLifecycleStatus(job.status),
+    createdAt: serializeJobTimestamp(job.created_at),
+    updatedAt: serializeJobTimestamp(job.updated_at),
+    completedAt: serializeJobTimestamp(job.completed_at),
+    poll: `/jobs/${job.id}`,
+    stream: `/jobs/${job.id}/stream`,
+    result: job.output ?? null,
+    error: null
+  };
+}
+
+function buildFailedJobLookupPayload(
+  job: JobData,
+  code: string,
+  defaultMessage: string
+): GptJobResultLookupPayload {
+  return {
+    jobId: job.id,
+    status: 'failed',
+    jobStatus: job.status,
+    lifecycleStatus: resolveGptJobLifecycleStatus(job.status),
+    createdAt: serializeJobTimestamp(job.created_at),
+    updatedAt: serializeJobTimestamp(job.updated_at),
+    completedAt: serializeJobTimestamp(job.completed_at),
+    poll: `/jobs/${job.id}`,
+    stream: `/jobs/${job.id}/stream`,
+    result: null,
+    error: buildJobFailurePayload(
+      code,
+      job.error_message ?? defaultMessage,
+      {
+        lifecycleStatus: resolveGptJobLifecycleStatus(job.status),
+        jobStatus: job.status
+      }
+    )
+  };
+}
+
+export function parseGptJobResultRequest(body: unknown): ParsedGptJobResultRequest {
+  const parsedRequest = gptJobResultRequestSchema.safeParse(body);
+
+  if (!parsedRequest.success) {
+    return {
+      ok: false,
+      error: parsedRequest.error.issues
+        .map(issue => `${issue.path.join('.') || 'body'}: ${issue.message}`)
+        .join('; ')
+    };
+  }
+
+  return {
+    ok: true,
+    jobId: parsedRequest.data.payload.jobId
+  };
+}
+
+export function buildStoredJobStatusPayload(job: JobData) {
+  return {
+    id: job.id,
+    job_type: job.job_type,
+    status: job.status,
+    lifecycle_status: resolveGptJobLifecycleStatus(job.status),
+    created_at: job.created_at,
+    updated_at: job.updated_at,
+    completed_at: job.completed_at ?? null,
+    cancel_requested_at: job.cancel_requested_at ?? null,
+    cancel_reason: job.cancel_reason ?? null,
+    retention_until: job.retention_until ?? null,
+    idempotency_until: job.idempotency_until ?? null,
+    expires_at: job.expires_at ?? null,
+    error_message: job.error_message ?? null,
+    output: job.output ?? null,
+    result: job.output ?? null
+  };
+}
+
+export function buildGptJobResultLookupPayload(
+  jobId: string,
+  job: JobData | null
+): GptJobResultLookupPayload {
+  if (!job) {
+    return {
+      jobId,
+      status: 'not_found',
+      jobStatus: null,
+      lifecycleStatus: 'not_found',
+      createdAt: null,
+      updatedAt: null,
+      completedAt: null,
+      poll: `/jobs/${jobId}`,
+      stream: `/jobs/${jobId}/stream`,
+      result: null,
+      error: buildJobFailurePayload('JOB_NOT_FOUND', 'Async GPT job was not found.')
+    };
+  }
+
+  if (job.status === 'completed') {
+    return buildCompletedJobLookupPayload(job);
+  }
+
+  if (job.status === 'failed') {
+    return buildFailedJobLookupPayload(job, 'JOB_FAILED', 'Async GPT job failed.');
+  }
+
+  if (job.status === 'cancelled') {
+    return buildFailedJobLookupPayload(job, 'JOB_CANCELLED', 'Async GPT job was cancelled.');
+  }
+
+  if (job.status === 'expired') {
+    return buildFailedJobLookupPayload(
+      job,
+      'JOB_EXPIRED',
+      'Async GPT job expired after its retention window.'
+    );
+  }
+
+  return buildPendingJobLookupPayload(job);
+}

--- a/src/shared/gpt/gptJobResult.ts
+++ b/src/shared/gpt/gptJobResult.ts
@@ -5,7 +5,12 @@ import { resolveGptJobLifecycleStatus } from './gptJobLifecycle.js';
 export const GPT_GET_RESULT_ACTION = 'get_result';
 
 const gptJobResultRequestSchema = z.object({
-  action: z.literal(GPT_GET_RESULT_ACTION),
+  action: z.preprocess(
+    (value) => typeof value === 'string'
+      ? value.trim().toLowerCase()
+      : value,
+    z.literal(GPT_GET_RESULT_ACTION)
+  ),
   payload: z.object({
     jobId: z.string().trim().min(1)
   }).passthrough()
@@ -140,14 +145,14 @@ export function buildStoredJobStatusPayload(job: JobData) {
     job_type: job.job_type,
     status: job.status,
     lifecycle_status: resolveGptJobLifecycleStatus(job.status),
-    created_at: job.created_at,
-    updated_at: job.updated_at,
-    completed_at: job.completed_at ?? null,
-    cancel_requested_at: job.cancel_requested_at ?? null,
+    created_at: serializeJobTimestamp(job.created_at),
+    updated_at: serializeJobTimestamp(job.updated_at),
+    completed_at: serializeJobTimestamp(job.completed_at),
+    cancel_requested_at: serializeJobTimestamp(job.cancel_requested_at),
     cancel_reason: job.cancel_reason ?? null,
-    retention_until: job.retention_until ?? null,
-    idempotency_until: job.idempotency_until ?? null,
-    expires_at: job.expires_at ?? null,
+    retention_until: serializeJobTimestamp(job.retention_until),
+    idempotency_until: serializeJobTimestamp(job.idempotency_until),
+    expires_at: serializeJobTimestamp(job.expires_at),
     error_message: job.error_message ?? null,
     output: job.output ?? null,
     result: job.output ?? null

--- a/tests/gpt-async-idempotency.route.test.ts
+++ b/tests/gpt-async-idempotency.route.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const mockRouteGptRequest = jest.fn();
 const findOrCreateGptJobMock = jest.fn();
+const getJobByIdMock = jest.fn();
 const planAutonomousWorkerJobMock = jest.fn();
 const waitForQueuedGptJobCompletionMock = jest.fn();
 const resolveAsyncGptPollIntervalMsMock = jest.fn(() => 250);
@@ -25,7 +26,7 @@ jest.unstable_mockModule('../src/core/db/repositories/jobRepository.js', () => (
   IdempotencyKeyConflictError: MockIdempotencyKeyConflictError,
   JobRepositoryUnavailableError: MockJobRepositoryUnavailableError,
   findOrCreateGptJob: findOrCreateGptJobMock,
-  getJobById: jest.fn(),
+  getJobById: getJobByIdMock,
   createJob: jest.fn(),
   claimNextPendingJob: jest.fn(),
   recordJobHeartbeat: jest.fn(),
@@ -125,6 +126,165 @@ describe('async /gpt idempotency', () => {
         route: 'async'
       })
     });
+  });
+
+  it('returns stored completed job results for explicit get_result actions without enqueueing work', async () => {
+    getJobByIdMock.mockResolvedValue({
+      id: 'job-lookup-complete',
+      job_type: 'gpt',
+      status: 'completed',
+      created_at: '2026-04-06T10:00:00.000Z',
+      updated_at: '2026-04-06T10:00:03.000Z',
+      completed_at: '2026-04-06T10:00:03.000Z',
+      output: {
+        ok: true,
+        result: {
+          answer: 'stored output'
+        }
+      },
+      error_message: null
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'get_result',
+        payload: {
+          jobId: 'job-lookup-complete'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      ok: true,
+      result: {
+        jobId: 'job-lookup-complete',
+        status: 'complete',
+        jobStatus: 'completed',
+        lifecycleStatus: 'completed',
+        createdAt: '2026-04-06T10:00:00.000Z',
+        updatedAt: '2026-04-06T10:00:03.000Z',
+        completedAt: '2026-04-06T10:00:03.000Z',
+        poll: '/jobs/job-lookup-complete',
+        stream: '/jobs/job-lookup-complete/stream',
+        result: {
+          ok: true,
+          result: {
+            answer: 'stored output'
+          }
+        },
+        error: null
+      },
+      _route: expect.objectContaining({
+        gptId: 'arcanos-core',
+        action: 'get_result',
+        route: 'job_result'
+      })
+    });
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns explicit pending status for get_result without enqueueing work', async () => {
+    getJobByIdMock.mockResolvedValue({
+      id: 'job-lookup-pending',
+      job_type: 'gpt',
+      status: 'running',
+      created_at: '2026-04-06T10:00:00.000Z',
+      updated_at: '2026-04-06T10:00:01.000Z',
+      completed_at: null,
+      output: null,
+      error_message: null
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'get_result',
+        payload: {
+          jobId: 'job-lookup-pending'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result).toMatchObject({
+      jobId: 'job-lookup-pending',
+      status: 'pending',
+      jobStatus: 'running',
+      lifecycleStatus: 'running',
+      result: null,
+      error: null
+    });
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+  });
+
+  it('returns explicit failed status for terminal get_result lookups without enqueueing work', async () => {
+    getJobByIdMock.mockResolvedValue({
+      id: 'job-lookup-failed',
+      job_type: 'gpt',
+      status: 'failed',
+      created_at: '2026-04-06T10:00:00.000Z',
+      updated_at: '2026-04-06T10:00:02.000Z',
+      completed_at: '2026-04-06T10:00:02.000Z',
+      output: null,
+      error_message: 'OpenAI upstream timed out'
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'get_result',
+        payload: {
+          jobId: 'job-lookup-failed'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result).toMatchObject({
+      jobId: 'job-lookup-failed',
+      status: 'failed',
+      jobStatus: 'failed',
+      lifecycleStatus: 'failed',
+      result: null,
+      error: {
+        code: 'JOB_FAILED',
+        message: 'OpenAI upstream timed out'
+      }
+    });
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+  });
+
+  it('returns explicit not_found status for missing get_result lookups without enqueueing work', async () => {
+    getJobByIdMock.mockResolvedValue(null);
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'get_result',
+        payload: {
+          jobId: 'missing-job'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result).toEqual({
+      jobId: 'missing-job',
+      status: 'not_found',
+      jobStatus: null,
+      lifecycleStatus: 'not_found',
+      createdAt: null,
+      updatedAt: null,
+      completedAt: null,
+      poll: '/jobs/missing-job',
+      stream: '/jobs/missing-job/stream',
+      result: null,
+      error: {
+        code: 'JOB_NOT_FOUND',
+        message: 'Async GPT job was not found.'
+      }
+    });
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
   });
 
   it('uses a short inline wait budget for heavy async core requests', async () => {

--- a/tests/gpt-async-idempotency.route.test.ts
+++ b/tests/gpt-async-idempotency.route.test.ts
@@ -186,6 +186,48 @@ describe('async /gpt idempotency', () => {
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
+  it('accepts normalized get_result action variants without enqueueing work', async () => {
+    getJobByIdMock.mockResolvedValue({
+      id: 'job-lookup-normalized',
+      job_type: 'gpt',
+      status: 'completed',
+      created_at: '2026-04-06T10:00:00.000Z',
+      updated_at: '2026-04-06T10:00:03.000Z',
+      completed_at: '2026-04-06T10:00:03.000Z',
+      output: {
+        ok: true,
+        result: {
+          answer: 'normalized output'
+        }
+      },
+      error_message: null
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: ' Get_Result ',
+        payload: {
+          jobId: 'job-lookup-normalized'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result).toMatchObject({
+      jobId: 'job-lookup-normalized',
+      status: 'complete',
+      result: {
+        ok: true,
+        result: {
+          answer: 'normalized output'
+        }
+      }
+    });
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
   it('returns explicit pending status for get_result without enqueueing work', async () => {
     getJobByIdMock.mockResolvedValue({
       id: 'job-lookup-pending',

--- a/tests/gpt-job-result.test.ts
+++ b/tests/gpt-job-result.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  buildStoredJobStatusPayload,
+  parseGptJobResultRequest
+} from '../src/shared/gpt/gptJobResult.js';
+
+describe('gpt job result helpers', () => {
+  it('normalizes get_result action values during request parsing', () => {
+    const parsed = parseGptJobResultRequest({
+      action: ' Get_Result ',
+      payload: {
+        jobId: 'job-123'
+      }
+    });
+
+    expect(parsed).toEqual({
+      ok: true,
+      jobId: 'job-123'
+    });
+  });
+
+  it('serializes stored job timestamps consistently', () => {
+    const payload = buildStoredJobStatusPayload({
+      id: 'job-123',
+      job_type: 'gpt',
+      status: 'completed',
+      created_at: new Date('2026-04-06T10:00:00.000Z'),
+      updated_at: new Date('2026-04-06T10:00:01.000Z'),
+      completed_at: new Date('2026-04-06T10:00:02.000Z'),
+      cancel_requested_at: null,
+      cancel_reason: null,
+      retention_until: new Date('2026-04-07T10:00:00.000Z'),
+      idempotency_until: new Date('2026-04-06T11:00:00.000Z'),
+      expires_at: new Date('2026-04-08T10:00:00.000Z'),
+      error_message: null,
+      output: {
+        ok: true
+      }
+    } as any);
+
+    expect(payload).toMatchObject({
+      created_at: '2026-04-06T10:00:00.000Z',
+      updated_at: '2026-04-06T10:00:01.000Z',
+      completed_at: '2026-04-06T10:00:02.000Z',
+      cancel_requested_at: null,
+      retention_until: '2026-04-07T10:00:00.000Z',
+      idempotency_until: '2026-04-06T11:00:00.000Z',
+      expires_at: '2026-04-08T10:00:00.000Z'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fix async job result retrieval so completed GPT jobs can be fetched without accidentally enqueueing new work.

## Root cause
Completed jobs were already persisted and readable through `/jobs/:id`, but `/gpt/:gptId` had no explicit result-retrieval contract. Requests that tried to "fetch a result" through the GPT route were treated as normal queries and fell back into the async dispatcher, which created a new job instead of reading the stored one.

## What changed
- Add explicit `action: "get_result"` handling to `/gpt/:gptId`
- Read persisted job state directly via `jobId` instead of routing retrieval through generation
- Standardize machine-readable retrieval states: `pending`, `complete`, `failed`, `not_found`
- Share job-result payload shaping between the GPT route and `/jobs/:id`
- Update TypeScript and Python clients plus API docs/OpenAPI examples
- Add route and client tests covering retrieval without enqueueing

## Impact
- Completed async jobs can now be fetched reliably by `jobId`
- Retrieval requests never enqueue new work
- Existing async generation, polling, and streaming behavior stay intact
- Failure modes are explicit and contract-driven

## Validation
- `python -m pytest daemon-python/tests/test_backend_client_chat.py`
- `npm run build:packages`
- `node --disable-warning=ExperimentalWarning --experimental-vm-modules node_modules/jest/bin/jest.js tests/gpt-async-idempotency.route.test.ts packages/cli/__tests__/gpt-client.test.ts tests/introspection-openapi-contract.route.test.ts --runInBand --coverage=false`
- `npx tsc -p tsconfig.json`
- `npm run build`
- Deployed to Railway `Arcanos / production / ARCANOS V2`
- Verified live that `action: "get_result"` returns the stored completed result and does not produce a new `async_enqueued` log entry

## Rollback
Previous successful `ARCANOS V2` deployment before this fix: `d6357f8e-feef-434f-a0b4-43b7b0fb99a4`.