### PR TITLE
[codex] add explicit async job result retrieval

### DIFF
--- a/contracts/custom_gpt_route.openapi.v1.json
+++ b/contracts/custom_gpt_route.openapi.v1.json
@@ -10,7 +10,7 @@
       "post": {
         "operationId": "invokeGptRoute",
         "summary": "Invoke a GPT-routed module request",
-        "description": "Send a prompt to any GPT/module binding using the path-bound GPT identifier. `action` is optional and should only be sent when the caller explicitly selects a backend-supported action.",
+        "description": "Send a prompt to any GPT/module binding using the path-bound GPT identifier. `action` is optional and should only be sent when the caller explicitly selects a backend-supported action. Use `action: \"get_result\"` with `payload.jobId` to retrieve a stored async GPT job result without enqueueing new work.",
         "parameters": [
           {
             "name": "gptId",
@@ -54,6 +54,15 @@
                     "action": "system_state",
                     "payload": {
                       "sessionId": "cli-123"
+                    }
+                  }
+                },
+                "getResult": {
+                  "summary": "Retrieve a stored async GPT job result without enqueuing new work",
+                  "value": {
+                    "action": "get_result",
+                    "payload": {
+                      "jobId": "59dbfb2b-0c64-4eda-8a1e-b950a63f7fe0"
                     }
                   }
                 }
@@ -124,7 +133,7 @@
           },
           "action": {
             "type": "string",
-            "description": "Optional explicit backend action. Omit by default so the backend can infer intent. Do not inject unsupported defaults such as \"ask\"."
+            "description": "Optional explicit backend action. Omit by default so the backend can infer intent. Do not inject unsupported defaults such as \"ask\". Use `get_result` only with `payload.jobId` when retrieving an existing async job result."
           },
           "payload": {
             "type": "object",

--- a/contracts/job_result.openapi.v1.json
+++ b/contracts/job_result.openapi.v1.json
@@ -1,0 +1,202 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Arcanos Async Job Result API",
+    "version": "1.0.0",
+    "description": "Canonical read contract for retrieving stored async GPT job results without enqueueing new work."
+  },
+  "paths": {
+    "/jobs/{jobId}/result": {
+      "get": {
+        "operationId": "getJobResult",
+        "summary": "Retrieve a stored async GPT job result",
+        "description": "Returns the stored result lifecycle for a job id. This route is read-only and never enqueues work. Missing jobs are reported in-body with `status: \"not_found\"`.",
+        "parameters": [
+          {
+            "name": "jobId",
+            "in": "path",
+            "required": true,
+            "description": "Async job identifier returned by `POST /gpt/{gptId}`.",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stored async job result lookup payload.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobResultLookup"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid job id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "JobResultLookupStatus": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "completed",
+          "failed",
+          "expired",
+          "not_found"
+        ]
+      },
+      "RouteError": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": false
+          },
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "details": {}
+            },
+            "required": [
+              "code",
+              "message"
+            ],
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "ok",
+          "error"
+        ],
+        "additionalProperties": true
+      },
+      "JobResultLookup": {
+        "type": "object",
+        "properties": {
+          "jobId": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/JobResultLookupStatus"
+          },
+          "jobStatus": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "lifecycleStatus": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "completedAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "retentionUntil": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "idempotencyUntil": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "expiresAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "poll": {
+            "type": "string"
+          },
+          "stream": {
+            "type": "string"
+          },
+          "result": {},
+          "error": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "details": {}
+            },
+            "required": [
+              "code",
+              "message"
+            ],
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "jobId",
+          "status",
+          "jobStatus",
+          "lifecycleStatus",
+          "createdAt",
+          "updatedAt",
+          "completedAt",
+          "retentionUntil",
+          "idempotencyUntil",
+          "expiresAt",
+          "poll",
+          "stream",
+          "result",
+          "error"
+        ],
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/packages/cli/__tests__/gpt-client.test.ts
+++ b/packages/cli/__tests__/gpt-client.test.ts
@@ -137,7 +137,7 @@ describe("GPT route OpenAPI contract and client", () => {
     ).toEqual({
       action: "get_result",
       payload: {
-        jobId: "job_123"
+        jobId: "59dbfb2b-0c64-4eda-8a1e-b950a63f7fe0"
       }
     });
   });

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -35,6 +35,7 @@ import { shouldTreatPromptAsDagExecution } from '@shared/dag/dagExecutionRouting
 import {
   IdempotencyKeyConflictError,
   JobRepositoryUnavailableError,
+  getJobById,
   findOrCreateGptJob
 } from '@core/db/repositories/jobRepository.js';
 import { planAutonomousWorkerJob } from '@services/workerAutonomyService.js';
@@ -58,6 +59,11 @@ import {
   summarizeGptJobTimings
 } from '@shared/gpt/gptJobLifecycle.js';
 import { getRequestActorKey } from '@platform/runtime/security.js';
+import {
+  GPT_GET_RESULT_ACTION,
+  buildGptJobResultLookupPayload,
+  parseGptJobResultRequest
+} from '@shared/gpt/gptJobResult.js';
 
 const router = express.Router();
 const ARCANOS_CORE_GPT_IDS = new Set(['arcanos-core', 'core', 'arcanos-daemon']);
@@ -638,6 +644,59 @@ router.post("/:gptId", async (req, res, next) => {
           gptId: incomingGptId,
           ...buildGptRequestAuthState(req),
         });
+
+        if (requestedAction === GPT_GET_RESULT_ACTION) {
+          const parsedJobResultRequest = parseGptJobResultRequest(normalizedBody ?? effectiveBody);
+
+          if (!parsedJobResultRequest.ok) {
+            requestLogger?.warn?.('gpt.request.result_lookup_invalid', {
+              endpoint: req.originalUrl,
+              gptId: incomingGptId,
+              requestId,
+              error: parsedJobResultRequest.error
+            });
+            return res.status(400).json({
+              ok: false,
+              error: {
+                code: 'JOB_ID_INVALID',
+                message: `get_result action requires payload.jobId. ${parsedJobResultRequest.error}`
+              },
+              _route: {
+                requestId,
+                gptId: incomingGptId,
+                action: GPT_GET_RESULT_ACTION,
+                route: 'job_result',
+                timestamp: new Date().toISOString()
+              }
+            });
+          }
+
+          const jobLookup = buildGptJobResultLookupPayload(
+            parsedJobResultRequest.jobId,
+            await getJobById(parsedJobResultRequest.jobId)
+          );
+          requestLogger?.info?.('gpt.request.result_lookup', {
+            endpoint: req.originalUrl,
+            gptId: incomingGptId,
+            requestId,
+            jobId: jobLookup.jobId,
+            lookupStatus: jobLookup.status,
+            jobStatus: jobLookup.jobStatus,
+            lifecycleStatus: jobLookup.lifecycleStatus
+          });
+
+          return res.status(200).json({
+            ok: true,
+            result: jobLookup,
+            _route: {
+              requestId,
+              gptId: incomingGptId,
+              action: GPT_GET_RESULT_ACTION,
+              route: 'job_result',
+              timestamp: new Date().toISOString()
+            }
+          });
+        }
 
         const explicitIdempotencyKey = normalizeExplicitIdempotencyKey(
           req.header('Idempotency-Key') ?? req.header('idempotency-key')

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -646,7 +646,7 @@ router.post("/:gptId", async (req, res, next) => {
         });
 
         if (requestedAction === GPT_GET_RESULT_ACTION) {
-          const parsedJobResultRequest = parseGptJobResultRequest(normalizedBody ?? effectiveBody);
+          const parsedJobResultRequest = parseGptJobResultRequest(effectiveBody);
 
           if (!parsedJobResultRequest.ok) {
             requestLogger?.warn?.('gpt.request.result_lookup_invalid', {

--- a/src/routes/introspection.ts
+++ b/src/routes/introspection.ts
@@ -12,18 +12,32 @@ const CUSTOM_GPT_OPENAPI_CONTRACT_PATH = path.resolve(
   "contracts",
   "custom_gpt_route.openapi.v1.json"
 );
+const JOB_RESULT_OPENAPI_CONTRACT_PATH = path.resolve(
+  process.cwd(),
+  'contracts',
+  'job_result.openapi.v1.json'
+);
 
-async function readCustomGptOpenApiContract(): Promise<unknown> {
-  const rawContract = await fs.readFile(CUSTOM_GPT_OPENAPI_CONTRACT_PATH, "utf8");
+async function readOpenApiContract(contractPath: string): Promise<unknown> {
+  const rawContract = await fs.readFile(contractPath, "utf8");
   return JSON.parse(rawContract) as unknown;
 }
 
 router.get(
   "/contracts/custom_gpt_route.openapi.v1.json",
   asyncHandler(async (_req: Request, res: Response) => {
-    const contract = await readCustomGptOpenApiContract();
+    const contract = await readOpenApiContract(CUSTOM_GPT_OPENAPI_CONTRACT_PATH);
     //audit Assumption: Custom GPT builders should always fetch the latest contract from the backend instead of caching a stale local copy; failure risk: action routing drifts back to deprecated paths like `/ask`; expected invariant: this endpoint returns the live canonical schema and discourages intermediary caching; handling strategy: serve deterministic JSON with `no-store`.
     res.set("cache-control", "no-store, max-age=0");
+    return res.json(contract);
+  })
+);
+
+router.get(
+  '/contracts/job_result.openapi.v1.json',
+  asyncHandler(async (_req: Request, res: Response) => {
+    const contract = await readOpenApiContract(JOB_RESULT_OPENAPI_CONTRACT_PATH);
+    res.set('cache-control', 'no-store, max-age=0');
     return res.json(contract);
   })
 );

--- a/src/routes/jobs.ts
+++ b/src/routes/jobs.ts
@@ -11,9 +11,12 @@ import type { JobData } from '@core/db/schema.js';
 import { sleep } from '@shared/sleep.js';
 import { getRequestActorKey } from '@platform/runtime/security.js';
 import {
-  isGptJobTerminalStatus,
-  resolveGptJobLifecycleStatus
+  isGptJobTerminalStatus
 } from '@shared/gpt/gptJobLifecycle.js';
+import {
+  buildGptJobResultLookupPayload,
+  buildStoredJobStatusPayload
+} from '@shared/gpt/gptJobResult.js';
 
 const router = express.Router();
 const DEFAULT_JOB_STREAM_POLL_MS = 500;
@@ -25,26 +28,6 @@ const jobIdSchema = z.object({
 
 function isTerminalJobStatus(status: JobData['status']): boolean {
   return isGptJobTerminalStatus(status);
-}
-
-function buildJobStatusPayload(job: JobData) {
-  return {
-    id: job.id,
-    job_type: job.job_type,
-    status: job.status,
-    lifecycle_status: resolveGptJobLifecycleStatus(job.status),
-    created_at: job.created_at,
-    updated_at: job.updated_at,
-    completed_at: job.completed_at ?? null,
-    cancel_requested_at: job.cancel_requested_at ?? null,
-    cancel_reason: job.cancel_reason ?? null,
-    retention_until: job.retention_until ?? null,
-    idempotency_until: job.idempotency_until ?? null,
-    expires_at: job.expires_at ?? null,
-    error_message: job.error_message ?? null,
-    output: job.output ?? null,
-    result: job.output ?? null
-  };
 }
 
 function writeSseEvent(
@@ -81,7 +64,18 @@ router.get(
       return;
     }
 
-    res.json(buildJobStatusPayload(job));
+    res.json(buildStoredJobStatusPayload(job));
+  })
+);
+
+router.get(
+  '/jobs/:id/result',
+  validateParams(jobIdSchema, { errorCode: 'JOB_ID_INVALID' }),
+  asyncHandler(async (req, res) => {
+    const { id } = req.validated!.params as z.infer<typeof jobIdSchema>;
+    const job = await getJobById(id);
+
+    res.json(buildGptJobResultLookupPayload(id, job));
   })
 );
 
@@ -163,7 +157,7 @@ router.post(
           code: 'JOB_ALREADY_TERMINAL',
           message: 'Terminal jobs cannot be cancelled.'
         },
-        job: cancellation.job ? buildJobStatusPayload(cancellation.job) : null
+        job: cancellation.job ? buildStoredJobStatusPayload(cancellation.job) : null
       });
       return;
     }
@@ -172,7 +166,7 @@ router.post(
     res.status(statusCode).json({
       ok: true,
       cancellationRequested: cancellation.outcome === 'cancellation_requested',
-      ...buildJobStatusPayload(cancellation.job!)
+      ...buildStoredJobStatusPayload(cancellation.job!)
     });
   })
 );
@@ -220,7 +214,7 @@ router.get(
           return;
         }
 
-        const payload = buildJobStatusPayload(job);
+        const payload = buildStoredJobStatusPayload(job);
         if (job.status !== lastObservedStatus) {
           writeSseEvent(
             res,

--- a/src/shared/gpt/gptJobResult.ts
+++ b/src/shared/gpt/gptJobResult.ts
@@ -1,0 +1,242 @@
+import { z } from 'zod';
+import type { JobData } from '@core/db/schema.js';
+import { resolveGptJobLifecycleStatus } from './gptJobLifecycle.js';
+
+export const GPT_GET_RESULT_ACTION = 'get_result';
+
+const gptJobResultRequestSchema = z.object({
+  action: z.preprocess(
+    (value) => typeof value === 'string'
+      ? value.trim().toLowerCase()
+      : value,
+    z.literal(GPT_GET_RESULT_ACTION)
+  ),
+  payload: z.object({
+    jobId: z.string().trim().min(1)
+  }).passthrough()
+}).passthrough();
+
+export interface GptJobResultLookupPayload {
+  jobId: string;
+  status: 'pending' | 'completed' | 'failed' | 'expired' | 'not_found';
+  jobStatus: string | null;
+  lifecycleStatus: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+  completedAt: string | null;
+  retentionUntil: string | null;
+  idempotencyUntil: string | null;
+  expiresAt: string | null;
+  poll: string;
+  stream: string;
+  result: unknown | null;
+  error: {
+    code: string;
+    message: string;
+    details?: Record<string, unknown>;
+  } | null;
+}
+
+export type ParsedGptJobResultRequest =
+  | { ok: true; jobId: string }
+  | { ok: false; error: string };
+
+function serializeJobTimestamp(value: string | Date | null | undefined): string | null {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return null;
+}
+
+function buildJobFailurePayload(
+  code: string,
+  message: string,
+  details?: Record<string, unknown>
+): GptJobResultLookupPayload['error'] {
+  return {
+    code,
+    message,
+    ...(details ? { details } : {})
+  };
+}
+
+function buildPendingJobLookupPayload(job: JobData): GptJobResultLookupPayload {
+  return {
+    jobId: job.id,
+    status: 'pending',
+    jobStatus: job.status,
+    lifecycleStatus: resolveGptJobLifecycleStatus(job.status),
+    createdAt: serializeJobTimestamp(job.created_at),
+    updatedAt: serializeJobTimestamp(job.updated_at),
+    completedAt: serializeJobTimestamp(job.completed_at),
+    retentionUntil: serializeJobTimestamp(job.retention_until),
+    idempotencyUntil: serializeJobTimestamp(job.idempotency_until),
+    expiresAt: serializeJobTimestamp(job.expires_at),
+    poll: `/jobs/${job.id}`,
+    stream: `/jobs/${job.id}/stream`,
+    result: null,
+    error: null
+  };
+}
+
+function buildCompletedJobLookupPayload(job: JobData): GptJobResultLookupPayload {
+  return {
+    jobId: job.id,
+    status: 'completed',
+    jobStatus: job.status,
+    lifecycleStatus: resolveGptJobLifecycleStatus(job.status),
+    createdAt: serializeJobTimestamp(job.created_at),
+    updatedAt: serializeJobTimestamp(job.updated_at),
+    completedAt: serializeJobTimestamp(job.completed_at),
+    retentionUntil: serializeJobTimestamp(job.retention_until),
+    idempotencyUntil: serializeJobTimestamp(job.idempotency_until),
+    expiresAt: serializeJobTimestamp(job.expires_at),
+    poll: `/jobs/${job.id}`,
+    stream: `/jobs/${job.id}/stream`,
+    result: job.output ?? null,
+    error: null
+  };
+}
+
+function buildFailedJobLookupPayload(
+  job: JobData,
+  code: string,
+  defaultMessage: string
+): GptJobResultLookupPayload {
+  return {
+    jobId: job.id,
+    status: 'failed',
+    jobStatus: job.status,
+    lifecycleStatus: resolveGptJobLifecycleStatus(job.status),
+    createdAt: serializeJobTimestamp(job.created_at),
+    updatedAt: serializeJobTimestamp(job.updated_at),
+    completedAt: serializeJobTimestamp(job.completed_at),
+    retentionUntil: serializeJobTimestamp(job.retention_until),
+    idempotencyUntil: serializeJobTimestamp(job.idempotency_until),
+    expiresAt: serializeJobTimestamp(job.expires_at),
+    poll: `/jobs/${job.id}`,
+    stream: `/jobs/${job.id}/stream`,
+    result: job.output ?? null,
+    error: buildJobFailurePayload(
+      code,
+      job.error_message ?? defaultMessage,
+      {
+        lifecycleStatus: resolveGptJobLifecycleStatus(job.status),
+        jobStatus: job.status,
+        resultRetained: job.output != null
+      }
+    )
+  };
+}
+
+function buildExpiredJobLookupPayload(job: JobData): GptJobResultLookupPayload {
+  return {
+    jobId: job.id,
+    status: 'expired',
+    jobStatus: job.status,
+    lifecycleStatus: resolveGptJobLifecycleStatus(job.status),
+    createdAt: serializeJobTimestamp(job.created_at),
+    updatedAt: serializeJobTimestamp(job.updated_at),
+    completedAt: serializeJobTimestamp(job.completed_at),
+    retentionUntil: serializeJobTimestamp(job.retention_until),
+    idempotencyUntil: serializeJobTimestamp(job.idempotency_until),
+    expiresAt: serializeJobTimestamp(job.expires_at),
+    poll: `/jobs/${job.id}`,
+    stream: `/jobs/${job.id}/stream`,
+    result: job.output ?? null,
+    error: buildJobFailurePayload(
+      'JOB_EXPIRED',
+      job.error_message ?? 'Async GPT job expired after its retention window.',
+      {
+        lifecycleStatus: resolveGptJobLifecycleStatus(job.status),
+        jobStatus: job.status,
+        resultRetained: job.output != null
+      }
+    )
+  };
+}
+
+export function parseGptJobResultRequest(body: unknown): ParsedGptJobResultRequest {
+  const parsedRequest = gptJobResultRequestSchema.safeParse(body);
+
+  if (!parsedRequest.success) {
+    return {
+      ok: false,
+      error: parsedRequest.error.issues
+        .map(issue => `${issue.path.join('.') || 'body'}: ${issue.message}`)
+        .join('; ')
+    };
+  }
+
+  return {
+    ok: true,
+    jobId: parsedRequest.data.payload.jobId
+  };
+}
+
+export function buildStoredJobStatusPayload(job: JobData) {
+  return {
+    id: job.id,
+    job_type: job.job_type,
+    status: job.status,
+    lifecycle_status: resolveGptJobLifecycleStatus(job.status),
+    created_at: serializeJobTimestamp(job.created_at),
+    updated_at: serializeJobTimestamp(job.updated_at),
+    completed_at: serializeJobTimestamp(job.completed_at),
+    cancel_requested_at: serializeJobTimestamp(job.cancel_requested_at),
+    cancel_reason: job.cancel_reason ?? null,
+    retention_until: serializeJobTimestamp(job.retention_until),
+    idempotency_until: serializeJobTimestamp(job.idempotency_until),
+    expires_at: serializeJobTimestamp(job.expires_at),
+    error_message: job.error_message ?? null,
+    output: job.output ?? null,
+    result: job.output ?? null
+  };
+}
+
+export function buildGptJobResultLookupPayload(
+  jobId: string,
+  job: JobData | null
+): GptJobResultLookupPayload {
+  if (!job) {
+    return {
+      jobId,
+      status: 'not_found',
+      jobStatus: null,
+      lifecycleStatus: 'not_found',
+      createdAt: null,
+      updatedAt: null,
+      completedAt: null,
+      retentionUntil: null,
+      idempotencyUntil: null,
+      expiresAt: null,
+      poll: `/jobs/${jobId}`,
+      stream: `/jobs/${jobId}/stream`,
+      result: null,
+      error: buildJobFailurePayload('JOB_NOT_FOUND', 'Async GPT job was not found.')
+    };
+  }
+
+  if (job.status === 'completed') {
+    return buildCompletedJobLookupPayload(job);
+  }
+
+  if (job.status === 'failed') {
+    return buildFailedJobLookupPayload(job, 'JOB_FAILED', 'Async GPT job failed.');
+  }
+
+  if (job.status === 'cancelled') {
+    return buildFailedJobLookupPayload(job, 'JOB_CANCELLED', 'Async GPT job was cancelled.');
+  }
+
+  if (job.status === 'expired') {
+    return buildExpiredJobLookupPayload(job);
+  }
+
+  return buildPendingJobLookupPayload(job);
+}

--- a/tests/gpt-async-idempotency.route.test.ts
+++ b/tests/gpt-async-idempotency.route.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const mockRouteGptRequest = jest.fn();
 const findOrCreateGptJobMock = jest.fn();
+const getJobByIdMock = jest.fn();
 const planAutonomousWorkerJobMock = jest.fn();
 const waitForQueuedGptJobCompletionMock = jest.fn();
 const resolveAsyncGptPollIntervalMsMock = jest.fn(() => 250);
@@ -25,7 +26,7 @@ jest.unstable_mockModule('../src/core/db/repositories/jobRepository.js', () => (
   IdempotencyKeyConflictError: MockIdempotencyKeyConflictError,
   JobRepositoryUnavailableError: MockJobRepositoryUnavailableError,
   findOrCreateGptJob: findOrCreateGptJobMock,
-  getJobById: jest.fn(),
+  getJobById: getJobByIdMock,
   createJob: jest.fn(),
   claimNextPendingJob: jest.fn(),
   recordJobHeartbeat: jest.fn(),
@@ -125,6 +126,269 @@ describe('async /gpt idempotency', () => {
         route: 'async'
       })
     });
+  });
+
+  it('returns stored completed job results for explicit get_result actions without enqueueing work', async () => {
+    getJobByIdMock.mockResolvedValue({
+      id: 'job-lookup-complete',
+      job_type: 'gpt',
+      status: 'completed',
+      created_at: '2026-04-06T10:00:00.000Z',
+      updated_at: '2026-04-06T10:00:03.000Z',
+      completed_at: '2026-04-06T10:00:03.000Z',
+      retention_until: null,
+      idempotency_until: null,
+      expires_at: null,
+      output: {
+        ok: true,
+        result: {
+          answer: 'stored output'
+        }
+      },
+      error_message: null
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'get_result',
+        payload: {
+          jobId: 'job-lookup-complete'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      ok: true,
+      result: {
+        jobId: 'job-lookup-complete',
+        status: 'completed',
+        jobStatus: 'completed',
+        lifecycleStatus: 'completed',
+        createdAt: '2026-04-06T10:00:00.000Z',
+        updatedAt: '2026-04-06T10:00:03.000Z',
+        completedAt: '2026-04-06T10:00:03.000Z',
+        retentionUntil: null,
+        idempotencyUntil: null,
+        expiresAt: null,
+        poll: '/jobs/job-lookup-complete',
+        stream: '/jobs/job-lookup-complete/stream',
+        result: {
+          ok: true,
+          result: {
+            answer: 'stored output'
+          }
+        },
+        error: null
+      },
+      _route: expect.objectContaining({
+        gptId: 'arcanos-core',
+        action: 'get_result',
+        route: 'job_result'
+      })
+    });
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('accepts normalized get_result action variants without enqueueing work', async () => {
+    getJobByIdMock.mockResolvedValue({
+      id: 'job-lookup-normalized',
+      job_type: 'gpt',
+      status: 'completed',
+      created_at: '2026-04-06T10:00:00.000Z',
+      updated_at: '2026-04-06T10:00:03.000Z',
+      completed_at: '2026-04-06T10:00:03.000Z',
+      output: {
+        ok: true,
+        result: {
+          answer: 'normalized output'
+        }
+      },
+      error_message: null
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: ' Get_Result ',
+        payload: {
+          jobId: 'job-lookup-normalized'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result).toMatchObject({
+      jobId: 'job-lookup-normalized',
+      status: 'completed',
+      result: {
+        ok: true,
+        result: {
+          answer: 'normalized output'
+        }
+      }
+    });
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns explicit pending status for get_result without enqueueing work', async () => {
+    getJobByIdMock.mockResolvedValue({
+      id: 'job-lookup-pending',
+      job_type: 'gpt',
+      status: 'running',
+      created_at: '2026-04-06T10:00:00.000Z',
+      updated_at: '2026-04-06T10:00:01.000Z',
+      completed_at: null,
+      output: null,
+      error_message: null
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'get_result',
+        payload: {
+          jobId: 'job-lookup-pending'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result).toMatchObject({
+      jobId: 'job-lookup-pending',
+      status: 'pending',
+      jobStatus: 'running',
+      lifecycleStatus: 'running',
+      result: null,
+      error: null
+    });
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+  });
+
+  it('returns explicit expired status and preserved retained output for get_result without enqueueing work', async () => {
+    getJobByIdMock.mockResolvedValue({
+      id: 'job-lookup-expired',
+      job_type: 'gpt',
+      status: 'expired',
+      created_at: '2026-04-06T10:00:00.000Z',
+      updated_at: '2026-04-06T10:15:00.000Z',
+      completed_at: '2026-04-06T10:01:30.000Z',
+      retention_until: '2026-04-06T10:10:00.000Z',
+      idempotency_until: '2026-04-06T10:05:00.000Z',
+      expires_at: '2026-04-06T10:15:00.000Z',
+      output: {
+        ok: true,
+        result: {
+          answer: 'retained expired output'
+        }
+      },
+      error_message: 'Expired after retention window.'
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'get_result',
+        payload: {
+          jobId: 'job-lookup-expired'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result).toMatchObject({
+      jobId: 'job-lookup-expired',
+      status: 'expired',
+      jobStatus: 'expired',
+      lifecycleStatus: 'expired',
+      retentionUntil: '2026-04-06T10:10:00.000Z',
+      idempotencyUntil: '2026-04-06T10:05:00.000Z',
+      expiresAt: '2026-04-06T10:15:00.000Z',
+      result: {
+        ok: true,
+        result: {
+          answer: 'retained expired output'
+        }
+      },
+      error: {
+        code: 'JOB_EXPIRED',
+        message: 'Expired after retention window.'
+      }
+    });
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
+  });
+
+  it('returns explicit failed status for terminal get_result lookups without enqueueing work', async () => {
+    getJobByIdMock.mockResolvedValue({
+      id: 'job-lookup-failed',
+      job_type: 'gpt',
+      status: 'failed',
+      created_at: '2026-04-06T10:00:00.000Z',
+      updated_at: '2026-04-06T10:00:02.000Z',
+      completed_at: '2026-04-06T10:00:02.000Z',
+      output: null,
+      error_message: 'OpenAI upstream timed out'
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'get_result',
+        payload: {
+          jobId: 'job-lookup-failed'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result).toMatchObject({
+      jobId: 'job-lookup-failed',
+      status: 'failed',
+      jobStatus: 'failed',
+      lifecycleStatus: 'failed',
+      result: null,
+      error: {
+        code: 'JOB_FAILED',
+        message: 'OpenAI upstream timed out'
+      }
+    });
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+  });
+
+  it('returns explicit not_found status for missing get_result lookups without enqueueing work', async () => {
+    getJobByIdMock.mockResolvedValue(null);
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'get_result',
+        payload: {
+          jobId: 'missing-job'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result).toEqual({
+      jobId: 'missing-job',
+      status: 'not_found',
+      jobStatus: null,
+      lifecycleStatus: 'not_found',
+      createdAt: null,
+      updatedAt: null,
+      completedAt: null,
+      retentionUntil: null,
+      idempotencyUntil: null,
+      expiresAt: null,
+      poll: '/jobs/missing-job',
+      stream: '/jobs/missing-job/stream',
+      result: null,
+      error: {
+        code: 'JOB_NOT_FOUND',
+        message: 'Async GPT job was not found.'
+      }
+    });
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
   });
 
   it('uses a short inline wait budget for heavy async core requests', async () => {

--- a/tests/introspection-openapi-contract.route.test.ts
+++ b/tests/introspection-openapi-contract.route.test.ts
@@ -20,4 +20,15 @@ describe('custom GPT OpenAPI contract route', () => {
     expect(Object.keys(response.body.paths ?? {})).toEqual(['/gpt/{gptId}']);
     expect(response.body.paths?.['/gpt/{gptId}']?.post?.operationId).toBe('invokeGptRoute');
   });
+
+  it('serves the canonical job-result contract with no-store caching', async () => {
+    const response = await request(buildApp())
+      .get('/contracts/job_result.openapi.v1.json');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['cache-control']).toContain('no-store');
+    expect(response.body.openapi).toBe('3.1.0');
+    expect(Object.keys(response.body.paths ?? {})).toEqual(['/jobs/{jobId}/result']);
+    expect(response.body.paths?.['/jobs/{jobId}/result']?.get?.operationId).toBe('getJobResult');
+  });
 });

--- a/tests/jobs.route.test.ts
+++ b/tests/jobs.route.test.ts
@@ -29,6 +29,81 @@ describe('/jobs routes', () => {
     jest.clearAllMocks();
   });
 
+  it('returns the canonical stored-result lookup payload without enqueueing work', async () => {
+    getJobByIdMock.mockResolvedValue({
+      id: 'job-result-123',
+      job_type: 'gpt',
+      status: 'completed',
+      created_at: '2026-04-06T10:00:00.000Z',
+      updated_at: '2026-04-06T10:01:00.000Z',
+      completed_at: '2026-04-06T10:01:00.000Z',
+      retention_until: '2026-04-07T10:01:00.000Z',
+      idempotency_until: '2026-04-07T10:01:00.000Z',
+      expires_at: null,
+      error_message: null,
+      output: {
+        ok: true,
+        result: {
+          answer: 'stored output'
+        }
+      },
+      cancel_requested_at: null,
+      cancel_reason: null
+    });
+
+    const response = await request(buildApp()).get('/jobs/job-result-123/result');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      jobId: 'job-result-123',
+      status: 'completed',
+      jobStatus: 'completed',
+      lifecycleStatus: 'completed',
+      createdAt: '2026-04-06T10:00:00.000Z',
+      updatedAt: '2026-04-06T10:01:00.000Z',
+      completedAt: '2026-04-06T10:01:00.000Z',
+      retentionUntil: '2026-04-07T10:01:00.000Z',
+      idempotencyUntil: '2026-04-07T10:01:00.000Z',
+      expiresAt: null,
+      poll: '/jobs/job-result-123',
+      stream: '/jobs/job-result-123/stream',
+      result: {
+        ok: true,
+        result: {
+          answer: 'stored output'
+        }
+      },
+      error: null
+    });
+  });
+
+  it('returns an explicit not_found payload for the canonical result route', async () => {
+    getJobByIdMock.mockResolvedValue(null);
+
+    const response = await request(buildApp()).get('/jobs/missing-job/result');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      jobId: 'missing-job',
+      status: 'not_found',
+      jobStatus: null,
+      lifecycleStatus: 'not_found',
+      createdAt: null,
+      updatedAt: null,
+      completedAt: null,
+      retentionUntil: null,
+      idempotencyUntil: null,
+      expiresAt: null,
+      poll: '/jobs/missing-job',
+      stream: '/jobs/missing-job/stream',
+      result: null,
+      error: {
+        code: 'JOB_NOT_FOUND',
+        message: 'Async GPT job was not found.'
+      }
+    });
+  });
+
   it('returns lifecycle metadata for job polling responses', async () => {
     getJobByIdMock.mockResolvedValue({
       id: 'job-123',


### PR DESCRIPTION
## What changed
- add a canonical read-only `GET /jobs/:id/result` retrieval contract for stored async GPT job results
- add explicit GPT-side retrieval via `POST /gpt/:gptId` with `action: "get_result"` and `payload.jobId`
- standardize retrieval payloads for `pending`, `completed`, `failed`, `expired`, and `not_found`
- expose the retrieval contract through OpenAPI and add regression coverage for route behavior

## Why
The worker and job store were already functioning correctly, and `/jobs/:id` could already return stored results. The bug was that GPT-facing retrieval attempts were still falling through the normal async query route, so prompt-based result fetches created a second job instead of reading the existing one.

## Impact
- `POST /gpt/:gptId` async job creation remains unchanged
- explicit retrieval paths now bypass async generation entirely
- completed jobs return stored output, pending jobs return pending, failed jobs return stored error, and expired jobs surface explicit lifecycle semantics
- retrieval is now machine-readable and does not rely on prompt text

## Root cause
The retrieval contract lived outside the GPT route path. `/jobs/:id` could read persisted job state, but `/gpt/:gptId` did not have a formal explicit result-lookup branch in source, so GPT-facing fetch attempts were interpreted as ordinary async queries.

## Validation
- `node --disable-warning=ExperimentalWarning --experimental-vm-modules node_modules/jest/bin/jest.js --coverage=false --runTestsByPath tests/gpt-async-idempotency.route.test.ts tests/jobs.route.test.ts tests/introspection-openapi-contract.route.test.ts`
- `npm run type-check`
- `npm run build`
- deployed `ARCANOS V2` to Railway production and validated end-to-end:
  - created async job `61f68ec5-e9e6-46d2-823a-188114fa1d24`
  - immediate `GET /jobs/:id/result` returned `pending`
  - later `GET /jobs/:id/result` returned stored `completed` output
  - `POST /gpt/arcanos-core` with `action: "get_result"` returned stored `completed` output
  - Railway logs showed one `gpt.request.async_enqueued` event for the job and a later `gpt.request.result_lookup`, with no second enqueue during retrieval
