### PR TITLE
[codex] Replace service-name worker role inference with explicit process kind

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,10 +34,11 @@ TRINITY_MULT_CRITICAL=1.8
 # Railway / Platform
 # Railway environment identifier (set automatically on Railway)
 # RAILWAY_ENVIRONMENT=production
-# Explicit Railway runtime contract for the shared launcher:
-# - web service: ARCANOS_PROCESS_KIND=web
-# - worker service: ARCANOS_PROCESS_KIND=worker
-ARCANOS_PROCESS_KIND=web
+# Explicit Railway runtime contract for the shared launcher.
+# Leave this unset for local direct runtime so RUN_WORKERS remains authoritative.
+# - Railway web service: ARCANOS_PROCESS_KIND=web
+# - Railway worker service: ARCANOS_PROCESS_KIND=worker
+# ARCANOS_PROCESS_KIND=web
 
 # Optional Railway management API token (only required for automation scripts/CI)
 RAILWAY_API_TOKEN=
@@ -68,7 +69,7 @@ ARC_LOG_PATH=/tmp/arc/log
 ARC_MEMORY_PATH=/tmp/arc/memory
 
 # Workers
-# Local direct-runtime toggle used when bypassing the Railway launcher.
+# Local direct-runtime toggle used when ARCANOS_PROCESS_KIND is unset or when bypassing the Railway launcher.
 RUN_WORKERS=true
 # OpenAI request timeout for worker API calls (ms)
 WORKER_API_TIMEOUT_MS=60000

--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,10 @@ TRINITY_MULT_CRITICAL=1.8
 # Railway / Platform
 # Railway environment identifier (set automatically on Railway)
 # RAILWAY_ENVIRONMENT=production
+# Explicit Railway runtime contract for the shared launcher:
+# - web service: ARCANOS_PROCESS_KIND=web
+# - worker service: ARCANOS_PROCESS_KIND=worker
+ARCANOS_PROCESS_KIND=web
 
 # Optional Railway management API token (only required for automation scripts/CI)
 RAILWAY_API_TOKEN=
@@ -64,6 +68,7 @@ ARC_LOG_PATH=/tmp/arc/log
 ARC_MEMORY_PATH=/tmp/arc/memory
 
 # Workers
+# Local direct-runtime toggle used when bypassing the Railway launcher.
 RUN_WORKERS=true
 # OpenAI request timeout for worker API calls (ms)
 WORKER_API_TIMEOUT_MS=60000

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,6 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
     CMD node -e "require('http').get('http://localhost:' + (process.env.PORT || 8080) + '/health', (res) => { process.exit(res.statusCode === 200 ? 0 : 1) }).on('error', () => process.exit(1))"
 
-# Start through the Railway launcher so web and worker services receive the
-# correct runtime role and worker flags even when service-level env vars drift.
+# Start through the Railway launcher so each Railway service enforces the
+# explicit ARCANOS_PROCESS_KIND contract at runtime.
 CMD ["node", "scripts/start-railway-service.mjs"]

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "worker:helper": "node scripts/worker-helper.mjs",
     "validate:railway": "node scripts/validate-railway-compatibility.js",
     "railway:smoke:production": "node scripts/railway-production-smoke-check.js --environment production",
+    "railway:probe:async": "node scripts/railway-async-job-probe.js",
     "validate:gpt:job-hardening": "node scripts/validate-gpt-job-hardening.js",
     "railway:alert:timeouts": "node scripts/check-railway-timeout-regressions.js",
     "railway:alert:budget-abort": "node scripts/check-railway-timeout-regressions.js --since 15m --lines 500 --fail-on-budget-abort",

--- a/railway.json
+++ b/railway.json
@@ -21,7 +21,7 @@
     "env": {
       "NODE_ENV": "production",
       "PORT": "$PORT",
-      "RUN_WORKERS": "false"
+      "ARCANOS_PROCESS_KIND": "$ARCANOS_PROCESS_KIND"
     }
   },
   "environments": {
@@ -36,7 +36,7 @@
         "GPT51_MODEL": "$GPT51_MODEL",
         "GPT5_MODEL": "$GPT5_MODEL",
         "RAILWAY_ENVIRONMENT": "production",
-        "RUN_WORKERS": "false",
+        "ARCANOS_PROCESS_KIND": "$ARCANOS_PROCESS_KIND",
         "WORKER_API_TIMEOUT_MS": "60000",
         "ARC_LOG_PATH": "/tmp/arc/log",
         "ENABLE_ACTION_PLANS": "false",
@@ -47,6 +47,7 @@
       "variables": {
         "NODE_ENV": "development",
         "PORT": "8080",
+        "ARCANOS_PROCESS_KIND": "$ARCANOS_PROCESS_KIND",
         "RUN_WORKERS": "true"
       }
     }

--- a/scripts/railway-async-job-probe.js
+++ b/scripts/railway-async-job-probe.js
@@ -1,0 +1,341 @@
+#!/usr/bin/env node
+/**
+ * Purpose: Submit one synthetic async GPT job against a live Railway app and verify it reaches a terminal completed state.
+ * Inputs/Outputs: Reads CLI args, POSTs one async request, polls the returned job endpoint, prints one PASS/FAIL line, and exits non-zero on failure.
+ * Edge cases: Supports inline 200 completions, 202 pending responses, transient polling delays, and explicit terminal failure statuses.
+ */
+
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+export const PROBE_STATUS = Object.freeze({
+  PASS: 'PASS',
+  FAIL: 'FAIL'
+});
+
+export const DEFAULTS = Object.freeze({
+  baseUrl: 'https://acranos-production.up.railway.app',
+  gptId: 'arcanos-core',
+  prompt: 'Reply with the single word PONG.',
+  timeoutMs: 30_000,
+  pollIntervalMs: 750,
+  requestTimeoutMs: 15_000
+});
+
+function readPositiveInteger(rawValue, fallbackValue) {
+  const parsedValue = Number(rawValue);
+  return Number.isFinite(parsedValue) && parsedValue > 0
+    ? Math.trunc(parsedValue)
+    : fallbackValue;
+}
+
+/**
+ * Purpose: Parse CLI flags into one normalized probe configuration.
+ * Inputs/Outputs: argv string array -> config object.
+ * Edge cases: Invalid numeric flags fall back to defaults so operator typos do not silently disable the probe.
+ *
+ * @param {string[]} argv - Raw process arguments after the script path.
+ * @returns {typeof DEFAULTS}
+ */
+export function parseArgs(argv) {
+  const config = { ...DEFAULTS };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argFlag = argv[index];
+    const next = argv[index + 1];
+
+    if (argFlag === '--base-url' && typeof next === 'string' && next.trim().length > 0) {
+      config.baseUrl = next.trim();
+      index += 1;
+      continue;
+    }
+
+    if (argFlag === '--gpt-id' && typeof next === 'string' && next.trim().length > 0) {
+      config.gptId = next.trim();
+      index += 1;
+      continue;
+    }
+
+    if (argFlag === '--prompt' && typeof next === 'string' && next.trim().length > 0) {
+      config.prompt = next.trim();
+      index += 1;
+      continue;
+    }
+
+    if (argFlag === '--timeout-ms' && typeof next === 'string' && next.trim().length > 0) {
+      config.timeoutMs = readPositiveInteger(next, DEFAULTS.timeoutMs);
+      index += 1;
+      continue;
+    }
+
+    if (argFlag === '--poll-interval-ms' && typeof next === 'string' && next.trim().length > 0) {
+      config.pollIntervalMs = readPositiveInteger(next, DEFAULTS.pollIntervalMs);
+      index += 1;
+      continue;
+    }
+
+    if (argFlag === '--request-timeout-ms' && typeof next === 'string' && next.trim().length > 0) {
+      config.requestTimeoutMs = readPositiveInteger(next, DEFAULTS.requestTimeoutMs);
+      index += 1;
+    }
+  }
+
+  return config;
+}
+
+function normalizeBaseUrl(baseUrl) {
+  const normalizedBaseUrl = baseUrl.trim().replace(/\/+$/, '');
+  return /^https?:\/\//i.test(normalizedBaseUrl)
+    ? normalizedBaseUrl
+    : `https://${normalizedBaseUrl}`;
+}
+
+function buildFailure(detail) {
+  return {
+    status: PROBE_STATUS.FAIL,
+    detail
+  };
+}
+
+function buildSuccess(detail) {
+  return {
+    status: PROBE_STATUS.PASS,
+    detail
+  };
+}
+
+function buildResultUrl(baseUrl, pollPath) {
+  const normalizedPollPath = String(pollPath ?? '').trim();
+  if (!normalizedPollPath) {
+    throw new Error('Async probe response did not include a poll path.');
+  }
+
+  const absolutePollUrl = normalizedPollPath.startsWith('http://') || normalizedPollPath.startsWith('https://')
+    ? normalizedPollPath
+    : `${baseUrl}${normalizedPollPath.startsWith('/') ? normalizedPollPath : `/${normalizedPollPath}`}`;
+
+  return absolutePollUrl.endsWith('/result')
+    ? absolutePollUrl
+    : `${absolutePollUrl.replace(/\/+$/, '')}/result`;
+}
+
+function createRequestTimeoutSignal(timeoutMs) {
+  const abortController = new AbortController();
+  const timeoutHandle = setTimeout(() => abortController.abort(), timeoutMs);
+  return {
+    signal: abortController.signal,
+    dispose() {
+      clearTimeout(timeoutHandle);
+    }
+  };
+}
+
+async function readJsonResponse(response) {
+  const bodyText = await response.text();
+  if (!bodyText.trim()) {
+    return {
+      ok: false,
+      bodyText,
+      parsedBody: null
+    };
+  }
+
+  try {
+    return {
+      ok: true,
+      bodyText,
+      parsedBody: JSON.parse(bodyText)
+    };
+  } catch {
+    return {
+      ok: false,
+      bodyText,
+      parsedBody: null
+    };
+  }
+}
+
+function extractTerminalStatus(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null;
+  }
+
+  const status = typeof payload.status === 'string'
+    ? payload.status.trim().toLowerCase()
+    : '';
+
+  return status.length > 0 ? status : null;
+}
+
+/**
+ * Purpose: Submit one synthetic async GPT request and either return the inline result or the queued job coordinates.
+ * Inputs/Outputs: Probe config + injected fetch -> normalized enqueue response.
+ * Edge cases: Accepts 200 inline completion or 202 queue acceptance; all other responses fail closed with body context.
+ *
+ * @param {typeof DEFAULTS} config - Normalized probe configuration.
+ * @param {{ fetchFn?: typeof fetch }} dependencies - Injectable dependencies for tests.
+ * @returns {Promise<{ mode: 'inline'; body: Record<string, unknown> } | { mode: 'queued'; jobId: string; resultUrl: string }>}
+ */
+export async function enqueueAsyncProbe(config, dependencies = {}) {
+  const fetchFn = dependencies.fetchFn ?? fetch;
+  const normalizedBaseUrl = normalizeBaseUrl(config.baseUrl);
+  const requestUrl = `${normalizedBaseUrl}/gpt/${encodeURIComponent(config.gptId)}`;
+  const timeout = createRequestTimeoutSignal(config.requestTimeoutMs);
+
+  try {
+    const response = await fetchFn(requestUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'user-agent': 'arcanos-railway-async-job-probe/1.0'
+      },
+      body: JSON.stringify({
+        message: config.prompt,
+        async: true
+      }),
+      signal: timeout.signal
+    });
+    const parsedResponse = await readJsonResponse(response);
+
+    if (!parsedResponse.ok || !parsedResponse.parsedBody || typeof parsedResponse.parsedBody !== 'object' || Array.isArray(parsedResponse.parsedBody)) {
+      throw new Error(`Probe request returned non-JSON body (status=${response.status}).`);
+    }
+
+    if (response.status === 200) {
+      return {
+        mode: 'inline',
+        body: parsedResponse.parsedBody
+      };
+    }
+
+    if (response.status !== 202) {
+      throw new Error(`Probe request failed with status=${response.status}, body=${parsedResponse.bodyText}`);
+    }
+
+    const jobId = typeof parsedResponse.parsedBody.jobId === 'string'
+      ? parsedResponse.parsedBody.jobId.trim()
+      : '';
+    const pollPath = typeof parsedResponse.parsedBody.poll === 'string'
+      ? parsedResponse.parsedBody.poll.trim()
+      : '';
+
+    if (!jobId || !pollPath) {
+      throw new Error(`Probe request returned incomplete async metadata: ${parsedResponse.bodyText}`);
+    }
+
+    return {
+      mode: 'queued',
+      jobId,
+      resultUrl: buildResultUrl(normalizedBaseUrl, pollPath)
+    };
+  } finally {
+    timeout.dispose();
+  }
+}
+
+/**
+ * Purpose: Poll the queued async GPT job until completion or timeout.
+ * Inputs/Outputs: Probe config + job coordinates + injected fetch/sleep/time deps -> one PASS/FAIL result.
+ * Edge cases: Missing jobs, failed jobs, cancelled jobs, expired jobs, and timeout windows all fail with explicit detail.
+ *
+ * @param {typeof DEFAULTS} config - Normalized probe configuration.
+ * @param {{ jobId: string; resultUrl: string }} queuedProbe - Queued job coordinates.
+ * @param {{ fetchFn?: typeof fetch; sleepFn?: (ms: number) => Promise<void>; nowFn?: () => number }} dependencies - Injectable dependencies for tests.
+ * @returns {Promise<{ status: 'PASS'|'FAIL'; detail: string }>}
+ */
+export async function pollAsyncProbe(config, queuedProbe, dependencies = {}) {
+  const fetchFn = dependencies.fetchFn ?? fetch;
+  const sleepFn = dependencies.sleepFn ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const nowFn = dependencies.nowFn ?? Date.now;
+  const deadlineMs = nowFn() + config.timeoutMs;
+
+  while (nowFn() <= deadlineMs) {
+    const timeout = createRequestTimeoutSignal(config.requestTimeoutMs);
+
+    try {
+      const response = await fetchFn(queuedProbe.resultUrl, {
+        method: 'GET',
+        headers: {
+          'user-agent': 'arcanos-railway-async-job-probe/1.0'
+        },
+        signal: timeout.signal
+      });
+      const parsedResponse = await readJsonResponse(response);
+
+      if (!response.ok) {
+        return buildFailure(`Queued probe job ${queuedProbe.jobId} lookup failed with status=${response.status}.`);
+      }
+
+      if (!parsedResponse.ok || !parsedResponse.parsedBody || typeof parsedResponse.parsedBody !== 'object' || Array.isArray(parsedResponse.parsedBody)) {
+        return buildFailure(`Queued probe job ${queuedProbe.jobId} lookup returned a non-JSON body.`);
+      }
+
+      const terminalStatus = extractTerminalStatus(parsedResponse.parsedBody);
+
+      if (terminalStatus === 'completed') {
+        return buildSuccess(`Async probe job ${queuedProbe.jobId} completed successfully via ${queuedProbe.resultUrl}.`);
+      }
+
+      if (
+        terminalStatus === 'failed'
+        || terminalStatus === 'cancelled'
+        || terminalStatus === 'expired'
+        || terminalStatus === 'not_found'
+      ) {
+        const errorMessage =
+          typeof parsedResponse.parsedBody?.error?.message === 'string'
+            ? parsedResponse.parsedBody.error.message
+            : 'terminal failure';
+        return buildFailure(`Async probe job ${queuedProbe.jobId} ended in status=${terminalStatus}: ${errorMessage}`);
+      }
+    } finally {
+      timeout.dispose();
+    }
+
+    const remainingMs = deadlineMs - nowFn();
+    if (remainingMs <= 0) {
+      break;
+    }
+
+    await sleepFn(Math.min(config.pollIntervalMs, remainingMs));
+  }
+
+  return buildFailure(`Async probe job ${queuedProbe.jobId} did not complete within ${config.timeoutMs}ms.`);
+}
+
+/**
+ * Purpose: Run one end-to-end async-job probe against the configured Railway app.
+ * Inputs/Outputs: Config + injected deps -> PASS/FAIL result object.
+ * Edge cases: Inline completion short-circuits immediately while queued completion falls through to polling.
+ *
+ * @param {typeof DEFAULTS} config - Normalized probe configuration.
+ * @param {{ fetchFn?: typeof fetch; sleepFn?: (ms: number) => Promise<void>; nowFn?: () => number }} dependencies - Injectable dependencies for tests.
+ * @returns {Promise<{ status: 'PASS'|'FAIL'; detail: string }>}
+ */
+export async function runAsyncProbe(config, dependencies = {}) {
+  const enqueueResult = await enqueueAsyncProbe(config, dependencies);
+
+  if (enqueueResult.mode === 'inline') {
+    return buildSuccess(`Async probe completed inline from /gpt/${config.gptId}.`);
+  }
+
+  return pollAsyncProbe(config, enqueueResult, dependencies);
+}
+
+export function printProbeResult(result) {
+  process.stdout.write(`[${result.status}] ${result.detail}\n`);
+}
+
+async function main() {
+  const config = parseArgs(process.argv.slice(2));
+  const result = await runAsyncProbe(config);
+  printProbeResult(result);
+  process.exitCode = result.status === PROBE_STATUS.PASS ? 0 : 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    printProbeResult(buildFailure(error instanceof Error ? error.message : String(error)));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/railway-async-job-probe.js
+++ b/scripts/railway-async-job-probe.js
@@ -110,13 +110,12 @@ function buildResultUrl(baseUrl, pollPath) {
     throw new Error('Async probe response did not include a poll path.');
   }
 
-  const absolutePollUrl = normalizedPollPath.startsWith('http://') || normalizedPollPath.startsWith('https://')
-    ? normalizedPollPath
-    : `${baseUrl}${normalizedPollPath.startsWith('/') ? normalizedPollPath : `/${normalizedPollPath}`}`;
+  const absolutePollUrl = new URL(normalizedPollPath, baseUrl);
+  if (!absolutePollUrl.pathname.endsWith('/result')) {
+    absolutePollUrl.pathname = `${absolutePollUrl.pathname.replace(/\/+$/, '')}/result`;
+  }
 
-  return absolutePollUrl.endsWith('/result')
-    ? absolutePollUrl
-    : `${absolutePollUrl.replace(/\/+$/, '')}/result`;
+  return absolutePollUrl.toString();
 }
 
 function createRequestTimeoutSignal(timeoutMs) {

--- a/scripts/railway-async-job-probe.js
+++ b/scripts/railway-async-job-probe.js
@@ -104,6 +104,13 @@ function buildSuccess(detail) {
   };
 }
 
+function redactResultUrlForLogs(resultUrl) {
+  const sanitizedUrl = new URL(resultUrl);
+  sanitizedUrl.search = '';
+  sanitizedUrl.hash = '';
+  return sanitizedUrl.toString();
+}
+
 function buildResultUrl(baseUrl, pollPath) {
   const normalizedPollPath = String(pollPath ?? '').trim();
   if (!normalizedPollPath) {
@@ -272,7 +279,8 @@ export async function pollAsyncProbe(config, queuedProbe, dependencies = {}) {
       const terminalStatus = extractTerminalStatus(parsedResponse.parsedBody);
 
       if (terminalStatus === 'completed') {
-        return buildSuccess(`Async probe job ${queuedProbe.jobId} completed successfully via ${queuedProbe.resultUrl}.`);
+        const safeResultUrl = redactResultUrlForLogs(queuedProbe.resultUrl);
+        return buildSuccess(`Async probe job ${queuedProbe.jobId} completed successfully via ${safeResultUrl}.`);
       }
 
       if (

--- a/scripts/start-railway-service.mjs
+++ b/scripts/start-railway-service.mjs
@@ -2,18 +2,25 @@
 /**
  * Railway-aware process launcher.
  *
- * Purpose:
- * - Start the correct runtime command for each Railway service from one shared
- *   `railway.json` start command.
- * - Keep worker services healthy under Railway by exposing a minimal health
- *   endpoint while the async runner is active.
+ * Service-name inference was removed because coupling runtime role selection to
+ * Railway service naming allowed misnamed or missing worker services to accept
+ * async jobs without ever consuming them.
+ *
+ * `ARCANOS_PROCESS_KIND` is now the explicit runtime contract:
+ * - `ARCANOS_PROCESS_KIND=web` starts the API server.
+ * - `ARCANOS_PROCESS_KIND=worker` starts the async worker runtime.
+ *
+ * Configure Railway services explicitly:
+ * - Web service: `ARCANOS_PROCESS_KIND=web`
+ * - Worker service: `ARCANOS_PROCESS_KIND=worker`
  *
  * Inputs/outputs:
- * - Input: Railway environment variables (`RAILWAY_SERVICE_NAME`, `PORT`).
+ * - Input: Railway environment variables (`ARCANOS_PROCESS_KIND`, `PORT`).
  * - Output: Spawns either web server runtime or worker runtime, exits with the
  *   spawned process exit code.
  *
  * Edge cases:
+ * - Missing or invalid `ARCANOS_PROCESS_KIND` is a hard startup failure.
  * - If `PORT` is missing/invalid in worker mode, falls back to `8080`.
  * - If worker process exits, health server is shut down and this launcher exits.
  */
@@ -22,28 +29,59 @@ import { spawn } from 'node:child_process';
 import { createServer } from 'node:http';
 import process from 'node:process';
 
-const WORKER_SERVICE_TOKEN = 'worker';
 const PROCESS_KIND_ENV = 'ARCANOS_PROCESS_KIND';
+const VALID_PROCESS_KINDS = new Set(['web', 'worker']);
 const HEALTH_PATHS = new Set(['/health', '/healthz', '/readyz']);
 const HEALTH_OK_BODY = 'ok';
 const HEALTH_NOT_FOUND_BODY = 'not found';
 const DEFAULT_HEALTH_PORT = 8080;
 
 /**
- * Resolve whether this Railway service should run the async worker entrypoint.
+ * Resolve the explicit runtime process kind from environment.
  *
  * Inputs/outputs:
- * - Input: `serviceName` from Railway env.
- * - Output: `true` when service name implies worker runtime.
+ * - Input: `ARCANOS_PROCESS_KIND` from environment.
+ * - Output: normalized process kind (`web` or `worker`).
  *
  * Edge case behavior:
- * - Empty service names default to web runtime for safer API availability.
+ * - Missing or invalid values throw to prevent ambiguous service boot.
  */
-function shouldRunWorkerRuntime(serviceName) {
-  const normalizedName = String(serviceName ?? '').trim().toLowerCase();
+function resolveProcessKindOrThrow() {
+  const rawProcessKind = process.env[PROCESS_KIND_ENV];
+  const normalizedProcessKind = String(rawProcessKind ?? '').trim().toLowerCase();
 
-  //audit Assumption: worker services include "worker" in service name; risk: false negatives for custom names; invariant: non-worker services must remain on web start path; handling: default to web when token missing.
-  return normalizedName.includes(WORKER_SERVICE_TOKEN);
+  if (normalizedProcessKind.length === 0) {
+    console.warn(
+      `[ARCANOS] Missing ${PROCESS_KIND_ENV}. Set ${PROCESS_KIND_ENV}=web on the web service and ${PROCESS_KIND_ENV}=worker on the worker service.`
+    );
+    throw new Error(`${PROCESS_KIND_ENV} is required and must be "web" or "worker".`);
+  }
+
+  if (!VALID_PROCESS_KINDS.has(normalizedProcessKind)) {
+    throw new Error(
+      `${PROCESS_KIND_ENV} must be "web" or "worker", received "${String(rawProcessKind)}".`
+    );
+  }
+
+  return normalizedProcessKind;
+}
+
+/**
+ * Emit a stable startup log for operator visibility.
+ *
+ * Inputs/outputs:
+ * - Input: resolved process kind.
+ * - Output: writes a startup log line to stdout.
+ *
+ * Edge case behavior:
+ * - Missing service name is omitted from the log line.
+ */
+function logStartup(processKind) {
+  const nodeEnv = process.env.NODE_ENV ?? 'development';
+  const railwayServiceName = process.env.RAILWAY_SERVICE_NAME?.trim();
+  const serviceSegment = railwayServiceName ? `, service: ${railwayServiceName}` : '';
+
+  console.log(`[ARCANOS] Starting process: ${processKind} (env: ${nodeEnv}${serviceSegment})`);
 }
 
 /**
@@ -207,10 +245,11 @@ async function runWorkerRuntimeWithHealthServer() {
  */
 async function main() {
   try {
-    const railwayServiceName = process.env.RAILWAY_SERVICE_NAME ?? '';
+    const processKind = resolveProcessKindOrThrow();
+    logStartup(processKind);
 
-    //audit Assumption: service-specific behavior should be deterministic from env metadata; risk: wrong process type launched; invariant: worker services take worker branch only; handling: branch on normalized service name token.
-    if (shouldRunWorkerRuntime(railwayServiceName)) {
+    //audit Assumption: runtime role must be selected from an explicit env contract, not infrastructure naming; risk: wrong process type launched; invariant: only validated `web`/`worker` values are accepted; handling: strict env validation before branch selection.
+    if (processKind === 'worker') {
       await runWorkerRuntimeWithHealthServer();
       return;
     }

--- a/scripts/validate-railway-compatibility.js
+++ b/scripts/validate-railway-compatibility.js
@@ -27,16 +27,18 @@ const EXPECTED_HEALTHCHECK_PATH = '/health';
 const EXPECTED_DOCKERFILE_CMD = 'CMD ["node", "scripts/start-railway-service.mjs"]';
 const EXPECTED_DOCKERFILE_PRISMA_COPY = 'COPY prisma/ ./prisma/';
 const EXPECTED_DOCKERFILE_PRISMA_GENERATE = 'npx --yes prisma@5.22.0 generate --schema ./prisma/schema.prisma';
+const PROCESS_KIND_ENV = 'ARCANOS_PROCESS_KIND';
 const REQUIRED_PRODUCTION_VARIABLES = [
   'NODE_ENV',
   'PORT',
   'DATABASE_URL',
   'OPENAI_API_KEY',
   'RAILWAY_ENVIRONMENT',
-  'RUN_WORKERS',
+  PROCESS_KIND_ENV,
 ];
 const DOCUMENTED_PRODUCTION_VARIABLES = [
   ...REQUIRED_PRODUCTION_VARIABLES,
+  'RUN_WORKERS',
   'OPENAI_BASE_URL',
   'AI_MODEL',
   'GPT51_MODEL',
@@ -98,6 +100,25 @@ export function isBooleanEnvironmentValue(value) {
 }
 
 /**
+ * Validate the explicit process kind runtime contract.
+ *
+ * @param {unknown} value - Raw environment value candidate.
+ * @returns {boolean} `true` when the value is an accepted explicit process kind or Railway pass-through.
+ */
+export function isProcessKindEnvironmentValue(value) {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  const normalizedValue = value.trim().toLowerCase();
+  return (
+    normalizedValue === 'web'
+    || normalizedValue === 'worker'
+    || normalizedValue === `$${PROCESS_KIND_ENV.toLowerCase()}`
+  );
+}
+
+/**
  * Validate core Railway deployment settings.
  *
  * @param {Record<string, unknown>} config - Parsed railway config.
@@ -141,10 +162,10 @@ export function validateConfig(config) {
     errors.push(`Expected deploy.restartPolicyType to be "ON_FAILURE" but found "${String(deploy.restartPolicyType ?? '')}"`);
   }
 
-  //audit Assumption: Railway deploy env should declare worker topology explicitly instead of inheriting a runtime default; risk: unreviewed config drift changes whether the web service starts in-process workers; invariant: deploy.env.RUN_WORKERS is present and boolean-like; handling: fail validation on missing or malformed values.
-  if (!isBooleanEnvironmentValue(deploy.env?.RUN_WORKERS)) {
+  //audit Assumption: Railway deploy env should declare runtime role explicitly instead of inferring it from service naming; risk: unreviewed config drift boots the wrong process type; invariant: deploy.env.ARCANOS_PROCESS_KIND is present and either explicit or service-level pass-through; handling: fail validation on missing or malformed values.
+  if (!isProcessKindEnvironmentValue(deploy.env?.[PROCESS_KIND_ENV])) {
     errors.push(
-      `Expected deploy.env.RUN_WORKERS to be one of "true", "false", "1", or "0" but found "${String(deploy.env?.RUN_WORKERS ?? '')}"`,
+      `Expected deploy.env.${PROCESS_KIND_ENV} to be "web", "worker", or "$${PROCESS_KIND_ENV}" but found "${String(deploy.env?.[PROCESS_KIND_ENV] ?? '')}"`,
     );
   }
 
@@ -157,10 +178,10 @@ export function validateConfig(config) {
       errors.push(`environments.production.variables missing required keys: ${missingVariables.join(', ')}`);
     }
 
-    //audit Assumption: environment-level worker topology should also remain explicit for operators inspecting Railway variables; risk: silent fallback to runtime defaults obscures service behavior; invariant: RUN_WORKERS is a boolean-like string when present in production variables; handling: fail validation on malformed values.
-    if (!isBooleanEnvironmentValue(productionVariables.RUN_WORKERS)) {
+    //audit Assumption: environment-level process role should also remain explicit for operators inspecting Railway variables; risk: silent fallback obscures whether a service should boot web or worker runtime; invariant: ARCANOS_PROCESS_KIND is a valid explicit value or Railway pass-through; handling: fail validation on malformed values.
+    if (!isProcessKindEnvironmentValue(productionVariables[PROCESS_KIND_ENV])) {
       errors.push(
-        `Expected environments.production.variables.RUN_WORKERS to be one of "true", "false", "1", or "0" but found "${String(productionVariables.RUN_WORKERS ?? '')}"`,
+        `Expected environments.production.variables.${PROCESS_KIND_ENV} to be "web", "worker", or "$${PROCESS_KIND_ENV}" but found "${String(productionVariables[PROCESS_KIND_ENV] ?? '')}"`,
       );
     }
   }

--- a/src/platform/runtime/unifiedConfig.ts
+++ b/src/platform/runtime/unifiedConfig.ts
@@ -123,14 +123,10 @@ export interface WorkerRuntimeModeResolution {
   resolvedRunWorkers: boolean;
   processKind: 'web' | 'worker' | 'unknown';
   railwayServiceName: string | null;
-  dedicatedWorkerServiceDetected: boolean;
-  webServiceWorkersOverride: boolean;
   reason:
     | 'requested'
     | 'process_kind_web'
-    | 'process_kind_worker'
-    | 'railway_web_service'
-    | 'railway_dedicated_worker_service';
+    | 'process_kind_worker';
 }
 
 const SHOULD_BYPASS_WORKER_RUNTIME_CACHE = getEnv('NODE_ENV') === 'test';
@@ -248,22 +244,10 @@ function normalizeProcessKind(raw: string | undefined): WorkerRuntimeModeResolut
   return 'unknown';
 }
 
-function hasDedicatedRailwayWorkerService(): boolean {
-  return Object.entries(process.env).some(([key, value]) => {
-    if (!/^RAILWAY_SERVICE_.*WORKER.*_URL$/u.test(key)) {
-      return false;
-    }
-
-    return typeof value === 'string' && value.trim().length > 0;
-  });
-}
-
 export function resolveWorkerRuntimeMode(): WorkerRuntimeModeResolution {
   const requestedRunWorkers = getEnvBoolean('RUN_WORKERS', getEnv('NODE_ENV') !== 'test');
   const processKind = normalizeProcessKind(getEnv('ARCANOS_PROCESS_KIND'));
   const railwayServiceName = getEnv('RAILWAY_SERVICE_NAME')?.trim() || null;
-  const dedicatedWorkerServiceDetected = isRailwayEnvironment() && hasDedicatedRailwayWorkerService();
-  const webServiceWorkersOverride = getEnvBoolean('ARCANOS_ALLOW_WEB_SERVICE_WORKERS', false);
 
   if (processKind === 'web') {
     return {
@@ -271,8 +255,6 @@ export function resolveWorkerRuntimeMode(): WorkerRuntimeModeResolution {
       resolvedRunWorkers: false,
       processKind,
       railwayServiceName,
-      dedicatedWorkerServiceDetected,
-      webServiceWorkersOverride,
       reason: 'process_kind_web'
     };
   }
@@ -283,43 +265,7 @@ export function resolveWorkerRuntimeMode(): WorkerRuntimeModeResolution {
       resolvedRunWorkers: true,
       processKind,
       railwayServiceName,
-      dedicatedWorkerServiceDetected,
-      webServiceWorkersOverride,
       reason: 'process_kind_worker'
-    };
-  }
-
-  const normalizedServiceName = railwayServiceName?.toLowerCase() ?? '';
-  if (
-    isRailwayEnvironment() &&
-    !webServiceWorkersOverride &&
-    normalizedServiceName.length > 0 &&
-    !normalizedServiceName.includes('worker')
-  ) {
-    return {
-      requestedRunWorkers,
-      resolvedRunWorkers: false,
-      processKind,
-      railwayServiceName,
-      dedicatedWorkerServiceDetected,
-      webServiceWorkersOverride,
-      reason: 'railway_web_service'
-    };
-  }
-
-  if (
-    dedicatedWorkerServiceDetected &&
-    normalizedServiceName.length > 0 &&
-    !normalizedServiceName.includes('worker')
-  ) {
-    return {
-      requestedRunWorkers,
-      resolvedRunWorkers: false,
-      processKind,
-      railwayServiceName,
-      dedicatedWorkerServiceDetected,
-      webServiceWorkersOverride,
-      reason: 'railway_dedicated_worker_service'
     };
   }
 
@@ -328,8 +274,6 @@ export function resolveWorkerRuntimeMode(): WorkerRuntimeModeResolution {
     resolvedRunWorkers: requestedRunWorkers,
     processKind,
     railwayServiceName,
-    dedicatedWorkerServiceDetected,
-    webServiceWorkersOverride,
     reason: 'requested'
   };
 }
@@ -350,14 +294,7 @@ export function getStableWorkerRuntimeMode(): WorkerRuntimeModeResolution {
 export function isWorkerRuntimeSuppressedForServiceRole(
   workerRuntimeMode: WorkerRuntimeModeResolution
 ): boolean {
-  return (
-    !workerRuntimeMode.resolvedRunWorkers
-    && (
-      workerRuntimeMode.processKind === 'web'
-      || workerRuntimeMode.reason === 'railway_web_service'
-      || workerRuntimeMode.reason === 'railway_dedicated_worker_service'
-    )
-  );
+  return !workerRuntimeMode.resolvedRunWorkers && workerRuntimeMode.processKind === 'web';
 }
 
 /**

--- a/src/platform/runtime/workerConfig.ts
+++ b/src/platform/runtime/workerConfig.ts
@@ -35,7 +35,6 @@ if (workerRuntimeMode.requestedRunWorkers && !workerRuntimeMode.resolvedRunWorke
     module: 'core',
     serviceName: workerRuntimeMode.railwayServiceName,
     processKind: workerRuntimeMode.processKind,
-    dedicatedWorkerServiceDetected: workerRuntimeMode.dedicatedWorkerServiceDetected,
     reason: workerRuntimeMode.reason
   });
 }
@@ -303,9 +302,7 @@ export interface WorkerBootstrapSummary {
 function buildWorkersDisabledSummary(): WorkerBootstrapSummary {
   const message =
     workerRuntimeMode.reason === 'process_kind_web'
-      || workerRuntimeMode.reason === 'railway_web_service'
-      || workerRuntimeMode.reason === 'railway_dedicated_worker_service'
-      ? 'RUN_WORKERS disabled for this service role; workers not started.'
+      ? 'RUN_WORKERS disabled for explicit web process role; workers not started.'
       : 'RUN_WORKERS disabled; workers not started.';
 
   return {

--- a/tests/predictive-healing-execution.test.ts
+++ b/tests/predictive-healing-execution.test.ts
@@ -19,17 +19,11 @@ const getStableWorkerRuntimeModeMock = jest.fn(() => ({
   resolvedRunWorkers: false,
   processKind: 'unknown',
   railwayServiceName: null,
-  dedicatedWorkerServiceDetected: false,
-  webServiceWorkersOverride: false,
   reason: 'requested'
 }));
 const isWorkerRuntimeSuppressedForServiceRoleMock = jest.fn((workerRuntimeMode) => (
   !workerRuntimeMode.resolvedRunWorkers
-  && (
-    workerRuntimeMode.processKind === 'web'
-    || workerRuntimeMode.reason === 'railway_web_service'
-    || workerRuntimeMode.reason === 'railway_dedicated_worker_service'
-  )
+  && workerRuntimeMode.processKind === 'web'
 ));
 
 function createStructuredLoggerMock() {

--- a/tests/predictive-healing-service.test.ts
+++ b/tests/predictive-healing-service.test.ts
@@ -54,17 +54,11 @@ const getStableWorkerRuntimeModeMock = jest.fn(() => ({
   resolvedRunWorkers: false,
   processKind: 'unknown',
   railwayServiceName: null,
-  dedicatedWorkerServiceDetected: false,
-  webServiceWorkersOverride: false,
   reason: 'requested'
 }));
 const isWorkerRuntimeSuppressedForServiceRoleMock = jest.fn((workerRuntimeMode) => (
   !workerRuntimeMode.resolvedRunWorkers
-  && (
-    workerRuntimeMode.processKind === 'web'
-    || workerRuntimeMode.reason === 'railway_web_service'
-    || workerRuntimeMode.reason === 'railway_dedicated_worker_service'
-  )
+  && workerRuntimeMode.processKind === 'web'
 ));
 
 jest.unstable_mockModule('@platform/runtime/workerConfig.js', () => ({

--- a/tests/railway-async-job-probe.test.js
+++ b/tests/railway-async-job-probe.test.js
@@ -1,0 +1,149 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  DEFAULTS,
+  PROBE_STATUS,
+  enqueueAsyncProbe,
+  parseArgs,
+  pollAsyncProbe,
+  runAsyncProbe
+} from '../scripts/railway-async-job-probe.js';
+
+describe('railway-async-job-probe', () => {
+  it('parses explicit CLI overrides', () => {
+    const parsed = parseArgs([
+      '--base-url', 'https://example.com',
+      '--gpt-id', 'custom-core',
+      '--prompt', 'Return OK.',
+      '--timeout-ms', '45000',
+      '--poll-interval-ms', '900',
+      '--request-timeout-ms', '5000'
+    ]);
+
+    expect(parsed).toEqual({
+      ...DEFAULTS,
+      baseUrl: 'https://example.com',
+      gptId: 'custom-core',
+      prompt: 'Return OK.',
+      timeoutMs: 45000,
+      pollIntervalMs: 900,
+      requestTimeoutMs: 5000
+    });
+  });
+
+  it('accepts queued async jobs and reports completion after polling', async () => {
+    const responses = [
+      {
+        status: 202,
+        ok: true,
+        text: async () => JSON.stringify({
+          ok: true,
+          status: 'pending',
+          jobId: 'job-123',
+          poll: '/jobs/job-123'
+        })
+      },
+      {
+        status: 200,
+        ok: true,
+        text: async () => JSON.stringify({
+          jobId: 'job-123',
+          status: 'pending'
+        })
+      },
+      {
+        status: 200,
+        ok: true,
+        text: async () => JSON.stringify({
+          jobId: 'job-123',
+          status: 'completed',
+          result: { ok: true }
+        })
+      }
+    ];
+    const fetchFn = async () => responses.shift();
+    const sleepFn = async () => {};
+
+    const result = await runAsyncProbe(
+      {
+        ...DEFAULTS,
+        baseUrl: 'https://example.com',
+        timeoutMs: 5_000,
+        pollIntervalMs: 10
+      },
+      {
+        fetchFn,
+        sleepFn,
+        nowFn: (() => {
+          let now = 0;
+          return () => {
+            now += 5;
+            return now;
+          };
+        })()
+      }
+    );
+
+    expect(result.status).toBe(PROBE_STATUS.PASS);
+    expect(result.detail).toMatch(/job-123/);
+  });
+
+  it('fails when the queued job reaches a terminal failed state', async () => {
+    const result = await pollAsyncProbe(
+      {
+        ...DEFAULTS,
+        timeoutMs: 1_000,
+        pollIntervalMs: 10
+      },
+      {
+        jobId: 'job-failed',
+        resultUrl: 'https://example.com/jobs/job-failed/result'
+      },
+      {
+        fetchFn: async () => ({
+          status: 200,
+          ok: true,
+          text: async () => JSON.stringify({
+            jobId: 'job-failed',
+            status: 'failed',
+            error: {
+              message: 'worker execution failed'
+            }
+          })
+        }),
+        sleepFn: async () => {},
+        nowFn: () => 0
+      }
+    );
+
+    expect(result.status).toBe(PROBE_STATUS.FAIL);
+    expect(result.detail).toMatch(/worker execution failed/);
+  });
+
+  it('returns queued probe metadata with a normalized result URL', async () => {
+    const enqueueResult = await enqueueAsyncProbe(
+      {
+        ...DEFAULTS,
+        baseUrl: 'example.com',
+        gptId: 'arcanos-core'
+      },
+      {
+        fetchFn: async () => ({
+          status: 202,
+          ok: true,
+          text: async () => JSON.stringify({
+            ok: true,
+            status: 'pending',
+            jobId: 'job-456',
+            poll: '/jobs/job-456'
+          })
+        })
+      }
+    );
+
+    expect(enqueueResult).toEqual({
+      mode: 'queued',
+      jobId: 'job-456',
+      resultUrl: 'https://example.com/jobs/job-456/result'
+    });
+  });
+});

--- a/tests/railway-async-job-probe.test.js
+++ b/tests/railway-async-job-probe.test.js
@@ -146,4 +146,32 @@ describe('railway-async-job-probe', () => {
       resultUrl: 'https://example.com/jobs/job-456/result'
     });
   });
+
+  it('preserves query parameters when the poll URL is already absolute', async () => {
+    const enqueueResult = await enqueueAsyncProbe(
+      {
+        ...DEFAULTS,
+        baseUrl: 'https://example.com',
+        gptId: 'arcanos-core'
+      },
+      {
+        fetchFn: async () => ({
+          status: 202,
+          ok: true,
+          text: async () => JSON.stringify({
+            ok: true,
+            status: 'pending',
+            jobId: 'job-789',
+            poll: 'https://example.com/jobs/job-789?token=abc123'
+          })
+        })
+      }
+    );
+
+    expect(enqueueResult).toEqual({
+      mode: 'queued',
+      jobId: 'job-789',
+      resultUrl: 'https://example.com/jobs/job-789/result?token=abc123'
+    });
+  });
 });

--- a/tests/railway-async-job-probe.test.js
+++ b/tests/railway-async-job-probe.test.js
@@ -87,6 +87,37 @@ describe('railway-async-job-probe', () => {
     expect(result.detail).toMatch(/job-123/);
   });
 
+  it('redacts query parameters from successful probe output', async () => {
+    const result = await pollAsyncProbe(
+      {
+        ...DEFAULTS,
+        timeoutMs: 1_000,
+        pollIntervalMs: 10
+      },
+      {
+        jobId: 'job-secret',
+        resultUrl: 'https://example.com/jobs/job-secret/result?trace=probe-secret'
+      },
+      {
+        fetchFn: async () => ({
+          status: 200,
+          ok: true,
+          text: async () => JSON.stringify({
+            jobId: 'job-secret',
+            status: 'completed',
+            result: { ok: true }
+          })
+        }),
+        sleepFn: async () => {},
+        nowFn: () => 0
+      }
+    );
+
+    expect(result.status).toBe(PROBE_STATUS.PASS);
+    expect(result.detail).toContain('https://example.com/jobs/job-secret/result');
+    expect(result.detail).not.toContain('trace=probe-secret');
+  });
+
   it('fails when the queued job reaches a terminal failed state', async () => {
     const result = await pollAsyncProbe(
       {
@@ -162,7 +193,7 @@ describe('railway-async-job-probe', () => {
             ok: true,
             status: 'pending',
             jobId: 'job-789',
-            poll: 'https://example.com/jobs/job-789?token=abc123'
+            poll: 'https://example.com/jobs/job-789?trace=abc123'
           })
         })
       }
@@ -171,7 +202,7 @@ describe('railway-async-job-probe', () => {
     expect(enqueueResult).toEqual({
       mode: 'queued',
       jobId: 'job-789',
-      resultUrl: 'https://example.com/jobs/job-789/result?token=abc123'
+      resultUrl: 'https://example.com/jobs/job-789/result?trace=abc123'
     });
   });
 });

--- a/tests/self-healing-loop.test.ts
+++ b/tests/self-healing-loop.test.ts
@@ -28,17 +28,11 @@ const getStableWorkerRuntimeModeMock = jest.fn(() => ({
   resolvedRunWorkers: false,
   processKind: 'unknown',
   railwayServiceName: null,
-  dedicatedWorkerServiceDetected: false,
-  webServiceWorkersOverride: false,
   reason: 'requested'
 }));
 const isWorkerRuntimeSuppressedForServiceRoleMock = jest.fn((workerRuntimeMode) => (
   !workerRuntimeMode.resolvedRunWorkers
-  && (
-    workerRuntimeMode.processKind === 'web'
-    || workerRuntimeMode.reason === 'railway_web_service'
-    || workerRuntimeMode.reason === 'railway_dedicated_worker_service'
-  )
+  && workerRuntimeMode.processKind === 'web'
 ));
 
 jest.unstable_mockModule('@platform/runtime/unifiedConfig.js', () => ({

--- a/tests/unified-config.worker-mode.test.ts
+++ b/tests/unified-config.worker-mode.test.ts
@@ -25,39 +25,7 @@ afterEach(() => {
 });
 
 describe('resolveWorkerRuntimeMode', () => {
-  it('suppresses in-process workers on Railway web services by default', () => {
-    resetEnv({
-      NODE_ENV: 'production',
-      RUN_WORKERS: 'true',
-      RAILWAY_ENVIRONMENT: 'production',
-      RAILWAY_SERVICE_NAME: 'ARCANOS V2',
-      RAILWAY_SERVICE_ARCANOS_WORKER_URL: 'arcanos-worker-production.up.railway.app'
-    });
-
-    const resolution = resolveWorkerRuntimeMode();
-
-    expect(resolution.resolvedRunWorkers).toBe(false);
-    expect(resolution.reason).toBe('railway_web_service');
-    expect(getConfig().runWorkers).toBe(false);
-  });
-
-  it('keeps workers enabled for dedicated Railway worker services', () => {
-    resetEnv({
-      NODE_ENV: 'production',
-      RUN_WORKERS: 'true',
-      RAILWAY_ENVIRONMENT: 'production',
-      RAILWAY_SERVICE_NAME: 'ARCANOS Worker',
-      RAILWAY_SERVICE_ARCANOS_WORKER_URL: 'arcanos-worker-production.up.railway.app'
-    });
-
-    const resolution = resolveWorkerRuntimeMode();
-
-    expect(resolution.resolvedRunWorkers).toBe(true);
-    expect(resolution.reason).toBe('requested');
-    expect(getConfig().runWorkers).toBe(true);
-  });
-
-  it('forces web role workers off when the launcher marks the process as web', () => {
+  it('forces workers off when the process kind is explicitly web', () => {
     resetEnv({
       NODE_ENV: 'production',
       RUN_WORKERS: 'true',
@@ -68,20 +36,48 @@ describe('resolveWorkerRuntimeMode', () => {
 
     expect(resolution.resolvedRunWorkers).toBe(false);
     expect(resolution.reason).toBe('process_kind_web');
+    expect(getConfig().runWorkers).toBe(false);
   });
 
-  it('allows Railway web services to opt back into in-process workers explicitly', () => {
+  it('forces workers on when the process kind is explicitly worker', () => {
     resetEnv({
       NODE_ENV: 'production',
-      RUN_WORKERS: 'true',
-      RAILWAY_ENVIRONMENT: 'production',
-      RAILWAY_SERVICE_NAME: 'ARCANOS V2',
-      ARCANOS_ALLOW_WEB_SERVICE_WORKERS: 'true'
+      RUN_WORKERS: 'false',
+      ARCANOS_PROCESS_KIND: 'worker'
     });
 
     const resolution = resolveWorkerRuntimeMode();
 
     expect(resolution.resolvedRunWorkers).toBe(true);
+    expect(resolution.reason).toBe('process_kind_worker');
+    expect(getConfig().runWorkers).toBe(true);
+  });
+
+  it('falls back to RUN_WORKERS without service-name suppression when process kind is missing', () => {
+    resetEnv({
+      NODE_ENV: 'production',
+      RUN_WORKERS: 'true',
+      RAILWAY_ENVIRONMENT: 'production',
+      RAILWAY_SERVICE_NAME: 'ARCANOS V2'
+    });
+
+    const resolution = resolveWorkerRuntimeMode();
+
+    expect(resolution.resolvedRunWorkers).toBe(true);
+    expect(resolution.reason).toBe('requested');
+  });
+
+  it('treats invalid process kinds as unknown and falls back to RUN_WORKERS', () => {
+    resetEnv({
+      NODE_ENV: 'production',
+      RUN_WORKERS: 'false',
+      ARCANOS_PROCESS_KIND: 'scheduler'
+    });
+
+    const resolution = resolveWorkerRuntimeMode();
+
+    expect(resolution.processKind).toBe('unknown');
+    expect(resolution.resolvedRunWorkers).toBe(false);
     expect(resolution.reason).toBe('requested');
   });
 });

--- a/tests/validate-railway-compatibility.test.js
+++ b/tests/validate-railway-compatibility.test.js
@@ -17,7 +17,7 @@ function buildMinimalRailwayConfig(overrides = {}) {
       healthcheckPath: '/health',
       restartPolicyType: 'ON_FAILURE',
       env: {
-        RUN_WORKERS: 'true',
+        ARCANOS_PROCESS_KIND: '$ARCANOS_PROCESS_KIND',
       },
     },
     environments: {
@@ -28,7 +28,7 @@ function buildMinimalRailwayConfig(overrides = {}) {
           DATABASE_URL: '$DATABASE_URL',
           OPENAI_API_KEY: '$OPENAI_API_KEY',
           RAILWAY_ENVIRONMENT: 'production',
-          RUN_WORKERS: 'true',
+          ARCANOS_PROCESS_KIND: '$ARCANOS_PROCESS_KIND',
         },
       },
     },
@@ -43,7 +43,7 @@ describe('validate-railway-compatibility', () => {
     expect(validationErrors).toEqual([]);
   });
 
-  it('rejects malformed RUN_WORKERS values in deploy and production env settings', () => {
+  it('rejects malformed ARCANOS_PROCESS_KIND values in deploy and production env settings', () => {
     const validationErrors = validateConfig(
       buildMinimalRailwayConfig({
         deploy: {
@@ -51,7 +51,7 @@ describe('validate-railway-compatibility', () => {
           healthcheckPath: '/health',
           restartPolicyType: 'ON_FAILURE',
           env: {
-            RUN_WORKERS: 'sometimes',
+            ARCANOS_PROCESS_KIND: 'sometimes',
           },
         },
         environments: {
@@ -62,7 +62,7 @@ describe('validate-railway-compatibility', () => {
               DATABASE_URL: '$DATABASE_URL',
               OPENAI_API_KEY: '$OPENAI_API_KEY',
               RAILWAY_ENVIRONMENT: 'production',
-              RUN_WORKERS: 'sometimes',
+              ARCANOS_PROCESS_KIND: 'sometimes',
             },
           },
         },
@@ -71,8 +71,8 @@ describe('validate-railway-compatibility', () => {
 
     expect(validationErrors).toEqual(
       expect.arrayContaining([
-        expect.stringContaining('deploy.env.RUN_WORKERS'),
-        expect.stringContaining('environments.production.variables.RUN_WORKERS'),
+        expect.stringContaining('deploy.env.ARCANOS_PROCESS_KIND'),
+        expect.stringContaining('environments.production.variables.ARCANOS_PROCESS_KIND'),
       ]),
     );
   });
@@ -84,6 +84,7 @@ describe('validate-railway-compatibility', () => {
 # DATABASE_URL=$DATABASE_URL
 # OPENAI_API_KEY=$OPENAI_API_KEY
 # RAILWAY_ENVIRONMENT=production
+# ARCANOS_PROCESS_KIND=web
 # RUN_WORKERS=false
 `);
 

--- a/tests/worker-duplication-suppression.test.ts
+++ b/tests/worker-duplication-suppression.test.ts
@@ -85,7 +85,7 @@ describe('worker duplication suppression', () => {
       runWorkers: false,
       workerCount: 0,
       workerIds: [],
-      message: 'RUN_WORKERS disabled for this service role; workers not started.'
+      message: 'RUN_WORKERS disabled for explicit web process role; workers not started.'
     }));
     expect(workerConfig.getWorkerRuntimeStatus()).toEqual(expect.objectContaining({
       enabled: false,

--- a/tests/worker-helper-route.test.ts
+++ b/tests/worker-helper-route.test.ts
@@ -640,7 +640,7 @@ describe('/worker-helper routes', () => {
       workerCount: 0,
       workerIds: [],
       model: 'gpt-5.1',
-      message: 'RUN_WORKERS disabled for this service role; workers not started.'
+      message: 'RUN_WORKERS disabled for explicit web process role; workers not started.'
     });
     getWorkerRuntimeStatusMock.mockReturnValue({
       enabled: false,
@@ -664,7 +664,7 @@ describe('/worker-helper routes', () => {
       restart: expect.objectContaining({
         started: false,
         runWorkers: false,
-        message: 'RUN_WORKERS disabled for this service role; workers not started.'
+        message: 'RUN_WORKERS disabled for explicit web process role; workers not started.'
       }),
       runtime: expect.objectContaining({
         enabled: false,


### PR DESCRIPTION
## Summary
- replace Railway service-name-based role detection with an explicit `ARCANOS_PROCESS_KIND=web|worker` runtime contract
- hard-fail launcher startup when `ARCANOS_PROCESS_KIND` is missing or invalid, with startup logging for process kind, environment, and service name
- add and wire an async job probe so queue health can be validated end to end

## Root Cause
Worker role selection was implicitly coupled to Railway service naming. When a worker service was absent or misnamed, the runtime accepted async jobs but no process consumed the queue, leaving jobs pending indefinitely.

## What Changed
- refactored `scripts/start-railway-service.mjs` to route only on `ARCANOS_PROCESS_KIND`
- removed service-name fallback logic from the runtime worker-mode resolver
- updated Railway compatibility validation and config fixtures to require `ARCANOS_PROCESS_KIND`
- documented the explicit launcher contract in `.env.example`
- kept existing web and worker execution paths unchanged

## Operator Impact
- Railway web service must set `ARCANOS_PROCESS_KIND=web`
- Railway worker service must set `ARCANOS_PROCESS_KIND=worker`
- service naming no longer affects runtime role selection

## Validation
- `npm run validate:railway`
- `npm run build:packages`
- `node --disable-warning=ExperimentalWarning --experimental-vm-modules node_modules/jest/bin/jest.js tests/unified-config.worker-mode.test.ts tests/validate-railway-compatibility.test.js tests/predictive-healing-execution.test.ts tests/predictive-healing-service.test.ts tests/self-healing-loop.test.ts tests/worker-duplication-suppression.test.ts tests/worker-helper-route.test.ts tests/railway-async-job-probe.test.js --coverage=false`
- `npm run railway:probe:async`
