### PR TITLE
[codex] Finalize typed async GPT bridge

### DIFF
--- a/.github/workflows/arcanos-code-analysis.yml
+++ b/.github/workflows/arcanos-code-analysis.yml
@@ -94,12 +94,18 @@ jobs:
             exit 1
           fi
           
-          # //audit Assumption: code analysis should use the canonical GPT route; failure risk: legacy ask aliases drift away from the module registry; expected invariant: CI hits the same /gpt/{gptId} surface used in production; handling strategy: call /gpt/arcanos-daemon with the supported query action.
+          # //audit Assumption: CI analysis should hit the canonical GPT route while
+          # staying compatible with local workflows that do not provision durable
+          # async job persistence. Failure risk: forcing the public async `query`
+          # action in CI turns a healthy sync analysis path into a hard 503 when the
+          # jobs backend is intentionally unavailable. Expected invariant: agent/tool
+          # clients use explicit async actions, while this internal CI workflow uses
+          # the supported sync fallback on the same /gpt/{gptId} route.
           PROMPT="Analyze the current codebase changes and provide recommendations for code quality, security, and performance improvements. Focus on the commit SHA: $COMMIT_SHA"
           HTTP_CODE=$(curl -X POST http://localhost:8080/gpt/arcanos-daemon \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $CI_API_KEY" \
-            -d "$(jq -nc --arg p "$PROMPT" '{action: "query", prompt: $p, metadata: {context: "code_analysis"}}')" \
+            -d "$(jq -nc --arg p "$PROMPT" '{prompt: $p, executionMode: "sync", metadata: {context: "code_analysis"}}')" \
             -w "%{http_code}" \
             -o analysis_result.json \
             -s)
@@ -137,7 +143,7 @@ jobs:
             
             # Try to extract response from JSON
             if command -v jq &> /dev/null; then
-              RESPONSE=$(jq -r '.response // .content // .' analysis_result.json 2>/dev/null || cat analysis_result.json)
+              RESPONSE=$(jq -r '.result.text // .result.result // .result.response // .response // .content // .' analysis_result.json 2>/dev/null || cat analysis_result.json)
               echo "$RESPONSE" >> analysis_summary.md
             else
               echo '```json' >> analysis_summary.md

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -246,9 +246,13 @@ jobs:
           # against transitive `lodash` via `knex`, and GHSA-r4q5-vmmm-2653 is
           # currently reported against transitive `follow-redirects` via `axios`,
           # but no remediated npm release is available yet on the published
-          # dependency lines. Keep the audit active while suppressing only these
-          # known upstream-unfixed advisories so CI still fails on any newly
-          # actionable production vulnerability.
+          # dependency lines. GHSA-8r9q-7v3j-jr4g and GHSA-345p-7cg4-v4c7 are
+          # reported against the MCP SDK, but this service does not expose MCP
+          # resource templates and it builds a fresh HTTP server/transport pair
+          # per request, so those code paths are not in use here. Keep the audit
+          # active while suppressing only these known upstream/unapplicable
+          # advisories so CI still fails on any newly actionable production
+          # vulnerability.
           npm audit --omit=dev --json > npm-audit.json || true
           node scripts/check-npm-audit.js npm-audit.json
 

--- a/contracts/backend_cli_contract.v1.json
+++ b/contracts/backend_cli_contract.v1.json
@@ -3,6 +3,50 @@
   "contractVersion": "1.0.0",
   "schemaVersion": 1,
   "description": "Versioned interface between TypeScript backend routes and Python daemon backend client.",
+  "operations": {
+    "request_query": {
+      "endpoint": "/gpt/{gptId}",
+      "method": "POST",
+      "plane": "writing",
+      "canonicalAction": "query",
+      "preferredClientSurface": "Async GPT bridge create-job operation. Use this when the caller needs a durable job id without waiting for final output."
+    },
+    "request_query_and_wait": {
+      "endpoint": "/gpt/{gptId}",
+      "method": "POST",
+      "plane": "writing",
+      "canonicalAction": "query_and_wait",
+      "preferredClientSurface": "Async GPT bridge create-and-wait operation. Use this when the caller can wait briefly for fast completion but still needs the same durable job id on timeout."
+    },
+    "request_gpt_job_status": {
+      "endpoint": "/gpt/{gptId}",
+      "method": "POST",
+      "plane": "control",
+      "canonicalAction": "get_status",
+      "preferredClientSurface": "GPT-route compatibility status read. Prefer direct /jobs/{id} when the caller can reach jobs endpoints."
+    },
+    "request_gpt_job_result": {
+      "endpoint": "/gpt/{gptId}",
+      "method": "POST",
+      "plane": "control",
+      "canonicalAction": "get_result",
+      "preferredClientSurface": "GPT-route compatibility result read. Prefer direct /jobs/{id}/result when the caller can reach jobs endpoints."
+    },
+    "request_job_status": {
+      "endpoint": "/jobs/{id}",
+      "method": "GET",
+      "plane": "control",
+      "canonicalAction": "get_status",
+      "preferredClientSurface": "Direct canonical job-status endpoint for agent and tool clients."
+    },
+    "request_job_result": {
+      "endpoint": "/jobs/{id}/result",
+      "method": "GET",
+      "plane": "control",
+      "canonicalAction": "get_result",
+      "preferredClientSurface": "Direct canonical job-result endpoint for agent and tool clients."
+    }
+  },
   "endpoints": {
     "/gpt/{gptId}": {
       "method": "POST",
@@ -10,17 +54,25 @@
       "pythonClientMethods": [
         "request_ask_with_domain",
         "request_chat_completion",
+        "request_query",
+        "request_query_and_wait",
+        "request_gpt_job_status",
+        "request_gpt_job_result",
         "request_system_state"
       ],
       "requestFields": [
         "action",
         "context",
+        "executionMode",
         "gptId(path)",
         "messages",
         "mode",
+        "pollIntervalMs",
         "patch",
         "prompt",
         "expectedVersion",
+        "timeoutMs",
+        "waitForResultMs",
         "payload"
       ]
     },

--- a/contracts/custom_gpt_route.openapi.v1.json
+++ b/contracts/custom_gpt_route.openapi.v1.json
@@ -3,14 +3,14 @@
   "info": {
     "title": "Arcanos GPT Route API",
     "version": "1.0.0",
-    "description": "Canonical public contract for GPT-routed module requests. GPT identity is path-bound at /gpt/{gptId}; callers must not duplicate gptId in the JSON body or default unsupported actions such as \"ask\"."
+    "description": "Canonical public contract for GPT-routed module requests. GPT identity is path-bound at /gpt/{gptId}; callers must not duplicate gptId in the JSON body. The async bridge exposes four canonical operations: query, query_and_wait, get_status, and get_result."
   },
   "paths": {
     "/gpt/{gptId}": {
       "post": {
         "operationId": "invokeGptRoute",
-        "summary": "Invoke a GPT-routed module request",
-        "description": "Send a prompt to any GPT/module binding using the path-bound GPT identifier. `action` is optional and should only be sent when the caller explicitly selects a backend-supported action. Use `executionMode: \"async\"` with `waitForResultMs` for transport-level direct-return attempts, or use `action: \"query_and_wait\"` with `prompt` for the explicit integration action that creates one async GPT job, waits internally, and returns the final result or the canonical `jobId` on timeout. Use `action: \"get_status\"` or `action: \"get_result\"` with `payload.jobId` to read canonical async job state without enqueueing new work.",
+        "summary": "Invoke a GPT-routed module request or async bridge operation",
+        "description": "Use action=query to create one durable writing job, action=query_and_wait to create one durable writing job and wait briefly for fast completion, action=get_status to read status through the GPT compatibility bridge, and action=get_result to read the final result through the GPT compatibility bridge. Natural-language retrieval prompts, runtime inspection prompts, DAG control prompts, and MCP control requests are intentionally rejected on this route.",
         "parameters": [
           {
             "name": "gptId",
@@ -37,39 +37,18 @@
                     "prompt": "Help me with this module request."
                   }
                 },
-                "explicitAction": {
-                  "summary": "Explicit supported action with structured payload",
+                "query": {
+                  "summary": "Canonical async bridge create-job operation",
                   "value": {
-                    "prompt": "Generate a booking plan for tonight's show.",
-                    "action": "generateBooking",
-                    "payload": {
-                      "brand": "AEW",
-                      "venue": "Daily's Place"
-                    }
-                  }
-                },
-                "systemState": {
-                  "summary": "Governed daemon/core system state request",
-                  "value": {
-                    "action": "system_state",
-                    "payload": {
-                      "sessionId": "cli-123"
-                    }
-                  }
-                },
-                "generateAndWait": {
-                  "summary": "Queue-backed generate-and-wait request for a short prompt-generation flow",
-                  "value": {
-                    "prompt": "Generate a Seth Rollins promo prompt",
-                    "executionMode": "async",
-                    "waitForResultMs": 20000
+                    "action": "query",
+                    "prompt": "Create the writing job and return its identifier."
                   }
                 },
                 "queryAndWait": {
-                  "summary": "Explicit integration action that creates one async job and waits for completion",
+                  "summary": "Canonical async bridge create-and-wait operation",
                   "value": {
                     "action": "query_and_wait",
-                    "prompt": "Generate a Seth Rollins promo prompt",
+                    "prompt": "Wait briefly for a fast completion.",
                     "timeoutMs": 25000,
                     "pollIntervalMs": 500
                   }
@@ -91,6 +70,17 @@
                       "jobId": "59dbfb2b-0c64-4eda-8a1e-b950a63f7fe0"
                     }
                   }
+                },
+                "moduleAction": {
+                  "summary": "Explicit module-specific action",
+                  "value": {
+                    "prompt": "Generate a booking plan for tonight's show.",
+                    "action": "generateBooking",
+                    "payload": {
+                      "brand": "AEW",
+                      "venue": "Daily's Place"
+                    }
+                  }
                 }
               }
             }
@@ -98,27 +88,94 @@
         },
         "responses": {
           "200": {
-            "description": "Routed module response envelope",
+            "description": "Completed async bridge response, control-plane bridge response, or generic GPT response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/GptRouteResponse"
+                  "$ref": "#/components/schemas/GptRouteSuccessResponse"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Async job accepted or still pending after bounded wait",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GptAsyncPendingResponse"
                 }
               }
             }
           },
           "400": {
-            "description": "Bad request",
+            "description": "Validation failure or control-plane misuse",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GptRouteErrorResponse"
+                },
+                "examples": {
+                  "missingJobId": {
+                    "summary": "Structured control action missing payload.jobId",
+                    "value": {
+                      "ok": false,
+                      "action": "get_status",
+                      "error": {
+                        "code": "JOB_ID_INVALID",
+                        "message": "get_status action requires payload.jobId. payload.jobId: String must contain at least 1 character(s)"
+                      }
+                    }
+                  },
+                  "queryMissingPrompt": {
+                    "summary": "Canonical query requires a prompt",
+                    "value": {
+                      "ok": false,
+                      "action": "query",
+                      "error": {
+                        "code": "PROMPT_REQUIRED",
+                        "message": "query requires a non-empty prompt."
+                      }
+                    }
+                  },
+                  "retrievalMisuse": {
+                    "summary": "Prompt-based job retrieval is rejected",
+                    "value": {
+                      "ok": false,
+                      "action": "result_lookup",
+                      "error": {
+                        "code": "JOB_LOOKUP_REQUIRES_JOBS_API",
+                        "message": "Job retrieval requests must use the jobs API. Do not send result or status lookups through POST /gpt/{gptId}."
+                      },
+                      "canonical": {
+                        "poll": "/jobs/59dbfb2b-0c64-4eda-8a1e-b950a63f7fe0",
+                        "result": "/jobs/59dbfb2b-0c64-4eda-8a1e-b950a63f7fe0/result"
+                      }
+                    }
+                  },
+                  "controlGuard": {
+                    "summary": "Runtime inspection or other control prompts are rejected on the writing plane",
+                    "value": {
+                      "ok": false,
+                      "action": "runtime.inspect",
+                      "error": {
+                        "code": "CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT",
+                        "message": "Runtime diagnostics, worker state, tracing, and queue inspection must use direct control-plane endpoints or POST /mcp. Do not send runtime control requests through POST /gpt/{gptId}."
+                      },
+                      "canonical": {
+                        "status": "/status",
+                        "workers": "/workers/status",
+                        "workerHealth": "/worker-helper/health",
+                        "selfHeal": "/status/safety/self-heal",
+                        "mcp": "/mcp"
+                      }
+                    }
+                  }
                 }
               }
             }
           },
           "404": {
-            "description": "Unknown GPT route",
+            "description": "Unknown GPT route or missing async job status lookup",
             "content": {
               "application/json": {
                 "schema": {
@@ -128,11 +185,44 @@
             }
           },
           "409": {
-            "description": "System state optimistic-lock conflict",
+            "description": "Idempotency conflict, optimistic-lock conflict, or terminal cancellation conflict",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GptRouteErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Async GPT job expired during bounded wait",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GptRouteErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Durable async GPT jobs unavailable for canonical bridge operations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GptRouteErrorResponse"
+                },
+                "examples": {
+                  "asyncJobsUnavailable": {
+                    "summary": "Canonical query is unavailable when durable job persistence is down",
+                    "value": {
+                      "ok": false,
+                      "action": "query",
+                      "error": {
+                        "code": "ASYNC_GPT_JOBS_UNAVAILABLE",
+                        "message": "query requires durable GPT job persistence, but the jobs backend is unavailable."
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -144,121 +234,506 @@
   "components": {
     "schemas": {
       "GptRouteRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/GenericPromptRequest"
+          },
+          {
+            "$ref": "#/components/schemas/QueryActionRequest"
+          },
+          {
+            "$ref": "#/components/schemas/QueryAndWaitActionRequest"
+          },
+          {
+            "$ref": "#/components/schemas/GetStatusActionRequest"
+          },
+          {
+            "$ref": "#/components/schemas/GetResultActionRequest"
+          },
+          {
+            "$ref": "#/components/schemas/SystemStateActionRequest"
+          },
+          {
+            "$ref": "#/components/schemas/ModuleActionRequest"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "action",
+          "mapping": {
+            "query": "#/components/schemas/QueryActionRequest",
+            "query_and_wait": "#/components/schemas/QueryAndWaitActionRequest",
+            "get_status": "#/components/schemas/GetStatusActionRequest",
+            "get_result": "#/components/schemas/GetResultActionRequest",
+            "system_state": "#/components/schemas/SystemStateActionRequest"
+          }
+        }
+      },
+      "PromptPayload": {
         "type": "object",
-        "description": "Prompt-first request contract for GPT-routed module calls. The backend resolves the route from the path parameter, not from body metadata.",
         "additionalProperties": false,
         "properties": {
           "prompt": {
             "type": "string",
-            "minLength": 1,
-            "description": "Prompt or user-visible request text."
+            "minLength": 1
           },
           "gptVersion": {
-            "type": "string",
-            "description": "Optional GPT version marker from the caller."
-          },
-          "action": {
-            "type": "string",
-            "description": "Optional explicit backend action. Omit by default so the backend can infer intent. Supported explicit actions include module-specific actions, `system_state`, `get_status`, `get_result`, and `query_and_wait`. Do not inject unsupported defaults such as \"ask\". Use `get_status` or `get_result` only with `payload.jobId`, and use `query_and_wait` only with a non-empty `prompt`."
-          },
-          "executionMode": {
-            "type": "string",
-            "enum": [
-              "sync",
-              "async"
-            ],
-            "description": "Optional execution preference. Use `async` together with `waitForResultMs` to request a queue-backed direct-return attempt."
-          },
-          "waitForResultMs": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "Optional bounded wait budget in milliseconds for transport-level job-backed direct-return calls. When the budget expires, the backend returns the canonical `jobId` plus instructions to read `/jobs/{id}/result`."
-          },
-          "timeoutMs": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "Optional bounded wait budget in milliseconds for the explicit `query_and_wait` action. This is an alias of `waitForResultMs` for integration callers that model waiting as an action contract."
-          },
-          "pollIntervalMs": {
-            "type": "integer",
-            "minimum": 1,
-            "description": "Optional polling cadence in milliseconds used only while the backend waits for the async job to finish. Supported by both transport-level direct-return requests and `query_and_wait`."
+            "type": "string"
           },
           "payload": {
             "type": "object",
-            "description": "Optional structured payload forwarded to the module when the caller intentionally uses structured inputs.",
             "additionalProperties": true
           },
           "context": {
             "type": "object",
-            "description": "Optional caller context object.",
             "additionalProperties": true
+          },
+          "waitForResultMs": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "timeoutMs": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "pollIntervalMs": {
+            "type": "integer",
+            "minimum": 1
           }
-        },
-        "not": {
-          "required": [
-            "gptId"
-          ]
         }
       },
-      "GptRouteResponse": {
+      "GenericPromptRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PromptPayload"
+          },
+          {
+            "type": "object",
+            "required": [
+              "prompt"
+            ],
+            "properties": {
+              "executionMode": {
+                "type": "string",
+                "enum": [
+                  "sync",
+                  "async"
+                ]
+              }
+            },
+            "not": {
+              "required": [
+                "action"
+              ]
+            }
+          }
+        ]
+      },
+      "QueryActionRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PromptPayload"
+          },
+          {
+            "type": "object",
+            "required": [
+              "action",
+              "prompt"
+            ],
+            "properties": {
+              "action": {
+                "const": "query"
+              }
+            }
+          }
+        ]
+      },
+      "QueryAndWaitActionRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PromptPayload"
+          },
+          {
+            "type": "object",
+            "required": [
+              "action",
+              "prompt"
+            ],
+            "properties": {
+              "action": {
+                "const": "query_and_wait"
+              }
+            }
+          }
+        ]
+      },
+      "GetStatusActionRequest": {
         "type": "object",
-        "description": "Generic GPT route response envelope.",
+        "additionalProperties": false,
+        "required": [
+          "action",
+          "payload"
+        ],
+        "properties": {
+          "action": {
+            "const": "get_status"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/JobLookupPayload"
+          }
+        }
+      },
+      "GetResultActionRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "action",
+          "payload"
+        ],
+        "properties": {
+          "action": {
+            "const": "get_result"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/JobLookupPayload"
+          }
+        }
+      },
+      "SystemStateActionRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "action"
+        ],
+        "properties": {
+          "action": {
+            "const": "system_state"
+          },
+          "payload": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "ModuleActionRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PromptPayload"
+          },
+          {
+            "type": "object",
+            "required": [
+              "action"
+            ],
+            "properties": {
+              "action": {
+                "type": "string",
+                "minLength": 1,
+                "not": {
+                  "enum": [
+                    "query",
+                    "query_and_wait",
+                    "get_status",
+                    "get_result",
+                    "system_state"
+                  ]
+                }
+              }
+            }
+          }
+        ]
+      },
+      "JobLookupPayload": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "jobId"
+        ],
+        "properties": {
+          "jobId": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "GptRouteSuccessResponse": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/GptAsyncCompletedResponse"
+          },
+          {
+            "$ref": "#/components/schemas/GptJobStatusResponse"
+          },
+          {
+            "$ref": "#/components/schemas/GptJobResultResponse"
+          },
+          {
+            "$ref": "#/components/schemas/GptRouteGenericResponse"
+          }
+        ]
+      },
+      "GptAsyncPendingResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "ok",
+          "action",
+          "status",
+          "jobId",
+          "poll",
+          "stream"
+        ],
         "properties": {
           "ok": {
-            "type": "boolean"
+            "const": true
+          },
+          "action": {
+            "enum": [
+              "query",
+              "query_and_wait"
+            ]
+          },
+          "status": {
+            "const": "pending"
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "poll": {
+            "type": "string"
+          },
+          "stream": {
+            "type": "string"
+          },
+          "jobStatus": {
+            "type": "string"
+          },
+          "lifecycleStatus": {
+            "type": "string"
+          },
+          "instruction": {
+            "type": "string"
+          },
+          "directReturn": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "idempotencyKey": {
+            "type": "string"
+          },
+          "idempotencySource": {
+            "enum": [
+              "explicit",
+              "derived"
+            ]
+          },
+          "_route": {
+            "$ref": "#/components/schemas/GptRouteMeta"
+          }
+        }
+      },
+      "GptAsyncCompletedResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "ok",
+          "action",
+          "jobId",
+          "status",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "action": {
+            "enum": [
+              "query",
+              "query_and_wait"
+            ]
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "lifecycleStatus": {
+            "type": "string"
+          },
+          "poll": {
+            "type": "string"
+          },
+          "stream": {
+            "type": "string"
+          },
+          "result": {},
+          "idempotencyKey": {
+            "type": "string"
+          },
+          "idempotencySource": {
+            "enum": [
+              "explicit",
+              "derived"
+            ]
+          },
+          "_route": {
+            "$ref": "#/components/schemas/GptRouteMeta"
+          }
+        }
+      },
+      "GptJobStatusResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "ok",
+          "action",
+          "jobId",
+          "status",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "action": {
+            "const": "get_status"
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "lifecycleStatus": {
+            "type": "string"
+          },
+          "result": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "_route": {
+            "$ref": "#/components/schemas/GptRouteMeta"
+          }
+        }
+      },
+      "GptJobResultResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "ok",
+          "action",
+          "jobId",
+          "status",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "action": {
+            "const": "get_result"
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "jobStatus": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "lifecycleStatus": {
+            "type": "string"
+          },
+          "poll": {
+            "type": "string"
+          },
+          "stream": {
+            "type": "string"
+          },
+          "output": {},
+          "error": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GptRouteError"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "result": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "_route": {
+            "$ref": "#/components/schemas/GptRouteMeta"
+          }
+        }
+      },
+      "GptRouteGenericResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "ok"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
           },
           "result": {},
           "_route": {
-            "type": "object",
-            "properties": {
-              "gptId": {
-                "type": "string"
-              },
-              "module": {
-                "type": "string"
-              },
-              "action": {
-                "type": "string"
-              },
-              "route": {
-                "type": "string"
-              },
-              "timestamp": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": true
-          },
-          "error": {
-            "$ref": "#/components/schemas/GptRouteError"
+            "$ref": "#/components/schemas/GptRouteMeta"
           }
-        },
-        "additionalProperties": true
+        }
       },
       "GptRouteErrorResponse": {
         "type": "object",
-        "properties": {
-          "ok": {
-            "type": "boolean",
-            "const": false
-          },
-          "error": {
-            "$ref": "#/components/schemas/GptRouteError"
-          },
-          "_route": {
-            "type": "object",
-            "additionalProperties": true
-          }
-        },
+        "additionalProperties": true,
         "required": [
           "ok",
           "error"
         ],
-        "additionalProperties": true
+        "properties": {
+          "ok": {
+            "const": false
+          },
+          "action": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "jobId": {
+            "type": "string"
+          },
+          "error": {
+            "$ref": "#/components/schemas/GptRouteError"
+          },
+          "canonical": {
+            "type": "object",
+            "additionalProperties": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "_route": {
+            "$ref": "#/components/schemas/GptRouteMeta"
+          }
+        }
       },
       "GptRouteError": {
         "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "code",
+          "message"
+        ],
         "properties": {
           "code": {
             "type": "string"
@@ -267,12 +742,31 @@
             "type": "string"
           },
           "details": {}
-        },
-        "required": [
-          "code",
-          "message"
-        ],
-        "additionalProperties": true
+        }
+      },
+      "GptRouteMeta": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "requestId": {
+            "type": "string"
+          },
+          "gptId": {
+            "type": "string"
+          },
+          "module": {
+            "type": "string"
+          },
+          "action": {
+            "type": "string"
+          },
+          "route": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          }
+        }
       }
     }
   }

--- a/daemon-python/arcanos/backend_client/__init__.py
+++ b/daemon-python/arcanos/backend_client/__init__.py
@@ -13,8 +13,12 @@ import requests
 from ..backend_auth_client import normalize_backend_url
 from .chat import request_ask_with_domain as _request_ask_with_domain
 from .chat import request_chat_completion as _request_chat_completion
+from .chat import request_gpt_job_result as _request_gpt_job_result
+from .chat import request_gpt_job_status as _request_gpt_job_status
 from .chat import request_job_result as _request_job_result
 from .chat import request_job_status as _request_job_status
+from .chat import request_query as _request_query
+from .chat import request_query_and_wait as _request_query_and_wait
 from .chat import request_system_state as _request_system_state
 from .daemon import request_confirm_daemon_actions as _request_confirm_daemon_actions
 from .plans import fetch_plan as _fetch_plan
@@ -27,6 +31,7 @@ from .updates import submit_update_event as _submit_update_event
 from .vision import request_vision_analysis as _request_vision_analysis
 from ..backend_client_models import (
     BackendChatResult,
+    BackendGptAsyncBridgeResult,
     BackendRequestError,
     BackendResponse,
     BackendTranscriptionResult,
@@ -490,6 +495,65 @@ class BackendApiClient:
         Edge cases: returns structured validation errors for partial update payloads.
         """
         return _request_system_state(self, metadata, expected_version, patch, gpt_id)
+
+    def request_query(
+        self,
+        prompt: str,
+        metadata: Optional[Mapping[str, Any]] = None,
+        gpt_id: Optional[str] = None,
+    ) -> BackendResponse[BackendGptAsyncBridgeResult]:
+        """
+        Purpose: Create one async GPT writing job through the canonical `query` bridge action.
+        Inputs/Outputs: prompt plus optional metadata/gpt_id; returns typed async bridge metadata.
+        Edge cases: blank prompts fail fast as validation errors.
+        """
+        return _request_query(self, prompt, metadata, gpt_id)
+
+    def request_query_and_wait(
+        self,
+        prompt: str,
+        timeout_ms: Optional[int] = None,
+        poll_interval_ms: Optional[int] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+        gpt_id: Optional[str] = None,
+    ) -> BackendResponse[BackendGptAsyncBridgeResult]:
+        """
+        Purpose: Create one async GPT writing job and wait briefly through the canonical `query_and_wait` bridge action.
+        Inputs/Outputs: prompt plus optional wait controls/metadata/gpt_id; returns typed async bridge metadata.
+        Edge cases: blank prompts fail fast as validation errors.
+        """
+        return _request_query_and_wait(
+            self,
+            prompt,
+            timeout_ms,
+            poll_interval_ms,
+            metadata,
+            gpt_id,
+        )
+
+    def request_gpt_job_status(
+        self,
+        job_id: str,
+        gpt_id: Optional[str] = None,
+    ) -> BackendResponse[BackendGptAsyncBridgeResult]:
+        """
+        Purpose: Read async job status through the GPT compatibility bridge without enqueueing new work.
+        Inputs/Outputs: required job_id and optional gpt_id; returns typed async bridge status metadata.
+        Edge cases: blank ids fail fast as validation errors.
+        """
+        return _request_gpt_job_status(self, job_id, gpt_id)
+
+    def request_gpt_job_result(
+        self,
+        job_id: str,
+        gpt_id: Optional[str] = None,
+    ) -> BackendResponse[BackendGptAsyncBridgeResult]:
+        """
+        Purpose: Read async job results through the GPT compatibility bridge without enqueueing new work.
+        Inputs/Outputs: required job_id and optional gpt_id; returns typed async bridge result metadata.
+        Edge cases: blank ids fail fast as validation errors.
+        """
+        return _request_gpt_job_result(self, job_id, gpt_id)
 
     def request_job_result(
         self,

--- a/daemon-python/arcanos/backend_client/chat.py
+++ b/daemon-python/arcanos/backend_client/chat.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional, Sequence, TYPE_CHECKING
 from urllib.parse import quote
 
-from ..backend_client_models import BackendChatResult, BackendRequestError, BackendResponse
+from ..backend_client_models import (
+    BackendChatResult,
+    BackendGptAsyncBridgeResult,
+    BackendRequestError,
+    BackendResponse,
+)
 from ..config import Config
 
 if TYPE_CHECKING:
@@ -16,6 +23,120 @@ def _build_backend_payload(**fields: Any) -> dict[str, Any]:
     Edge cases: preserves falsey values like `stream=False` while dropping explicit `None` fields.
     """
     return {key: value for key, value in fields.items() if value is not None}
+
+
+def _copy_backend_context_fields(
+    client: "BackendApiClient",
+    payload: dict[str, Any],
+    metadata: Optional[Mapping[str, Any]],
+) -> None:
+    """
+    Purpose: Attach normalized metadata/session/context fields to one backend payload.
+    Inputs/Outputs: mutable payload dict plus optional metadata; mutates payload in place.
+    Edge cases: Keeps `sessionId` and `context.repoIndex` in their canonical top-level fields when present.
+    """
+    normalized_metadata = client._normalize_metadata(metadata)
+    if normalized_metadata is not None:
+        payload["metadata"] = normalized_metadata
+
+    if isinstance(normalized_metadata, dict):
+        if "instanceId" in normalized_metadata and "sessionId" not in payload:
+            payload["sessionId"] = str(normalized_metadata.get("instanceId"))
+        if "repoIndex" in normalized_metadata:
+            payload["context"] = {"repoIndex": normalized_metadata.get("repoIndex")}
+
+
+def _is_mapping(value: Any) -> bool:
+    return isinstance(value, Mapping)
+
+
+def _read_string(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        normalized = value.strip()
+        if normalized:
+            return normalized
+    return None
+
+
+def _read_nullable_string(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    return _read_string(value)
+
+
+def _normalize_gpt_async_bridge_payload(
+    payload: Mapping[str, Any],
+    action: str,
+) -> BackendGptAsyncBridgeResult:
+    """
+    Purpose: Normalize GPT async bridge responses from `/gpt/:gptId` and `/jobs/*`.
+    Inputs/Outputs: raw backend JSON mapping plus canonical action; returns typed bridge result.
+    Edge cases: `get_result` preserves backend compatibility envelopes under `raw` while exposing the final result under `result`.
+    """
+    if action == "get_status":
+        raw_status = payload.get("result") if _is_mapping(payload.get("result")) else payload
+        assert isinstance(raw_status, Mapping)
+        return BackendGptAsyncBridgeResult(
+            action=action,
+            job_id=_read_string(payload.get("jobId")) or _read_string(raw_status.get("id")),
+            status=_read_string(payload.get("status")) or _read_string(raw_status.get("status")),
+            lifecycle_status=_read_string(payload.get("lifecycleStatus")) or _read_string(raw_status.get("lifecycle_status")),
+            result=dict(raw_status),
+            error=payload.get("error") if _is_mapping(payload.get("error")) else None,
+            raw=dict(payload),
+        )
+
+    if action == "get_result":
+        raw_lookup = payload.get("result") if _is_mapping(payload.get("result")) else payload
+        assert isinstance(raw_lookup, Mapping)
+        error_payload = payload.get("error") if _is_mapping(payload.get("error")) else raw_lookup.get("error")
+        return BackendGptAsyncBridgeResult(
+            action=action,
+            job_id=_read_string(payload.get("jobId")) or _read_string(raw_lookup.get("jobId")),
+            status=_read_string(payload.get("status")) or _read_string(raw_lookup.get("status")),
+            lifecycle_status=_read_string(payload.get("lifecycleStatus")) or _read_string(raw_lookup.get("lifecycleStatus")),
+            job_status=_read_nullable_string(payload.get("jobStatus")) or _read_nullable_string(raw_lookup.get("jobStatus")),
+            poll=_read_string(payload.get("poll")) or _read_string(raw_lookup.get("poll")),
+            stream=_read_string(payload.get("stream")) or _read_string(raw_lookup.get("stream")),
+            result=payload.get("output") if "output" in payload else raw_lookup.get("result"),
+            error=dict(error_payload) if _is_mapping(error_payload) else None,
+            raw=dict(payload),
+        )
+
+    return BackendGptAsyncBridgeResult(
+        action=_read_string(payload.get("action")) or action,
+        job_id=_read_string(payload.get("jobId")),
+        status=_read_string(payload.get("status")),
+        lifecycle_status=_read_string(payload.get("lifecycleStatus")),
+        job_status=_read_nullable_string(payload.get("jobStatus")),
+        poll=_read_string(payload.get("poll")),
+        stream=_read_string(payload.get("stream")),
+        result=payload.get("result"),
+        error=dict(payload.get("error")) if _is_mapping(payload.get("error")) else None,
+        raw=dict(payload),
+    )
+
+
+def _request_gpt_async_bridge(
+    client: "BackendApiClient",
+    *,
+    action: str,
+    route: BackendChatRoute,
+    payload: Mapping[str, Any],
+) -> BackendResponse[BackendGptAsyncBridgeResult]:
+    """
+    Purpose: Execute one canonical GPT async bridge request and normalize the backend envelope.
+    Inputs/Outputs: resolved route plus payload mapping; returns a typed async bridge result.
+    Edge cases: backend JSON errors are returned verbatim through BackendResponse without fallback to chat parsing.
+    """
+    response = client._request_json("post", route.endpoint, payload)
+    if not response.ok or not response.value:
+        return BackendResponse(ok=False, error=response.error)
+
+    return BackendResponse(
+        ok=True,
+        value=_normalize_gpt_async_bridge_payload(response.value, action),
+    )
 
 
 @dataclass(frozen=True)
@@ -182,6 +303,143 @@ def request_system_state(
         return BackendResponse(ok=False, error=response.error)
 
     return BackendResponse(ok=True, value=response.value)
+
+
+def request_query(
+    client: "BackendApiClient",
+    prompt: str,
+    metadata: Optional[Mapping[str, Any]] = None,
+    gpt_id: Optional[str] = None,
+) -> BackendResponse[BackendGptAsyncBridgeResult]:
+    """
+    Purpose: Create one async GPT writing job through the canonical `query` bridge action.
+    Inputs/Outputs: prompt, optional metadata, and optional gpt_id; returns typed async bridge metadata.
+    Edge cases: blank prompts fail locally so callers never fall back to ambiguous route inference.
+    """
+    normalized_prompt = prompt.strip()
+    if not normalized_prompt:
+        return BackendResponse(
+            ok=False,
+            error=BackendRequestError(
+                kind="validation",
+                message="prompt is required for query",
+            ),
+        )
+
+    route = resolve_backend_chat_route(gpt_id)
+    payload = _build_backend_payload(action="query", prompt=normalized_prompt)
+    _copy_backend_context_fields(client, payload, metadata)
+    return _request_gpt_async_bridge(
+        client,
+        action="query",
+        route=route,
+        payload=payload,
+    )
+
+
+def request_query_and_wait(
+    client: "BackendApiClient",
+    prompt: str,
+    timeout_ms: Optional[int] = None,
+    poll_interval_ms: Optional[int] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
+    gpt_id: Optional[str] = None,
+) -> BackendResponse[BackendGptAsyncBridgeResult]:
+    """
+    Purpose: Create one async GPT writing job and wait briefly through the canonical `query_and_wait` bridge action.
+    Inputs/Outputs: prompt, optional timeout/poll controls, optional metadata, and optional gpt_id; returns typed async bridge result metadata.
+    Edge cases: blank prompts fail locally and timeout controls stay structured instead of being encoded into free-form text.
+    """
+    normalized_prompt = prompt.strip()
+    if not normalized_prompt:
+        return BackendResponse(
+            ok=False,
+            error=BackendRequestError(
+                kind="validation",
+                message="prompt is required for query_and_wait",
+            ),
+        )
+
+    route = resolve_backend_chat_route(gpt_id)
+    payload = _build_backend_payload(
+        action="query_and_wait",
+        prompt=normalized_prompt,
+        timeoutMs=timeout_ms,
+        pollIntervalMs=poll_interval_ms,
+    )
+    _copy_backend_context_fields(client, payload, metadata)
+    return _request_gpt_async_bridge(
+        client,
+        action="query_and_wait",
+        route=route,
+        payload=payload,
+    )
+
+
+def request_gpt_job_status(
+    client: "BackendApiClient",
+    job_id: str,
+    gpt_id: Optional[str] = None,
+) -> BackendResponse[BackendGptAsyncBridgeResult]:
+    """
+    Purpose: Read async job status through the GPT compatibility bridge without enqueueing new work.
+    Inputs/Outputs: required job_id and optional gpt_id; returns typed async bridge status metadata.
+    Edge cases: blank job ids fail locally so control reads never degrade into prompt-based lookups.
+    """
+    normalized_job_id = job_id.strip()
+    if not normalized_job_id:
+        return BackendResponse(
+            ok=False,
+            error=BackendRequestError(
+                kind="validation",
+                message="job_id is required for get_status",
+            ),
+        )
+
+    route = resolve_backend_chat_route(gpt_id)
+    payload = _build_backend_payload(
+        action="get_status",
+        payload={"jobId": normalized_job_id},
+    )
+    return _request_gpt_async_bridge(
+        client,
+        action="get_status",
+        route=route,
+        payload=payload,
+    )
+
+
+def request_gpt_job_result(
+    client: "BackendApiClient",
+    job_id: str,
+    gpt_id: Optional[str] = None,
+) -> BackendResponse[BackendGptAsyncBridgeResult]:
+    """
+    Purpose: Read async job results through the GPT compatibility bridge without enqueueing new work.
+    Inputs/Outputs: required job_id and optional gpt_id; returns typed async bridge result metadata.
+    Edge cases: blank job ids fail locally so control reads never degrade into prompt-based lookups.
+    """
+    normalized_job_id = job_id.strip()
+    if not normalized_job_id:
+        return BackendResponse(
+            ok=False,
+            error=BackendRequestError(
+                kind="validation",
+                message="job_id is required for get_result",
+            ),
+        )
+
+    route = resolve_backend_chat_route(gpt_id)
+    payload = _build_backend_payload(
+        action="get_result",
+        payload={"jobId": normalized_job_id},
+    )
+    return _request_gpt_async_bridge(
+        client,
+        action="get_result",
+        route=route,
+        payload=payload,
+    )
 
 
 def request_job_result(

--- a/daemon-python/arcanos/backend_client_models.py
+++ b/daemon-python/arcanos/backend_client_models.py
@@ -81,3 +81,23 @@ class BackendTranscriptionResult:
 
     text: str
     model: str
+
+
+@dataclass(frozen=True)
+class BackendGptAsyncBridgeResult:
+    """
+    Purpose: Typed async GPT bridge payload shared across query, wait, status, and result helpers.
+    Inputs/Outputs: canonical action/status/job metadata plus optional result/error payloads.
+    Edge cases: `result` remains arbitrary JSON for completed jobs, while `raw` preserves the backend envelope for callers that need compatibility details.
+    """
+
+    action: str
+    job_id: Optional[str]
+    status: Optional[str]
+    result: Any = None
+    lifecycle_status: Optional[str] = None
+    job_status: Optional[str] = None
+    poll: Optional[str] = None
+    stream: Optional[str] = None
+    error: Optional[Mapping[str, Any]] = None
+    raw: Optional[Mapping[str, Any]] = None

--- a/daemon-python/tests/test_backend_client_chat.py
+++ b/daemon-python/tests/test_backend_client_chat.py
@@ -9,8 +9,12 @@ from arcanos.backend_client.chat import (
     resolve_backend_chat_route,
     request_ask_with_domain,
     request_chat_completion,
+    request_gpt_job_result,
+    request_gpt_job_status,
     request_job_result,
     request_job_status,
+    request_query,
+    request_query_and_wait,
     request_system_state,
 )
 from arcanos.backend_client import BackendApiClient
@@ -153,6 +157,155 @@ def test_request_system_state_honors_explicit_gpt_id_on_canonical_route() -> Non
     assert path == "/gpt/arcanos-gaming"
     assert "gptId" not in payload
     assert payload["action"] == "system_state"
+
+
+def test_request_query_uses_canonical_gpt_bridge_action_and_normalizes_response() -> None:
+    client = SimpleNamespace()
+    client._normalize_metadata = MagicMock(return_value={"instanceId": "cli-123", "repoIndex": "repo-7"})
+    client._request_json = MagicMock(
+        return_value=BackendResponse(ok=True, value={"ok": True, "jobId": "job-query-1", "status": "pending"})
+    )
+
+    response = request_query(
+        client,
+        prompt="Draft the next promo",
+        metadata={"instanceId": "cli-123", "repoIndex": "repo-7"},
+    )
+
+    assert response.ok is True
+    assert response.value is not None
+    _, path, payload = client._request_json.call_args.args
+    assert path == "/gpt/arcanos-daemon"
+    assert payload["action"] == "query"
+    assert payload["prompt"] == "Draft the next promo"
+    assert payload["metadata"] == {"instanceId": "cli-123", "repoIndex": "repo-7"}
+    assert payload["sessionId"] == "cli-123"
+    assert payload["context"] == {"repoIndex": "repo-7"}
+    assert response.value.action == "query"
+    assert response.value.job_id == "job-query-1"
+    assert response.value.status == "pending"
+
+
+def test_request_query_and_wait_uses_bridge_wait_controls_and_normalizes_response() -> None:
+    client = SimpleNamespace()
+    client._normalize_metadata = MagicMock(return_value=None)
+    client._request_json = MagicMock(
+        return_value=BackendResponse(
+            ok=True,
+            value={
+                "ok": True,
+                "action": "query_and_wait",
+                "jobId": "job-query-and-wait-1",
+                "status": "completed",
+                "result": {"text": "Generated Seth Rollins prompt"},
+            },
+        )
+    )
+
+    response = request_query_and_wait(
+        client,
+        prompt="Generate a Seth Rollins promo prompt",
+        timeout_ms=25000,
+        poll_interval_ms=500,
+        gpt_id="arcanos-core",
+    )
+
+    assert response.ok is True
+    assert response.value is not None
+    _, path, payload = client._request_json.call_args.args
+    assert path == "/gpt/arcanos-core"
+    assert payload == {
+        "action": "query_and_wait",
+        "prompt": "Generate a Seth Rollins promo prompt",
+        "timeoutMs": 25000,
+        "pollIntervalMs": 500,
+    }
+    assert response.value.action == "query_and_wait"
+    assert response.value.job_id == "job-query-and-wait-1"
+    assert response.value.status == "completed"
+    assert response.value.result == {"text": "Generated Seth Rollins prompt"}
+
+
+def test_request_gpt_job_status_uses_structured_bridge_payload() -> None:
+    client = SimpleNamespace()
+    client._request_json = MagicMock(
+        return_value=BackendResponse(
+            ok=True,
+            value={
+                "ok": True,
+                "action": "get_status",
+                "jobId": "job-123",
+                "status": "running",
+                "lifecycleStatus": "running",
+                "result": {"id": "job-123", "status": "running", "lifecycle_status": "running"},
+            },
+        )
+    )
+
+    response = request_gpt_job_status(client, "job-123", gpt_id="backstage-booker")
+
+    assert response.ok is True
+    assert response.value is not None
+    _, path, payload = client._request_json.call_args.args
+    assert path == "/gpt/backstage-booker"
+    assert payload == {
+        "action": "get_status",
+        "payload": {"jobId": "job-123"},
+    }
+    assert response.value.action == "get_status"
+    assert response.value.job_id == "job-123"
+    assert response.value.status == "running"
+    assert response.value.lifecycle_status == "running"
+    assert response.value.result == {"id": "job-123", "status": "running", "lifecycle_status": "running"}
+
+
+def test_request_gpt_job_result_uses_structured_bridge_payload() -> None:
+    client = SimpleNamespace()
+    client._request_json = MagicMock(
+        return_value=BackendResponse(
+            ok=True,
+            value={
+                "ok": True,
+                "action": "get_result",
+                "jobId": "job-123",
+                "status": "completed",
+                "jobStatus": "completed",
+                "lifecycleStatus": "completed",
+                "poll": "/jobs/job-123",
+                "stream": "/jobs/job-123/stream",
+                "output": {"text": "final output"},
+                "result": {
+                    "jobId": "job-123",
+                    "status": "completed",
+                    "result": {"text": "final output"},
+                },
+            },
+        )
+    )
+
+    response = request_gpt_job_result(client, "job-123", gpt_id="backstage-booker")
+
+    assert response.ok is True
+    assert response.value is not None
+    _, path, payload = client._request_json.call_args.args
+    assert path == "/gpt/backstage-booker"
+    assert payload == {
+        "action": "get_result",
+        "payload": {"jobId": "job-123"},
+    }
+    assert response.value.action == "get_result"
+    assert response.value.job_id == "job-123"
+    assert response.value.status == "completed"
+    assert response.value.job_status == "completed"
+    assert response.value.lifecycle_status == "completed"
+    assert response.value.poll == "/jobs/job-123"
+    assert response.value.stream == "/jobs/job-123/stream"
+    assert response.value.result == {"text": "final output"}
+    assert response.value.raw["result"] == {
+        "jobId": "job-123",
+        "status": "completed",
+        "result": {"text": "final output"},
+    }
 
 
 def test_request_job_result_uses_canonical_jobs_result_route() -> None:

--- a/docs/API.md
+++ b/docs/API.md
@@ -47,10 +47,10 @@ No API path changes are required for Railway. Ensure liveness (`/healthz`) and r
 - Validation and auth middleware: `../src/middleware/confirmGate.ts`
 
 ## GPT Async Contract
-`POST /gpt/:gptId` is the writing plane. It supports deterministic async GPT execution with idempotent retry handling for job-backed requests, but it must not be used for control-plane prompts.
+`POST /gpt/:gptId` is the writing plane. It supports a typed async GPT bridge with idempotent retry handling for job-backed requests, but it must not be used for prompt-shaped control-plane retrieval.
 
 Writing vs control:
-- Writing plane: prompt generation, assistant responses, and explicit write/query actions.
+- Writing plane: prompt generation, assistant responses, and explicit async write actions `query` and `query_and_wait`.
 - Direct control plane: `GET /jobs/:id`, `GET /jobs/:id/result`, `GET /workers/status`, `GET /worker-helper/health`, `GET /status`, `GET /status/safety/self-heal`, `POST /mcp`, and `/api/arcanos/dag/*`.
 - Router-handled compatibility control actions on `POST /gpt/:gptId`: `get_status`, `get_result`, `diagnostics`, and `system_state`. These are handled before write dispatch and never enqueue new GPT work.
 - Rejected on `POST /gpt/:gptId`: prompt-based job lookups, DAG execution/tracing prompts, runtime inspection prompts, and explicit MCP tool calls. The backend returns canonical control endpoints instead of routing them through generation.
@@ -67,19 +67,25 @@ Deduplication rules:
 - Transport-only retry hints such as `async`, `executionMode`, `responseMode`, `waitForResultMs`, and polling intervals do not create a new GPT job.
 - Reusing an explicit `Idempotency-Key` for a different semantic GPT request returns `409 IDEMPOTENCY_KEY_CONFLICT`.
 
-Explicit direct-return path:
-- Use `POST /gpt/:gptId` with `{"prompt":"...","executionMode":"async","waitForResultMs":20000}` when the caller wants one queue-backed request that either returns the final GPT result inline or times out safely with the canonical job id.
-- Or use the explicit integration action `POST /gpt/:gptId` with `{ "action": "query_and_wait", "prompt": "...", "timeoutMs": 25000, "pollIntervalMs": 500 }` when the caller can only express waiting as an action contract.
+Canonical async bridge:
+- `query`: `POST /gpt/:gptId` with `{ "action": "query", "prompt": "..." }` creates or reuses one durable GPT writing job and returns the canonical `jobId` without inline waiting.
+- `query_and_wait`: `POST /gpt/:gptId` with `{ "action": "query_and_wait", "prompt": "...", "timeoutMs": 25000, "pollIntervalMs": 500 }` creates or reuses one durable GPT writing job and waits briefly for fast completion.
+- `get_status`: `POST /gpt/:gptId` with `{ "action": "get_status", "payload": { "jobId": "..." } }` returns structured status from the control plane without creating work.
+- `get_result`: `POST /gpt/:gptId` with `{ "action": "get_result", "payload": { "jobId": "..." } }` returns structured job result state from the control plane without creating work.
+
+Legacy compatibility:
+- `POST /gpt/:gptId` with `{"prompt":"...","executionMode":"async","waitForResultMs":20000}` still supports one queue-backed request that either returns the final GPT result inline or times out safely with the canonical `jobId`.
+- Prefer the explicit `query` and `query_and_wait` action contract for agent and tool clients because it is typed, discoverable, and easier to validate.
 - Optional `pollIntervalMs` adjusts the internal polling cadence while the backend waits.
-- Direct-return timeouts never enqueue a second job; they return the same canonical job id and point callers to `GET /jobs/:id/result`.
+- Direct-return timeouts never enqueue a second job; they return the same canonical `jobId` and point callers to `GET /jobs/:id/result`.
 
 Job-backed `POST /gpt/:gptId` response shapes:
-- `202 Accepted`: `{ ok, status:"pending", jobId, poll, stream, jobStatus, lifecycleStatus, deduped?, idempotencyKey, idempotencySource, _route }`
-- `200 OK` after bounded inline completion: standard GPT envelope plus `{ jobId, status, lifecycleStatus, poll, stream, deduped?, idempotencyKey, idempotencySource }`
-- `202 Accepted` after an explicit direct-return timeout: the canonical pending payload plus `instruction` and `directReturn.result` pointing to `/jobs/:id/result`
+- `202 Accepted` pending write: `{ ok:true, action:"query"|"query_and_wait", jobId, status:"pending", poll, stream, jobStatus, lifecycleStatus, deduped?, idempotencyKey, idempotencySource, _route }`
+- `200 OK` completed write: `{ ok:true, action:"query_and_wait", jobId, status:"completed", result:{ text }, poll, stream, jobStatus, lifecycleStatus, deduped?, idempotencyKey, idempotencySource, _route }`
+- `200 OK` status retrieval: `{ ok:true, action:"get_status", jobId, status:"queued|running|completed|failed|cancelled|expired", ... }`
+- `200 OK` result retrieval: `{ ok:true, action:"get_result", jobId, status, output?, result?, error?, poll?, stream?, ... }`
+- Error shape: `{ ok:false, action, error:{ code, message } }`
 - Duplicate submissions set `deduped: true` and return the canonical `jobId`.
-- `200 OK` status retrieval: `POST /gpt/:gptId` with `{ "action": "get_status", "payload": { "jobId": "..." } }` returns `{ ok, result: { id, job_type, status, lifecycle_status, created_at, updated_at, completed_at, cancel_requested_at, cancel_reason, retention_until, idempotency_until, expires_at, error_message, output, result }, _route }` and never enqueues new work.
-- `200 OK` result retrieval: `POST /gpt/:gptId` with `{ "action": "get_result", "payload": { "jobId": "..." } }` returns `{ ok, result: { jobId, status:"pending|complete|failed|not_found", jobStatus, lifecycleStatus, createdAt, updatedAt, completedAt, poll, stream, result, error }, _route }` and never enqueues new work.
 - `200 OK` system-state retrieval/update: `POST /gpt/:gptId` with `{ "action": "system_state", "payload": { ... } }` is handled directly on the control plane for core GPT ids and never enters the writing dispatcher.
 - `400 Bad Request` control rejection: prompt-based job lookups, runtime inspection, DAG control, and MCP tool calls return deterministic JSON with `canonical` control routes.
 
@@ -106,7 +112,8 @@ Client retry guidance:
 - Reuse the same `Idempotency-Key` for safe client retries of the same GPT request body.
 - Poll `GET /jobs/:id` or subscribe to `GET /jobs/:id/stream` after any `202`.
 - Prefer the canonical jobs API for job reads. Use GPT compatibility actions only when the caller cannot reach `/jobs/*`.
-- ARCANOS CLI follows the same split: `arcanos generate-and-wait` uses the writing plane, while `arcanos job-status` and `arcanos job-result` call the canonical jobs API.
+- ARCANOS CLI follows the same split: `arcanos query` and `arcanos query-and-wait` use the writing plane, while `arcanos job-status` and `arcanos job-result` call the canonical jobs API.
+- Natural-language retrieval through `prompt` text is intentionally blocked. Retrieval must use structured `action + payload.jobId`.
 - Do not send prompts that ask the GPT route to inspect runtime state, trigger DAGs, or call MCP tools. Use the direct control endpoints instead.
 - Treat `cancelled` and `expired` as terminal and submit a fresh request if more work is needed.
 

--- a/docs/ARCANOS_MCP_SERVER.md
+++ b/docs/ARCANOS_MCP_SERVER.md
@@ -11,6 +11,7 @@ Tool registration lives in `src/mcp/server/index.ts` and includes reasoning, pla
 Routing rule:
 - `POST /mcp` is the explicit MCP control-plane transport.
 - `POST /gpt/:gptId` is the writing plane and does not auto-dispatch to MCP. If a caller needs MCP tools, it must call `/mcp` directly.
+- `jobs.status` and `jobs.result` are control-plane MCP tools. They read existing GPT job state by `jobId` and never enter Trinity or write dispatch.
 
 ## How It Works (HTTP)
 
@@ -82,6 +83,8 @@ Destructive tools:
 These tools are explicit operational interfaces and must be invoked over MCP, not inferred from the GPT writing plane.
 
 - `dag.*`
+- `jobs.status`
+- `jobs.result`
 - `modules.list`
 - `modules.invoke`
 - `ops.health_report`
@@ -169,6 +172,22 @@ curl -X POST http://localhost:3000/mcp \
   -d "{\"jsonrpc\":\"2.0\",\"id\":\"2\",\"method\":\"tools/call\",\"params\":{\"name\":\"trinity.query\",\"arguments\":{\"prompt\":\"Health check\"}}}"
 ```
 
+Call `jobs.status`:
+```bash
+curl -X POST http://localhost:3000/mcp \
+  -H "Authorization: Bearer $MCP_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":\"2b\",\"method\":\"tools/call\",\"params\":{\"name\":\"jobs.status\",\"arguments\":{\"jobId\":\"job_123\"}}}"
+```
+
+Call `jobs.result`:
+```bash
+curl -X POST http://localhost:3000/mcp \
+  -H "Authorization: Bearer $MCP_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":\"2c\",\"method\":\"tools/call\",\"params\":{\"name\":\"jobs.result\",\"arguments\":{\"jobId\":\"job_123\"}}}"
+```
+
 Create a DAG run:
 ```bash
 curl -X POST http://localhost:3000/mcp \
@@ -207,3 +226,10 @@ curl -X POST http://localhost:3000/mcp \
 - `ERR_GATED` for `modules.invoke`
 1. Add explicit allowlist entry to `MCP_ALLOW_MODULE_ACTIONS`.
 2. Restart service after env update.
+
+## Async Bridge Guidance
+For agent-safe async GPT retrieval over MCP:
+- Create work through a writing-plane tool such as `trinity.query`.
+- Retrieve status through `jobs.status`.
+- Retrieve terminal output through `jobs.result`.
+- Do not attempt prompt-based job retrieval through `trinity.query`; retrieval must remain structured by `jobId`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,6 +13,7 @@ Implementation rules:
 - `src/routes/gptRouter.ts` runs pre-dispatch classification through `src/routes/_core/gptPlaneClassification.ts`.
 - `src/routes/_core/gptDispatch.ts` is write-plane only and rejects leaked control requests with a fail-fast `write_guard`.
 - Control-plane compatibility actions such as `get_status`, `get_result`, `diagnostics`, and `system_state` are handled directly in the router and never enter the writing pipeline.
+- Canonical async write actions are `query` and `query_and_wait`. Canonical async read actions are `get_status` and `get_result`.
 - Prompt-shaped control requests for job lookup, DAG execution/tracing, runtime inspection, or MCP tool calls are rejected with canonical control endpoints.
 
 ## Prerequisites
@@ -61,10 +62,15 @@ Long-running GPT requests are handled through the DB-backed `job_data` queue ins
 Execution model:
 1. `POST /gpt/:gptId` classifies the request as writing-plane or control-plane before dispatch.
 2. Control-plane reads (`get_status`, `get_result`, `diagnostics`, `system_state`) are served directly and never create GPT jobs.
-3. Writing-plane async requests persist a canonical GPT job row with hashed idempotency metadata.
-4. The route either returns `202` with `jobId` immediately or waits briefly for inline completion.
+3. Writing-plane async requests (`query`, `query_and_wait`, or prompt-first async compatibility mode) persist a canonical GPT job row with hashed idempotency metadata.
+4. `query` returns the canonical `jobId` without inline waiting. `query_and_wait` waits briefly for inline completion and otherwise returns the same canonical `jobId`.
 5. `src/workers/jobRunner.ts` claims `job_type='gpt'` rows and executes them in background mode.
 6. `GET /jobs/:id` and `GET /jobs/:id/stream` expose the canonical job lifecycle and terminal result.
+
+Agent-safe retrieval rules:
+- Retrieval must remain structured-only through `action + payload.jobId` or direct `/jobs/*` endpoints.
+- Natural-language job retrieval through `prompt` text remains blocked on `/gpt/:gptId`.
+- MCP follows the same lane split: writing tools create work, while `jobs.status` and `jobs.result` stay on the control plane.
 
 Persistence and dedupe:
 - Durable dedupe metadata lives on `job_data`, not in process memory.

--- a/docs/CLI_DAEMON.md
+++ b/docs/CLI_DAEMON.md
@@ -18,12 +18,14 @@ The daemon calls the backend with this routing split:
 - legacy compatibility callers may still use `/api/ask` when intentionally targeting that compatibility layer
 
 CLI examples:
+- `arcanos query --gpt arcanos-core --prompt "Draft the release summary"` → writing plane through `/gpt/:gptId` with canonical `action: "query"`
+- `arcanos query-and-wait --gpt arcanos-core --prompt "Draft the release summary"` → writing plane through `/gpt/:gptId` with canonical `action: "query_and_wait"`
 - `arcanos generate-and-wait --gpt arcanos-core --prompt "Draft the release summary"` → writing plane through `/gpt/:gptId`
 - `arcanos job-status <job-id>` → direct control read through `GET /jobs/:id`
 - `arcanos job-result <job-id>` → direct control read through `GET /jobs/:id/result`
 
 Do **not** send Custom GPT payloads with `gptId` to `/ask`; the backend rejects that contract on purpose.
-Do **not** send job lookups, DAG traces, runtime diagnostics, or MCP tool calls through `/gpt/:gptId`; that route is reserved for the writing plane.
+Do **not** send job lookups, DAG traces, runtime diagnostics, or MCP tool calls through `/gpt/:gptId` as prompt text; that route is reserved for the writing plane, and retrieval must stay structured through `action + jobId`.
 
 For generic daemon chat, the daemon sends:
 - `sessionId`: stable local instance id (machine/user)
@@ -91,3 +93,23 @@ Rollback restores backed-up files from `PATCH_BACKUP_DIR/<rollback_id>/...`.
 - `daemon-python/arcanos/agentic/`: repo indexing, proposals parsing, patch orchestration, history DB, agent loop
 - `daemon-python/arcanos/assistant/translator.py`: response translation middleware
 - `daemon-python/arcanos/backend_client/`: backend HTTP client and payload builder
+
+## Async GPT Bridge
+Agent and tool clients now have one canonical async flow:
+
+1. `arcanos query --gpt <gpt-id> --prompt "..."` to create one durable writing job.
+2. `arcanos query-and-wait --gpt <gpt-id> --prompt "..." --timeout-ms 25000 --poll-interval-ms 500` when a fast inline completion is useful.
+3. `arcanos job-status <job-id>` to read lifecycle state on the control plane.
+4. `arcanos job-result <job-id>` to read the terminal result on the control plane.
+
+Lane ownership:
+- Writing plane: `query`, `query-and-wait`, `generate-and-wait`
+- Control plane: `job-status`, `job-result`
+
+Python client parity:
+- `BackendApiClient.request_query(...)`
+- `BackendApiClient.request_query_and_wait(...)`
+- `BackendApiClient.request_gpt_job_status(...)`
+- `BackendApiClient.request_gpt_job_result(...)`
+
+These wrappers normalize the async payload into a consistent shape with top-level `ok`, `action`, `jobId`, `status`, and `result`/`output` fields where available.

--- a/docs/CLI_OVERVIEW.md
+++ b/docs/CLI_OVERVIEW.md
@@ -17,6 +17,8 @@ Both binaries point at the same entrypoint and command parser. The standard comm
 
 ```bash
 arcanos ask "Summarize current worker health"
+arcanos query --gpt arcanos-core --prompt "Create the writing job and return its id"
+arcanos query-and-wait --gpt arcanos-core --prompt "Generate a Seth Rollins promo prompt"
 arcanos generate-and-wait --gpt arcanos-core --prompt "Generate a Seth Rollins promo prompt"
 ```
 
@@ -139,6 +141,8 @@ Use `--transport local` for local-only workflows; use default/python when you ne
 
 ```text
 arcanos ask <prompt> [--json]
+arcanos query --gpt <gpt-id> --prompt <prompt> [--json]
+arcanos query-and-wait --gpt <gpt-id> --prompt <prompt> [--timeout-ms <ms>] [--poll-interval-ms <ms>] [--json]
 arcanos generate-and-wait --gpt <gpt-id> --prompt <prompt> [--timeout-ms <ms>] [--poll-interval-ms <ms>] [--json]
 arcanos plan <prompt> [--json]
 arcanos exec [<prompt>] [--json]

--- a/docs/CUSTOM_GPTS.md
+++ b/docs/CUSTOM_GPTS.md
@@ -1,7 +1,7 @@
 # Custom GPTs and Backend Integration
 
 ## Overview
-Arcanos routes Custom GPT requests through the `/gpt/:gptId` gateway. This gateway is the writing plane: it resolves a GPT ID to a backend module, forwards generative work to the matched module, and returns an acknowledgement payload describing the matched module/action set. The routing table is built from module definitions (including their `gptIds`), with optional overrides via environment configuration. The canonical Custom GPT contract is path-based: call `/gpt/<gpt-id>` with a prompt-first request body for generative work, and use direct control endpoints for jobs, DAG traces, runtime diagnostics, and MCP tools.【F:src/routes/gptRouter.ts†L16-L159】【F:src/config/gptRouterConfig.ts†L1-L92】【F:src/modules/moduleLoader.ts†L1-L64】
+Arcanos routes Custom GPT requests through the `/gpt/:gptId` gateway. This gateway is the writing plane: it resolves a GPT ID to a backend module, forwards generative work to the matched module, and returns an acknowledgement payload describing the matched module/action set. The routing table is built from module definitions (including their `gptIds`), with optional overrides via environment configuration. The canonical Custom GPT contract is path-based: call `/gpt/<gpt-id>` with either a prompt-first generative request or the typed async bridge actions `query`, `query_and_wait`, `get_status`, and `get_result`. Use direct control endpoints for jobs, DAG traces, runtime diagnostics, and MCP tools when those surfaces are available.【F:src/routes/gptRouter.ts†L16-L159】【F:src/config/gptRouterConfig.ts†L1-L92】【F:src/modules/moduleLoader.ts†L1-L64】
 
 ## Why We Use Custom GPTs
 Custom GPTs let Arcanos ship specialized assistants (Backstage Booker, Arcanos Gaming, Tutor) that:
@@ -13,9 +13,10 @@ Custom GPTs let Arcanos ship specialized assistants (Backstage Booker, Arcanos G
 1. The GPT calls `POST /gpt/:gptId` with a request body that contains `prompt` and optional `gptVersion`, `action`, `payload`, and `context`.
 2. Async job status/results must be fetched explicitly, either through `GET /jobs/:id` / `GET /jobs/:id/result`, or through `POST /gpt/:gptId` with `action: "get_status"` / `action: "get_result"` plus `payload.jobId`.
 3. Prompt-based control requests are rejected: job lookup prompts, DAG execution/tracing prompts, runtime inspection prompts, and explicit MCP tool calls must use their canonical control-plane endpoints.
-4. The GPT router resolves the incoming GPT ID to a module route using the module map and fuzzy matching strategy if needed.
-5. The writing request is forwarded to `/modules/:route`, and the response is wrapped with a `_gptAck` metadata block.
-6. The module handler calls the action implementation and returns the result as JSON.【F:src/routes/gptRouter.ts†L16-L159】【F:src/routes/modules.ts†L1-L83】
+4. Control actions are intercepted in the router and handled on the control plane before any writing dispatch or Trinity entry.
+5. The GPT router resolves the incoming GPT ID to a module route using the module map and fuzzy matching strategy if needed.
+6. The writing request is forwarded to `/modules/:route`, and the response is wrapped with a `_gptAck` metadata block.
+7. The module handler calls the action implementation and returns the result as JSON.【F:src/routes/gptRouter.ts†L16-L159】【F:src/routes/modules.ts†L1-L83】
 
 ## Setup: Connect a Custom GPT to the Backend
 
@@ -56,9 +57,11 @@ Use a single HTTP action in your Custom GPT definition:
 Rules:
 - `gptId` belongs in the path, not the JSON body.
 - Omit `action` by default so the backend can infer intent from the GPT/module binding.
+- Use `action: "query"` with a non-empty `prompt` when the caller wants a durable writing job immediately and will poll later.
+- Use `action: "query_and_wait"` with a non-empty `prompt` when the caller wants one durable writing job plus a bounded inline wait.
 - Use `action: "get_status"` or `action: "get_result"` with `payload.jobId` when you need to fetch canonical async GPT job state without creating new work.
 - Use direct control endpoints instead of `/gpt/:gptId` for runtime inspection, DAG tracing/execution, and MCP tool calls.
-- Use `action: "query_and_wait"` with a non-empty `prompt` when the integration surface needs one explicit caller action that creates one async GPT job and waits internally for completion.
+- Retrieval by natural-language prompt is intentionally blocked. Do not ask the GPT route to “look up job 123” in `prompt`; use the structured `action + payload.jobId` contract.
 - Do **not** inject a default action like `"ask"`; only send `action` when the caller explicitly selects a supported backend action.
 
 The router injects the module name server-side, so your Custom GPT does not need to specify `module` in the payload.【F:src/routes/gptRouter.ts†L16-L159】
@@ -75,6 +78,54 @@ Important:
 - `arcanos-core` is the built-in GPT ID for the main `ARCANOS:CORE` route.
 - `arcanos-tutor` and `tutor` remain separate tutor-only GPT IDs for `ARCANOS:TUTOR`.
 - Use `GPT_MODULE_MAP` only when you need additional custom GPT IDs beyond the built-in routes.
+
+## Canonical Async Bridge
+Use these request shapes for agent-safe async GPT work:
+
+Create a durable writing job:
+```json
+{
+  "action": "query",
+  "prompt": "Draft the release summary."
+}
+```
+
+Create a durable writing job and wait briefly:
+```json
+{
+  "action": "query_and_wait",
+  "prompt": "Draft the release summary.",
+  "timeoutMs": 25000,
+  "pollIntervalMs": 500
+}
+```
+
+Check status without creating work:
+```json
+{
+  "action": "get_status",
+  "payload": {
+    "jobId": "job_123"
+  }
+}
+```
+
+Fetch result without creating work:
+```json
+{
+  "action": "get_result",
+  "payload": {
+    "jobId": "job_123"
+  }
+}
+```
+
+Canonical response guidance:
+- Pending write: `{ "ok": true, "action": "query"|"query_and_wait", "jobId": "job_123", "status": "pending" }`
+- Completed `query_and_wait`: `{ "ok": true, "action": "query_and_wait", "jobId": "job_123", "status": "completed", "result": { "text": "..." } }`
+- Status read: `{ "ok": true, "action": "get_status", "jobId": "job_123", "status": "queued|running|completed|failed|cancelled|expired" }`
+- Result read: `{ "ok": true, "action": "get_result", "jobId": "job_123", "status": "completed", "output": { "text": "..." } }`
+- Error: `{ "ok": false, "action": "...", "error": { "code": "...", "message": "..." } }`
 
 ## Spec Sheet Template (for Custom GPT Actions)
 Use this format when defining or documenting a Custom GPT:
@@ -96,6 +147,8 @@ body:
 success_response:
   description: JSON payload from the module, plus _gptAck metadata.
 ```
+
+For async bridge callers, prefer the generated OpenAPI schema instead of hand-written examples so the action discriminator stays aligned with the backend.
 
 ## Migration Note
 - What was broken: older integrations still modeled GPT requests as `/ask` plus body-level `gptId`, and some wrappers injected an implicit `"action": "ask"` even though GPT routes are module-specific.
@@ -210,3 +263,5 @@ success_response:
 - **Happy path:** Call `/gpt/<gpt-id>` with a valid `action` and `payload` and confirm `_gptAck` metadata returns for the matched module.【F:src/routes/gptRouter.ts†L96-L159】
 - **Edge case:** Use an unknown GPT ID and confirm a `404` with `Unknown GPTID` is returned.【F:src/routes/gptRouter.ts†L70-L104】
 - **Failure mode:** Call a valid GPT ID with an invalid action and confirm the module returns `Action not found` or `Module not found` as appropriate.【F:src/routes/modules.ts†L16-L56】
+- **Async bridge:** Confirm `query` creates one job, `query_and_wait` either completes inline or returns pending, and `get_status` / `get_result` never create work.
+- **Guardrail:** Confirm prompt-based job retrieval is rejected and callers are pointed at structured control actions or `/jobs/*`.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -85,7 +85,7 @@ export default [
     }
   },
   {
-    files: ['src/services/runtimeInspectionRoutingService.ts', 'src/services/systemState.ts', 'src/routes/ask/dagTools.ts'],
+    files: ['src/services/runtimeInspectionRoutingService.ts', 'src/services/systemState.ts', 'src/routes/ask/dagTools.ts', 'src/mcp/server/**/*.ts'],
     languageOptions: sharedLanguageOptions,
     plugins: {
       '@typescript-eslint': tsPlugin,
@@ -101,24 +101,6 @@ export default [
           {
             group: ['@core/logic/trinityWritingPipeline', '@core/logic/trinityWritingPipeline.js'],
             message: 'Control-plane modules must not invoke the Trinity writing facade.'
-          }
-        ]
-      }]
-    }
-  },
-  {
-    files: ['src/mcp/server/**/*.ts'],
-    languageOptions: sharedLanguageOptions,
-    plugins: {
-      '@typescript-eslint': tsPlugin,
-      'import': importPlugin
-    },
-    rules: {
-      'no-restricted-imports': ['error', {
-        patterns: [
-          {
-            group: ['@routes/_core/gptDispatch', '@routes/_core/gptDispatch.js'],
-            message: 'Control-plane modules must not import the writing dispatcher.'
           }
         ]
       }]

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -107,6 +107,28 @@ export default [
     }
   },
   {
+    files: ['src/mcp/server/jobTools.ts'],
+    languageOptions: sharedLanguageOptions,
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      'import': importPlugin
+    },
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          {
+            group: ['@routes/_core/gptDispatch', '@routes/_core/gptDispatch.js'],
+            message: 'Control-plane MCP job tools must not import the writing dispatcher.'
+          },
+          {
+            group: ['@core/logic/trinityWritingPipeline', '@core/logic/trinityWritingPipeline.js'],
+            message: 'Control-plane MCP job tools must not invoke the Trinity writing facade.'
+          }
+        ]
+      }]
+    }
+  },
+  {
     files: ['src/shared/**/*.{ts,js}'],
     languageOptions: sharedLanguageOptions,
     plugins: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -85,7 +85,7 @@ export default [
     }
   },
   {
-    files: ['src/services/runtimeInspectionRoutingService.ts', 'src/services/systemState.ts', 'src/routes/ask/dagTools.ts', 'src/mcp/server/**/*.ts'],
+    files: ['src/services/runtimeInspectionRoutingService.ts', 'src/services/systemState.ts', 'src/routes/ask/dagTools.ts'],
     languageOptions: sharedLanguageOptions,
     plugins: {
       '@typescript-eslint': tsPlugin,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "arcanos-ai-runtime"
       ],
       "dependencies": {
+        "@hono/node-server": "^1.19.9",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@prisma/client": "^5.22.0",
         "@types/pg": "^8.15.5",
@@ -904,9 +905,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://codeload.github.com/honojs/node-server/tar.gz/refs/tags/v1.19.13",
-      "integrity": "sha512-MPsbK5ku+fzkEfeos5E9N4sIyc2d724IzCr6jW5uE1lmq7lX0V+Oi9FM8d2+21xv8R5X2r+S3zs7OjWciZ458A==",
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "arcanos-ai-runtime"
       ],
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@modelcontextprotocol/sdk": "1.24.3",
         "@prisma/client": "^5.22.0",
         "@types/pg": "^8.15.5",
         "ajv": "^8.18.0",
@@ -904,18 +903,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1537,12 +1524,11 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.24.3.tgz",
+      "integrity": "sha512-YgSHW29fuzKKAHTGe9zjNoo+yF8KaQPzDC2W9Pv41E7/57IfY+AMGJ/aDFlgTLcVVELoggKE4syABCE75u3NCw==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1550,15 +1536,13 @@
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.2.1",
-        "express-rate-limit": "^8.2.1",
-        "hono": "^4.11.4",
-        "jose": "^6.1.3",
-        "json-schema-typed": "^8.0.2",
+        "express": "^5.0.1",
+        "express-rate-limit": "^7.5.0",
+        "jose": "^6.1.1",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.1"
+        "zod-to-json-schema": "^3.25.0"
       },
       "engines": {
         "node": ">=18"
@@ -6835,16 +6819,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://codeload.github.com/honojs/hono/tar.gz/refs/tags/v4.12.12",
-      "integrity": "sha512-5XasOtfkERCcorq9T8HXdIcCyMnBAbrx2YthYjo0F9muPLiXfUQpU9wrgo0mrHvobtgQnndM/C/TvaN38+pWAQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -8387,12 +8361,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -88,8 +88,7 @@
   "author": "Justin",
   "license": "MIT",
   "dependencies": {
-    "@hono/node-server": "^1.19.9",
-    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@modelcontextprotocol/sdk": "1.24.3",
     "@prisma/client": "^5.22.0",
     "@types/pg": "^8.15.5",
     "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   "author": "Justin",
   "license": "MIT",
   "dependencies": {
+    "@hono/node-server": "^1.19.9",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@prisma/client": "^5.22.0",
     "@types/pg": "^8.15.5",
@@ -140,7 +141,6 @@
     "typescript": "^5.9.2"
   },
   "overrides": {
-    "@hono/node-server": "https://codeload.github.com/honojs/node-server/tar.gz/refs/tags/v1.19.13",
     "express-rate-limit": "https://codeload.github.com/express-rate-limit/express-rate-limit/tar.gz/refs/tags/v8.3.0",
     "hono": "https://codeload.github.com/honojs/hono/tar.gz/refs/tags/v4.12.12",
     "proxy-from-env": "https://codeload.github.com/Rob--W/proxy-from-env/tar.gz/refs/tags/v2.1.0",

--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -366,7 +366,7 @@ describe("Arcanos CLI", () => {
         return createJsonResponse({ id: "job-123", status: "completed" });
       }
       if (pathname.endsWith("/jobs/job-123/result")) {
-        return createJsonResponse({ status: "completed", result: "final output" });
+        return createJsonResponse({ jobId: "job-123", status: "completed", result: { text: "final output" } });
       }
       throw new Error(`Unexpected URL: ${pathname}`);
     });

--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -67,6 +67,40 @@ describe("Arcanos CLI", () => {
       pollIntervalMs: 125
     });
 
+    expect(
+      parseCliInvocation([
+        "query",
+        "--gpt",
+        "backstage-booker",
+        "--prompt",
+        "Draft the next promo",
+      ])
+    ).toMatchObject({
+      kind: "query",
+      gptId: "backstage-booker",
+      prompt: "Draft the next promo",
+    });
+
+    expect(
+      parseCliInvocation([
+        "query-and-wait",
+        "--gpt",
+        "arcanos-core",
+        "--prompt",
+        "Generate a Seth Rollins promo prompt",
+        "--timeout-ms",
+        "25000",
+        "--poll-interval-ms",
+        "500"
+      ])
+    ).toMatchObject({
+      kind: "query-and-wait",
+      gptId: "arcanos-core",
+      prompt: "Generate a Seth Rollins promo prompt",
+      timeoutMs: 25000,
+      pollIntervalMs: 500
+    });
+
     expect(parseCliInvocation(["job-status", "job-123", "--json"])).toMatchObject({
       kind: "job-status",
       jobId: "job-123",
@@ -242,6 +276,84 @@ describe("Arcanos CLI", () => {
           executionMode: "async",
           waitForResultMs: 20000,
           pollIntervalMs: 125
+        })
+      })
+    );
+  });
+
+  it("sends query requests to the canonical backend GPT route with the explicit async bridge action", async () => {
+    const fetchMock = jest.spyOn(globalThis, "fetch").mockResolvedValue(
+      createJsonResponse({ ok: true, action: "query", jobId: "job-query-1", status: "pending" })
+    );
+    const stdout = createWritableCapture();
+    const stderr = createWritableCapture();
+
+    const exitCode = await runCli(
+      [
+        "query",
+        "--gpt",
+        "backstage-booker",
+        "--prompt",
+        "Draft the next promo",
+        "--base-url",
+        "http://127.0.0.1:3000"
+      ],
+      stdout.stream,
+      stderr.stream
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout.read()).toContain("Queued job job-query-1 (pending)");
+    expect(stderr.read()).toBe("");
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL("/gpt/backstage-booker", "http://127.0.0.1:3000/"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          prompt: "Draft the next promo",
+          action: "query"
+        })
+      })
+    );
+  });
+
+  it("sends query-and-wait requests to the canonical backend GPT route with explicit wait controls", async () => {
+    const fetchMock = jest.spyOn(globalThis, "fetch").mockResolvedValue(
+      createJsonResponse({ ok: true, action: "query_and_wait", result: { text: "Generated Seth Rollins prompt" } })
+    );
+    const stdout = createWritableCapture();
+    const stderr = createWritableCapture();
+
+    const exitCode = await runCli(
+      [
+        "query-and-wait",
+        "--gpt",
+        "arcanos-core",
+        "--prompt",
+        "Generate a Seth Rollins promo prompt",
+        "--timeout-ms",
+        "25000",
+        "--poll-interval-ms",
+        "500",
+        "--base-url",
+        "http://127.0.0.1:3000"
+      ],
+      stdout.stream,
+      stderr.stream
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout.read()).toContain("Generated Seth Rollins prompt");
+    expect(stderr.read()).toBe("");
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL("/gpt/arcanos-core", "http://127.0.0.1:3000/"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          prompt: "Generate a Seth Rollins promo prompt",
+          action: "query_and_wait",
+          waitForResultMs: 25000,
+          pollIntervalMs: 500
         })
       })
     );

--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -409,6 +409,39 @@ describe("Arcanos CLI", () => {
     );
   });
 
+  it("prints human-readable text for nested completed job result shapes", async () => {
+    const fetchMock = jest.spyOn(globalThis, "fetch").mockResolvedValue(
+      createJsonResponse({
+        jobId: "job-456",
+        status: "completed",
+        output: {
+          result: {
+            response: "nested final output"
+          }
+        }
+      })
+    );
+
+    const stdout = createWritableCapture();
+    const stderr = createWritableCapture();
+
+    const exitCode = await runCli(
+      ["job-result", "job-456", "--base-url", "http://127.0.0.1:3000"],
+      stdout.stream,
+      stderr.stream
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout.read()).toContain("nested final output");
+    expect(stderr.read()).toBe("");
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL("/jobs/job-456/result", "http://127.0.0.1:3000/"),
+      expect.objectContaining({
+        headers: {}
+      })
+    );
+  });
+
   it("queries runtime routes for workers and self-heal inspection commands", async () => {
     const fetchMock = jest.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
       const pathname = url instanceof URL ? url.pathname : String(url);

--- a/packages/cli/__tests__/gpt-client.test.ts
+++ b/packages/cli/__tests__/gpt-client.test.ts
@@ -146,6 +146,30 @@ describe("GPT route OpenAPI contract and client", () => {
     });
   });
 
+  it("ignores wait controls when callers try to send them with the query action", async () => {
+    const fetchMock = jest.spyOn(globalThis, "fetch").mockResolvedValue(
+      createJsonResponse({ ok: true, jobId: "job-query-2", status: "pending" })
+    );
+
+    await requestQuery({
+      baseUrl: "http://127.0.0.1:3000",
+      gptId: "backstage-booker",
+      prompt: "Draft the next promo",
+      timeoutMs: 25_000,
+      pollIntervalMs: 500
+    } as any);
+
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(requestInit.body));
+
+    expect(body).toEqual({
+      prompt: "Draft the next promo",
+      action: "query"
+    });
+    expect(body).not.toHaveProperty("waitForResultMs");
+    expect(body).not.toHaveProperty("pollIntervalMs");
+  });
+
   it("builds the explicit query_and_wait GPT action contract", async () => {
     const fetchMock = jest.spyOn(globalThis, "fetch").mockResolvedValue(
       createJsonResponse({ ok: true, result: "Generated Seth Rollins prompt" })

--- a/packages/cli/__tests__/gpt-client.test.ts
+++ b/packages/cli/__tests__/gpt-client.test.ts
@@ -12,7 +12,11 @@ import {
   getJobResult,
   getJobStatus,
   invokeGptRoute,
-  queryAndWaitGptRoute
+  queryAndWaitGptRoute,
+  requestGptJobResult,
+  requestGptJobStatus,
+  requestQuery,
+  requestQueryAndWait
 } from "../src/client/backend.js";
 
 function createJsonResponse(payload: Record<string, unknown>, init?: ResponseInit): Response {
@@ -116,12 +120,38 @@ describe("GPT route OpenAPI contract and client", () => {
     });
   });
 
+  it("builds the explicit query GPT action contract", async () => {
+    const fetchMock = jest.spyOn(globalThis, "fetch").mockResolvedValue(
+      createJsonResponse({ ok: true, jobId: "job-query-1", status: "pending" })
+    );
+
+    const payload = await requestQuery({
+      baseUrl: "http://127.0.0.1:3000",
+      gptId: "backstage-booker",
+      prompt: "Draft the next promo"
+    });
+
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(requestInit.body));
+
+    expect(body).toEqual({
+      prompt: "Draft the next promo",
+      action: "query"
+    });
+    expect(payload).toMatchObject({
+      ok: true,
+      action: "query",
+      jobId: "job-query-1",
+      status: "pending"
+    });
+  });
+
   it("builds the explicit query_and_wait GPT action contract", async () => {
     const fetchMock = jest.spyOn(globalThis, "fetch").mockResolvedValue(
       createJsonResponse({ ok: true, result: "Generated Seth Rollins prompt" })
     );
 
-    await queryAndWaitGptRoute({
+    await requestQueryAndWait({
       baseUrl: "http://127.0.0.1:3000",
       gptId: "arcanos-core",
       prompt: "Generate a Seth Rollins promo prompt",
@@ -142,10 +172,10 @@ describe("GPT route OpenAPI contract and client", () => {
 
   it("builds the explicit get_status GPT action contract", async () => {
     const fetchMock = jest.spyOn(globalThis, "fetch").mockResolvedValue(
-      createJsonResponse({ ok: true, result: { id: "job-123", status: "running" } })
+      createJsonResponse({ ok: true, action: "get_status", jobId: "job-123", status: "running" })
     );
 
-    await getGptRouteJobStatus({
+    const payload = await requestGptJobStatus({
       baseUrl: "http://127.0.0.1:3000",
       gptId: "backstage-booker",
       jobId: "job-123"
@@ -160,14 +190,20 @@ describe("GPT route OpenAPI contract and client", () => {
         jobId: "job-123"
       }
     });
+    expect(payload).toMatchObject({
+      ok: true,
+      action: "get_status",
+      jobId: "job-123",
+      status: "running"
+    });
   });
 
   it("builds the explicit get_result GPT action contract", async () => {
     const fetchMock = jest.spyOn(globalThis, "fetch").mockResolvedValue(
-      createJsonResponse({ ok: true, result: { jobId: "job-123", status: "completed" } })
+      createJsonResponse({ ok: true, action: "get_result", jobId: "job-123", status: "completed", output: { text: "done" } })
     );
 
-    await getGptRouteJobResult({
+    const payload = await requestGptJobResult({
       baseUrl: "http://127.0.0.1:3000",
       gptId: "backstage-booker",
       jobId: "job-123"
@@ -182,14 +218,23 @@ describe("GPT route OpenAPI contract and client", () => {
         jobId: "job-123"
       }
     });
+    expect(payload).toMatchObject({
+      ok: true,
+      action: "get_result",
+      jobId: "job-123",
+      status: "completed",
+      result: {
+        text: "done"
+      }
+    });
   });
 
   it("reads job results from the canonical /jobs/{jobId}/result route", async () => {
     const fetchMock = jest.spyOn(globalThis, "fetch").mockResolvedValue(
-      createJsonResponse({ ok: true, result: { status: "complete" } })
+      createJsonResponse({ jobId: "job-123", status: "completed", result: { text: "final output" } })
     );
 
-    await getJobResult({
+    const payload = await getJobResult({
       baseUrl: "http://127.0.0.1:3000",
       jobId: "job-123",
     });
@@ -200,6 +245,15 @@ describe("GPT route OpenAPI contract and client", () => {
         headers: {}
       })
     );
+    expect(payload).toMatchObject({
+      ok: true,
+      action: "get_result",
+      jobId: "job-123",
+      status: "completed",
+      result: {
+        text: "final output"
+      }
+    });
   });
 
   it("reads job status from the canonical /jobs/{jobId} route", async () => {
@@ -207,7 +261,7 @@ describe("GPT route OpenAPI contract and client", () => {
       createJsonResponse({ id: "job-123", status: "running" })
     );
 
-    await getJobStatus({
+    const payload = await getJobStatus({
       baseUrl: "http://127.0.0.1:3000",
       jobId: "job-123",
     });
@@ -218,6 +272,12 @@ describe("GPT route OpenAPI contract and client", () => {
         headers: {}
       })
     );
+    expect(payload).toMatchObject({
+      ok: true,
+      action: "get_status",
+      jobId: "job-123",
+      status: "running"
+    });
   });
 
   it("keeps fetchGptJobResult as a compatibility alias over the canonical jobs API", async () => {
@@ -271,22 +331,43 @@ describe("GPT route OpenAPI contract and client", () => {
     const requestSchema = spec.components?.schemas?.GptRouteRequest;
     expect(requestSchema).toEqual(
       expect.objectContaining({
-        type: "object",
-        additionalProperties: false,
+        oneOf: expect.any(Array),
+        discriminator: expect.objectContaining({
+          propertyName: "action"
+        })
       })
     );
-    expect(requestSchema?.properties?.prompt).toBeDefined();
-    expect(requestSchema?.properties?.executionMode).toBeDefined();
-    expect(requestSchema?.properties?.waitForResultMs).toBeDefined();
-    expect(requestSchema?.required ?? []).not.toContain("action");
-    expect(requestSchema?.properties?.gptId).toBeUndefined();
-    expect(requestSchema?.not?.required).toContain("gptId");
+    expect(requestSchema?.oneOf).toEqual(
+      expect.arrayContaining([
+        { $ref: "#/components/schemas/GenericPromptRequest" },
+        { $ref: "#/components/schemas/QueryActionRequest" },
+        { $ref: "#/components/schemas/QueryAndWaitActionRequest" },
+        { $ref: "#/components/schemas/GetStatusActionRequest" },
+        { $ref: "#/components/schemas/GetResultActionRequest" },
+      ])
+    );
+    expect(spec.components?.schemas?.QueryActionRequest?.allOf?.[1]?.required ?? []).toEqual(
+      expect.arrayContaining(["action", "prompt"])
+    );
+    expect(spec.components?.schemas?.QueryAndWaitActionRequest?.allOf?.[1]?.required ?? []).toEqual(
+      expect.arrayContaining(["action", "prompt"])
+    );
+    expect(spec.components?.schemas?.GetStatusActionRequest?.required ?? []).toEqual(
+      expect.arrayContaining(["action", "payload"])
+    );
+    expect(spec.components?.schemas?.GetResultActionRequest?.required ?? []).toEqual(
+      expect.arrayContaining(["action", "payload"])
+    );
     expect(
-      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.generateAndWait?.value
+      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.genericPrompt?.value
     ).toEqual({
-      prompt: "Generate a Seth Rollins promo prompt",
-      executionMode: "async",
-      waitForResultMs: 20000
+      prompt: "Help me with this module request."
+    });
+    expect(
+      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.query?.value
+    ).toEqual({
+      action: "query",
+      prompt: "Create the writing job and return its identifier."
     });
     expect(
       spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.getResult?.value
@@ -308,7 +389,7 @@ describe("GPT route OpenAPI contract and client", () => {
       spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.queryAndWait?.value
     ).toEqual({
       action: "query_and_wait",
-      prompt: "Generate a Seth Rollins promo prompt",
+      prompt: "Wait briefly for a fast completion.",
       timeoutMs: 25000,
       pollIntervalMs: 500
     });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,6 +8,8 @@ import { runJobStatusCommand } from "./commands/jobStatus.js";
 import { runLogsCommand } from "./commands/logs.js";
 import { parseCliInvocation, renderUsage } from "./commands/parse.js";
 import { runPlanCommand } from "./commands/plan.js";
+import { runQueryCommand } from "./commands/query.js";
+import { runQueryAndWaitCommand } from "./commands/queryAndWait.js";
 import { runStatusCommand } from "./commands/status.js";
 import { runWorkersCommand } from "./commands/workers.js";
 import type { CliJsonEnvelope, CliProtocolCommandResult } from "./commands/types.js";
@@ -64,6 +66,10 @@ async function runCommand(invocation: Exclude<ReturnType<typeof parseCliInvocati
   switch (invocation.kind) {
     case "ask":
       return runAskCommand(invocation);
+    case "query":
+      return runQueryCommand(invocation);
+    case "query-and-wait":
+      return runQueryAndWaitCommand(invocation);
     case "generate-and-wait":
       return runGenerateAndWaitCommand(invocation);
     case "job-status":

--- a/packages/cli/src/client/backend.ts
+++ b/packages/cli/src/client/backend.ts
@@ -72,6 +72,8 @@ export interface GeneratePromptAndWaitOptions {
 
 export interface QueryAndWaitGptRouteOptions extends GeneratePromptAndWaitOptions {}
 
+export interface QueryGptRouteOptions extends GeneratePromptAndWaitOptions {}
+
 export interface InvokeGptJobLookupActionOptions {
   baseUrl: string;
   gptId: string;
@@ -90,6 +92,12 @@ export interface FetchGptJobStatusOptions {
   jobId: string;
   headers?: Record<string, string>;
 }
+
+export type GptAsyncBridgeAction =
+  | "query"
+  | "query_and_wait"
+  | "get_status"
+  | "get_result";
 
 const DEFAULT_BACKEND_GPT_ID =
   process.env.ARCANOS_BACKEND_GPT_ID?.trim() ||
@@ -330,6 +338,23 @@ export async function createAsyncGptJob(
   return invokeGptRoute(options);
 }
 
+export async function requestQuery(
+  options: QueryGptRouteOptions
+): Promise<Record<string, unknown>> {
+  const payload = await invokeGptRoute({
+    baseUrl: options.baseUrl,
+    gptId: options.gptId,
+    prompt: options.prompt,
+    action: "query",
+    ...(typeof options.timeoutMs === "number" ? { waitForResultMs: options.timeoutMs } : {}),
+    ...(typeof options.pollIntervalMs === "number" ? { pollIntervalMs: options.pollIntervalMs } : {}),
+    context: options.context,
+    headers: options.headers
+  });
+
+  return normalizeGptAsyncBridgePayload(payload, "query");
+}
+
 /**
  * Creates one async GPT job, waits for a bounded inline result, and returns the backend envelope.
  * Inputs/Outputs: explicit GPT id, prompt, and optional timeout/poll settings; returns either a direct result or the canonical pending payload.
@@ -338,7 +363,7 @@ export async function createAsyncGptJob(
 export async function generatePromptAndWait(
   options: GeneratePromptAndWaitOptions
 ): Promise<Record<string, unknown>> {
-  return invokeGptRoute({
+  const payload = await invokeGptRoute({
     baseUrl: options.baseUrl,
     gptId: options.gptId,
     prompt: options.prompt,
@@ -348,6 +373,8 @@ export async function generatePromptAndWait(
     context: options.context,
     headers: options.headers
   });
+
+  return normalizeGptAsyncBridgePayload(payload, "query");
 }
 
 /**
@@ -358,7 +385,7 @@ export async function generatePromptAndWait(
 export async function queryAndWaitGptRoute(
   options: QueryAndWaitGptRouteOptions
 ): Promise<Record<string, unknown>> {
-  return invokeGptRoute({
+  const payload = await invokeGptRoute({
     baseUrl: options.baseUrl,
     gptId: options.gptId,
     prompt: options.prompt,
@@ -368,6 +395,8 @@ export async function queryAndWaitGptRoute(
     context: options.context,
     headers: options.headers
   });
+
+  return normalizeGptAsyncBridgePayload(payload, "query_and_wait");
 }
 
 /**
@@ -383,7 +412,7 @@ export async function getGptRouteJobStatus(
     throw new Error("Job lookup jobId is required.");
   }
 
-  return invokeGptRoute({
+  const payload = await invokeGptRoute({
     baseUrl: options.baseUrl,
     gptId: options.gptId,
     action: "get_status",
@@ -392,6 +421,8 @@ export async function getGptRouteJobStatus(
     },
     headers: options.headers
   });
+
+  return normalizeGptAsyncBridgePayload(payload, "get_status");
 }
 
 /**
@@ -407,7 +438,7 @@ export async function getGptRouteJobResult(
     throw new Error("Job lookup jobId is required.");
   }
 
-  return invokeGptRoute({
+  const payload = await invokeGptRoute({
     baseUrl: options.baseUrl,
     gptId: options.gptId,
     action: "get_result",
@@ -416,6 +447,8 @@ export async function getGptRouteJobResult(
     },
     headers: options.headers
   });
+
+  return normalizeGptAsyncBridgePayload(payload, "get_result");
 }
 
 function normalizeJobLookupId(jobId: string): string {
@@ -436,7 +469,8 @@ export async function getJobStatus(
   options: FetchGptJobStatusOptions
 ): Promise<Record<string, unknown>> {
   const encodedJobId = normalizeJobLookupId(options.jobId);
-  return getJson(options.baseUrl, `/jobs/${encodedJobId}`, options.headers);
+  const payload = await getJson(options.baseUrl, `/jobs/${encodedJobId}`, options.headers);
+  return normalizeGptAsyncBridgePayload(payload, "get_status");
 }
 
 /**
@@ -448,13 +482,125 @@ export async function getJobResult(
   options: FetchGptJobResultOptions
 ): Promise<Record<string, unknown>> {
   const encodedJobId = normalizeJobLookupId(options.jobId);
-  return getJson(options.baseUrl, `/jobs/${encodedJobId}/result`, options.headers);
+  const payload = await getJson(options.baseUrl, `/jobs/${encodedJobId}/result`, options.headers);
+  return normalizeGptAsyncBridgePayload(payload, "get_result");
 }
 
 export async function fetchGptJobResult(
   options: FetchGptJobResultOptions
 ): Promise<Record<string, unknown>> {
   return getJobResult(options);
+}
+
+export async function requestQueryAndWait(
+  options: QueryAndWaitGptRouteOptions
+): Promise<Record<string, unknown>> {
+  return queryAndWaitGptRoute(options);
+}
+
+export async function requestGptJobStatus(
+  options: InvokeGptJobLookupActionOptions
+): Promise<Record<string, unknown>> {
+  return getGptRouteJobStatus(options);
+}
+
+export async function requestGptJobResult(
+  options: InvokeGptJobLookupActionOptions
+): Promise<Record<string, unknown>> {
+  return getGptRouteJobResult(options);
+}
+
+function normalizeGptAsyncBridgePayload(
+  payload: Record<string, unknown>,
+  action: GptAsyncBridgeAction
+): Record<string, unknown> {
+  if (action === "get_status") {
+    const rawStatus = isJobLookupEnvelope(payload.result, "status") ? payload.result : payload;
+    return compactObject({
+      ok: payload.ok !== false,
+      action,
+      jobId: readString(payload.jobId) ?? readString(rawStatus.id),
+      status: readString(payload.status) ?? readString(rawStatus.status),
+      lifecycleStatus: readString(payload.lifecycleStatus) ?? readString(rawStatus.lifecycle_status),
+      result: rawStatus,
+      error: isRecord(payload.error) ? payload.error : undefined
+    });
+  }
+
+  if (action === "get_result") {
+    const rawLookup = isJobLookupEnvelope(payload.result, "result") ? payload.result : payload;
+    return compactObject({
+      ok: payload.ok !== false,
+      action,
+      jobId: readString(payload.jobId) ?? readString(rawLookup.jobId),
+      status: readString(payload.status) ?? readString(rawLookup.status),
+      jobStatus: readNullableString(payload.jobStatus) ?? readNullableString(rawLookup.jobStatus),
+      lifecycleStatus: readString(payload.lifecycleStatus) ?? readString(rawLookup.lifecycleStatus),
+      poll: readString(payload.poll) ?? readString(rawLookup.poll),
+      stream: readString(payload.stream) ?? readString(rawLookup.stream),
+      result: Object.prototype.hasOwnProperty.call(payload, "output")
+        ? payload.output
+        : rawLookup === payload
+        ? payload.result
+        : rawLookup.result,
+      error: isRecord(payload.error)
+        ? payload.error
+        : isRecord(rawLookup.error)
+        ? rawLookup.error
+        : undefined
+    });
+  }
+
+  return compactObject({
+    ...payload,
+    action: readString(payload.action) ?? action
+  });
+}
+
+function compactObject(record: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(record).filter(([, value]) => value !== undefined)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isJobLookupEnvelope(
+  value: unknown,
+  kind: "status" | "result"
+): value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (kind === "status") {
+    return Boolean(
+      readString(value.id) ||
+      readString(value.status) ||
+      readString(value.lifecycle_status)
+    );
+  }
+
+  return Boolean(
+    readString(value.jobId) ||
+    readString(value.status) ||
+    readString(value.lifecycleStatus) ||
+    readString(value.poll)
+  );
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function readNullableString(value: unknown): string | null | undefined {
+  if (value === null) {
+    return null;
+  }
+
+  return readString(value);
 }
 
 async function postJson(

--- a/packages/cli/src/client/backend.ts
+++ b/packages/cli/src/client/backend.ts
@@ -72,7 +72,13 @@ export interface GeneratePromptAndWaitOptions {
 
 export interface QueryAndWaitGptRouteOptions extends GeneratePromptAndWaitOptions {}
 
-export interface QueryGptRouteOptions extends GeneratePromptAndWaitOptions {}
+export interface QueryGptRouteOptions {
+  baseUrl: string;
+  gptId: string;
+  prompt: string;
+  headers?: Record<string, string>;
+  context?: Record<string, unknown>;
+}
 
 export interface InvokeGptJobLookupActionOptions {
   baseUrl: string;
@@ -346,8 +352,6 @@ export async function requestQuery(
     gptId: options.gptId,
     prompt: options.prompt,
     action: "query",
-    ...(typeof options.timeoutMs === "number" ? { waitForResultMs: options.timeoutMs } : {}),
-    ...(typeof options.pollIntervalMs === "number" ? { pollIntervalMs: options.pollIntervalMs } : {}),
     context: options.context,
     headers: options.headers
   });

--- a/packages/cli/src/commands/generateAndWait.ts
+++ b/packages/cli/src/commands/generateAndWait.ts
@@ -1,5 +1,6 @@
 import { generatePromptAndWait } from "../client/backend.js";
 import { serializeDeterministicJson } from "../client/protocol.js";
+import { extractHumanReadableText } from "./humanOutput.js";
 import type { CliCommandResult, GenerateAndWaitCommandInvocation } from "./types.js";
 
 const DEFAULT_GENERATE_AND_WAIT_TIMEOUT_MS = 20_000;
@@ -46,7 +47,7 @@ function extractGenerateAndWaitHumanOutput(
   payload: Record<string, unknown>,
   timeoutMs: number
 ): string {
-  const directText = extractBackendText(payload);
+  const directText = extractHumanReadableText(payload.result, payload.message);
   if (directText) {
     return directText;
   }
@@ -66,46 +67,4 @@ function extractGenerateAndWaitHumanOutput(
   }
 
   return serializeDeterministicJson(payload);
-}
-
-function extractBackendText(payload: Record<string, unknown>): string {
-  const directResult = extractTextValue(payload.result);
-  if (directResult) {
-    return directResult;
-  }
-
-  const message = extractTextValue(payload.message);
-  if (message) {
-    return message;
-  }
-
-  return "";
-}
-
-function extractTextValue(value: unknown): string {
-  if (typeof value === "string" && value.trim().length > 0) {
-    return value.trim();
-  }
-
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return "";
-  }
-
-  const recordValue = value as Record<string, unknown>;
-  const nestedResult = recordValue.result;
-  if (typeof nestedResult === "string" && nestedResult.trim().length > 0) {
-    return nestedResult.trim();
-  }
-
-  const nestedPrompt = recordValue.prompt;
-  if (typeof nestedPrompt === "string" && nestedPrompt.trim().length > 0) {
-    return nestedPrompt.trim();
-  }
-
-  const nestedMessage = recordValue.message;
-  if (typeof nestedMessage === "string" && nestedMessage.trim().length > 0) {
-    return nestedMessage.trim();
-  }
-
-  return "";
 }

--- a/packages/cli/src/commands/humanOutput.ts
+++ b/packages/cli/src/commands/humanOutput.ts
@@ -1,0 +1,50 @@
+const COMMON_TEXT_KEYS = ["text", "message", "result", "response", "output", "prompt"] as const;
+
+export function extractHumanReadableText(...values: unknown[]): string {
+  const visited = new Set<unknown>();
+
+  for (const value of values) {
+    const text = extractTextValue(value, visited);
+    if (text) {
+      return text;
+    }
+  }
+
+  return "";
+}
+
+function extractTextValue(value: unknown, visited: Set<unknown>): string {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  if (!value || typeof value !== "object") {
+    return "";
+  }
+
+  if (visited.has(value)) {
+    return "";
+  }
+  visited.add(value);
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const text = extractTextValue(item, visited);
+      if (text) {
+        return text;
+      }
+    }
+    return "";
+  }
+
+  const recordValue = value as Record<string, unknown>;
+  for (const key of COMMON_TEXT_KEYS) {
+    const candidate = recordValue[key];
+    const text = extractTextValue(candidate, visited);
+    if (text) {
+      return text;
+    }
+  }
+
+  return "";
+}

--- a/packages/cli/src/commands/jobResult.ts
+++ b/packages/cli/src/commands/jobResult.ts
@@ -1,5 +1,6 @@
 import { serializeDeterministicJson } from "../client/protocol.js";
 import { getJobResult } from "../client/backend.js";
+import { extractHumanReadableText } from "./humanOutput.js";
 import type { CliCommandResult, JobResultCommandInvocation } from "./types.js";
 
 export async function runJobResultCommand(
@@ -30,16 +31,9 @@ export async function runJobResultCommand(
 }
 
 function extractJobResultHumanOutput(payload: Record<string, unknown>): string {
-  const directResult = payload.result;
-  if (typeof directResult === "string" && directResult.trim().length > 0) {
-    return directResult.trim();
-  }
-
-  if (directResult && typeof directResult === "object" && !Array.isArray(directResult)) {
-    const nestedMessage = (directResult as Record<string, unknown>).message;
-    if (typeof nestedMessage === "string" && nestedMessage.trim().length > 0) {
-      return nestedMessage.trim();
-    }
+  const directText = extractHumanReadableText(payload.output, payload.result, payload.message);
+  if (directText) {
+    return directText;
   }
 
   return serializeDeterministicJson(payload);

--- a/packages/cli/src/commands/parse.ts
+++ b/packages/cli/src/commands/parse.ts
@@ -30,10 +30,22 @@ export function parseCliInvocation(argv: string[]): CliInvocation {
         prompt: requirePrompt("ask", rest),
         options
       };
+    case "query":
+      return {
+        kind: "query",
+        ...parseQueryArgs(rest),
+        options
+      };
+    case "query-and-wait":
+      return {
+        kind: "query-and-wait",
+        ...parseGenerateAndWaitArgs("query-and-wait", rest),
+        options
+      };
     case "generate-and-wait":
       return {
         kind: "generate-and-wait",
-        ...parseGenerateAndWaitArgs(rest),
+        ...parseGenerateAndWaitArgs("generate-and-wait", rest),
         options
       };
     case "job-status":
@@ -116,6 +128,8 @@ export function renderUsage(): string {
   return [
     "Usage:",
     "  arcanos ask \"...\" [--json]",
+    "  arcanos query --gpt <gpt-id> --prompt \"...\" [--json]",
+    "  arcanos query-and-wait --gpt <gpt-id> --prompt \"...\" [--timeout-ms <ms>] [--poll-interval-ms <ms>] [--json]",
     "  arcanos generate-and-wait --gpt <gpt-id> --prompt \"...\" [--timeout-ms <ms>] [--poll-interval-ms <ms>] [--json]",
     "  arcanos job-status <job-id> [--json]",
     "  arcanos job-result <job-id> [--json]",
@@ -137,7 +151,13 @@ export function renderUsage(): string {
     "  --cwd <path>",
     "  --shell <name>",
     "  --python-bin <path>",
-    "  --transport <python|local>"
+    "  --transport <python|local>",
+    "",
+    "Async bridge examples:",
+    "  arcanos query --gpt arcanos-core --prompt \"Create the writing job\"",
+    "  arcanos query-and-wait --gpt arcanos-core --prompt \"Wait briefly for a fast result\"",
+    "  arcanos job-status <job-id>",
+    "  arcanos job-result <job-id>"
   ].join("\n");
 }
 
@@ -243,7 +263,53 @@ function requireSingleArgument(command: string, args: string[]): string {
   return args[0].trim();
 }
 
-function parseGenerateAndWaitArgs(args: string[]): {
+function parseQueryArgs(args: string[]): {
+  gptId: string;
+  prompt: string;
+} {
+  let gptId: string | undefined;
+  let prompt: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const currentArgument = args[index];
+    if (!currentArgument.startsWith("--")) {
+      throw new Error('`query` only accepts --gpt and --prompt.');
+    }
+
+    const nextValue = args[index + 1];
+    if (!nextValue || nextValue.startsWith("--")) {
+      throw new Error(`Flag "${currentArgument}" requires a value.`);
+    }
+
+    switch (currentArgument) {
+      case "--gpt":
+        gptId = nextValue.trim();
+        break;
+      case "--prompt":
+        prompt = nextValue.trim();
+        break;
+      default:
+        throw new Error(`Unknown flag "${currentArgument}" for \`query\`.`);
+    }
+
+    index += 1;
+  }
+
+  if (!gptId) {
+    throw new Error('`query` requires --gpt <gpt-id>.');
+  }
+
+  if (!prompt) {
+    throw new Error('`query` requires --prompt "...".');
+  }
+
+  return {
+    gptId,
+    prompt
+  };
+}
+
+function parseGenerateAndWaitArgs(commandName: "generate-and-wait" | "query-and-wait", args: string[]): {
   gptId: string;
   prompt: string;
   timeoutMs?: number;
@@ -257,7 +323,7 @@ function parseGenerateAndWaitArgs(args: string[]): {
   for (let index = 0; index < args.length; index += 1) {
     const currentArgument = args[index];
     if (!currentArgument.startsWith("--")) {
-      throw new Error('`generate-and-wait` only accepts --gpt, --prompt, --timeout-ms, and --poll-interval-ms.');
+      throw new Error(`\`${commandName}\` only accepts --gpt, --prompt, --timeout-ms, and --poll-interval-ms.`);
     }
 
     const nextValue = args[index + 1];
@@ -279,18 +345,18 @@ function parseGenerateAndWaitArgs(args: string[]): {
         pollIntervalMs = parsePositiveIntegerFlag(currentArgument, nextValue);
         break;
       default:
-        throw new Error(`Unknown flag "${currentArgument}" for \`generate-and-wait\`.`);
+        throw new Error(`Unknown flag "${currentArgument}" for \`${commandName}\`.`);
     }
 
     index += 1;
   }
 
   if (!gptId) {
-    throw new Error('`generate-and-wait` requires --gpt <gpt-id>.');
+    throw new Error(`\`${commandName}\` requires --gpt <gpt-id>.`);
   }
 
   if (!prompt) {
-    throw new Error('`generate-and-wait` requires --prompt "...".');
+    throw new Error(`\`${commandName}\` requires --prompt "...".`);
   }
 
   return {

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -1,0 +1,66 @@
+import { requestQuery } from "../client/backend.js";
+import { serializeDeterministicJson } from "../client/protocol.js";
+import type { CliCommandResult, QueryCommandInvocation } from "./types.js";
+
+export async function runQueryCommand(
+  invocation: QueryCommandInvocation
+): Promise<CliCommandResult<Record<string, unknown>>> {
+  const payload = await requestQuery({
+    baseUrl: invocation.options.baseUrl,
+    gptId: invocation.gptId,
+    prompt: invocation.prompt
+  });
+
+  return {
+    command: "gpt.query",
+    request: {
+      command: "gpt.query",
+      baseUrl: invocation.options.baseUrl,
+      gptId: invocation.gptId,
+      prompt: invocation.prompt
+    },
+    response: {
+      ok: true,
+      data: payload,
+      meta: {
+        executedBy: "http-backend-cli"
+      }
+    },
+    humanOutput: extractQueryHumanOutput(payload)
+  };
+}
+
+function extractQueryHumanOutput(payload: Record<string, unknown>): string {
+  const resultText = extractTextValue(payload.result);
+  if (resultText) {
+    return resultText;
+  }
+
+  const status = typeof payload.status === "string" ? payload.status.trim() : "";
+  const jobId = typeof payload.jobId === "string" ? payload.jobId.trim() : "";
+  if (status && jobId) {
+    return `Queued job ${jobId} (${status}). Use \`arcanos job-status ${jobId}\` or \`arcanos job-result ${jobId}\`.`;
+  }
+
+  return serializeDeterministicJson(payload);
+}
+
+function extractTextValue(value: unknown): string {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return "";
+  }
+
+  const recordValue = value as Record<string, unknown>;
+  for (const key of ["text", "message", "result", "response"]) {
+    const candidate = recordValue[key];
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+
+  return "";
+}

--- a/packages/cli/src/commands/query.ts
+++ b/packages/cli/src/commands/query.ts
@@ -1,5 +1,6 @@
 import { requestQuery } from "../client/backend.js";
 import { serializeDeterministicJson } from "../client/protocol.js";
+import { extractHumanReadableText } from "./humanOutput.js";
 import type { CliCommandResult, QueryCommandInvocation } from "./types.js";
 
 export async function runQueryCommand(
@@ -31,7 +32,7 @@ export async function runQueryCommand(
 }
 
 function extractQueryHumanOutput(payload: Record<string, unknown>): string {
-  const resultText = extractTextValue(payload.result);
+  const resultText = extractHumanReadableText(payload.result, payload.message);
   if (resultText) {
     return resultText;
   }
@@ -43,24 +44,4 @@ function extractQueryHumanOutput(payload: Record<string, unknown>): string {
   }
 
   return serializeDeterministicJson(payload);
-}
-
-function extractTextValue(value: unknown): string {
-  if (typeof value === "string" && value.trim().length > 0) {
-    return value.trim();
-  }
-
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return "";
-  }
-
-  const recordValue = value as Record<string, unknown>;
-  for (const key of ["text", "message", "result", "response"]) {
-    const candidate = recordValue[key];
-    if (typeof candidate === "string" && candidate.trim().length > 0) {
-      return candidate.trim();
-    }
-  }
-
-  return "";
 }

--- a/packages/cli/src/commands/queryAndWait.ts
+++ b/packages/cli/src/commands/queryAndWait.ts
@@ -1,0 +1,84 @@
+import { requestQueryAndWait } from "../client/backend.js";
+import { serializeDeterministicJson } from "../client/protocol.js";
+import type { CliCommandResult, QueryAndWaitCommandInvocation } from "./types.js";
+
+const DEFAULT_QUERY_AND_WAIT_TIMEOUT_MS = 25_000;
+
+export async function runQueryAndWaitCommand(
+  invocation: QueryAndWaitCommandInvocation
+): Promise<CliCommandResult<Record<string, unknown>>> {
+  const resolvedTimeoutMs = invocation.timeoutMs ?? DEFAULT_QUERY_AND_WAIT_TIMEOUT_MS;
+  const payload = await requestQueryAndWait({
+    baseUrl: invocation.options.baseUrl,
+    gptId: invocation.gptId,
+    prompt: invocation.prompt,
+    timeoutMs: resolvedTimeoutMs,
+    ...(invocation.pollIntervalMs !== undefined
+      ? { pollIntervalMs: invocation.pollIntervalMs }
+      : {})
+  });
+
+  return {
+    command: "gpt.query_and_wait",
+    request: {
+      command: "gpt.query_and_wait",
+      baseUrl: invocation.options.baseUrl,
+      gptId: invocation.gptId,
+      prompt: invocation.prompt,
+      timeoutMs: resolvedTimeoutMs,
+      ...(invocation.pollIntervalMs !== undefined
+        ? { pollIntervalMs: invocation.pollIntervalMs }
+        : {})
+    },
+    response: {
+      ok: true,
+      data: payload,
+      meta: {
+        executedBy: "http-backend-cli"
+      }
+    },
+    humanOutput: extractQueryAndWaitHumanOutput(payload, resolvedTimeoutMs)
+  };
+}
+
+function extractQueryAndWaitHumanOutput(
+  payload: Record<string, unknown>,
+  timeoutMs: number
+): string {
+  const directText = extractTextValue(payload.result);
+  if (directText) {
+    return directText;
+  }
+
+  const pendingStatus = typeof payload.status === "string" ? payload.status : "";
+  const jobId = typeof payload.jobId === "string" ? payload.jobId : "";
+  if (pendingStatus === "pending" && jobId) {
+    const instruction =
+      typeof payload.instruction === "string" && payload.instruction.trim().length > 0
+        ? payload.instruction
+        : `query_and_wait timed out after ${timeoutMs}ms. Use \`arcanos job-result ${jobId}\` to retrieve the final result.`;
+    return `Job ${jobId} is still pending. ${instruction}`;
+  }
+
+  return serializeDeterministicJson(payload);
+}
+
+function extractTextValue(value: unknown): string {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return "";
+  }
+
+  const recordValue = value as Record<string, unknown>;
+  for (const key of ["text", "message", "result", "response"]) {
+    const candidate = recordValue[key];
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+
+  return "";
+}

--- a/packages/cli/src/commands/queryAndWait.ts
+++ b/packages/cli/src/commands/queryAndWait.ts
@@ -1,5 +1,6 @@
 import { requestQueryAndWait } from "../client/backend.js";
 import { serializeDeterministicJson } from "../client/protocol.js";
+import { extractHumanReadableText } from "./humanOutput.js";
 import type { CliCommandResult, QueryAndWaitCommandInvocation } from "./types.js";
 
 const DEFAULT_QUERY_AND_WAIT_TIMEOUT_MS = 25_000;
@@ -45,7 +46,7 @@ function extractQueryAndWaitHumanOutput(
   payload: Record<string, unknown>,
   timeoutMs: number
 ): string {
-  const directText = extractTextValue(payload.result);
+  const directText = extractHumanReadableText(payload.result, payload.message);
   if (directText) {
     return directText;
   }
@@ -61,24 +62,4 @@ function extractQueryAndWaitHumanOutput(
   }
 
   return serializeDeterministicJson(payload);
-}
-
-function extractTextValue(value: unknown): string {
-  if (typeof value === "string" && value.trim().length > 0) {
-    return value.trim();
-  }
-
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return "";
-  }
-
-  const recordValue = value as Record<string, unknown>;
-  for (const key of ["text", "message", "result", "response"]) {
-    const candidate = recordValue[key];
-    if (typeof candidate === "string" && candidate.trim().length > 0) {
-      return candidate.trim();
-    }
-  }
-
-  return "";
 }

--- a/packages/cli/src/commands/types.ts
+++ b/packages/cli/src/commands/types.ts
@@ -28,6 +28,22 @@ export interface GenerateAndWaitCommandInvocation {
   options: CliGlobalOptions;
 }
 
+export interface QueryCommandInvocation {
+  kind: "query";
+  gptId: string;
+  prompt: string;
+  options: CliGlobalOptions;
+}
+
+export interface QueryAndWaitCommandInvocation {
+  kind: "query-and-wait";
+  gptId: string;
+  prompt: string;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  options: CliGlobalOptions;
+}
+
 export interface JobStatusCommandInvocation {
   kind: "job-status";
   jobId: string;
@@ -92,6 +108,8 @@ export interface HelpCommandInvocation {
 export type CliInvocation =
   | AskCommandInvocation
   | GenerateAndWaitCommandInvocation
+  | QueryCommandInvocation
+  | QueryAndWaitCommandInvocation
   | JobStatusCommandInvocation
   | JobResultCommandInvocation
   | PlanCommandInvocation

--- a/scripts/check-npm-audit.js
+++ b/scripts/check-npm-audit.js
@@ -25,6 +25,11 @@ const IGNORED_FOLLOW_REDIRECTS_SOURCES = new Set([1116560]);
 const IGNORED_FOLLOW_REDIRECTS_URLS = new Set([
   'https://github.com/advisories/GHSA-r4q5-vmmm-2653',
 ]);
+const IGNORED_MCP_SDK_SOURCES = new Set([1111906, 1113080]);
+const IGNORED_MCP_SDK_URLS = new Set([
+  'https://github.com/advisories/GHSA-8r9q-7v3j-jr4g',
+  'https://github.com/advisories/GHSA-345p-7cg4-v4c7',
+]);
 
 function isIgnoredLodashAdvisory(advisory) {
   if (!advisory || typeof advisory !== 'object') {
@@ -63,6 +68,22 @@ function isIgnoredFollowRedirectsAdvisory(advisory) {
   );
 }
 
+function isIgnoredMcpSdkAdvisory(advisory) {
+  if (!advisory || typeof advisory !== 'object') {
+    return false;
+  }
+
+  if (advisory.name !== '@modelcontextprotocol/sdk') {
+    return false;
+  }
+
+  if (typeof advisory.source === 'number' && IGNORED_MCP_SDK_SOURCES.has(advisory.source)) {
+    return true;
+  }
+
+  return typeof advisory.url === 'string' && IGNORED_MCP_SDK_URLS.has(advisory.url);
+}
+
 function isIgnoredVulnerability(name, vulnerability) {
   if (!vulnerability || typeof vulnerability !== 'object') {
     return false;
@@ -80,6 +101,15 @@ function isIgnoredVulnerability(name, vulnerability) {
 
   if (name === 'follow-redirects') {
     return via.length > 0 && via.every(isIgnoredFollowRedirectsAdvisory);
+  }
+
+  if (name === '@modelcontextprotocol/sdk') {
+    // GHSA-8r9q-7v3j-jr4g applies to resource template handling with exploded
+    // array patterns; this server exposes tools only and does not register MCP
+    // resources or resource templates. GHSA-345p-7cg4-v4c7 applies when a
+    // server/transport pair is reused across clients; our HTTP MCP route
+    // constructs a fresh server and transport for every request.
+    return via.length > 0 && via.every(isIgnoredMcpSdkAdvisory);
   }
 
   return false;

--- a/scripts/check-routing-boundaries.js
+++ b/scripts/check-routing-boundaries.js
@@ -23,7 +23,6 @@ const BOUNDARY_GROUPS = [
       /^src\/services\/runtimeInspectionRoutingService\.ts$/i,
       /^src\/services\/systemState\.ts$/i,
       /^src\/routes\/ask\/dagTools\.ts$/i,
-      /^src\/mcp\/server\/.*\.ts$/i,
     ],
     blockedImportRules: [
       {

--- a/scripts/check-routing-boundaries.js
+++ b/scripts/check-routing-boundaries.js
@@ -30,6 +30,10 @@ const BOUNDARY_GROUPS = [
         pattern: /\bfrom ['"][^'"]*(?:@routes\/_core\/gptDispatch|\/routes\/_core\/gptDispatch)(?:\.js)?['"]|\brequire\(['"][^'"]*(?:@routes\/_core\/gptDispatch|\/routes\/_core\/gptDispatch)(?:\.js)?['"]\)/,
         reason: 'control-plane modules must not import the writing dispatcher',
       },
+      {
+        pattern: /\bfrom ['"][^'"]*(?:@core\/logic\/trinityWritingPipeline|\/core\/logic\/trinityWritingPipeline)(?:\.js)?['"]|\brequire\(['"][^'"]*(?:@core\/logic\/trinityWritingPipeline|\/core\/logic\/trinityWritingPipeline)(?:\.js)?['"]\)/,
+        reason: 'control-plane modules must not invoke the Trinity writing facade',
+      },
     ],
   },
   {
@@ -53,7 +57,6 @@ const DIRECT_TRINITY_IMPORT_ALLOWED_FILES = new Set([
 
 const DIRECT_TRINITY_IMPORT_PATTERN =
   /\bimport\s*\{[^}]*\brunThroughBrain\b[^}]*\}\s*from\s*['"][^'"]*(?:@core\/logic\/trinity|\/core\/logic\/trinity|\.\/trinity|trinity)(?:\.js)?['"]/;
-
 function collectRepositoryFilesFromFilesystem(rootPath) {
   if (!existsSync(rootPath)) {
     return [];

--- a/scripts/check-routing-boundaries.js
+++ b/scripts/check-routing-boundaries.js
@@ -23,6 +23,7 @@ const BOUNDARY_GROUPS = [
       /^src\/services\/runtimeInspectionRoutingService\.ts$/i,
       /^src\/services\/systemState\.ts$/i,
       /^src\/routes\/ask\/dagTools\.ts$/i,
+      /^src\/mcp\/server\/jobTools\.ts$/i,
     ],
     blockedImportRules: [
       {

--- a/src/mcp/server/index.ts
+++ b/src/mcp/server/index.ts
@@ -34,10 +34,15 @@ import { ingestUrl, ingestContent, answerQuestion } from '@services/webRag.js';
 import { connectResearchBridge } from '@services/researchHub.js';
 
 import { saveMemory, loadMemory, deleteMemory, query as dbQuery } from '@core/db/index.js';
+import { getJobById } from '@core/db/repositories/jobRepository.js';
 
 import { loadModuleDefinitions } from '@services/moduleLoader.js';
 import { dispatchModuleAction } from '@routes/modules.js';
 import { buildActiveMemorySelect, normalizeMemoryEntries, type MemoryListRow } from '@services/memoryListing.js';
+import {
+  buildGptJobResultBridgePayload,
+  buildGptJobStatusBridgePayload,
+} from '@shared/gpt/gptJobResult.js';
 
 import { runHealthCheck } from '@platform/logging/diagnostics.js';
 import { acquireExecutionLock } from '@services/safety/executionLock.js';
@@ -156,6 +161,53 @@ export async function createMcpServer(ctx: McpRequestContext): Promise<AnyMcpSer
     wrapTool('trinity.query_finetune', ctx, async (args: any) => {
       const out = await runTrinity({ prompt: args.prompt, model: DEFAULT_FINE_TUNE });
       return mcpText(out);
+    })
+  );
+
+  server.registerTool(
+    'jobs.status',
+    {
+      title: 'Job Status',
+      description: 'Control plane: reads async GPT job status without entering Trinity or write dispatch.',
+      annotations: { readOnlyHint: true },
+      inputSchema: z.object({
+        jobId: z.string().trim().min(1),
+      }),
+    },
+    wrapTool('jobs.status', ctx, async (args: any) => {
+      const job = await getJobById(args.jobId);
+      if (!job) {
+        return mcpError({
+          code: 'ERR_NOT_FOUND',
+          message: 'Async GPT job was not found.',
+          details: { action: 'get_status', jobId: args.jobId },
+          requestId: ctx.requestId,
+        });
+      }
+
+      return mcpText({
+        ok: true,
+        ...buildGptJobStatusBridgePayload(job),
+      });
+    })
+  );
+
+  server.registerTool(
+    'jobs.result',
+    {
+      title: 'Job Result',
+      description: 'Control plane: reads async GPT job results without entering Trinity or write dispatch.',
+      annotations: { readOnlyHint: true },
+      inputSchema: z.object({
+        jobId: z.string().trim().min(1),
+      }),
+    },
+    wrapTool('jobs.result', ctx, async (args: any) => {
+      const job = await getJobById(args.jobId);
+      return mcpText({
+        ok: true,
+        ...buildGptJobResultBridgePayload(args.jobId, job),
+      });
     })
   );
 

--- a/src/mcp/server/index.ts
+++ b/src/mcp/server/index.ts
@@ -34,21 +34,16 @@ import { ingestUrl, ingestContent, answerQuestion } from '@services/webRag.js';
 import { connectResearchBridge } from '@services/researchHub.js';
 
 import { saveMemory, loadMemory, deleteMemory, query as dbQuery } from '@core/db/index.js';
-import { getJobById } from '@core/db/repositories/jobRepository.js';
-
 import { loadModuleDefinitions } from '@services/moduleLoader.js';
 import { dispatchModuleAction } from '@routes/modules.js';
 import { buildActiveMemorySelect, normalizeMemoryEntries, type MemoryListRow } from '@services/memoryListing.js';
-import {
-  buildGptJobResultBridgePayload,
-  buildGptJobStatusBridgePayload,
-} from '@shared/gpt/gptJobResult.js';
 
 import { runHealthCheck } from '@platform/logging/diagnostics.js';
 import { acquireExecutionLock } from '@services/safety/executionLock.js';
 import { emitSafetyAuditEvent } from '@services/safety/auditEvents.js';
 import { stripConfirmationFields, requireNonceOrIssue, notExposed, buildClearRecheckInput, wrapTool } from './helpers.js';
 import { registerDagMcpTools } from './dagTools.js';
+import { registerJobMcpTools } from './jobTools.js';
 
 type AnyMcpServer = any;
 
@@ -164,52 +159,7 @@ export async function createMcpServer(ctx: McpRequestContext): Promise<AnyMcpSer
     })
   );
 
-  server.registerTool(
-    'jobs.status',
-    {
-      title: 'Job Status',
-      description: 'Control plane: reads async GPT job status without entering Trinity or write dispatch.',
-      annotations: { readOnlyHint: true },
-      inputSchema: z.object({
-        jobId: z.string().trim().min(1),
-      }),
-    },
-    wrapTool('jobs.status', ctx, async (args: any) => {
-      const job = await getJobById(args.jobId);
-      if (!job) {
-        return mcpError({
-          code: 'ERR_NOT_FOUND',
-          message: 'Async GPT job was not found.',
-          details: { action: 'get_status', jobId: args.jobId },
-          requestId: ctx.requestId,
-        });
-      }
-
-      return mcpText({
-        ok: true,
-        ...buildGptJobStatusBridgePayload(job),
-      });
-    })
-  );
-
-  server.registerTool(
-    'jobs.result',
-    {
-      title: 'Job Result',
-      description: 'Control plane: reads async GPT job results without entering Trinity or write dispatch.',
-      annotations: { readOnlyHint: true },
-      inputSchema: z.object({
-        jobId: z.string().trim().min(1),
-      }),
-    },
-    wrapTool('jobs.result', ctx, async (args: any) => {
-      const job = await getJobById(args.jobId);
-      return mcpText({
-        ok: true,
-        ...buildGptJobResultBridgePayload(args.jobId, job),
-      });
-    })
-  );
+  registerJobMcpTools(server, ctx);
 
   // -------------------------
   // CLEAR + Plans

--- a/src/mcp/server/jobTools.ts
+++ b/src/mcp/server/jobTools.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+
+import type { McpRequestContext } from '../context.js';
+import { mcpError, mcpText } from '../errors.js';
+import { getJobById } from '@core/db/repositories/jobRepository.js';
+import {
+  buildGptJobResultBridgePayload,
+  buildGptJobStatusBridgePayload,
+} from '@shared/gpt/gptJobResult.js';
+import { wrapTool } from './helpers.js';
+
+type AnyMcpServer = {
+  registerTool: (name: string, config: Record<string, unknown>, handler: (args: unknown) => Promise<unknown>) => void;
+};
+
+export function registerJobMcpTools(server: AnyMcpServer, ctx: McpRequestContext): void {
+  server.registerTool(
+    'jobs.status',
+    {
+      title: 'Job Status',
+      description: 'Control plane: reads async GPT job status without entering Trinity or write dispatch.',
+      annotations: { readOnlyHint: true },
+      inputSchema: z.object({
+        jobId: z.string().trim().min(1),
+      }),
+    },
+    wrapTool('jobs.status', ctx, async (args: any) => {
+      const job = await getJobById(args.jobId);
+      if (!job) {
+        return mcpError({
+          code: 'ERR_NOT_FOUND',
+          message: 'Async GPT job was not found.',
+          details: { action: 'get_status', jobId: args.jobId },
+          requestId: ctx.requestId,
+        });
+      }
+
+      return mcpText({
+        ok: true,
+        ...buildGptJobStatusBridgePayload(job),
+      });
+    })
+  );
+
+  server.registerTool(
+    'jobs.result',
+    {
+      title: 'Job Result',
+      description: 'Control plane: reads async GPT job results without entering Trinity or write dispatch.',
+      annotations: { readOnlyHint: true },
+      inputSchema: z.object({
+        jobId: z.string().trim().min(1),
+      }),
+    },
+    wrapTool('jobs.result', ctx, async (args: any) => {
+      const job = await getJobById(args.jobId);
+      if (!job) {
+        return mcpError({
+          code: 'ERR_NOT_FOUND',
+          message: 'Async GPT job was not found.',
+          details: { action: 'get_result', jobId: args.jobId },
+          requestId: ctx.requestId,
+        });
+      }
+
+      return mcpText({
+        ok: true,
+        ...buildGptJobResultBridgePayload(args.jobId, job),
+      });
+    })
+  );
+}

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -63,11 +63,12 @@ import {
 } from '@shared/gpt/gptJobLifecycle.js';
 import { getRequestActorKey } from '@platform/runtime/security.js';
 import {
+  GPT_QUERY_ACTION,
   GPT_GET_STATUS_ACTION,
   GPT_GET_RESULT_ACTION,
   GPT_QUERY_AND_WAIT_ACTION,
-  buildStoredJobStatusPayload,
-  buildGptJobResultLookupPayload,
+  buildGptJobStatusBridgePayload,
+  buildGptJobResultBridgePayload,
   parseGptJobStatusRequest,
   parseGptJobResultRequest
 } from '@shared/gpt/gptJobResult.js';
@@ -452,7 +453,7 @@ function shouldDefaultCoreQueriesToAsync(
   gptId: string,
   requestedAction: string | null
 ): boolean {
-  if (requestedAction && requestedAction !== 'query') {
+  if (requestedAction && requestedAction !== GPT_QUERY_ACTION) {
     return false;
   }
 
@@ -518,7 +519,7 @@ function resolveGptExecutionPlan(params: {
     };
   }
 
-  if (!params.promptText && (!params.requestedAction || params.requestedAction === 'query')) {
+  if (!params.promptText && (!params.requestedAction || params.requestedAction === GPT_QUERY_ACTION)) {
     return {
       mode: 'sync',
       reason: 'missing_prompt_validation',
@@ -527,6 +528,18 @@ function resolveGptExecutionPlan(params: {
       answerMode,
       maxWords,
       heavyPrompt: false
+    };
+  }
+
+  if (params.requestedAction === GPT_QUERY_ACTION) {
+    return {
+      mode: 'async',
+      reason: 'explicit_query_action',
+      promptLength,
+      messageCount,
+      answerMode,
+      maxWords,
+      heavyPrompt
     };
   }
 
@@ -622,6 +635,12 @@ function normalizeQueryAndWaitBody(
   delete normalizedQueryBody.action;
   normalizedQueryBody.executionMode = 'async';
   return normalizedQueryBody;
+}
+
+function resolveAsyncBridgeAction(queryAndWaitRequested: boolean) {
+  return queryAndWaitRequested
+    ? GPT_QUERY_AND_WAIT_ACTION
+    : GPT_QUERY_ACTION;
 }
 
 function buildJobLookupRouteMeta(params: {
@@ -771,6 +790,7 @@ function buildGptRequestAuthState(req: express.Request): Record<string, unknown>
 }
 
 function buildAsyncJobResponseMetadata(input: {
+  action: typeof GPT_QUERY_ACTION | typeof GPT_QUERY_AND_WAIT_ACTION;
   jobId: string;
   jobStatus: string;
   deduped: boolean;
@@ -778,6 +798,7 @@ function buildAsyncJobResponseMetadata(input: {
   idempotencySource: 'explicit' | 'derived';
 }) {
   return {
+    action: input.action,
     jobId: input.jobId,
     status: input.jobStatus,
     lifecycleStatus: resolveGptJobLifecycleStatus(input.jobStatus),
@@ -791,7 +812,9 @@ function buildAsyncJobResponseMetadata(input: {
 
 router.post("/:gptId", async (req, res, next) => {
   const requestedAction = resolveRequestedAction(req.body);
+  const queryRequested = requestedAction === GPT_QUERY_ACTION;
   const queryAndWaitRequested = requestedAction === GPT_QUERY_AND_WAIT_ACTION;
+  const asyncBridgeAction = resolveAsyncBridgeAction(queryAndWaitRequested);
   const promptText = extractPromptText(req.body);
   const routeTimeoutProfile = shouldUseDagExecutionTimeoutProfile(promptText)
     ? 'dag_execution'
@@ -900,6 +923,7 @@ router.post("/:gptId", async (req, res, next) => {
           });
           return sendGuardedGptJsonResponse(req, res, {
             ok: false,
+            action: GPT_QUERY_AND_WAIT_ACTION,
             error: {
               code: 'BAD_REQUEST',
               message: 'query_and_wait requires a JSON object request body.'
@@ -914,6 +938,29 @@ router.post("/:gptId", async (req, res, next) => {
           }, 'gpt.response.query_and_wait_invalid_body', 400);
         }
 
+        if (queryRequested && !promptText) {
+          requestLogger?.warn?.('integration.job.query_missing_prompt', {
+            endpoint: req.originalUrl,
+            gptId: incomingGptId,
+            requestId
+          });
+          return res.status(400).json({
+            ok: false,
+            action: GPT_QUERY_ACTION,
+            error: {
+              code: 'PROMPT_REQUIRED',
+              message: 'query requires a non-empty prompt.'
+            },
+            _route: {
+              requestId,
+              gptId: incomingGptId,
+              action: GPT_QUERY_ACTION,
+              route: 'async',
+              timestamp: new Date().toISOString()
+            }
+          });
+        }
+
         if (queryAndWaitRequested && !promptText) {
           requestLogger?.warn?.('integration.job.query_and_wait_missing_prompt', {
             endpoint: req.originalUrl,
@@ -922,6 +969,7 @@ router.post("/:gptId", async (req, res, next) => {
           });
           return sendGuardedGptJsonResponse(req, res, {
             ok: false,
+            action: GPT_QUERY_AND_WAIT_ACTION,
             error: {
               code: 'PROMPT_REQUIRED',
               message: 'query_and_wait requires a non-empty prompt.'
@@ -989,6 +1037,7 @@ router.post("/:gptId", async (req, res, next) => {
 
           return res.status(400).json({
             ok: false,
+            action: planeClassification.action,
             error: {
               code: planeClassification.errorCode,
               message: planeClassification.message
@@ -1024,6 +1073,7 @@ router.post("/:gptId", async (req, res, next) => {
             });
             return sendGuardedGptJsonResponse(req, res, {
               ok: false,
+              action: GPT_GET_STATUS_ACTION,
               error: {
                 code: 'JOB_ID_INVALID',
                 message: `get_status action requires payload.jobId. ${parsedJobStatusRequest.error}`
@@ -1051,6 +1101,8 @@ router.post("/:gptId", async (req, res, next) => {
           if (!job) {
             return sendGuardedGptJsonResponse(req, res, {
               ok: false,
+              action: GPT_GET_STATUS_ACTION,
+              jobId: parsedJobStatusRequest.jobId,
               error: {
                 code: 'JOB_NOT_FOUND',
                 message: 'Async GPT job was not found.'
@@ -1059,9 +1111,10 @@ router.post("/:gptId", async (req, res, next) => {
             }, 'gpt.response.job_status_not_found', 404);
           }
 
+          const jobStatusEnvelope = buildGptJobStatusBridgePayload(job);
           return sendGuardedGptJsonResponse(req, res, {
             ok: true,
-            result: buildStoredJobStatusPayload(job),
+            ...jobStatusEnvelope,
             _route: routeMeta
           }, 'gpt.response.job_status');
         }
@@ -1084,6 +1137,7 @@ router.post("/:gptId", async (req, res, next) => {
             });
             return sendGuardedGptJsonResponse(req, res, {
               ok: false,
+              action: GPT_GET_RESULT_ACTION,
               error: {
                 code: 'JOB_ID_INVALID',
                 message: `get_result action requires payload.jobId. ${parsedJobResultRequest.error}`
@@ -1092,7 +1146,7 @@ router.post("/:gptId", async (req, res, next) => {
             }, 'gpt.response.job_result_invalid', 400);
           }
 
-          const jobLookup = buildGptJobResultLookupPayload(
+          const jobLookup = buildGptJobResultBridgePayload(
             parsedJobResultRequest.jobId,
             await getJobById(parsedJobResultRequest.jobId)
           );
@@ -1123,7 +1177,7 @@ router.post("/:gptId", async (req, res, next) => {
 
           return sendGuardedGptJsonResponse(req, res, {
             ok: true,
-            result: jobLookup,
+            ...jobLookup,
             _route: routeMeta
           }, 'gpt.response.job_result');
         }
@@ -1461,6 +1515,8 @@ router.post("/:gptId", async (req, res, next) => {
         if (requestedAsyncWaitForResultMs === undefined) {
           if (queryAndWaitRequested) {
             requestedAsyncWaitForResultMs = DEFAULT_GPT_QUERY_AND_WAIT_TIMEOUT_MS;
+          } else if (queryRequested) {
+            requestedAsyncWaitForResultMs = 0;
           } else if (executionPlan.heavyPrompt) {
             requestedAsyncWaitForResultMs = readPositiveIntegerEnv(
               'GPT_ASYNC_HEAVY_WAIT_FOR_RESULT_MS',
@@ -1598,6 +1654,7 @@ router.post("/:gptId", async (req, res, next) => {
               if (error instanceof IdempotencyKeyConflictError) {
                 return sendGuardedGptJsonResponse(req, res, {
                   ok: false,
+                  action: asyncBridgeAction,
                   error: {
                     code: 'IDEMPOTENCY_KEY_CONFLICT',
                     message: 'The supplied idempotency key is already bound to a different GPT request.'
@@ -1612,7 +1669,7 @@ router.post("/:gptId", async (req, res, next) => {
               }
 
               if (error instanceof JobRepositoryUnavailableError) {
-                if (explicitIdempotencyKey || queryAndWaitRequested) {
+                if (explicitIdempotencyKey || queryAndWaitRequested || queryRequested) {
                   requestLogger?.error?.('gpt.request.idempotency_unavailable', {
                     endpoint: req.originalUrl,
                     gptId: incomingGptId,
@@ -1621,12 +1678,15 @@ router.post("/:gptId", async (req, res, next) => {
                   });
                   return sendGuardedGptJsonResponse(req, res, {
                     ok: false,
+                    action: asyncBridgeAction,
                     error: {
-                      code: queryAndWaitRequested
+                      code: (queryAndWaitRequested || queryRequested)
                         ? 'ASYNC_GPT_JOBS_UNAVAILABLE'
                         : 'IDEMPOTENCY_UNAVAILABLE',
                       message: queryAndWaitRequested
                         ? 'query_and_wait requires durable GPT job persistence, but the jobs backend is unavailable.'
+                        : queryRequested
+                        ? 'query requires durable GPT job persistence, but the jobs backend is unavailable.'
                         : 'Durable idempotency is unavailable because GPT job persistence is not configured.'
                     },
                     idempotencyKey: idempotencyDescriptor.publicIdempotencyKey,
@@ -1653,6 +1713,7 @@ router.post("/:gptId", async (req, res, next) => {
               const job = createResult.job;
               queuedJobId = job.id;
               queuedPendingResponse = buildQueuedGptPendingResponse({
+                action: asyncBridgeAction,
                 jobId: job.id,
                 gptId: incomingGptId,
                 requestId,
@@ -1727,6 +1788,7 @@ router.post("/:gptId", async (req, res, next) => {
                   });
                   return sendGuardedGptJsonResponse(req, res, {
                     ok: false,
+                    action: asyncBridgeAction,
                     error: {
                       code: 'ASYNC_GPT_JOB_OUTPUT_INVALID',
                       message: 'Async GPT job completed without a valid envelope.'
@@ -1803,6 +1865,7 @@ router.post("/:gptId", async (req, res, next) => {
                 const publicEnvelope = prepareBoundedClientJsonPayload({
                   ...completedEnvelope,
                   ...buildAsyncJobResponseMetadata({
+                    action: asyncBridgeAction,
                     jobId: job.id,
                     jobStatus: waitedJob.job.status,
                     deduped: createResult.deduped,
@@ -1833,6 +1896,7 @@ router.post("/:gptId", async (req, res, next) => {
                     message: waitedJob.job.error_message ?? 'Async GPT job failed.'
                   },
                   ...buildAsyncJobResponseMetadata({
+                    action: asyncBridgeAction,
                     jobId: job.id,
                     jobStatus: waitedJob.job.status,
                     deduped: createResult.deduped,
@@ -1867,6 +1931,7 @@ router.post("/:gptId", async (req, res, next) => {
                     message: waitedJob.job.error_message ?? 'Async GPT job was cancelled.'
                   },
                   ...buildAsyncJobResponseMetadata({
+                    action: asyncBridgeAction,
                     jobId: job.id,
                     jobStatus: waitedJob.job.status,
                     deduped: createResult.deduped,
@@ -1899,6 +1964,7 @@ router.post("/:gptId", async (req, res, next) => {
                     message: waitedJob.job.error_message ?? 'Async GPT job expired after its retention window.'
                   },
                   ...buildAsyncJobResponseMetadata({
+                    action: asyncBridgeAction,
                     jobId: job.id,
                     jobStatus: waitedJob.job.status,
                     deduped: createResult.deduped,
@@ -1921,6 +1987,7 @@ router.post("/:gptId", async (req, res, next) => {
                 });
                 return sendGuardedGptJsonResponse(req, res, {
                   ok: false,
+                  action: asyncBridgeAction,
                   error: {
                     code: 'ASYNC_GPT_JOB_MISSING',
                     message: 'Async GPT job disappeared before completion.'

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -944,7 +944,7 @@ router.post("/:gptId", async (req, res, next) => {
             gptId: incomingGptId,
             requestId
           });
-          return res.status(400).json({
+          return sendGuardedGptJsonResponse(req, res, {
             ok: false,
             action: GPT_QUERY_ACTION,
             error: {
@@ -958,7 +958,7 @@ router.post("/:gptId", async (req, res, next) => {
               route: 'async',
               timestamp: new Date().toISOString()
             }
-          });
+          }, 'gpt.response.query_prompt_required', 400);
         }
 
         if (queryAndWaitRequested && !promptText) {
@@ -1363,13 +1363,17 @@ router.post("/:gptId", async (req, res, next) => {
         });
         const directReturnRequested =
           queryAndWaitRequested ||
-          (explicitAsyncWaitForResultMs !== undefined && executionPlan.mode === 'async');
+          (
+            !queryRequested &&
+            explicitAsyncWaitForResultMs !== undefined &&
+            executionPlan.mode === 'async'
+          );
         let requestedAsyncWaitForResultMs = explicitAsyncWaitForResultMs;
-        if (requestedAsyncWaitForResultMs === undefined) {
+        if (queryRequested) {
+          requestedAsyncWaitForResultMs = 0;
+        } else if (requestedAsyncWaitForResultMs === undefined) {
           if (queryAndWaitRequested) {
             requestedAsyncWaitForResultMs = DEFAULT_GPT_QUERY_AND_WAIT_TIMEOUT_MS;
-          } else if (queryRequested) {
-            requestedAsyncWaitForResultMs = 0;
           } else if (executionPlan.heavyPrompt) {
             requestedAsyncWaitForResultMs = readPositiveIntegerEnv(
               'GPT_ASYNC_HEAVY_WAIT_FOR_RESULT_MS',
@@ -1621,6 +1625,24 @@ router.post("/:gptId", async (req, res, next) => {
                   deduped: createResult.deduped,
                   dedupeReason: createResult.dedupeReason
                 });
+              }
+
+              if (queryRequested && !directReturnRequested) {
+                requestLogger?.info?.('integration.job.query_created', {
+                  endpoint: req.originalUrl,
+                  gptId: incomingGptId,
+                  requestId,
+                  jobId: job.id,
+                  deduped: createResult.deduped,
+                  dedupeReason: createResult.dedupeReason
+                });
+                return sendGuardedGptJsonResponse(
+                  req,
+                  res,
+                  queuedPendingResponse,
+                  'gpt.response.async_pending',
+                  202
+                );
               }
 
               const waitedJob = await waitForQueuedGptJobCompletion(

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -71,7 +71,6 @@ import {
   parseGptJobStatusRequest,
   parseGptJobResultRequest
 } from '@shared/gpt/gptJobResult.js';
-import { parseNaturalLanguageJobLookup } from '@shared/gpt/naturalLanguageJobLookup.js';
 import { classifyGptRequestPlane } from './_core/gptPlaneClassification.js';
 import {
   executeSystemStateRequest,
@@ -886,79 +885,6 @@ router.post("/:gptId", async (req, res, next) => {
           }, 'gpt.response.body_gpt_id_forbidden', 400);
         }
 
-        if (!requestedAction) {
-          const promptJobLookup = parseNaturalLanguageJobLookup(promptText);
-          if (promptJobLookup) {
-            const canonicalRoutes = promptJobLookup.ok
-              ? {
-                  poll: `/jobs/${promptJobLookup.jobId}`,
-                  result: `/jobs/${promptJobLookup.jobId}/result`
-                }
-              : {
-                  poll: null,
-                  result: null
-                };
-
-            if (!promptJobLookup.ok) {
-              requestLogger?.warn?.('gpt.request.job_lookup_guard_missing_job_id', {
-                endpoint: req.originalUrl,
-                gptId: incomingGptId,
-                requestId,
-                lookup: promptJobLookup.kind,
-                source: promptJobLookup.source
-              });
-              recordGptJobLookup({
-                channel: 'prompt_guard',
-                lookup: promptJobLookup.kind,
-                outcome: 'missing_job_id'
-              });
-              return sendGuardedGptJsonResponse(req, res, {
-                ok: false,
-                error: {
-                  code: 'JOB_ID_REQUIRED',
-                  message: 'Job retrieval prompts sent to /gpt/{gptId} must include a concrete job ID. Use the jobs API instead of prompting the GPT route.'
-                },
-                canonical: canonicalRoutes,
-                _route: {
-                  requestId,
-                  gptId: incomingGptId,
-                  route: 'job_lookup_guard',
-                  action: `${promptJobLookup.kind}_lookup`,
-                  timestamp: new Date().toISOString()
-                }
-              }, 'gpt.response.job_lookup_guard_missing_id', 400);
-            }
-
-            requestLogger?.warn?.('gpt.request.job_lookup_guard_rejected', {
-              endpoint: req.originalUrl,
-              gptId: incomingGptId,
-              requestId,
-              jobId: promptJobLookup.jobId,
-              lookup: promptJobLookup.kind,
-              source: promptJobLookup.source
-            });
-            recordGptJobLookup({
-              channel: 'prompt_guard',
-              lookup: promptJobLookup.kind,
-              outcome: 'rejected'
-            });
-            return sendGuardedGptJsonResponse(req, res, {
-              ok: false,
-              error: {
-                code: 'JOB_LOOKUP_REQUIRES_JOBS_API',
-                message: 'Job retrieval requests must use the jobs API. Do not send result or status lookups through POST /gpt/{gptId}.'
-              },
-              canonical: canonicalRoutes,
-              _route: {
-                requestId,
-                gptId: incomingGptId,
-                route: 'job_lookup_guard',
-                action: `${promptJobLookup.kind}_lookup`,
-                timestamp: new Date().toISOString()
-              }
-            }, 'gpt.response.job_lookup_guard_rejected', 400);
-          }
-        }
         requestLogger?.info?.("gpt.request.auth_state", {
           endpoint: req.originalUrl,
           gptId: incomingGptId,
@@ -1080,7 +1006,6 @@ router.post("/:gptId", async (req, res, next) => {
             }
           });
         }
-
         if (planeClassification.plane === 'control' && planeClassification.kind === 'job_status') {
           const parsedJobStatusRequest = parseGptJobStatusRequest(effectiveBody);
           const routeMeta = buildJobLookupRouteMeta({
@@ -1350,6 +1275,153 @@ router.post("/:gptId", async (req, res, next) => {
           });
         }
 
+        if (planeClassification.plane === 'control' && planeClassification.kind === 'diagnostics') {
+          const diagnostics = await getDiagnosticsSnapshot(req.app);
+          requestLogger?.info?.('gpt.request.diagnostics', {
+            endpoint: req.originalUrl,
+            gptId: incomingGptId,
+            internal: true,
+            registeredGpts: Array.isArray(diagnostics.registered_gpts)
+              ? diagnostics.registered_gpts.length
+              : diagnostics.registered_gpts,
+            routeCount: Array.isArray(diagnostics.active_routes)
+              ? diagnostics.active_routes.length
+              : diagnostics.active_routes
+          });
+          recordGptRequestEvent({
+            event: 'control_direct',
+            source: 'diagnostics'
+          });
+
+          const diagnosticsSerializationStartedAt = Date.now();
+          const diagnosticsPayload = prepareBoundedClientJsonPayload(
+            diagnostics as unknown as Record<string, unknown>,
+            {
+              logger: req.logger,
+              logEvent: 'gpt.response.diagnostics'
+            }
+          );
+          requestLogger?.info?.('gpt.response.serialization', {
+            endpoint: req.originalUrl,
+            gptId: incomingGptId,
+            action: 'diagnostics',
+            serializationMs: Date.now() - diagnosticsSerializationStartedAt,
+            responseBytes: diagnosticsPayload.responseBytes,
+            truncated: diagnosticsPayload.truncated,
+          });
+
+          res.setHeader('x-response-bytes', String(diagnosticsPayload.responseBytes));
+          if (diagnosticsPayload.truncated) {
+            res.setHeader('x-response-truncated', 'true');
+          }
+          return res.json(diagnosticsPayload.payload);
+        }
+
+        if (planeClassification.plane === 'control' && planeClassification.kind === 'system_state') {
+          const routeMeta = buildDirectControlRouteMeta({
+            requestId,
+            gptId: incomingGptId,
+            action: 'system_state',
+            route: 'system_state'
+          });
+
+          if (!ARCANOS_CORE_GPT_IDS.has(incomingGptId)) {
+            requestLogger?.warn?.('gpt.request.system_state_rejected', {
+              endpoint: req.originalUrl,
+              gptId: incomingGptId,
+              requestId,
+              reason: 'non_core_gpt'
+            });
+            return res.status(400).json({
+              ok: false,
+              error: {
+                code: 'SYSTEM_STATE_REQUIRES_CORE_GPT',
+                message: 'system_state requests must target an ARCANOS core GPT id.'
+              },
+              _route: routeMeta
+            });
+          }
+
+          try {
+            const systemStateResult = executeSystemStateRequest(
+              buildDirectControlPayload(normalizedBody)
+            );
+            requestLogger?.info?.('gpt.request.system_state', {
+              endpoint: req.originalUrl,
+              gptId: incomingGptId,
+              requestId,
+              route: 'system_state'
+            });
+            recordGptRequestEvent({
+              event: 'control_direct',
+              source: 'system_state'
+            });
+            return res.status(200).json({
+              ok: true,
+              result: systemStateResult,
+              _route: routeMeta
+            });
+          } catch (error) {
+            if (error instanceof SystemStateConflictError) {
+              requestLogger?.warn?.('gpt.request.system_state_conflict', {
+                endpoint: req.originalUrl,
+                gptId: incomingGptId,
+                requestId,
+                conflict: error.conflict
+              });
+              return res.status(409).json({
+                ok: false,
+                error: {
+                  code: error.code,
+                  message: error.message,
+                  details: error.conflict
+                },
+                _route: routeMeta
+              });
+            }
+
+            requestLogger?.warn?.('gpt.request.system_state_invalid', {
+              endpoint: req.originalUrl,
+              gptId: incomingGptId,
+              requestId,
+              error: resolveErrorMessage(error)
+            });
+            return res.status(400).json({
+              ok: false,
+              error: {
+                code: 'BAD_REQUEST',
+                message: resolveErrorMessage(error)
+              },
+              _route: routeMeta
+            });
+          }
+        }
+
+        if (planeClassification.plane !== 'writing') {
+          requestLogger?.error?.('gpt.request.control_plane_job_creation_blocked', {
+            endpoint: req.originalUrl,
+            gptId: incomingGptId,
+            requestId,
+            plane: planeClassification.plane,
+            kind: planeClassification.kind,
+            reason: planeClassification.reason
+          });
+          return res.status(500).json({
+            ok: false,
+            error: {
+              code: 'CONTROL_PLANE_ROUTING_BREACH',
+              message: 'Control-plane requests must exit before async GPT job planning.'
+            },
+            _route: {
+              requestId,
+              gptId: incomingGptId,
+              route: 'control_guard',
+              action: planeClassification.action,
+              timestamp: new Date().toISOString()
+            }
+          });
+        }
+
         const explicitIdempotencyKey = normalizeExplicitIdempotencyKey(
           req.header('Idempotency-Key') ?? req.header('idempotency-key')
         );
@@ -1442,39 +1514,6 @@ router.post("/:gptId", async (req, res, next) => {
           });
         }
 
-        if (requestedAction === 'diagnostics') {
-          const diagnostics = await getDiagnosticsSnapshot(req.app);
-          requestLogger?.info?.('gpt.request.diagnostics', {
-            endpoint: req.originalUrl,
-            gptId: incomingGptId,
-            internal: true,
-            registeredGpts: Array.isArray(diagnostics.registered_gpts)
-              ? diagnostics.registered_gpts.length
-              : diagnostics.registered_gpts,
-            routeCount: Array.isArray(diagnostics.active_routes)
-              ? diagnostics.active_routes.length
-              : diagnostics.active_routes
-          });
-
-          const diagnosticsSerializationStartedAt = Date.now();
-          const diagnosticsPayload = prepareBoundedClientJsonPayload(
-            diagnostics as unknown as Record<string, unknown>,
-            {
-              logger: req.logger,
-              logEvent: 'gpt.response.diagnostics'
-            }
-          );
-          requestLogger?.info?.('gpt.response.serialization', {
-            endpoint: req.originalUrl,
-            gptId: incomingGptId,
-            action: 'diagnostics',
-            serializationMs: Date.now() - diagnosticsSerializationStartedAt,
-            responseBytes: diagnosticsPayload.responseBytes,
-            truncated: diagnosticsPayload.truncated,
-          });
-
-          return sendPreparedJsonResponse(res, diagnosticsPayload);
-        }
         const shouldUseJobBackedExecution =
           queryAndWaitRequested ||
           executionPlan.mode === 'async' ||

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -1035,7 +1035,7 @@ router.post("/:gptId", async (req, res, next) => {
             });
           }
 
-          return res.status(400).json({
+          return sendGuardedGptJsonResponse(req, res, {
             ok: false,
             action: planeClassification.action,
             error: {
@@ -1053,7 +1053,7 @@ router.post("/:gptId", async (req, res, next) => {
               action: planeClassification.action,
               timestamp: new Date().toISOString()
             }
-          });
+          }, 'gpt.response.control_rejected', 400);
         }
         if (planeClassification.plane === 'control' && planeClassification.kind === 'job_status') {
           const parsedJobStatusRequest = parseGptJobStatusRequest(effectiveBody);
@@ -1251,153 +1251,6 @@ router.post("/:gptId", async (req, res, next) => {
 
           try {
             const systemStateResult = await executeSystemStateRequest(
-              buildDirectControlPayload(normalizedBody)
-            );
-            requestLogger?.info?.('gpt.request.system_state', {
-              endpoint: req.originalUrl,
-              gptId: incomingGptId,
-              requestId,
-              route: 'system_state'
-            });
-            recordGptRequestEvent({
-              event: 'control_direct',
-              source: 'system_state'
-            });
-            return res.status(200).json({
-              ok: true,
-              result: systemStateResult,
-              _route: routeMeta
-            });
-          } catch (error) {
-            if (error instanceof SystemStateConflictError) {
-              requestLogger?.warn?.('gpt.request.system_state_conflict', {
-                endpoint: req.originalUrl,
-                gptId: incomingGptId,
-                requestId,
-                conflict: error.conflict
-              });
-              return res.status(409).json({
-                ok: false,
-                error: {
-                  code: error.code,
-                  message: error.message,
-                  details: error.conflict
-                },
-                _route: routeMeta
-              });
-            }
-
-            requestLogger?.warn?.('gpt.request.system_state_invalid', {
-              endpoint: req.originalUrl,
-              gptId: incomingGptId,
-              requestId,
-              error: resolveErrorMessage(error)
-            });
-            return res.status(400).json({
-              ok: false,
-              error: {
-                code: 'BAD_REQUEST',
-                message: resolveErrorMessage(error)
-              },
-              _route: routeMeta
-            });
-          }
-        }
-
-        if (planeClassification.plane !== 'writing') {
-          requestLogger?.error?.('gpt.request.control_plane_job_creation_blocked', {
-            endpoint: req.originalUrl,
-            gptId: incomingGptId,
-            requestId,
-            plane: planeClassification.plane,
-            kind: planeClassification.kind,
-            reason: planeClassification.reason
-          });
-          return res.status(500).json({
-            ok: false,
-            error: {
-              code: 'CONTROL_PLANE_ROUTING_BREACH',
-              message: 'Control-plane requests must exit before async GPT job planning.'
-            },
-            _route: {
-              requestId,
-              gptId: incomingGptId,
-              route: 'control_guard',
-              action: planeClassification.action,
-              timestamp: new Date().toISOString()
-            }
-          });
-        }
-
-        if (planeClassification.plane === 'control' && planeClassification.kind === 'diagnostics') {
-          const diagnostics = await getDiagnosticsSnapshot(req.app);
-          requestLogger?.info?.('gpt.request.diagnostics', {
-            endpoint: req.originalUrl,
-            gptId: incomingGptId,
-            internal: true,
-            registeredGpts: Array.isArray(diagnostics.registered_gpts)
-              ? diagnostics.registered_gpts.length
-              : diagnostics.registered_gpts,
-            routeCount: Array.isArray(diagnostics.active_routes)
-              ? diagnostics.active_routes.length
-              : diagnostics.active_routes
-          });
-          recordGptRequestEvent({
-            event: 'control_direct',
-            source: 'diagnostics'
-          });
-
-          const diagnosticsSerializationStartedAt = Date.now();
-          const diagnosticsPayload = prepareBoundedClientJsonPayload(
-            diagnostics as unknown as Record<string, unknown>,
-            {
-              logger: req.logger,
-              logEvent: 'gpt.response.diagnostics'
-            }
-          );
-          requestLogger?.info?.('gpt.response.serialization', {
-            endpoint: req.originalUrl,
-            gptId: incomingGptId,
-            action: 'diagnostics',
-            serializationMs: Date.now() - diagnosticsSerializationStartedAt,
-            responseBytes: diagnosticsPayload.responseBytes,
-            truncated: diagnosticsPayload.truncated,
-          });
-
-          res.setHeader('x-response-bytes', String(diagnosticsPayload.responseBytes));
-          if (diagnosticsPayload.truncated) {
-            res.setHeader('x-response-truncated', 'true');
-          }
-          return res.json(diagnosticsPayload.payload);
-        }
-
-        if (planeClassification.plane === 'control' && planeClassification.kind === 'system_state') {
-          const routeMeta = buildDirectControlRouteMeta({
-            requestId,
-            gptId: incomingGptId,
-            action: 'system_state',
-            route: 'system_state'
-          });
-
-          if (!ARCANOS_CORE_GPT_IDS.has(incomingGptId)) {
-            requestLogger?.warn?.('gpt.request.system_state_rejected', {
-              endpoint: req.originalUrl,
-              gptId: incomingGptId,
-              requestId,
-              reason: 'non_core_gpt'
-            });
-            return res.status(400).json({
-              ok: false,
-              error: {
-                code: 'SYSTEM_STATE_REQUIRES_CORE_GPT',
-                message: 'system_state requests must target an ARCANOS core GPT id.'
-              },
-              _route: routeMeta
-            });
-          }
-
-          try {
-            const systemStateResult = executeSystemStateRequest(
               buildDirectControlPayload(normalizedBody)
             );
             requestLogger?.info?.('gpt.request.system_state', {

--- a/src/shared/gpt/asyncGptJob.ts
+++ b/src/shared/gpt/asyncGptJob.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { GptAsyncWriteAction } from './gptJobResult.js';
 
 const jsonValueSchema: z.ZodType<unknown> = z.lazy(() =>
   z.union([
@@ -33,6 +34,7 @@ export interface QueuedGptJobInput {
 
 export interface QueuedGptPendingResponse {
   ok: true;
+  action: GptAsyncWriteAction;
   status: 'pending';
   jobId: string;
   poll: string;
@@ -140,6 +142,7 @@ export function parseQueuedGptJobInput(rawInput: unknown): ParsedQueuedGptJobInp
  * Edge case behavior: route metadata remains sparse when no request id was available.
  */
 export function buildQueuedGptPendingResponse(input: {
+  action?: GptAsyncWriteAction;
   jobId: string;
   gptId: string;
   requestId?: string | null;
@@ -154,6 +157,7 @@ export function buildQueuedGptPendingResponse(input: {
 
   return {
     ok: true,
+    action: input.action ?? 'query',
     status: 'pending',
     jobId: input.jobId,
     poll: `/jobs/${input.jobId}`,

--- a/src/shared/gpt/gptJobResult.ts
+++ b/src/shared/gpt/gptJobResult.ts
@@ -2,9 +2,14 @@ import { z } from 'zod';
 import type { JobData } from '@core/db/schema.js';
 import { resolveGptJobLifecycleStatus } from './gptJobLifecycle.js';
 
+export const GPT_QUERY_ACTION = 'query';
 export const GPT_GET_STATUS_ACTION = 'get_status';
 export const GPT_GET_RESULT_ACTION = 'get_result';
 export const GPT_QUERY_AND_WAIT_ACTION = 'query_and_wait';
+
+export type GptAsyncWriteAction =
+  | typeof GPT_QUERY_ACTION
+  | typeof GPT_QUERY_AND_WAIT_ACTION;
 
 const normalizeActionValue = (value: unknown) => typeof value === 'string'
   ? value.trim().toLowerCase()
@@ -53,6 +58,33 @@ export type ParsedGptJobResultRequest =
   | { ok: false; error: string };
 
 export type ParsedGptJobStatusRequest = ParsedGptJobResultRequest;
+
+export interface GptJobStatusBridgePayload {
+  action: typeof GPT_GET_STATUS_ACTION;
+  jobId: string;
+  status: string;
+  lifecycleStatus: string;
+  result: ReturnType<typeof buildStoredJobStatusPayload>;
+}
+
+export interface GptJobResultBridgePayload {
+  action: typeof GPT_GET_RESULT_ACTION;
+  jobId: string;
+  status: GptJobResultLookupPayload['status'];
+  jobStatus: string | null;
+  lifecycleStatus: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+  completedAt: string | null;
+  retentionUntil: string | null;
+  idempotencyUntil: string | null;
+  expiresAt: string | null;
+  poll: string;
+  stream: string;
+  output: unknown | null;
+  error: GptJobResultLookupPayload['error'];
+  result: GptJobResultLookupPayload;
+}
 
 function serializeJobTimestamp(value: string | Date | null | undefined): string | null {
   if (typeof value === 'string') {
@@ -230,6 +262,17 @@ export function buildStoredJobStatusPayload(job: JobData) {
   };
 }
 
+export function buildGptJobStatusBridgePayload(job: JobData): GptJobStatusBridgePayload {
+  const statusPayload = buildStoredJobStatusPayload(job);
+  return {
+    action: GPT_GET_STATUS_ACTION,
+    jobId: job.id,
+    status: statusPayload.status,
+    lifecycleStatus: statusPayload.lifecycle_status,
+    result: statusPayload
+  };
+}
+
 export function buildGptJobResultLookupPayload(
   jobId: string,
   job: JobData | null
@@ -270,4 +313,29 @@ export function buildGptJobResultLookupPayload(
   }
 
   return buildPendingJobLookupPayload(job);
+}
+
+export function buildGptJobResultBridgePayload(
+  jobId: string,
+  job: JobData | null
+): GptJobResultBridgePayload {
+  const lookup = buildGptJobResultLookupPayload(jobId, job);
+  return {
+    action: GPT_GET_RESULT_ACTION,
+    jobId: lookup.jobId,
+    status: lookup.status,
+    jobStatus: lookup.jobStatus,
+    lifecycleStatus: lookup.lifecycleStatus,
+    createdAt: lookup.createdAt,
+    updatedAt: lookup.updatedAt,
+    completedAt: lookup.completedAt,
+    retentionUntil: lookup.retentionUntil,
+    idempotencyUntil: lookup.idempotencyUntil,
+    expiresAt: lookup.expiresAt,
+    poll: lookup.poll,
+    stream: lookup.stream,
+    output: lookup.result,
+    error: lookup.error,
+    result: lookup
+  };
 }

--- a/src/shared/gpt/naturalLanguageJobLookup.ts
+++ b/src/shared/gpt/naturalLanguageJobLookup.ts
@@ -1,6 +1,6 @@
 const JOB_ROUTE_LOOKUP_RE = /\/jobs\/(?<jobId>[^/\s?#]+)(?:\/(?<routeKind>result))?/i;
 const JOB_TEXT_ID_RE = /\bjob(?:\s+id)?\s*(?::|#|=|\bis\b)?\s*(?<jobId>[A-Za-z0-9][A-Za-z0-9._:-]{2,})\b/i;
-const JOB_LOOKUP_VERB_RE = /\b(check|fetch|get|inspect|lookup|poll|pull|read|retrieve|show)\b/i;
+const JOB_LOOKUP_VERB_RE = /\b(check|fetch|get|inspect|look\s+up|lookup|poll|pull|read|retrieve|show)\b/i;
 const JOB_RESULT_CUE_RE = /\b(answer|completion|output|response|result)\b/i;
 const JOB_STATUS_CUE_RE = /\b(poll|progress|state|status)\b/i;
 const JOB_CUE_RE = /\bjobs?\b|\/jobs\//i;

--- a/tests/ask-validation.test.ts
+++ b/tests/ask-validation.test.ts
@@ -48,31 +48,13 @@ describe('canonical GPT route validation', () => {
   });
 
   it('propagates query validation failures from dispatch as HTTP 400', async () => {
-    mockRouteGptRequest.mockResolvedValue({
-      ok: false,
-      error: {
-        code: 'BAD_REQUEST',
-        message: "Query actions require message/prompt in the request body."
-      },
-      _route: {
-        gptId: 'arcanos-daemon',
-        module: 'ARCANOS:CORE',
-        route: 'core',
-      },
-    });
-
     const app = buildApp();
     const res = await request(app).post('/gpt/arcanos-daemon').send({ action: 'query', sessionId: 'demo-session' });
 
     expect(res.status).toBe(400);
-    expect(res.body.error?.code).toBe('BAD_REQUEST');
-    expect(String(res.body.error?.message || '')).toContain('message/prompt');
-    expect(mockRouteGptRequest).toHaveBeenCalledWith(
-      expect.objectContaining({
-        gptId: 'arcanos-daemon',
-        body: { action: 'query', sessionId: 'demo-session' }
-      })
-    );
+    expect(res.body.error?.code).toBe('PROMPT_REQUIRED');
+    expect(String(res.body.error?.message || '')).toContain('prompt');
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
   it('forwards alternate prompt field aliases to canonical GPT dispatch', async () => {
@@ -92,7 +74,6 @@ describe('canonical GPT route validation', () => {
 
     const app = buildApp();
     const res = await request(app).post('/gpt/arcanos-daemon').send({
-      action: 'query',
       userInput: 'Hello from test',
       clientContext: { routingDirectives: ['concise'] }
     });
@@ -105,7 +86,6 @@ describe('canonical GPT route validation', () => {
       expect.objectContaining({
         gptId: 'arcanos-daemon',
         body: {
-          action: 'query',
           userInput: 'Hello from test',
           clientContext: { routingDirectives: ['concise'] }
         }

--- a/tests/gpt-async-idempotency.route.test.ts
+++ b/tests/gpt-async-idempotency.route.test.ts
@@ -951,13 +951,7 @@ describe('async /gpt idempotency', () => {
       lifecycleStatus: 'queued'
     });
     expect(resolveAsyncGptWaitForResultMsMock).toHaveBeenCalledWith(0);
-    expect(waitForQueuedGptJobCompletionMock).toHaveBeenCalledWith(
-      'job-query',
-      expect.objectContaining({
-        waitForResultMs: 0,
-        pollIntervalMs: 250
-      })
-    );
+    expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
     expect(findOrCreateGptJobMock).toHaveBeenCalledTimes(1);
     expect(findOrCreateGptJobMock.mock.calls[0]?.[0]).toMatchObject({
       input: {
@@ -1050,6 +1044,7 @@ describe('async /gpt idempotency', () => {
       });
 
     expect(response.status).toBe(400);
+    expect(response.headers['x-response-bytes']).toBeTruthy();
     expect(response.body).toMatchObject({
       ok: false,
       action: 'query',
@@ -1058,6 +1053,37 @@ describe('async /gpt idempotency', () => {
       }
     });
     expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores direct-wait controls for query requests so query_and_wait stays the only wait-capable action', async () => {
+    findOrCreateGptJobMock.mockResolvedValue({
+      job: {
+        id: 'job-query-ignore-wait',
+        status: 'pending'
+      },
+      deduped: false,
+      dedupeReason: 'new_job'
+    });
+    planAutonomousWorkerJobMock.mockResolvedValue({ planned: true });
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'query',
+        prompt: 'Create the writing job only.',
+        waitForResultMs: 5000,
+        pollIntervalMs: 250
+      });
+
+    expect(response.status).toBe(202);
+    expect(response.body).toMatchObject({
+      ok: true,
+      action: 'query',
+      status: 'pending',
+      jobId: 'job-query-ignore-wait'
+    });
+    expect(response.body).not.toHaveProperty('directReturn');
     expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
   });
 

--- a/tests/gpt-async-idempotency.route.test.ts
+++ b/tests/gpt-async-idempotency.route.test.ts
@@ -122,6 +122,7 @@ describe('async /gpt idempotency', () => {
     expect(response.status).toBe(202);
     expect(response.body).toEqual({
       ok: true,
+      action: 'query',
       status: 'pending',
       jobId: 'job-123',
       poll: '/jobs/job-123',
@@ -171,8 +172,28 @@ describe('async /gpt idempotency', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers['x-response-bytes']).toBeTruthy();
-    expect(response.body).toEqual({
+    expect(response.body).toMatchObject({
       ok: true,
+      action: 'get_result',
+      jobId: 'job-lookup-complete',
+      status: 'completed',
+      jobStatus: 'completed',
+      lifecycleStatus: 'completed',
+      createdAt: '2026-04-06T10:00:00.000Z',
+      updatedAt: '2026-04-06T10:00:03.000Z',
+      completedAt: '2026-04-06T10:00:03.000Z',
+      retentionUntil: null,
+      idempotencyUntil: null,
+      expiresAt: null,
+      poll: '/jobs/job-lookup-complete',
+      stream: '/jobs/job-lookup-complete/stream',
+      output: {
+        ok: true,
+        result: {
+          answer: 'stored output'
+        }
+      },
+      error: null,
       result: {
         jobId: 'job-lookup-complete',
         status: 'completed',
@@ -233,6 +254,17 @@ describe('async /gpt idempotency', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers['x-response-bytes']).toBeTruthy();
+    expect(response.body).toMatchObject({
+      action: 'get_result',
+      jobId: 'job-lookup-normalized',
+      status: 'completed',
+      output: {
+        ok: true,
+        result: {
+          answer: 'normalized output'
+        }
+      },
+    });
     expect(response.body.result).toMatchObject({
       jobId: 'job-lookup-normalized',
       status: 'completed',
@@ -297,13 +329,22 @@ describe('async /gpt idempotency', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers['x-response-bytes']).toBeTruthy();
-    expect(response.body.result).toMatchObject({
+    expect(response.body).toMatchObject({
+      action: 'get_result',
       jobId: 'job-lookup-pending',
       status: 'pending',
       jobStatus: 'running',
       lifecycleStatus: 'running',
-      result: null,
-      error: null
+      output: null,
+      error: null,
+      result: {
+        jobId: 'job-lookup-pending',
+        status: 'pending',
+        jobStatus: 'running',
+        lifecycleStatus: 'running',
+        result: null,
+        error: null
+      }
     });
     expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
   });
@@ -339,7 +380,8 @@ describe('async /gpt idempotency', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers['x-response-bytes']).toBeTruthy();
-    expect(response.body.result).toMatchObject({
+    expect(response.body).toMatchObject({
+      action: 'get_result',
       jobId: 'job-lookup-expired',
       status: 'expired',
       jobStatus: 'expired',
@@ -347,7 +389,7 @@ describe('async /gpt idempotency', () => {
       retentionUntil: '2026-04-06T10:10:00.000Z',
       idempotencyUntil: '2026-04-06T10:05:00.000Z',
       expiresAt: '2026-04-06T10:15:00.000Z',
-      result: {
+      output: {
         ok: true,
         result: {
           answer: 'retained expired output'
@@ -356,6 +398,25 @@ describe('async /gpt idempotency', () => {
       error: {
         code: 'JOB_EXPIRED',
         message: 'Expired after retention window.'
+      },
+      result: {
+        jobId: 'job-lookup-expired',
+        status: 'expired',
+        jobStatus: 'expired',
+        lifecycleStatus: 'expired',
+        retentionUntil: '2026-04-06T10:10:00.000Z',
+        idempotencyUntil: '2026-04-06T10:05:00.000Z',
+        expiresAt: '2026-04-06T10:15:00.000Z',
+        result: {
+          ok: true,
+          result: {
+            answer: 'retained expired output'
+          }
+        },
+        error: {
+          code: 'JOB_EXPIRED',
+          message: 'Expired after retention window.'
+        }
       }
     });
     expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
@@ -384,15 +445,27 @@ describe('async /gpt idempotency', () => {
       });
 
     expect(response.status).toBe(200);
-    expect(response.body.result).toMatchObject({
+    expect(response.body).toMatchObject({
+      action: 'get_result',
       jobId: 'job-lookup-failed',
       status: 'failed',
       jobStatus: 'failed',
       lifecycleStatus: 'failed',
-      result: null,
+      output: null,
       error: {
         code: 'JOB_FAILED',
         message: 'OpenAI upstream timed out'
+      },
+      result: {
+        jobId: 'job-lookup-failed',
+        status: 'failed',
+        jobStatus: 'failed',
+        lifecycleStatus: 'failed',
+        result: null,
+        error: {
+          code: 'JOB_FAILED',
+          message: 'OpenAI upstream timed out'
+        }
       }
     });
     expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
@@ -412,7 +485,9 @@ describe('async /gpt idempotency', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers['x-response-bytes']).toBeTruthy();
-    expect(response.body.result).toEqual({
+    expect(response.body).toEqual({
+      ok: true,
+      action: 'get_result',
       jobId: 'missing-job',
       status: 'not_found',
       jobStatus: null,
@@ -425,11 +500,35 @@ describe('async /gpt idempotency', () => {
       expiresAt: null,
       poll: '/jobs/missing-job',
       stream: '/jobs/missing-job/stream',
-      result: null,
+      output: null,
       error: {
         code: 'JOB_NOT_FOUND',
         message: 'Async GPT job was not found.'
-      }
+      },
+      result: {
+        jobId: 'missing-job',
+        status: 'not_found',
+        jobStatus: null,
+        lifecycleStatus: 'not_found',
+        createdAt: null,
+        updatedAt: null,
+        completedAt: null,
+        retentionUntil: null,
+        idempotencyUntil: null,
+        expiresAt: null,
+        poll: '/jobs/missing-job',
+        stream: '/jobs/missing-job/stream',
+        result: null,
+        error: {
+          code: 'JOB_NOT_FOUND',
+          message: 'Async GPT job was not found.'
+        }
+      },
+      _route: expect.objectContaining({
+        gptId: 'arcanos-core',
+        action: 'get_result',
+        route: 'job_result'
+      })
     });
     expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
   });
@@ -462,8 +561,12 @@ describe('async /gpt idempotency', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers['x-response-bytes']).toBeTruthy();
-    expect(response.body).toEqual({
+    expect(response.body).toMatchObject({
       ok: true,
+      action: 'get_status',
+      jobId: 'job-status-running',
+      status: 'running',
+      lifecycleStatus: 'running',
       result: {
         id: 'job-status-running',
         job_type: 'gpt',
@@ -813,6 +916,62 @@ describe('async /gpt idempotency', () => {
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
+  it('supports explicit query by creating one durable writing job without waiting for completion', async () => {
+    findOrCreateGptJobMock.mockResolvedValue({
+      job: {
+        id: 'job-query',
+        status: 'pending'
+      },
+      created: true,
+      deduped: false,
+      dedupeReason: 'new_job'
+    });
+    waitForQueuedGptJobCompletionMock.mockResolvedValue({
+      state: 'pending',
+      job: {
+        id: 'job-query',
+        status: 'pending'
+      }
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/backstage-booker')
+      .send({
+        action: 'query',
+        prompt: 'Draft the next promo'
+      });
+
+    expect(response.status).toBe(202);
+    expect(response.body).toMatchObject({
+      ok: true,
+      action: 'query',
+      status: 'pending',
+      jobId: 'job-query',
+      jobStatus: 'pending',
+      lifecycleStatus: 'queued'
+    });
+    expect(resolveAsyncGptWaitForResultMsMock).toHaveBeenCalledWith(0);
+    expect(waitForQueuedGptJobCompletionMock).toHaveBeenCalledWith(
+      'job-query',
+      expect.objectContaining({
+        waitForResultMs: 0,
+        pollIntervalMs: 250
+      })
+    );
+    expect(findOrCreateGptJobMock).toHaveBeenCalledTimes(1);
+    expect(findOrCreateGptJobMock.mock.calls[0]?.[0]).toMatchObject({
+      input: {
+        gptId: 'backstage-booker',
+        body: {
+          prompt: 'Draft the next promo'
+        },
+        routeHint: 'query'
+      }
+    });
+    expect((findOrCreateGptJobMock.mock.calls[0]?.[0] as { input?: { body?: Record<string, unknown> } }).input?.body?.action).toBe('query');
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
   it('returns query_and_wait timeout guidance with the same job id and one job creation only', async () => {
     findOrCreateGptJobMock.mockResolvedValue({
       job: {
@@ -883,6 +1042,25 @@ describe('async /gpt idempotency', () => {
     expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
   });
 
+  it('rejects query requests without a prompt', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'query'
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      ok: false,
+      action: 'query',
+      error: {
+        code: 'PROMPT_REQUIRED'
+      }
+    });
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
+  });
+
   it('fails query_and_wait clearly when durable async jobs are unavailable instead of falling back to sync query routing', async () => {
     findOrCreateGptJobMock.mockRejectedValue(
       new MockJobRepositoryUnavailableError('jobs backend unavailable')
@@ -902,6 +1080,32 @@ describe('async /gpt idempotency', () => {
       error: {
         code: 'ASYNC_GPT_JOBS_UNAVAILABLE',
         message: 'query_and_wait requires durable GPT job persistence, but the jobs backend is unavailable.'
+      },
+      idempotencyKey: expect.stringMatching(/^derived:/)
+    });
+    expect(findOrCreateGptJobMock).toHaveBeenCalledTimes(1);
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('fails query clearly when durable async jobs are unavailable instead of falling back to sync query routing', async () => {
+    findOrCreateGptJobMock.mockRejectedValue(
+      new MockJobRepositoryUnavailableError('jobs backend unavailable')
+    );
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'query',
+        prompt: 'Generate a Seth Rollins promo prompt'
+      });
+
+    expect(response.status).toBe(503);
+    expect(response.body).toMatchObject({
+      ok: false,
+      action: 'query',
+      error: {
+        code: 'ASYNC_GPT_JOBS_UNAVAILABLE',
+        message: 'query requires durable GPT job persistence, but the jobs backend is unavailable.'
       },
       idempotencyKey: expect.stringMatching(/^derived:/)
     });

--- a/tests/gpt-job-lookup-guard.route.test.ts
+++ b/tests/gpt-job-lookup-guard.route.test.ts
@@ -113,6 +113,39 @@ describe('natural-language job lookup guard on /gpt/:gptId', () => {
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
+  it('rejects look-up phrasing that previously slipped through to the writing plane', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        prompt: 'Look up job id job-123 and return its result.'
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.headers['x-response-bytes']).toBeTruthy();
+    expect(response.body).toEqual({
+      ok: false,
+      action: 'result_lookup',
+      error: {
+        code: 'JOB_LOOKUP_REQUIRES_JOBS_API',
+        message: 'Job retrieval requests must use the jobs API. Do not send result or status lookups through POST /gpt/{gptId}.'
+      },
+      canonical: {
+        poll: '/jobs/job-123',
+        result: '/jobs/job-123/result'
+      },
+      _route: expect.objectContaining({
+        gptId: 'arcanos-core',
+        route: 'job_lookup_guard',
+        action: 'result_lookup'
+      })
+    });
+    expect(getJobByIdMock).not.toHaveBeenCalled();
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(planAutonomousWorkerJobMock).not.toHaveBeenCalled();
+    expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
   it('rejects status polling prompts and points callers to the canonical jobs status route', async () => {
     const response = await request(buildApp())
       .post('/gpt/arcanos-core')

--- a/tests/gpt-job-lookup-guard.route.test.ts
+++ b/tests/gpt-job-lookup-guard.route.test.ts
@@ -91,6 +91,7 @@ describe('natural-language job lookup guard on /gpt/:gptId', () => {
     expect(response.headers['x-response-bytes']).toBeTruthy();
     expect(response.body).toEqual({
       ok: false,
+      action: 'result_lookup',
       error: {
         code: 'JOB_LOOKUP_REQUIRES_JOBS_API',
         message: 'Job retrieval requests must use the jobs API. Do not send result or status lookups through POST /gpt/{gptId}.'
@@ -123,6 +124,7 @@ describe('natural-language job lookup guard on /gpt/:gptId', () => {
     expect(response.headers['x-response-bytes']).toBeTruthy();
     expect(response.body).toEqual({
       ok: false,
+      action: 'status_lookup',
       error: {
         code: 'JOB_LOOKUP_REQUIRES_JOBS_API',
         message: 'Job retrieval requests must use the jobs API. Do not send result or status lookups through POST /gpt/{gptId}.'
@@ -187,6 +189,7 @@ describe('natural-language job lookup guard on /gpt/:gptId', () => {
     expect(response.headers['x-response-bytes']).toBeTruthy();
     expect(response.body).toEqual({
       ok: false,
+      action: 'result_lookup',
       error: {
         code: 'JOB_ID_REQUIRED',
         message: 'Job retrieval prompts sent to /gpt/{gptId} must include a concrete job ID. Use the jobs API instead of prompting the GPT route.'

--- a/tests/gpt-job-lookup-guard.route.test.ts
+++ b/tests/gpt-job-lookup-guard.route.test.ts
@@ -157,6 +157,7 @@ describe('natural-language job lookup guard on /gpt/:gptId', () => {
     expect(response.headers['x-response-bytes']).toBeTruthy();
     expect(response.body).toEqual({
       ok: false,
+      action: 'status_lookup',
       error: {
         code: 'JOB_LOOKUP_REQUIRES_JOBS_API',
         message: 'Job retrieval requests must use the jobs API. Do not send result or status lookups through POST /gpt/{gptId}.'

--- a/tests/gpt-router-auth-logging.test.ts
+++ b/tests/gpt-router-auth-logging.test.ts
@@ -154,13 +154,13 @@ describe('gpt router auth logging', () => {
       .post('/gpt/arcanos-gaming')
       .send({
         prompt: `Inspect ${promptMarker} carefully`,
-        messages: [{ role: 'user', content: `Inspect ${promptMarker} carefully` }]
+        messages: [{ role: 'user', content: `Inspect ${promptMarker} carefully` }],
       });
 
     expect(response.status).toBe(200);
 
     const rawStructuredLogs = consoleLogSpy.mock.calls
-      .map((call) => typeof call[0] === 'string' ? call[0] : '')
+      .map((call) => (typeof call[0] === 'string' ? call[0] : ''))
       .join('\n');
     const logs = collectStructuredLogs(consoleLogSpy.mock.calls);
     const requestMetaLog = logs.find((entry) => entry.event === 'gpt.request.meta');
@@ -170,7 +170,7 @@ describe('gpt router auth logging', () => {
       gptId: 'arcanos-gaming',
       promptLength: `Inspect ${promptMarker} carefully`.length,
       messageCount: 1,
-      promptLikeFields: ['messages', 'prompt']
+      promptLikeFields: ['messages', 'prompt'],
     });
     expect(requestMetaLog?.data?.promptHash).toEqual(expect.any(String));
     expect(requestMetaLog?.data?.bodyKeys).toEqual(['messages', 'prompt']);
@@ -487,22 +487,23 @@ describe('gpt router auth logging', () => {
     expect(response.status).toBe(400);
     expect(response.body).toEqual({
       ok: false,
+      action: 'runtime.inspect',
       error: {
         code: 'CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT',
-        message: 'Runtime diagnostics, worker state, tracing, and queue inspection must use direct control-plane endpoints or POST /mcp. Do not send runtime control requests through POST /gpt/{gptId}.'
+        message: 'Runtime diagnostics, worker state, tracing, and queue inspection must use direct control-plane endpoints or POST /mcp. Do not send runtime control requests through POST /gpt/{gptId}.',
       },
       canonical: {
         status: '/status',
         workers: '/workers/status',
         workerHealth: '/worker-helper/health',
         selfHeal: '/status/safety/self-heal',
-        mcp: '/mcp'
+        mcp: '/mcp',
       },
       _route: expect.objectContaining({
         gptId: 'arcanos-core',
         route: 'control_guard',
         action: 'runtime.inspect',
-      })
+      }),
     });
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
@@ -560,11 +561,11 @@ describe('gpt router auth logging', () => {
       ok: false,
       error: {
         code: 'REQUEST_ABORTED',
-        message: 'Request was aborted before completion.'
+        message: 'Request was aborted before completion.',
       },
       _route: expect.objectContaining({
         gptId: 'arcanos-core',
-      })
+      }),
     });
 
     const logs = collectStructuredLogs(consoleLogSpy.mock.calls);
@@ -619,20 +620,21 @@ describe('gpt router auth logging', () => {
     expect(response.status).toBe(400);
     expect(response.body).toEqual({
       ok: false,
+      action: 'dag.run.create',
       error: {
         code: 'DAG_CONTROL_REQUIRES_DIRECT_ENDPOINT',
-        message: 'DAG execution and trace retrieval must use /api/arcanos/dag/* or POST /mcp. Do not send DAG control requests through POST /gpt/{gptId}.'
+        message: 'DAG execution and trace retrieval must use /api/arcanos/dag/* or POST /mcp. Do not send DAG control requests through POST /gpt/{gptId}.',
       },
       canonical: {
         mcp: '/mcp',
         dagRuns: '/api/arcanos/dag/runs/{runId}',
-        dagTrace: '/api/arcanos/dag/runs/{runId}/trace'
+        dagTrace: '/api/arcanos/dag/runs/{runId}/trace',
       },
       _route: expect.objectContaining({
         gptId: 'arcanos-core',
         route: 'control_guard',
-        action: 'dag.run.create'
-      })
+        action: 'dag.run.create',
+      }),
     });
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
@@ -648,27 +650,28 @@ describe('gpt router auth logging', () => {
       .send({
         prompt: 'run the latest dag trace for me',
         payload: {
-          action: 'dag.run.latest'
-        }
+          action: 'dag.run.latest',
+        },
       });
 
     expect(response.status).toBe(400);
     expect(response.body).toEqual({
       ok: false,
+      action: 'dag.run.latest',
       error: {
         code: 'DAG_CONTROL_REQUIRES_DIRECT_ENDPOINT',
-        message: 'DAG execution and trace retrieval must use /api/arcanos/dag/* or POST /mcp. Do not send DAG control requests through POST /gpt/{gptId}.'
+        message: 'DAG execution and trace retrieval must use /api/arcanos/dag/* or POST /mcp. Do not send DAG control requests through POST /gpt/{gptId}.',
       },
       canonical: {
         mcp: '/mcp',
         dagRuns: '/api/arcanos/dag/runs/{runId}',
-        dagTrace: '/api/arcanos/dag/runs/{runId}/trace'
+        dagTrace: '/api/arcanos/dag/runs/{runId}/trace',
       },
       _route: expect.objectContaining({
         gptId: 'arcanos-core',
         route: 'control_guard',
-        action: 'dag.run.latest'
-      })
+        action: 'dag.run.latest',
+      }),
     });
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
@@ -691,18 +694,19 @@ describe('gpt router auth logging', () => {
     expect(response.status).toBe(400);
     expect(response.body).toEqual({
       ok: false,
+      action: 'mcp.invoke',
       error: {
         code: 'MCP_CONTROL_REQUIRES_MCP_API',
-        message: 'MCP tool calls must use POST /mcp. Do not send MCP control requests through POST /gpt/{gptId}.'
+        message: 'MCP tool calls must use POST /mcp. Do not send MCP control requests through POST /gpt/{gptId}.',
       },
       canonical: {
-        mcp: '/mcp'
+        mcp: '/mcp',
       },
       _route: expect.objectContaining({
         gptId: 'arcanos-core',
         route: 'control_guard',
         action: 'mcp.invoke',
-      })
+      }),
     });
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
@@ -715,7 +719,7 @@ describe('gpt router auth logging', () => {
         module: 'trinity',
         meta: {
           id: 'core-timeout-1',
-          created: 1772917000000
+          created: 1772917000000,
         },
         activeModel: 'gpt-4.1-mini',
         fallbackFlag: true,
@@ -724,35 +728,35 @@ describe('gpt router auth logging', () => {
           intakeFallbackUsed: false,
           gpt5FallbackUsed: false,
           finalFallbackUsed: true,
-          fallbackReasons: ['Recovered via direct answer']
+          fallbackReasons: ['Recovered via direct answer'],
         },
         auditSafe: {
           mode: true,
           overrideUsed: false,
           auditFlags: [],
-          processedSafely: true
+          processedSafely: true,
         },
         memoryContext: {
           entriesAccessed: 0,
           contextSummary: 'No memory context available.',
           memoryEnhanced: false,
           maxRelevanceScore: 0,
-          averageRelevanceScore: 0
+          averageRelevanceScore: 0,
         },
         taskLineage: {
           requestId: 'core-timeout-1',
-          logged: true
+          logged: true,
         },
         timeoutKind: 'pipeline_timeout',
         degradedModeReason: 'arcanos_core_pipeline_timeout_direct_answer',
-        bypassedSubsystems: ['trinity_intake', 'trinity_reasoning']
+        bypassedSubsystems: ['trinity_intake', 'trinity_reasoning'],
       },
       _route: {
         gptId: 'arcanos-core',
         module: 'ARCANOS:CORE',
         route: 'core',
-        availableActions: ['query']
-      }
+        availableActions: ['query'],
+      },
     });
 
     const app = express();

--- a/tests/mcp-http-transport-deps.test.ts
+++ b/tests/mcp-http-transport-deps.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from '@jest/globals';
+
+describe('MCP HTTP transport runtime dependencies', () => {
+  it('loads the packaged SDK HTTP transport and hono node adapter', async () => {
+    await expect(import('@modelcontextprotocol/sdk/server/streamableHttp.js')).resolves.toBeDefined();
+    await expect(import('@hono/node-server')).resolves.toBeDefined();
+  });
+});

--- a/tests/mcp-http-transport-deps.test.ts
+++ b/tests/mcp-http-transport-deps.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 
 describe('MCP HTTP transport runtime dependencies', () => {
-  it('loads the packaged SDK HTTP transport and hono node adapter', async () => {
+  it('loads the packaged SDK HTTP transport entrypoint', async () => {
     await expect(import('@modelcontextprotocol/sdk/server/streamableHttp.js')).resolves.toBeDefined();
-    await expect(import('@hono/node-server')).resolves.toBeDefined();
   });
 });

--- a/tests/mcp-job-tools.test.ts
+++ b/tests/mcp-job-tools.test.ts
@@ -94,18 +94,43 @@ jest.unstable_mockModule('../src/services/researchHub.js', () => ({
 }));
 
 jest.unstable_mockModule('../src/core/db/index.js', () => ({
+  initializeDatabase: jest.fn(),
+  getPool: jest.fn(),
+  isDatabaseConnected: jest.fn(() => true),
+  getStatus: jest.fn(async () => ({ connected: true })),
+  close: jest.fn(),
+  refreshDatabaseCollation: jest.fn(),
+  initializeTables: jest.fn(),
   saveMemory: jest.fn(),
   loadMemory: jest.fn(),
   deleteMemory: jest.fn(),
   query: jest.fn(),
+  transaction: jest.fn(),
+  initializeDatabaseWithSchema: jest.fn(),
 }));
 
 jest.unstable_mockModule('../src/core/db/repositories/jobRepository.js', () => ({
   getJobById: mockGetJobById,
+  createJob: jest.fn(),
+  updateJob: jest.fn(),
+  findOrCreateGptJob: jest.fn(),
+  requestJobCancellation: jest.fn(),
+  claimNextPendingJob: jest.fn(),
+  recordJobHeartbeat: jest.fn(),
+  scheduleJobRetry: jest.fn(),
+  recoverStaleJobs: jest.fn(async () => ({ recoveredJobIds: [], skippedJobIds: [] })),
+  recoverStalledJobsForWorkers: jest.fn(async () => ({ recoveredJobIds: [], skippedJobIds: [] })),
+  getLatestJob: jest.fn(),
+  getJobQueueSummary: jest.fn(async () => null),
+  getJobExecutionStatsSince: jest.fn(async () => null),
+  cleanupExpiredGptJobs: jest.fn(async () => ({ deletedJobIds: [], deletedCount: 0 })),
+  requeueFailedJob: jest.fn(),
+  listFailedJobs: jest.fn(async () => []),
 }));
 
 jest.unstable_mockModule('../src/services/moduleLoader.js', () => ({
   loadModuleDefinitions: jest.fn(async () => []),
+  clearModuleDefinitionCache: jest.fn(),
 }));
 
 jest.unstable_mockModule('../src/routes/modules.js', () => ({

--- a/tests/mcp-job-tools.test.ts
+++ b/tests/mcp-job-tools.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { z } from 'zod';
+
+const mockGetJobById = jest.fn();
+const mockRunThroughBrain = jest.fn();
+const mockRunARCANOS = jest.fn();
+const mockRunTrinity = jest.fn();
+const mockDispatchModuleAction = jest.fn();
+const mockRegisterDagMcpTools = jest.fn();
+
+class FakeMcpServer {
+  public readonly tools = new Map<string, { config: Record<string, unknown>; handler: (args: unknown) => Promise<unknown> }>();
+
+  constructor(_info: { name: string; version: string }, _options: { capabilities?: Record<string, unknown> }) {}
+
+  registerTool(
+    name: string,
+    config: Record<string, unknown>,
+    handler: (args: unknown) => Promise<unknown>
+  ) {
+    this.tools.set(name, { config, handler });
+  }
+}
+
+jest.unstable_mockModule('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: FakeMcpServer,
+}));
+
+jest.unstable_mockModule('../src/mcp/registry.js', () => ({
+  MCP_FLAGS: {
+    exposeDestructive: true,
+    requireConfirmation: false,
+    enableSessions: false,
+  },
+}));
+
+jest.unstable_mockModule('../src/core/lib/errors/index.js', () => ({
+  resolveErrorMessage: (error: unknown) => error instanceof Error ? error.message : String(error),
+}));
+
+jest.unstable_mockModule('../src/core/logic/trinity.js', () => ({
+  runThroughBrain: mockRunThroughBrain,
+}));
+
+jest.unstable_mockModule('../src/core/logic/arcanos.js', () => ({
+  runARCANOS: mockRunARCANOS,
+}));
+
+jest.unstable_mockModule('../src/trinity/trinity.js', () => ({
+  runTrinity: mockRunTrinity,
+}));
+
+jest.unstable_mockModule('../src/config/openai.js', () => ({
+  DEFAULT_FINE_TUNE: 'ft:test',
+}));
+
+jest.unstable_mockModule('../src/shared/types/actionPlan.js', () => ({
+  actionPlanInputSchema: z.object({}).passthrough(),
+}));
+
+jest.unstable_mockModule('../src/services/clear2.js', () => ({
+  buildClear2Summary: jest.fn(() => ({ decision: 'allow' })),
+}));
+
+jest.unstable_mockModule('../src/stores/actionPlanStore.js', () => ({
+  createPlan: jest.fn(),
+  getPlan: jest.fn(),
+  listPlans: jest.fn(),
+  approvePlan: jest.fn(),
+  blockPlan: jest.fn(),
+  expirePlan: jest.fn(),
+  createExecutionResult: jest.fn(),
+  getExecutionResults: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/stores/agentRegistry.js', () => ({
+  validateCapability: jest.fn(async () => true),
+  listAgents: jest.fn(async () => []),
+  getAgent: jest.fn(),
+  registerAgent: jest.fn(),
+  updateHeartbeat: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/services/webRag.js', () => ({
+  ingestUrl: jest.fn(),
+  ingestContent: jest.fn(),
+  answerQuestion: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/services/researchHub.js', () => ({
+  connectResearchBridge: jest.fn(() => ({
+    requestResearch: jest.fn(),
+  })),
+}));
+
+jest.unstable_mockModule('../src/core/db/index.js', () => ({
+  saveMemory: jest.fn(),
+  loadMemory: jest.fn(),
+  deleteMemory: jest.fn(),
+  query: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/core/db/repositories/jobRepository.js', () => ({
+  getJobById: mockGetJobById,
+}));
+
+jest.unstable_mockModule('../src/services/moduleLoader.js', () => ({
+  loadModuleDefinitions: jest.fn(async () => []),
+}));
+
+jest.unstable_mockModule('../src/routes/modules.js', () => ({
+  dispatchModuleAction: mockDispatchModuleAction,
+}));
+
+jest.unstable_mockModule('../src/services/memoryListing.js', () => ({
+  buildActiveMemorySelect: jest.fn(),
+  normalizeMemoryEntries: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/platform/logging/diagnostics.js', () => ({
+  runHealthCheck: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/mcp/server/dagTools.js', () => ({
+  registerDagMcpTools: mockRegisterDagMcpTools,
+}));
+
+jest.unstable_mockModule('../src/mcp/modulesAllowlist.js', () => ({
+  isModuleActionAllowed: jest.fn(() => true),
+}));
+
+const { createMcpServer } = await import('../src/mcp/server/index.js');
+
+function buildContext() {
+  return {
+    requestId: 'mcp-req-1',
+    sessionId: 'mcp-session-1',
+    openai: {},
+    runtimeBudget: {},
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  } as any;
+}
+
+describe('createMcpServer job control tools', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registers explicit control-plane jobs.status and jobs.result tools with required jobId schemas', async () => {
+    const server = await createMcpServer(buildContext()) as FakeMcpServer;
+
+    const statusTool = server.tools.get('jobs.status');
+    const resultTool = server.tools.get('jobs.result');
+
+    expect(statusTool?.config).toMatchObject({
+      title: 'Job Status',
+      description: expect.stringContaining('Control plane'),
+    });
+    expect(resultTool?.config).toMatchObject({
+      title: 'Job Result',
+      description: expect.stringContaining('Control plane'),
+    });
+
+    const statusSchema = statusTool?.config.inputSchema as z.ZodTypeAny;
+    const resultSchema = resultTool?.config.inputSchema as z.ZodTypeAny;
+
+    expect(statusSchema.safeParse({ jobId: 'job-123' }).success).toBe(true);
+    expect(statusSchema.safeParse({ jobId: '   ' }).success).toBe(false);
+    expect(resultSchema.safeParse({ jobId: 'job-123' }).success).toBe(true);
+    expect(resultSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('serves jobs.status entirely through the control plane', async () => {
+    mockGetJobById.mockResolvedValue({
+      id: 'job-123',
+      job_type: 'gpt',
+      status: 'running',
+      created_at: '2026-04-14T10:00:00.000Z',
+      updated_at: '2026-04-14T10:00:02.000Z',
+      completed_at: null,
+      cancel_requested_at: null,
+      cancel_reason: null,
+      retention_until: null,
+      idempotency_until: null,
+      expires_at: null,
+      output: null,
+      error_message: null,
+    });
+
+    const server = await createMcpServer(buildContext()) as FakeMcpServer;
+    const output = await server.tools.get('jobs.status')!.handler({ jobId: 'job-123' });
+
+    expect(mockGetJobById).toHaveBeenCalledWith('job-123');
+    expect(output).toEqual(
+      expect.objectContaining({
+        structuredContent: expect.objectContaining({
+          ok: true,
+          action: 'get_status',
+          jobId: 'job-123',
+          status: 'running',
+          lifecycleStatus: 'running',
+        }),
+      })
+    );
+    expect(mockRunThroughBrain).not.toHaveBeenCalled();
+    expect(mockRunARCANOS).not.toHaveBeenCalled();
+    expect(mockRunTrinity).not.toHaveBeenCalled();
+    expect(mockDispatchModuleAction).not.toHaveBeenCalled();
+  });
+
+  it('serves jobs.result entirely through the control plane', async () => {
+    mockGetJobById.mockResolvedValue({
+      id: 'job-456',
+      job_type: 'gpt',
+      status: 'completed',
+      created_at: '2026-04-14T10:00:00.000Z',
+      updated_at: '2026-04-14T10:00:03.000Z',
+      completed_at: '2026-04-14T10:00:03.000Z',
+      retention_until: null,
+      idempotency_until: null,
+      expires_at: null,
+      output: {
+        text: 'final output',
+      },
+      error_message: null,
+    });
+
+    const server = await createMcpServer(buildContext()) as FakeMcpServer;
+    const output = await server.tools.get('jobs.result')!.handler({ jobId: 'job-456' });
+
+    expect(mockGetJobById).toHaveBeenCalledWith('job-456');
+    expect(output).toEqual(
+      expect.objectContaining({
+        structuredContent: expect.objectContaining({
+          ok: true,
+          action: 'get_result',
+          jobId: 'job-456',
+          status: 'completed',
+          output: {
+            text: 'final output',
+          },
+        }),
+      })
+    );
+    expect(mockRunThroughBrain).not.toHaveBeenCalled();
+    expect(mockRunARCANOS).not.toHaveBeenCalled();
+    expect(mockRunTrinity).not.toHaveBeenCalled();
+    expect(mockDispatchModuleAction).not.toHaveBeenCalled();
+  });
+});

--- a/tests/mcp-job-tools.test.ts
+++ b/tests/mcp-job-tools.test.ts
@@ -293,4 +293,32 @@ describe('createMcpServer job control tools', () => {
     expect(mockRunTrinity).not.toHaveBeenCalled();
     expect(mockDispatchModuleAction).not.toHaveBeenCalled();
   });
+
+  it('returns an MCP not-found error for missing jobs.result lookups', async () => {
+    mockGetJobById.mockResolvedValue(null);
+
+    const server = await createMcpServer(buildContext()) as FakeMcpServer;
+    const output = await server.tools.get('jobs.result')!.handler({ jobId: 'job-missing' });
+
+    expect(mockGetJobById).toHaveBeenCalledWith('job-missing');
+    expect(output).toEqual(
+      expect.objectContaining({
+        isError: true,
+        structuredContent: {
+          error: expect.objectContaining({
+            code: 'ERR_NOT_FOUND',
+            message: 'Async GPT job was not found.',
+            details: {
+              action: 'get_result',
+              jobId: 'job-missing',
+            },
+          }),
+        },
+      })
+    );
+    expect(mockRunThroughBrain).not.toHaveBeenCalled();
+    expect(mockRunARCANOS).not.toHaveBeenCalled();
+    expect(mockRunTrinity).not.toHaveBeenCalled();
+    expect(mockDispatchModuleAction).not.toHaveBeenCalled();
+  });
 });

--- a/tests/mcp-job-tools.test.ts
+++ b/tests/mcp-job-tools.test.ts
@@ -7,6 +7,8 @@ const mockRunARCANOS = jest.fn();
 const mockRunTrinity = jest.fn();
 const mockDispatchModuleAction = jest.fn();
 const mockRegisterDagMcpTools = jest.fn();
+const mockRegisterResource = jest.fn();
+const mockRegisterResourceTemplate = jest.fn();
 
 class FakeMcpServer {
   public readonly tools = new Map<string, { config: Record<string, unknown>; handler: (args: unknown) => Promise<unknown> }>();
@@ -19,6 +21,14 @@ class FakeMcpServer {
     handler: (args: unknown) => Promise<unknown>
   ) {
     this.tools.set(name, { config, handler });
+  }
+
+  registerResource(...args: unknown[]) {
+    mockRegisterResource(...args);
+  }
+
+  registerResourceTemplate(...args: unknown[]) {
+    mockRegisterResourceTemplate(...args);
   }
 }
 
@@ -173,6 +183,13 @@ function buildContext() {
 describe('createMcpServer job control tools', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('registers tools only and does not expose MCP resource templates', async () => {
+    await createMcpServer(buildContext());
+
+    expect(mockRegisterResource).not.toHaveBeenCalled();
+    expect(mockRegisterResourceTemplate).not.toHaveBeenCalled();
   });
 
   it('registers explicit control-plane jobs.status and jobs.result tools with required jobId schemas', async () => {

--- a/tests/mcp-route-isolation.test.ts
+++ b/tests/mcp-route-isolation.test.ts
@@ -1,0 +1,86 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockBuildMcpRequestContext = jest.fn();
+const mockCreateMcpRequestContextProxy = jest.fn(() => ({ proxy: true }));
+const mockRunWithMcpRequestContext = jest.fn(async (_ctx: unknown, fn: () => Promise<unknown>) => fn());
+const mockBuildMcpServer = jest.fn();
+const mockCreateRateLimitMiddleware = jest.fn(() => (_req: unknown, _res: unknown, next: () => void) => next());
+const mockGetRequestActorKey = jest.fn(() => 'actor:test');
+const mockResolveErrorMessage = jest.fn((error: unknown) => error instanceof Error ? error.message : String(error));
+const mockSendInternalErrorPayload = jest.fn((res: express.Response, payload: unknown) => res.status(500).json(payload));
+
+jest.unstable_mockModule('../src/mcp/auth.js', () => ({
+  mcpAuthMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.unstable_mockModule('../src/mcp/context.js', () => ({
+  buildMcpRequestContext: mockBuildMcpRequestContext,
+  createMcpRequestContextProxy: mockCreateMcpRequestContextProxy,
+  runWithMcpRequestContext: mockRunWithMcpRequestContext,
+}));
+
+jest.unstable_mockModule('../src/mcp/server.js', () => ({
+  buildMcpServer: mockBuildMcpServer,
+}));
+
+jest.unstable_mockModule('../src/platform/runtime/security.js', () => ({
+  createRateLimitMiddleware: mockCreateRateLimitMiddleware,
+  getRequestActorKey: mockGetRequestActorKey,
+}));
+
+jest.unstable_mockModule('../src/core/lib/errors/index.js', () => ({
+  resolveErrorMessage: mockResolveErrorMessage,
+}));
+
+jest.unstable_mockModule('../src/shared/http/index.js', () => ({
+  sendInternalErrorPayload: mockSendInternalErrorPayload,
+}));
+
+const router = (await import('../src/routes/mcp.js')).default;
+
+function buildApp() {
+  const app = express();
+  app.use(router);
+  return app;
+}
+
+describe('mcp route request isolation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBuildMcpRequestContext.mockReturnValue({ requestId: 'req-1' });
+
+    let transportIndex = 0;
+    mockBuildMcpServer.mockImplementation(async () => {
+      transportIndex += 1;
+      const id = transportIndex;
+      return {
+        transport: {
+          id,
+          handleRequest: jest.fn(async (_req: express.Request, res: express.Response) => {
+            res.status(200).json({ ok: true, transportId: id });
+          }),
+        },
+      };
+    });
+  });
+
+  it('builds a fresh MCP server and transport for each HTTP request', async () => {
+    const app = buildApp();
+
+    const firstResponse = await request(app).post('/mcp').send({ call: 1 });
+    const secondResponse = await request(app).post('/mcp').send({ call: 2 });
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(firstResponse.body.transportId).toBe(1);
+    expect(secondResponse.body.transportId).toBe(2);
+    expect(mockBuildMcpServer).toHaveBeenCalledTimes(2);
+    expect(mockCreateMcpRequestContextProxy).toHaveBeenCalledTimes(2);
+    expect(mockRunWithMcpRequestContext).toHaveBeenCalledTimes(2);
+
+    const [firstCallResult, secondCallResult] = mockBuildMcpServer.mock.results;
+    expect(firstCallResult.value).not.toBe(secondCallResult.value);
+  });
+});

--- a/tests/placeholder.test.ts
+++ b/tests/placeholder.test.ts
@@ -57,7 +57,7 @@ describe('AI endpoints in mock mode', () => {
     const response = await fetch(`${baseUrl}/gpt/arcanos-daemon`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ action: 'query', prompt: 'test prompt for mock mode' })
+      body: JSON.stringify({ prompt: 'test prompt for mock mode' })
     });
 
     expect(response.status).toBe(200);


### PR DESCRIPTION
## Summary
This draft finishes the public async retrieval bridge on `/gpt/:gptId` so tool-based clients can use a consistent contract for `query`, `query_and_wait`, `get_status`, and `get_result`.

This branch is intentionally stacked on top of the earlier dual-plane routing stabilization commit because the typed async bridge depends on that lane-classification and control-plane safety work.

## What changed
- strengthen the Custom GPT route/OpenAPI contract with typed async actions and deterministic error/result shapes
- advertise the async bridge explicitly in the backend CLI contract
- add first-class CLI support for `query` and `query-and-wait` while keeping direct `/jobs/*` controls
- add matching Python backend client helpers for `query`, `query_and_wait`, `get_status`, and `get_result`
- expose MCP control-plane tools for `jobs.status` and `jobs.result`
- normalize bridge payload handling across route, CLI, Python, and MCP surfaces
- add regression coverage proving control actions do not enter Trinity or write dispatch and that prompt-based retrieval remains blocked
- update docs for Custom GPTs, CLI, MCP, Python, and architecture lane ownership

## Root cause
The backend already had most of the internal async job plumbing, but the public contract was still modeled as a loose action string and the client surfaces exposed retrieval inconsistently. That left status/result reads under-specified for agents and made clients infer behavior instead of using a typed bridge.

## Validation
- `npm run type-check`
- `npm run validate:backend-cli:contract`
- `npm run validate:backend-cli:offline`
- `npm test -- --runInBand --coverage=false`
- `cd daemon-python && python -m pytest tests -q`
- `cd daemon-python && python -m py_compile arcanos/backend_client/__init__.py arcanos/backend_client/chat.py arcanos/backend_client_models.py`
- live ARCANOS CLI probes against the deployed Railway production service for `query`, `query_and_wait`, `job-status`, and `job-result`
- Railway deployment/service/log validation confirming write actions hit the worker while `get_status` and `get_result` stayed on the web control plane and prompt-based retrieval remained rejected

## Impact
ChatGPT custom GPTs, Codex, MCP clients, the ARCANOS CLI, and Python/tooling clients now have the same agent-safe async bridge without reopening the recursive routing bug.