### PR TITLE
Add GPT control planner and bounded shaping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,12 @@ RAILWAY_API_TOKEN=
 # RAILWAY_GRAPHQL_ENDPOINT=https://backboard.railway.app/graphql/v2
 # RAILWAY_GRAPHQL_TIMEOUT_MS=15000
 
+# Public GPT response bounds
+# Default falls back to CLIENT_RESPONSE_MAX_BYTES or 32768 bytes when unset.
+# Set lower in preview/test to exercise explicit partial-response shaping.
+# GPT_PUBLIC_RESPONSE_MAX_BYTES=8000
+# Enables X-Debug-Max-Bytes for /gpt control responses outside production only.
+# ARCANOS_ENABLE_DEBUG_GPT_CONTROLS=false
 
 # Optional owner bootstrap (used only when identity modules are enabled).
 # Use a verified email that should automatically receive owner/internal privileges.

--- a/contracts/custom_gpt_route.openapi.v1.json
+++ b/contracts/custom_gpt_route.openapi.v1.json
@@ -3,14 +3,14 @@
   "info": {
     "title": "Arcanos GPT Route API",
     "version": "1.0.0",
-    "description": "Canonical public contract for GPT-routed module requests. GPT identity is path-bound at /gpt/{gptId}; callers must not duplicate gptId in the JSON body. The async bridge exposes four canonical operations: query, query_and_wait, get_status, and get_result."
+    "description": "Canonical public contract for GPT-routed module requests and allowlisted control-plane dispatch. GPT identity is path-bound at /gpt/{gptId}; callers must not duplicate gptId in the JSON body. POST /gpt/{gptId} accepts flexible request bodies with action as a string and payload as an open object so both durable GPT actions and approved runtime inspection actions can share one public endpoint. A bounded deterministic planner may normalize detail and section profiles for runtime inspection actions before execution, without inventing unsupported actions or bypassing response guards."
   },
   "paths": {
     "/gpt/{gptId}": {
       "post": {
         "operationId": "invokeGptRoute",
-        "summary": "Invoke a GPT-routed module request or async bridge operation",
-        "description": "Use action=query to create one durable writing job, action=query_and_wait to create one durable writing job and wait briefly for fast completion, action=get_status to read status through the GPT compatibility bridge, and action=get_result to read the final result through the GPT compatibility bridge. Natural-language retrieval prompts, runtime inspection prompts, DAG control prompts, and MCP control requests are intentionally rejected on this route.",
+        "summary": "Invoke a GPT-routed module request or universal control action",
+        "description": "POST /gpt/{gptId} is the universal public dispatcher. Use action=query to create one durable writing job, action=query_and_wait to create one durable writing job and wait briefly for fast completion, action=get_status to read status through the GPT compatibility bridge, action=get_result to read the final result through the GPT compatibility bridge, and approved control actions such as diagnostics, runtime.inspect, workers.status, queue.inspect, self_heal.status, and system_state for runtime inspection. For runtime.inspect and self_heal.status, payload.detail and payload.sections can request summary, standard, or full response profiles, and a deterministic bounded planner fills safe defaults when callers omit them. Unknown control-plane action names are rejected with a typed 400 error. Natural-language retrieval prompts, runtime inspection prompts without an explicit allowlisted action, DAG control prompts, and MCP control requests are still intentionally rejected on this route.",
         "parameters": [
           {
             "name": "gptId",
@@ -71,6 +71,50 @@
                     }
                   }
                 },
+                "runtimeInspect": {
+                  "summary": "Inspect the live runtime through the universal dispatcher with planner defaults",
+                  "value": {
+                    "action": "runtime.inspect"
+                  }
+                },
+                "runtimeInspectStandard": {
+                  "summary": "Request standard runtime inspection detail explicitly",
+                  "value": {
+                    "action": "runtime.inspect",
+                    "payload": {
+                      "detail": "standard"
+                    }
+                  }
+                },
+                "runtimeInspectFull": {
+                  "summary": "Request full runtime inspection detail for selected sections",
+                  "value": {
+                    "action": "runtime.inspect",
+                    "payload": {
+                      "detail": "full",
+                      "sections": [
+                        "workers",
+                        "queues",
+                        "memory"
+                      ]
+                    }
+                  }
+                },
+                "selfHealSummary": {
+                  "summary": "Request a compact self-heal summary through the universal dispatcher",
+                  "value": {
+                    "action": "self_heal.status",
+                    "payload": {
+                      "detail": "summary"
+                    }
+                  }
+                },
+                "workersStatus": {
+                  "summary": "Inspect worker runtime and queue state through the universal dispatcher",
+                  "value": {
+                    "action": "workers.status"
+                  }
+                },
                 "moduleAction": {
                   "summary": "Explicit module-specific action",
                   "value": {
@@ -108,7 +152,7 @@
             }
           },
           "400": {
-            "description": "Validation failure or control-plane misuse",
+            "description": "Validation failure, unsupported action, or control-plane misuse",
             "content": {
               "application/json": {
                 "schema": {
@@ -153,7 +197,7 @@
                     }
                   },
                   "controlGuard": {
-                    "summary": "Runtime inspection or other control prompts are rejected on the writing plane",
+                    "summary": "Prompt-based runtime inspection remains rejected without an explicit allowlisted action",
                     "value": {
                       "ok": false,
                       "action": "runtime.inspect",
@@ -167,6 +211,43 @@
                         "workerHealth": "/worker-helper/health",
                         "selfHeal": "/status/safety/self-heal",
                         "mcp": "/mcp"
+                      }
+                    }
+                  },
+                  "unknownControlAction": {
+                    "summary": "Unknown reserved control actions are rejected safely",
+                    "value": {
+                      "ok": false,
+                      "action": "runtime.unknown",
+                      "error": {
+                        "code": "UNSUPPORTED_GPT_ACTION",
+                        "message": "Unsupported control action 'runtime.unknown'. Supported control actions: diagnostics, system_state, runtime.inspect, workers.status, queue.inspect, self_heal.status."
+                      },
+                      "canonical": {
+                        "supportedActions": "diagnostics, system_state, runtime.inspect, workers.status, queue.inspect, self_heal.status"
+                      }
+                    }
+                  },
+                  "invalidDetail": {
+                    "summary": "Invalid planner detail is rejected safely",
+                    "value": {
+                      "ok": false,
+                      "action": "runtime.inspect",
+                      "error": {
+                        "code": "INVALID_GPT_DETAIL",
+                        "message": "Unsupported detail 'verbose'. Supported detail values: summary, standard, full."
+                      },
+                      "canonical": {
+                        "action": "runtime.inspect",
+                        "supportedDetail": "summary, standard, full",
+                        "availableSections": [
+                          "workers",
+                          "queues",
+                          "memory",
+                          "incidents",
+                          "events",
+                          "trace"
+                        ]
                       }
                     }
                   }
@@ -234,37 +315,76 @@
   "components": {
     "schemas": {
       "GptRouteRequest": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/GenericPromptRequest"
+        "type": "object",
+        "additionalProperties": true,
+        "description": "Universal GPT-route request. action is an open string field so callers can send canonical async bridge actions, module actions, and approved control-plane/runtime inspection actions through POST /gpt/{gptId}. Runtime inspection actions may also use a bounded planner profile via payload.detail and payload.sections.",
+        "properties": {
+          "action": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Requested action name. Canonical built-ins include query, query_and_wait, get_status, get_result, diagnostics, runtime.inspect, workers.status, queue.inspect, self_heal.status, and system_state. Module-specific action names are also allowed. Unsupported reserved control action names are rejected with HTTP 400."
           },
-          {
-            "$ref": "#/components/schemas/QueryActionRequest"
+          "prompt": {
+            "type": "string",
+            "minLength": 1
           },
-          {
-            "$ref": "#/components/schemas/QueryAndWaitActionRequest"
+          "message": {
+            "type": "string",
+            "minLength": 1
           },
-          {
-            "$ref": "#/components/schemas/GetStatusActionRequest"
+          "query": {
+            "type": "string",
+            "minLength": 1
           },
-          {
-            "$ref": "#/components/schemas/GetResultActionRequest"
+          "content": {
+            "type": "string",
+            "minLength": 1
           },
-          {
-            "$ref": "#/components/schemas/SystemStateActionRequest"
+          "text": {
+            "type": "string",
+            "minLength": 1
           },
-          {
-            "$ref": "#/components/schemas/ModuleActionRequest"
-          }
-        ],
-        "discriminator": {
-          "propertyName": "action",
-          "mapping": {
-            "query": "#/components/schemas/QueryActionRequest",
-            "query_and_wait": "#/components/schemas/QueryAndWaitActionRequest",
-            "get_status": "#/components/schemas/GetStatusActionRequest",
-            "get_result": "#/components/schemas/GetResultActionRequest",
-            "system_state": "#/components/schemas/SystemStateActionRequest"
+          "userInput": {
+            "type": "string",
+            "minLength": 1
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "gptVersion": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Open payload object. For runtime.inspect and self_heal.status, payload.detail supports summary | standard | full and payload.sections accepts an allowlisted string array such as workers, queues, memory, incidents, events, or trace."
+          },
+          "context": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "executionMode": {
+            "type": "string",
+            "enum": [
+              "sync",
+              "async"
+            ]
+          },
+          "waitForResultMs": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "timeoutMs": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "pollIntervalMs": {
+            "type": "integer",
+            "minimum": 1
           }
         }
       },

--- a/contracts/custom_gpt_route.openapi.v1.json
+++ b/contracts/custom_gpt_route.openapi.v1.json
@@ -361,7 +361,7 @@
           "payload": {
             "type": "object",
             "additionalProperties": true,
-            "description": "Open payload object. For runtime.inspect and self_heal.status, payload.detail supports summary | standard | full and payload.sections accepts an allowlisted string array such as workers, queues, memory, incidents, events, or trace."
+            "description": "Open payload object. For runtime.inspect and self_heal.status, payload.detail supports summary | standard | full. Valid payload.sections values are action-specific allowlisted strings: for example, runtime.inspect may use sections such as workers, queues, memory, incidents, events, or trace, while self_heal.status may use sections such as system or predictive."
           },
           "context": {
             "type": "object",

--- a/packages/cli/__tests__/gpt-client.test.ts
+++ b/packages/cli/__tests__/gpt-client.test.ts
@@ -355,33 +355,27 @@ describe("GPT route OpenAPI contract and client", () => {
     const requestSchema = spec.components?.schemas?.GptRouteRequest;
     expect(requestSchema).toEqual(
       expect.objectContaining({
-        oneOf: expect.any(Array),
-        discriminator: expect.objectContaining({
-          propertyName: "action"
+        type: "object",
+        additionalProperties: true,
+        properties: expect.objectContaining({
+          action: expect.objectContaining({
+            type: "string"
+          }),
+          payload: expect.objectContaining({
+            type: "object",
+            additionalProperties: true
+          }),
+          context: expect.objectContaining({
+            type: "object",
+            additionalProperties: true
+          })
         })
       })
     );
-    expect(requestSchema?.oneOf).toEqual(
-      expect.arrayContaining([
-        { $ref: "#/components/schemas/GenericPromptRequest" },
-        { $ref: "#/components/schemas/QueryActionRequest" },
-        { $ref: "#/components/schemas/QueryAndWaitActionRequest" },
-        { $ref: "#/components/schemas/GetStatusActionRequest" },
-        { $ref: "#/components/schemas/GetResultActionRequest" },
-      ])
-    );
-    expect(spec.components?.schemas?.QueryActionRequest?.allOf?.[1]?.required ?? []).toEqual(
-      expect.arrayContaining(["action", "prompt"])
-    );
-    expect(spec.components?.schemas?.QueryAndWaitActionRequest?.allOf?.[1]?.required ?? []).toEqual(
-      expect.arrayContaining(["action", "prompt"])
-    );
-    expect(spec.components?.schemas?.GetStatusActionRequest?.required ?? []).toEqual(
-      expect.arrayContaining(["action", "payload"])
-    );
-    expect(spec.components?.schemas?.GetResultActionRequest?.required ?? []).toEqual(
-      expect.arrayContaining(["action", "payload"])
-    );
+    expect(requestSchema?.description).toContain("Universal GPT-route request");
+    expect(requestSchema?.properties?.action?.description).toContain("runtime.inspect");
+    expect(requestSchema?.properties?.payload?.description).toContain("payload.detail");
+    expect(requestSchema?.properties?.payload?.description).toContain("payload.sections");
     expect(
       spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.genericPrompt?.value
     ).toEqual({
@@ -408,6 +402,41 @@ describe("GPT route OpenAPI contract and client", () => {
       payload: {
         jobId: "59dbfb2b-0c64-4eda-8a1e-b950a63f7fe0"
       }
+    });
+    expect(
+      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.runtimeInspect?.value
+    ).toEqual({
+      action: "runtime.inspect"
+    });
+    expect(
+      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.runtimeInspectStandard?.value
+    ).toEqual({
+      action: "runtime.inspect",
+      payload: {
+        detail: "standard"
+      }
+    });
+    expect(
+      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.runtimeInspectFull?.value
+    ).toEqual({
+      action: "runtime.inspect",
+      payload: {
+        detail: "full",
+        sections: ["workers", "queues", "memory"]
+      }
+    });
+    expect(
+      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.selfHealSummary?.value
+    ).toEqual({
+      action: "self_heal.status",
+      payload: {
+        detail: "summary"
+      }
+    });
+    expect(
+      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.workersStatus?.value
+    ).toEqual({
+      action: "workers.status"
     });
     expect(
       spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.queryAndWait?.value

--- a/src/platform/runtime/writingPlaneContract.ts
+++ b/src/platform/runtime/writingPlaneContract.ts
@@ -2,6 +2,11 @@ import { classifyRuntimeInspectionPrompt } from '@services/runtimeInspectionRout
 import { shouldTreatPromptAsDagExecution } from '@shared/dag/dagExecutionRouting.js';
 import { normalizeGptRequestBody } from '@shared/gpt/gptIdempotency.js';
 import {
+  GPT_DIRECT_CONTROL_ACTIONS,
+  isReservedGptControlNamespace,
+  normalizeGptDirectControlAction,
+} from '@shared/gpt/gptControlActions.js';
+import {
   GPT_GET_RESULT_ACTION,
   GPT_GET_STATUS_ACTION,
   GPT_QUERY_AND_WAIT_ACTION,
@@ -18,14 +23,23 @@ export type WritingPlaneControlKind =
   | 'job_result'
   | 'job_status'
   | 'mcp_control'
+  | 'queue_inspection_action'
   | 'runtime_inspection'
-  | 'system_state';
+  | 'runtime_inspection_action'
+  | 'self_heal_status_action'
+  | 'system_state'
+  | 'unsupported_control_action'
+  | 'workers_status_action';
 
 export type DirectWritingPlaneControlKind =
   | 'diagnostics'
   | 'job_result'
   | 'job_status'
-  | 'system_state';
+  | 'queue_inspection_action'
+  | 'runtime_inspection_action'
+  | 'self_heal_status_action'
+  | 'system_state'
+  | 'workers_status_action';
 
 export type WritingPlaneInputClassification =
   | {
@@ -83,6 +97,12 @@ function normalizeDagControlAction(action: string | null | undefined): string | 
   return normalizedAction && normalizedAction.startsWith('dag.') ? normalizedAction : null;
 }
 
+function buildUnsupportedControlActionCanonical() {
+  return {
+    supportedActions: GPT_DIRECT_CONTROL_ACTIONS.join(', '),
+  };
+}
+
 function getString(record: Record<string, unknown>, key: string): string | null {
   const value = record[key];
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
@@ -131,6 +151,7 @@ export function classifyWritingPlaneInput(input: {
 }): WritingPlaneInputClassification {
   const normalizedAction = normalizeAction(input.requestedAction);
   const normalizedMode = readBodyMode(input.body);
+  const explicitDirectControlAction = normalizeGptDirectControlAction(normalizedAction);
 
   if (normalizedAction === GPT_GET_STATUS_ACTION) {
     return {
@@ -188,6 +209,74 @@ export function classifyWritingPlaneInput(input: {
       canonical: {
         systemState: '/gpt/arcanos-core',
       },
+    };
+  }
+
+  if (explicitDirectControlAction === 'runtime.inspect') {
+    return {
+      plane: 'control',
+      kind: 'runtime_inspection_action',
+      action: explicitDirectControlAction,
+      reason: 'explicit_action_runtime_inspect',
+      errorCode: 'TRINITY_CONTROL_LEAK',
+      message: 'Runtime inspection is a control-plane operation and must not execute inside Trinity.',
+      canonical: {
+        runtimeInspect: '/gpt/{gptId}',
+      },
+    };
+  }
+
+  if (explicitDirectControlAction === 'workers.status') {
+    return {
+      plane: 'control',
+      kind: 'workers_status_action',
+      action: explicitDirectControlAction,
+      reason: 'explicit_action_workers_status',
+      errorCode: 'TRINITY_CONTROL_LEAK',
+      message: 'Worker status inspection is a control-plane operation and must not execute inside Trinity.',
+      canonical: {
+        workers: '/gpt/{gptId}',
+      },
+    };
+  }
+
+  if (explicitDirectControlAction === 'queue.inspect') {
+    return {
+      plane: 'control',
+      kind: 'queue_inspection_action',
+      action: explicitDirectControlAction,
+      reason: 'explicit_action_queue_inspect',
+      errorCode: 'TRINITY_CONTROL_LEAK',
+      message: 'Queue inspection is a control-plane operation and must not execute inside Trinity.',
+      canonical: {
+        queueInspect: '/gpt/{gptId}',
+      },
+    };
+  }
+
+  if (explicitDirectControlAction === 'self_heal.status') {
+    return {
+      plane: 'control',
+      kind: 'self_heal_status_action',
+      action: explicitDirectControlAction,
+      reason: 'explicit_action_self_heal_status',
+      errorCode: 'TRINITY_CONTROL_LEAK',
+      message: 'Self-heal status inspection is a control-plane operation and must not execute inside Trinity.',
+      canonical: {
+        selfHealStatus: '/gpt/{gptId}',
+      },
+    };
+  }
+
+  if (normalizedAction && isReservedGptControlNamespace(normalizedAction)) {
+    return {
+      plane: 'control',
+      kind: 'unsupported_control_action',
+      action: normalizedAction,
+      reason: 'unsupported_reserved_control_action',
+      errorCode: 'UNSUPPORTED_GPT_ACTION',
+      message: `Unsupported control action '${normalizedAction}'. Supported control actions: ${GPT_DIRECT_CONTROL_ACTIONS.join(', ')}.`,
+      canonical: buildUnsupportedControlActionCanonical(),
     };
   }
 
@@ -324,5 +413,14 @@ export function classifyWritingPlaneInput(input: {
 export function isDirectControlPlaneKind(
   kind: WritingPlaneControlKind
 ): kind is DirectWritingPlaneControlKind {
-  return kind === 'job_status' || kind === 'job_result' || kind === 'diagnostics' || kind === 'system_state';
+  return (
+    kind === 'job_status' ||
+    kind === 'job_result' ||
+    kind === 'diagnostics' ||
+    kind === 'runtime_inspection_action' ||
+    kind === 'workers_status_action' ||
+    kind === 'queue_inspection_action' ||
+    kind === 'self_heal_status_action' ||
+    kind === 'system_state'
+  );
 }

--- a/src/platform/runtime/writingPlaneContract.ts
+++ b/src/platform/runtime/writingPlaneContract.ts
@@ -3,6 +3,7 @@ import { shouldTreatPromptAsDagExecution } from '@shared/dag/dagExecutionRouting
 import { normalizeGptRequestBody } from '@shared/gpt/gptIdempotency.js';
 import {
   GPT_DIRECT_CONTROL_ACTIONS,
+  type GptDirectControlAction,
   isReservedGptControlNamespace,
   normalizeGptDirectControlAction,
 } from '@shared/gpt/gptControlActions.js';
@@ -41,6 +42,25 @@ export type DirectWritingPlaneControlKind =
   | 'system_state'
   | 'workers_status_action';
 
+type ExplicitWritingPlaneControlAction =
+  | 'runtime.inspect'
+  | 'workers.status'
+  | 'queue.inspect'
+  | 'self_heal.status';
+
+type ExplicitWritingPlaneControlClassification = {
+  kind: Extract<
+    DirectWritingPlaneControlKind,
+    | 'runtime_inspection_action'
+    | 'workers_status_action'
+    | 'queue_inspection_action'
+    | 'self_heal_status_action'
+  >;
+  reason: string;
+  message: string;
+  canonical: Record<string, string>;
+};
+
 export type WritingPlaneInputClassification =
   | {
       plane: 'writing';
@@ -60,6 +80,44 @@ export type WritingPlaneInputClassification =
     };
 
 type McpControlAction = 'mcp.invoke' | 'mcp.list_tools';
+
+const EXPLICIT_WRITING_PLANE_CONTROL_CLASSIFICATIONS: Record<
+  ExplicitWritingPlaneControlAction,
+  ExplicitWritingPlaneControlClassification
+> = {
+  'runtime.inspect': {
+    kind: 'runtime_inspection_action',
+    reason: 'explicit_action_runtime_inspect',
+    message: 'Runtime inspection is a control-plane operation and must not execute inside Trinity.',
+    canonical: {
+      runtimeInspect: '/gpt/{gptId}',
+    },
+  },
+  'workers.status': {
+    kind: 'workers_status_action',
+    reason: 'explicit_action_workers_status',
+    message: 'Worker status inspection is a control-plane operation and must not execute inside Trinity.',
+    canonical: {
+      workers: '/gpt/{gptId}',
+    },
+  },
+  'queue.inspect': {
+    kind: 'queue_inspection_action',
+    reason: 'explicit_action_queue_inspect',
+    message: 'Queue inspection is a control-plane operation and must not execute inside Trinity.',
+    canonical: {
+      queueInspect: '/gpt/{gptId}',
+    },
+  },
+  'self_heal.status': {
+    kind: 'self_heal_status_action',
+    reason: 'explicit_action_self_heal_status',
+    message: 'Self-heal status inspection is a control-plane operation and must not execute inside Trinity.',
+    canonical: {
+      selfHealStatus: '/gpt/{gptId}',
+    },
+  },
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -95,6 +153,15 @@ function normalizeMcpAction(action: string | null | undefined): McpControlAction
 function normalizeDagControlAction(action: string | null | undefined): string | null {
   const normalizedAction = normalizeAction(action);
   return normalizedAction && normalizedAction.startsWith('dag.') ? normalizedAction : null;
+}
+
+function isExplicitWritingPlaneControlAction(
+  action: GptDirectControlAction | null
+): action is ExplicitWritingPlaneControlAction {
+  return action === 'runtime.inspect' ||
+    action === 'workers.status' ||
+    action === 'queue.inspect' ||
+    action === 'self_heal.status';
 }
 
 function buildUnsupportedControlActionCanonical() {
@@ -212,59 +279,18 @@ export function classifyWritingPlaneInput(input: {
     };
   }
 
-  if (explicitDirectControlAction === 'runtime.inspect') {
-    return {
-      plane: 'control',
-      kind: 'runtime_inspection_action',
-      action: explicitDirectControlAction,
-      reason: 'explicit_action_runtime_inspect',
-      errorCode: 'TRINITY_CONTROL_LEAK',
-      message: 'Runtime inspection is a control-plane operation and must not execute inside Trinity.',
-      canonical: {
-        runtimeInspect: '/gpt/{gptId}',
-      },
-    };
-  }
+  if (isExplicitWritingPlaneControlAction(explicitDirectControlAction)) {
+    const controlClassification =
+      EXPLICIT_WRITING_PLANE_CONTROL_CLASSIFICATIONS[explicitDirectControlAction];
 
-  if (explicitDirectControlAction === 'workers.status') {
     return {
       plane: 'control',
-      kind: 'workers_status_action',
+      kind: controlClassification.kind,
       action: explicitDirectControlAction,
-      reason: 'explicit_action_workers_status',
+      reason: controlClassification.reason,
       errorCode: 'TRINITY_CONTROL_LEAK',
-      message: 'Worker status inspection is a control-plane operation and must not execute inside Trinity.',
-      canonical: {
-        workers: '/gpt/{gptId}',
-      },
-    };
-  }
-
-  if (explicitDirectControlAction === 'queue.inspect') {
-    return {
-      plane: 'control',
-      kind: 'queue_inspection_action',
-      action: explicitDirectControlAction,
-      reason: 'explicit_action_queue_inspect',
-      errorCode: 'TRINITY_CONTROL_LEAK',
-      message: 'Queue inspection is a control-plane operation and must not execute inside Trinity.',
-      canonical: {
-        queueInspect: '/gpt/{gptId}',
-      },
-    };
-  }
-
-  if (explicitDirectControlAction === 'self_heal.status') {
-    return {
-      plane: 'control',
-      kind: 'self_heal_status_action',
-      action: explicitDirectControlAction,
-      reason: 'explicit_action_self_heal_status',
-      errorCode: 'TRINITY_CONTROL_LEAK',
-      message: 'Self-heal status inspection is a control-plane operation and must not execute inside Trinity.',
-      canonical: {
-        selfHealStatus: '/gpt/{gptId}',
-      },
+      message: controlClassification.message,
+      canonical: controlClassification.canonical,
     };
   }
 

--- a/src/routes/_core/gptDispatch.ts
+++ b/src/routes/_core/gptDispatch.ts
@@ -65,6 +65,7 @@ export type RouteGptRequestInput = {
   requestId?: string;
   logger?: any;
   request?: Request;
+  bypassIntentRouting?: boolean;
   runtimeExecutionMode?: 'request' | 'background';
   parentAbortSignal?: AbortSignal;
 };
@@ -106,6 +107,42 @@ function buildDiagnosticRouteResult(): { ok: true; route: "diagnostic"; message:
   };
 }
 
+const FORWARDED_TOP_LEVEL_PAYLOAD_KEYS = [
+  'message',
+  'prompt',
+  'userInput',
+  'content',
+  'text',
+  'query',
+  'messages',
+  'sessionId',
+  'overrideAuditSafe',
+  'answerMode',
+  'maxWords',
+  'max_words',
+  '__arcanosExecutionMode',
+] as const;
+
+function mergeForwardedTopLevelPayloadFields(
+  body: Record<string, unknown>,
+  explicitPayload: Record<string, unknown>
+): Record<string, unknown> {
+  const mergedPayload = { ...explicitPayload };
+
+  for (const key of FORWARDED_TOP_LEVEL_PAYLOAD_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(mergedPayload, key)) {
+      continue;
+    }
+
+    const forwardedValue = body[key];
+    if (forwardedValue !== undefined) {
+      mergedPayload[key] = forwardedValue;
+    }
+  }
+
+  return mergedPayload;
+}
+
 /**
  * Build module action payload while preserving explicit caller payloads.
  * Inputs: raw request body and resolved module action.
@@ -116,8 +153,8 @@ function buildDispatchPayload(body: unknown): unknown {
   //audit Assumption: explicit payload should take precedence for module actions; failure risk: action contracts receiving reshaped fields; expected invariant: payload passed through unchanged when provided; handling strategy: prefer `body.payload`.
   if (isRecord(body) && Object.prototype.hasOwnProperty.call(body, "payload")) {
     const explicitPayload = body.payload;
-    if (isRecord(explicitPayload) && Object.prototype.hasOwnProperty.call(explicitPayload, 'gptId')) {
-      const sanitizedPayload = { ...explicitPayload };
+    if (isRecord(explicitPayload)) {
+      const sanitizedPayload = mergeForwardedTopLevelPayloadFields(body, explicitPayload);
       delete sanitizedPayload.gptId;
       return sanitizedPayload;
     }
@@ -780,7 +817,16 @@ export async function resolveGptRouting(gptId: string, requestId?: string): Prom
   };
 }
 export async function routeGptRequest(input: RouteGptRequestInput): Promise<AskEnvelope> {
-  const { gptId, body, requestId, logger, request, runtimeExecutionMode, parentAbortSignal } = input;
+  const {
+    gptId,
+    body,
+    requestId,
+    logger,
+    request,
+    bypassIntentRouting,
+    runtimeExecutionMode,
+    parentAbortSignal
+  } = input;
   const trimmedGptId = (gptId ?? "").trim();
   const requestEndpoint = request?.originalUrl ?? request?.url ?? request?.path;
   const preDispatchPayload = applyRuntimeExecutionModeOverride(
@@ -959,7 +1005,7 @@ export async function routeGptRequest(input: RouteGptRequestInput): Promise<AskE
   });
 
   const forcedDirectResolved = resolveForcedDirectGptEntry(trimmedGptId);
-  const forceDirectModuleRouting = Boolean(forcedDirectResolved);
+  const forceDirectModuleRouting = Boolean(forcedDirectResolved) || bypassIntentRouting === true;
   let gptModuleMap = forcedDirectResolved ? null : await getGptModuleMap();
   let resolved = forcedDirectResolved ?? resolveGptEntry(trimmedGptId, (gptModuleMap ?? {}) as any);
   if (!resolved) {
@@ -1009,6 +1055,7 @@ export async function routeGptRequest(input: RouteGptRequestInput): Promise<AskE
     route: entry.route,
     matchMethod,
     forcedDirectRoute: forceDirectModuleRouting,
+    bypassIntentRouting: bypassIntentRouting === true,
   });
   const payload = preDispatchPayload;
   const prompt = extractPrompt(payload);

--- a/src/routes/_core/gptPlaneClassification.ts
+++ b/src/routes/_core/gptPlaneClassification.ts
@@ -8,13 +8,18 @@ export type GptDirectControlKind =
   | 'diagnostics'
   | 'job_result'
   | 'job_status'
-  | 'system_state';
+  | 'queue_inspection_action'
+  | 'runtime_inspection_action'
+  | 'self_heal_status_action'
+  | 'system_state'
+  | 'workers_status_action';
 
 export type GptRejectedControlKind =
   | 'dag_control'
   | 'job_lookup'
   | 'mcp_control'
-  | 'runtime_inspection';
+  | 'runtime_inspection'
+  | 'unsupported_control_action';
 
 export type GptPlaneClassification =
   | {

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -156,19 +156,59 @@ function resolveRequestedAction(body: unknown): string | null {
   return payloadAction ? payloadAction.toLowerCase() : null;
 }
 
+function readPayloadRecord(
+  normalizedBody: Record<string, unknown> | null
+): Record<string, unknown> | null {
+  const payload = normalizedBody?.payload;
+  return payload && typeof payload === 'object' && !Array.isArray(payload)
+    ? (payload as Record<string, unknown>)
+    : null;
+}
+
+function extractPromptTextFromRecord(record: Record<string, unknown> | null): string | null {
+  const candidate =
+    record?.message ??
+    record?.prompt ??
+    record?.userInput ??
+    record?.content ??
+    record?.text ??
+    record?.query;
+
+  if (typeof candidate === 'string' && candidate.trim().length > 0) {
+    return candidate.trim();
+  }
+
+  if (!Array.isArray(record?.messages)) {
+    return null;
+  }
+
+  const lastUserMessage = [...record.messages].reverse().find((entry) => {
+    const candidate = typeof entry === 'object' && entry !== null && !Array.isArray(entry)
+      ? (entry as Record<string, unknown>)
+      : null;
+    return (
+      candidate?.role === 'user' &&
+      typeof candidate.content === 'string' &&
+      candidate.content.trim().length > 0
+    );
+  });
+
+  const normalizedLastUserMessage =
+    typeof lastUserMessage === 'object' && lastUserMessage !== null && !Array.isArray(lastUserMessage)
+      ? (lastUserMessage as Record<string, unknown>)
+      : null;
+
+  return normalizedLastUserMessage && typeof normalizedLastUserMessage.content === 'string'
+    ? normalizedLastUserMessage.content.trim()
+    : null;
+}
+
 function extractPromptText(body: unknown): string | null {
   const normalizedBody = normalizeGptRequestBody(body);
-  const candidate =
-    normalizedBody?.message ??
-    normalizedBody?.prompt ??
-    normalizedBody?.userInput ??
-    normalizedBody?.content ??
-    normalizedBody?.text ??
-    normalizedBody?.query;
-
-  return typeof candidate === 'string' && candidate.trim().length > 0
-    ? candidate.trim()
-    : null;
+  return (
+    extractPromptTextFromRecord(normalizedBody) ??
+    extractPromptTextFromRecord(readPayloadRecord(normalizedBody))
+  );
 }
 
 function hashPromptText(promptText: string | null): string | null {
@@ -368,13 +408,20 @@ function resolveRequestedExecutionMode(
   body: unknown
 ): GptExecutionMode | null {
   const normalizedBody = normalizeGptRequestBody(body);
+  const payload = readPayloadRecord(normalizedBody);
   const bodyModeCandidate =
     typeof normalizedBody?.executionMode === 'string'
       ? normalizedBody.executionMode
+      : typeof payload?.executionMode === 'string'
+      ? payload.executionMode
       : typeof normalizedBody?.responseMode === 'string'
       ? normalizedBody.responseMode
+      : typeof payload?.responseMode === 'string'
+      ? payload.responseMode
       : typeof normalizedBody?.mode === 'string'
       ? normalizedBody.mode
+      : typeof payload?.mode === 'string'
+      ? payload.mode
       : null;
   const normalizedBodyMode = bodyModeCandidate?.trim().toLowerCase();
   if (normalizedBodyMode === 'async') {
@@ -438,14 +485,18 @@ function resolveRequestedExecutionMode(
 
 function extractMessageCount(body: unknown): number {
   const normalizedBody = normalizeGptRequestBody(body);
-  return Array.isArray(normalizedBody?.messages)
-    ? normalizedBody.messages.length
-    : 0;
+  if (Array.isArray(normalizedBody?.messages)) {
+    return normalizedBody.messages.length;
+  }
+
+  const payload = readPayloadRecord(normalizedBody);
+  return Array.isArray(payload?.messages) ? payload.messages.length : 0;
 }
 
 function extractAnswerMode(body: unknown): string | null {
   const normalizedBody = normalizeGptRequestBody(body);
-  const answerMode = normalizedBody?.answerMode;
+  const payload = readPayloadRecord(normalizedBody);
+  const answerMode = normalizedBody?.answerMode ?? payload?.answerMode;
   return typeof answerMode === 'string' && answerMode.trim().length > 0
     ? answerMode.trim().toLowerCase()
     : null;
@@ -453,7 +504,13 @@ function extractAnswerMode(body: unknown): string | null {
 
 function extractMaxWords(body: unknown): number | null {
   const normalizedBody = normalizeGptRequestBody(body);
-  const candidates = [normalizedBody?.maxWords, normalizedBody?.max_words];
+  const payload = readPayloadRecord(normalizedBody);
+  const candidates = [
+    normalizedBody?.maxWords,
+    normalizedBody?.max_words,
+    payload?.maxWords,
+    payload?.max_words
+  ];
 
   for (const candidate of candidates) {
     if (typeof candidate === 'number' && Number.isFinite(candidate) && candidate > 0) {
@@ -650,6 +707,25 @@ function normalizeQueryAndWaitBody(
   delete normalizedQueryBody.action;
   normalizedQueryBody.executionMode = 'async';
   return normalizedQueryBody;
+}
+
+function hydrateDirectQueryBody(
+  normalizedBody: Record<string, unknown> | null,
+  promptText: string | null,
+  enabled: boolean
+): Record<string, unknown> | null {
+  if (!enabled || !normalizedBody || !promptText) {
+    return normalizedBody;
+  }
+
+  if (extractPromptTextFromRecord(normalizedBody)) {
+    return normalizedBody;
+  }
+
+  return {
+    ...normalizedBody,
+    prompt: promptText
+  };
 }
 
 function resolveAsyncBridgeAction(queryAndWaitRequested: boolean) {
@@ -1255,6 +1331,7 @@ router.post("/:gptId", async (req, res, next) => {
   const requestedAction = resolveRequestedAction(req.body);
   const queryRequested = requestedAction === GPT_QUERY_ACTION;
   const queryAndWaitRequested = requestedAction === GPT_QUERY_AND_WAIT_ACTION;
+  const bypassIntentRouting = queryRequested || queryAndWaitRequested;
   const asyncBridgeAction = resolveAsyncBridgeAction(queryAndWaitRequested);
   const promptText = extractPromptText(req.body);
   const routeTimeoutProfile = shouldUseDagExecutionTimeoutProfile(promptText)
@@ -1304,7 +1381,12 @@ router.post("/:gptId", async (req, res, next) => {
         const normalizedBody = normalizeGptRequestBody(req.body);
         const bodyGptId = resolveBodyGptId(req.body);
         const effectiveRequestedAction = queryAndWaitRequested ? 'query' : requestedAction;
-        const effectiveBody = normalizeQueryAndWaitBody(normalizedBody, requestedAction) ?? req.body;
+        const effectiveBody =
+          hydrateDirectQueryBody(
+            normalizeQueryAndWaitBody(normalizedBody, requestedAction) ?? normalizedBody,
+            promptText,
+            bypassIntentRouting
+          ) ?? req.body;
         applyCanonicalGptRouteHeaders(res, incomingGptId);
 
         requestLogger?.info?.('gpt.request.timeout_plan', {
@@ -1839,6 +1921,7 @@ router.post("/:gptId", async (req, res, next) => {
               gptId: incomingGptId,
               body: effectiveBody as Record<string, unknown>,
               prompt: promptText,
+              bypassIntentRouting,
               requestId,
               routeHint: effectiveRequestedAction ?? 'query',
               requestPath: req.originalUrl,
@@ -2292,6 +2375,7 @@ router.post("/:gptId", async (req, res, next) => {
           requestId,
           logger: requestLogger,
           request: req,
+          bypassIntentRouting,
         });
 
         if (!envelope.ok) {

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -182,25 +182,23 @@ function extractPromptTextFromRecord(record: Record<string, unknown> | null): st
     return null;
   }
 
-  const lastUserMessage = [...record.messages].reverse().find((entry) => {
-    const candidate = typeof entry === 'object' && entry !== null && !Array.isArray(entry)
-      ? (entry as Record<string, unknown>)
-      : null;
-    return (
-      candidate?.role === 'user' &&
-      typeof candidate.content === 'string' &&
-      candidate.content.trim().length > 0
-    );
-  });
+  for (let index = record.messages.length - 1; index >= 0; index -= 1) {
+    const entry = record.messages[index];
+    const normalizedEntry =
+      typeof entry === 'object' && entry !== null && !Array.isArray(entry)
+        ? (entry as Record<string, unknown>)
+        : null;
 
-  const normalizedLastUserMessage =
-    typeof lastUserMessage === 'object' && lastUserMessage !== null && !Array.isArray(lastUserMessage)
-      ? (lastUserMessage as Record<string, unknown>)
-      : null;
+    if (
+      normalizedEntry?.role === 'user' &&
+      typeof normalizedEntry.content === 'string' &&
+      normalizedEntry.content.trim().length > 0
+    ) {
+      return normalizedEntry.content.trim();
+    }
+  }
 
-  return normalizedLastUserMessage && typeof normalizedLastUserMessage.content === 'string'
-    ? normalizedLastUserMessage.content.trim()
-    : null;
+  return null;
 }
 
 function extractPromptText(body: unknown): string | null {

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -103,6 +103,7 @@ const DEFAULT_GPT_QUERY_AND_WAIT_TIMEOUT_MS = 25_000;
 const DIRECT_RETURN_ROUTE_TIMEOUT_HEADROOM_MS = 750;
 const DEFAULT_GPT_QUERY_AND_WAIT_ROUTE_TIMEOUT_MS =
   DEFAULT_GPT_QUERY_AND_WAIT_TIMEOUT_MS + DIRECT_RETURN_ROUTE_TIMEOUT_HEADROOM_MS;
+const DEBUG_GPT_MAX_BYTES_HEADER = 'x-debug-max-bytes';
 const DIRECT_RETURN_WAIT_KEYS = [
   'waitForResultMs',
   'wait_for_result_ms',
@@ -207,6 +208,23 @@ function extractPromptText(body: unknown): string | null {
     extractPromptTextFromRecord(normalizedBody) ??
     extractPromptTextFromRecord(readPayloadRecord(normalizedBody))
   );
+}
+
+function resolveDebugGptPublicResponseMaxBytes(req: express.Request): number | undefined {
+  if (
+    process.env.NODE_ENV === 'production' ||
+    process.env.ARCANOS_ENABLE_DEBUG_GPT_CONTROLS !== 'true'
+  ) {
+    return undefined;
+  }
+
+  const rawValue = req.header(DEBUG_GPT_MAX_BYTES_HEADER);
+  if (!rawValue) {
+    return undefined;
+  }
+
+  const parsedValue = Number.parseInt(rawValue, 10);
+  return Number.isFinite(parsedValue) && parsedValue > 0 ? parsedValue : undefined;
 }
 
 function hashPromptText(promptText: string | null): string | null {
@@ -1065,6 +1083,7 @@ async function dispatchDirectControlAction(params: {
       routeMeta,
       logger: params.req.logger,
       logEvent: 'gpt.response.runtime_inspection',
+      maxResponseBytes: resolveDebugGptPublicResponseMaxBytes(params.req),
     });
     return {
       kind: 'prepared',
@@ -1189,6 +1208,7 @@ async function dispatchDirectControlAction(params: {
     routeMeta,
     logger: params.req.logger,
     logEvent: 'gpt.response.self_heal_status',
+    maxResponseBytes: resolveDebugGptPublicResponseMaxBytes(params.req),
   });
   return {
     kind: 'prepared',

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -72,11 +72,26 @@ import {
   parseGptJobStatusRequest,
   parseGptJobResultRequest
 } from '@shared/gpt/gptJobResult.js';
+import {
+  type GptDirectControlAction,
+  normalizeGptDirectControlAction,
+} from '@shared/gpt/gptControlActions.js';
+import {
+  buildGptControlResponseMeta,
+  getGptExecutionPlanAvailableSections,
+  isPlannableGptControlAction,
+  planGptControlExecution,
+  type GptExecutionPlan as GptControlExecutionPlan,
+} from '@shared/gpt/gptExecutionPlanner.js';
+import { prepareShapedControlResponse } from '@shared/gpt/gptControlResponseShape.js';
 import { classifyGptRequestPlane } from './_core/gptPlaneClassification.js';
 import {
   executeSystemStateRequest,
   SystemStateConflictError
 } from '@services/systemState.js';
+import { executeRuntimeInspection } from '@services/runtimeInspectionRoutingService.js';
+import { getWorkerControlStatus } from '@services/workerControlService.js';
+import { buildSafetySelfHealSnapshot } from '@services/selfHealRuntimeInspectionService.js';
 
 const router = express.Router();
 const ARCANOS_CORE_GPT_IDS = new Set(['arcanos-core', 'core', 'arcanos-daemon']);
@@ -690,6 +705,432 @@ function buildDirectControlPayload(
   return payload;
 }
 
+type DirectControlDispatchResponse =
+  | {
+      kind: 'guarded';
+      statusCode: number;
+      logEvent: string;
+      payload: Record<string, unknown>;
+    }
+  | {
+      kind: 'prepared';
+      statusCode: number;
+      payload: Record<string, unknown>;
+      headers?: Record<string, string>;
+    };
+
+async function dispatchDirectControlAction(params: {
+  req: express.Request;
+  requestId: string | undefined;
+  gptId: string;
+  action: GptDirectControlAction;
+  normalizedBody: Record<string, unknown> | null;
+  promptText: string | null;
+  logger?: {
+    info?: (...args: any[]) => void;
+    warn?: (...args: any[]) => void;
+  };
+}): Promise<DirectControlDispatchResponse> {
+  const routeMeta = buildDirectControlRouteMeta({
+    requestId: params.requestId,
+    gptId: params.gptId,
+    action: params.action,
+    route: params.action.replace(/[._]/g, '_')
+  });
+  const directControlPayload = buildDirectControlPayload(params.normalizedBody);
+  const directControlPlanResult = isPlannableGptControlAction(params.action)
+    ? planGptControlExecution({
+        action: params.action,
+        promptText: params.promptText,
+        payload: directControlPayload,
+      })
+    : null;
+
+  if (directControlPlanResult && !directControlPlanResult.ok) {
+    params.logger?.warn?.('gpt.request.control_plan_invalid', {
+      endpoint: params.req.originalUrl,
+      gptId: params.gptId,
+      requestId: params.requestId,
+      action: params.action,
+      errorCode: directControlPlanResult.error.code,
+      canonical: directControlPlanResult.canonical,
+    });
+    return {
+      kind: 'guarded',
+      statusCode: 400,
+      logEvent: 'gpt.response.control_plan_invalid',
+      payload: {
+        ok: false,
+        action: params.action,
+        error: directControlPlanResult.error,
+        canonical: directControlPlanResult.canonical,
+        _route: routeMeta,
+      }
+    };
+  }
+
+  const directControlPlan = directControlPlanResult?.ok === true
+    ? directControlPlanResult.plan
+    : null;
+  const directControlAvailableSections = directControlPlanResult?.ok === true
+    ? directControlPlanResult.availableSections
+    : [];
+
+  if (directControlPlan) {
+    params.logger?.info?.('gpt.request.control_plan', {
+      endpoint: params.req.originalUrl,
+      gptId: params.gptId,
+      requestId: params.requestId,
+      action: directControlPlan.action,
+      detail: directControlPlan.detail,
+      sections: directControlPlan.sections,
+      shouldUseAsync: directControlPlan.shouldUseAsync,
+      source: directControlPlan.source,
+    });
+  }
+
+  if (params.action === 'diagnostics') {
+    const diagnostics = await getDiagnosticsSnapshot(params.req.app);
+    params.logger?.info?.('gpt.request.diagnostics', {
+      endpoint: params.req.originalUrl,
+      gptId: params.gptId,
+      internal: true,
+      registeredGpts: Array.isArray(diagnostics.registered_gpts)
+        ? diagnostics.registered_gpts.length
+        : diagnostics.registered_gpts,
+      routeCount: Array.isArray(diagnostics.active_routes)
+        ? diagnostics.active_routes.length
+        : diagnostics.active_routes
+    });
+    recordGptRequestEvent({
+      event: 'control_direct',
+      source: 'diagnostics'
+    });
+
+    const diagnosticsSerializationStartedAt = Date.now();
+    const diagnosticsPayload = prepareBoundedClientJsonPayload(
+      diagnostics as unknown as Record<string, unknown>,
+      {
+        logger: (params.req as any).logger,
+        logEvent: 'gpt.response.diagnostics'
+      }
+    );
+    params.logger?.info?.('gpt.response.serialization', {
+      endpoint: params.req.originalUrl,
+      gptId: params.gptId,
+      action: 'diagnostics',
+      serializationMs: Date.now() - diagnosticsSerializationStartedAt,
+      responseBytes: diagnosticsPayload.responseBytes,
+      truncated: diagnosticsPayload.truncated,
+    });
+
+    const headers: Record<string, string> = {
+      'x-response-bytes': String(diagnosticsPayload.responseBytes)
+    };
+    if (diagnosticsPayload.truncated) {
+      headers['x-response-truncated'] = 'true';
+    }
+
+    return {
+      kind: 'prepared',
+      statusCode: 200,
+      payload: diagnosticsPayload.payload,
+      headers,
+    };
+  }
+
+  if (params.action === 'system_state') {
+    if (!ARCANOS_CORE_GPT_IDS.has(params.gptId)) {
+      params.logger?.warn?.('gpt.request.system_state_rejected', {
+        endpoint: params.req.originalUrl,
+        gptId: params.gptId,
+        requestId: params.requestId,
+        reason: 'non_core_gpt'
+      });
+      return {
+        kind: 'guarded',
+        statusCode: 400,
+        logEvent: 'gpt.response.system_state_rejected',
+        payload: {
+          ok: false,
+          error: {
+            code: 'SYSTEM_STATE_REQUIRES_CORE_GPT',
+            message: 'system_state requests must target an ARCANOS core GPT id.'
+          },
+          _route: routeMeta
+        }
+      };
+    }
+
+    try {
+      const systemStateResult = await executeSystemStateRequest(
+        directControlPayload
+      );
+      params.logger?.info?.('gpt.request.system_state', {
+        endpoint: params.req.originalUrl,
+        gptId: params.gptId,
+        requestId: params.requestId,
+        route: 'system_state'
+      });
+      recordGptRequestEvent({
+        event: 'control_direct',
+        source: 'system_state'
+      });
+      return {
+        kind: 'guarded',
+        statusCode: 200,
+        logEvent: 'gpt.response.system_state',
+        payload: {
+          ok: true,
+          result: systemStateResult,
+          _route: routeMeta
+        }
+      };
+    } catch (error) {
+      if (error instanceof SystemStateConflictError) {
+        params.logger?.warn?.('gpt.request.system_state_conflict', {
+          endpoint: params.req.originalUrl,
+          gptId: params.gptId,
+          requestId: params.requestId,
+          conflict: error.conflict
+        });
+        return {
+          kind: 'guarded',
+          statusCode: 409,
+          logEvent: 'gpt.response.system_state_conflict',
+          payload: {
+            ok: false,
+            error: {
+              code: error.code,
+              message: error.message,
+              details: error.conflict
+            },
+            _route: routeMeta
+          }
+        };
+      }
+
+      params.logger?.warn?.('gpt.request.system_state_invalid', {
+        endpoint: params.req.originalUrl,
+        gptId: params.gptId,
+        requestId: params.requestId,
+        error: resolveErrorMessage(error)
+      });
+      return {
+        kind: 'guarded',
+        statusCode: 400,
+        logEvent: 'gpt.response.system_state_invalid',
+        payload: {
+          ok: false,
+          error: {
+            code: 'BAD_REQUEST',
+            message: resolveErrorMessage(error)
+          },
+          _route: routeMeta
+        }
+      };
+    }
+  }
+
+  if (params.action === 'runtime.inspect') {
+    const runtimeInspection = await executeRuntimeInspection({
+      requestId: params.requestId ?? `${params.gptId}:runtime.inspect`,
+      rawPrompt: params.promptText ?? 'runtime inspect live runtime status',
+      normalizedPrompt: params.promptText ?? 'runtime inspect live runtime status',
+      request: params.req
+    });
+
+    if (!runtimeInspection.ok || !runtimeInspection.responsePayload) {
+      params.logger?.warn?.('gpt.request.runtime_inspection_unavailable', {
+        endpoint: params.req.originalUrl,
+        gptId: params.gptId,
+        requestId: params.requestId,
+        selectedTools: runtimeInspection.selectedTools,
+        runtimeEndpointsQueried: runtimeInspection.runtimeEndpointsQueried,
+        cliUsed: runtimeInspection.cliUsed,
+      });
+      return {
+        kind: 'guarded',
+        statusCode: 503,
+        logEvent: 'gpt.response.runtime_inspection_unavailable',
+        payload: {
+          ok: false,
+          action: params.action,
+          error: runtimeInspection.error ?? {
+            code: 'RUNTIME_INSPECTION_UNAVAILABLE',
+            message: 'runtime inspection unavailable'
+          },
+          _route: routeMeta
+        }
+      };
+    }
+
+    params.logger?.info?.('gpt.request.runtime_inspection', {
+      endpoint: params.req.originalUrl,
+      gptId: params.gptId,
+      requestId: params.requestId,
+      selectedTools: runtimeInspection.selectedTools,
+      runtimeEndpointsQueried: runtimeInspection.runtimeEndpointsQueried,
+      cliUsed: runtimeInspection.cliUsed,
+    });
+    recordGptRequestEvent({
+      event: 'control_direct',
+      source: 'runtime.inspect'
+    });
+    const shapedRuntimeInspection = prepareShapedControlResponse({
+      action: 'runtime.inspect',
+      rawResult: runtimeInspection.responsePayload,
+      plan: (directControlPlan ??
+        {
+          action: 'runtime.inspect',
+          detail: 'summary',
+          sections: getGptExecutionPlanAvailableSections('runtime.inspect'),
+          shouldUseAsync: false,
+          source: 'planner',
+        }) as GptControlExecutionPlan<'runtime.inspect'>,
+      routeMeta,
+      logger: params.req.logger,
+      logEvent: 'gpt.response.runtime_inspection',
+    });
+    return {
+      kind: 'prepared',
+      statusCode: 200,
+      payload: shapedRuntimeInspection.payload,
+      headers: {
+        'x-response-bytes': String(shapedRuntimeInspection.responseBytes),
+        ...(
+          shapedRuntimeInspection.explicitTruncated || shapedRuntimeInspection.truncated
+            ? { 'x-response-truncated': 'true' }
+            : {}
+        ),
+      },
+    };
+  }
+
+  if (params.action === 'workers.status') {
+    const workerStatus = await getWorkerControlStatus();
+    params.logger?.info?.('gpt.request.workers_status', {
+      endpoint: params.req.originalUrl,
+      gptId: params.gptId,
+      requestId: params.requestId,
+      overallStatus: workerStatus.workerService.health.overallStatus,
+    });
+    recordGptRequestEvent({
+      event: 'control_direct',
+      source: 'workers.status'
+    });
+    return {
+      kind: 'guarded',
+      statusCode: 200,
+      logEvent: 'gpt.response.workers_status',
+      payload: {
+        ok: true,
+        action: params.action,
+        result: workerStatus,
+        ...(directControlPlan
+          ? {
+              meta: buildGptControlResponseMeta({
+                plan: directControlPlan,
+                availableSections: directControlAvailableSections,
+                truncated: false,
+              }),
+            }
+          : {}),
+        _route: routeMeta
+      }
+    };
+  }
+
+  if (params.action === 'queue.inspect') {
+    const workerStatus = await getWorkerControlStatus();
+    const queueInspection = {
+      timestamp: workerStatus.timestamp,
+      workerService: {
+        observationMode: workerStatus.workerService.observationMode,
+        database: workerStatus.workerService.database,
+        queueSummary: workerStatus.workerService.queueSummary,
+        queueSemantics: workerStatus.workerService.queueSemantics,
+        retryPolicy: workerStatus.workerService.retryPolicy,
+        recentFailedJobs: workerStatus.workerService.recentFailedJobs,
+        latestJob: workerStatus.workerService.latestJob,
+        health: workerStatus.workerService.health,
+      }
+    };
+    params.logger?.info?.('gpt.request.queue_inspect', {
+      endpoint: params.req.originalUrl,
+      gptId: params.gptId,
+      requestId: params.requestId,
+      queuePending: workerStatus.workerService.queueSummary?.pending ?? null,
+      queueRunning: workerStatus.workerService.queueSummary?.running ?? null,
+    });
+    recordGptRequestEvent({
+      event: 'control_direct',
+      source: 'queue.inspect'
+    });
+    return {
+      kind: 'guarded',
+      statusCode: 200,
+      logEvent: 'gpt.response.queue_inspect',
+      payload: {
+        ok: true,
+        action: params.action,
+        result: queueInspection,
+        ...(directControlPlan
+          ? {
+              meta: buildGptControlResponseMeta({
+                plan: directControlPlan,
+                availableSections: directControlAvailableSections,
+                truncated: false,
+              }),
+            }
+          : {}),
+        _route: routeMeta
+      }
+    };
+  }
+
+  const selfHealStatus = buildSafetySelfHealSnapshot();
+  params.logger?.info?.('gpt.request.self_heal_status', {
+    endpoint: params.req.originalUrl,
+    gptId: params.gptId,
+    requestId: params.requestId,
+    active: selfHealStatus.active,
+    enabled: selfHealStatus.enabled,
+  });
+  recordGptRequestEvent({
+    event: 'control_direct',
+    source: 'self_heal.status'
+  });
+  const shapedSelfHealStatus = prepareShapedControlResponse({
+    action: 'self_heal.status',
+    rawResult: selfHealStatus as Record<string, unknown>,
+    plan: (directControlPlan ??
+      {
+        action: 'self_heal.status',
+        detail: 'summary',
+        sections: getGptExecutionPlanAvailableSections('self_heal.status'),
+        shouldUseAsync: false,
+        source: 'planner',
+      }) as GptControlExecutionPlan<'self_heal.status'>,
+    routeMeta,
+    logger: params.req.logger,
+    logEvent: 'gpt.response.self_heal_status',
+  });
+  return {
+    kind: 'prepared',
+    statusCode: 200,
+    payload: shapedSelfHealStatus.payload,
+    headers: {
+      'x-response-bytes': String(shapedSelfHealStatus.responseBytes),
+      ...(
+        shapedSelfHealStatus.explicitTruncated || shapedSelfHealStatus.truncated
+          ? { 'x-response-truncated': 'true' }
+          : {}
+      ),
+    },
+  };
+}
+
 function normalizeCompletedAsyncGptResponse(
   output: unknown
 ): ({
@@ -1182,125 +1623,35 @@ router.post("/:gptId", async (req, res, next) => {
           }, 'gpt.response.job_result');
         }
 
-        if (planeClassification.plane === 'control' && planeClassification.kind === 'diagnostics') {
-          const diagnostics = await getDiagnosticsSnapshot(req.app);
-          requestLogger?.info?.('gpt.request.diagnostics', {
-            endpoint: req.originalUrl,
-            gptId: incomingGptId,
-            internal: true,
-            registeredGpts: Array.isArray(diagnostics.registered_gpts)
-              ? diagnostics.registered_gpts.length
-              : diagnostics.registered_gpts,
-            routeCount: Array.isArray(diagnostics.active_routes)
-              ? diagnostics.active_routes.length
-              : diagnostics.active_routes
-          });
-          recordGptRequestEvent({
-            event: 'control_direct',
-            source: 'diagnostics'
-          });
-
-          const diagnosticsSerializationStartedAt = Date.now();
-          const diagnosticsPayload = prepareBoundedClientJsonPayload(
-            diagnostics as unknown as Record<string, unknown>,
-            {
-              logger: req.logger,
-              logEvent: 'gpt.response.diagnostics'
-            }
-          );
-          requestLogger?.info?.('gpt.response.serialization', {
-            endpoint: req.originalUrl,
-            gptId: incomingGptId,
-            action: 'diagnostics',
-            serializationMs: Date.now() - diagnosticsSerializationStartedAt,
-            responseBytes: diagnosticsPayload.responseBytes,
-            truncated: diagnosticsPayload.truncated,
-          });
-
-          res.setHeader('x-response-bytes', String(diagnosticsPayload.responseBytes));
-          if (diagnosticsPayload.truncated) {
-            res.setHeader('x-response-truncated', 'true');
-          }
-          return res.json(diagnosticsPayload.payload);
-        }
-
-        if (planeClassification.plane === 'control' && planeClassification.kind === 'system_state') {
-          const routeMeta = buildDirectControlRouteMeta({
-            requestId,
-            gptId: incomingGptId,
-            action: 'system_state',
-            route: 'system_state'
-          });
-
-          if (!ARCANOS_CORE_GPT_IDS.has(incomingGptId)) {
-            requestLogger?.warn?.('gpt.request.system_state_rejected', {
-              endpoint: req.originalUrl,
-              gptId: incomingGptId,
+        if (planeClassification.plane === 'control') {
+          const directControlAction = normalizeGptDirectControlAction(planeClassification.action);
+          if (directControlAction) {
+            const directControlResponse = await dispatchDirectControlAction({
+              req,
               requestId,
-              reason: 'non_core_gpt'
+              gptId: incomingGptId,
+              action: directControlAction,
+              normalizedBody,
+              promptText,
+              logger: requestLogger,
             });
-            return res.status(400).json({
-              ok: false,
-              error: {
-                code: 'SYSTEM_STATE_REQUIRES_CORE_GPT',
-                message: 'system_state requests must target an ARCANOS core GPT id.'
-              },
-              _route: routeMeta
-            });
-          }
 
-          try {
-            const systemStateResult = await executeSystemStateRequest(
-              buildDirectControlPayload(normalizedBody)
+            if (directControlResponse.kind === 'prepared') {
+              for (const [headerName, headerValue] of Object.entries(
+                directControlResponse.headers ?? {}
+              )) {
+                res.setHeader(headerName, headerValue);
+              }
+              return res.status(directControlResponse.statusCode).json(directControlResponse.payload);
+            }
+
+            return sendGuardedGptJsonResponse(
+              req,
+              res,
+              directControlResponse.payload,
+              directControlResponse.logEvent,
+              directControlResponse.statusCode
             );
-            requestLogger?.info?.('gpt.request.system_state', {
-              endpoint: req.originalUrl,
-              gptId: incomingGptId,
-              requestId,
-              route: 'system_state'
-            });
-            recordGptRequestEvent({
-              event: 'control_direct',
-              source: 'system_state'
-            });
-            return res.status(200).json({
-              ok: true,
-              result: systemStateResult,
-              _route: routeMeta
-            });
-          } catch (error) {
-            if (error instanceof SystemStateConflictError) {
-              requestLogger?.warn?.('gpt.request.system_state_conflict', {
-                endpoint: req.originalUrl,
-                gptId: incomingGptId,
-                requestId,
-                conflict: error.conflict
-              });
-              return res.status(409).json({
-                ok: false,
-                error: {
-                  code: error.code,
-                  message: error.message,
-                  details: error.conflict
-                },
-                _route: routeMeta
-              });
-            }
-
-            requestLogger?.warn?.('gpt.request.system_state_invalid', {
-              endpoint: req.originalUrl,
-              gptId: incomingGptId,
-              requestId,
-              error: resolveErrorMessage(error)
-            });
-            return res.status(400).json({
-              ok: false,
-              error: {
-                code: 'BAD_REQUEST',
-                message: resolveErrorMessage(error)
-              },
-              _route: routeMeta
-            });
           }
         }
 

--- a/src/shared/gpt/asyncGptJob.ts
+++ b/src/shared/gpt/asyncGptJob.ts
@@ -16,6 +16,7 @@ const queuedGptJobInputSchema = z.object({
   gptId: z.string().trim().min(1).max(128),
   body: z.record(jsonValueSchema),
   prompt: z.string().trim().min(1).optional(),
+  bypassIntentRouting: z.boolean().optional(),
   requestId: z.string().trim().min(1).max(128).optional(),
   routeHint: z.string().trim().min(1).max(64).optional(),
   requestPath: z.string().trim().min(1).max(256).optional(),
@@ -26,6 +27,7 @@ export interface QueuedGptJobInput {
   gptId: string;
   body: Record<string, unknown>;
   prompt?: string;
+  bypassIntentRouting?: boolean;
   requestId?: string;
   routeHint?: string;
   requestPath?: string;
@@ -71,6 +73,7 @@ export function buildQueuedGptJobInput(input: {
   gptId: string;
   body: Record<string, unknown>;
   prompt?: string | null;
+  bypassIntentRouting?: boolean;
   requestId?: string | null;
   routeHint?: string | null;
   requestPath?: string | null;
@@ -84,6 +87,10 @@ export function buildQueuedGptJobInput(input: {
   const normalizedPrompt = normalizeOptionalString(input.prompt ?? undefined);
   if (normalizedPrompt) {
     normalizedJobInput.prompt = normalizedPrompt;
+  }
+
+  if (input.bypassIntentRouting === true) {
+    normalizedJobInput.bypassIntentRouting = true;
   }
 
   const normalizedRequestId = normalizeOptionalString(input.requestId ?? undefined);

--- a/src/shared/gpt/gptControlActions.ts
+++ b/src/shared/gpt/gptControlActions.ts
@@ -1,0 +1,42 @@
+export const GPT_DIRECT_CONTROL_ACTIONS = [
+  'diagnostics',
+  'system_state',
+  'runtime.inspect',
+  'workers.status',
+  'queue.inspect',
+  'self_heal.status',
+] as const;
+
+export type GptDirectControlAction = (typeof GPT_DIRECT_CONTROL_ACTIONS)[number];
+
+const GPT_DIRECT_CONTROL_ACTION_ALIASES: Record<string, GptDirectControlAction> = {
+  diagnostics: 'diagnostics',
+  system_state: 'system_state',
+  'runtime.inspect': 'runtime.inspect',
+  'workers.status': 'workers.status',
+  'queue.inspect': 'queue.inspect',
+  'self_heal.status': 'self_heal.status',
+  'self-heal.status': 'self_heal.status',
+};
+
+const GPT_RESERVED_CONTROL_PREFIXES = ['runtime.', 'workers.', 'queue.', 'self_heal.', 'self-heal.'];
+
+function normalizeAction(action: string | null | undefined): string | null {
+  return typeof action === 'string' && action.trim().length > 0
+    ? action.trim().toLowerCase()
+    : null;
+}
+
+export function normalizeGptDirectControlAction(
+  action: string | null | undefined
+): GptDirectControlAction | null {
+  const normalizedAction = normalizeAction(action);
+  return normalizedAction ? GPT_DIRECT_CONTROL_ACTION_ALIASES[normalizedAction] ?? null : null;
+}
+
+export function isReservedGptControlNamespace(action: string | null | undefined): boolean {
+  const normalizedAction = normalizeAction(action);
+  return normalizedAction
+    ? GPT_RESERVED_CONTROL_PREFIXES.some((prefix) => normalizedAction.startsWith(prefix))
+    : false;
+}

--- a/src/shared/gpt/gptControlResponseShape.ts
+++ b/src/shared/gpt/gptControlResponseShape.ts
@@ -4,7 +4,7 @@ import {
   measureJsonBytes,
   readBoolean,
   readString,
-  resolveClientResponseMaxBytes,
+  resolveGptPublicResponseMaxBytes,
   truncateText,
 } from '@shared/http/clientResponseCommon.js';
 import { prepareBoundedClientJsonPayload } from '@shared/http/clientJsonPayload.js';
@@ -44,7 +44,7 @@ const DETAIL_PRUNE_BUDGETS: Record<GptExecutionPlanDetail, DetailPruneBudget> = 
 };
 
 const PARTIAL_RESPONSE_MESSAGE =
-  'Response exceeded public route bounds. Narrow sections or use a less verbose detail level.';
+  'Response exceeded public route bounds. Narrow sections or reduce detail.';
 
 type PlannedControlPreparedResponse = PreparedClientJsonPayload<Record<string, unknown>> & {
   explicitTruncated: boolean;
@@ -393,6 +393,7 @@ function buildMinimalPartialEnvelope(params: {
         generatedAt: params.generatedAt,
         availableSections: getGptExecutionPlanAvailableSections(params.action),
         truncated: true,
+        returnedSections: [],
         omittedSections: params.omittedSections,
       }),
       message: PARTIAL_RESPONSE_MESSAGE,
@@ -419,6 +420,7 @@ function buildMinimalPartialEnvelope(params: {
       generatedAt: params.generatedAt,
       availableSections: getGptExecutionPlanAvailableSections(params.action),
       truncated: true,
+      returnedSections: [],
       omittedSections: params.omittedSections,
     }),
     message: PARTIAL_RESPONSE_MESSAGE,
@@ -466,8 +468,9 @@ export function prepareShapedControlResponse(params: {
   routeMeta: Record<string, unknown>;
   logger?: RequestScopedLogger;
   logEvent?: string;
+  maxResponseBytes?: number;
 }): PlannedControlPreparedResponse {
-  const maxResponseBytes = resolveClientResponseMaxBytes();
+  const maxResponseBytes = resolveGptPublicResponseMaxBytes(params.maxResponseBytes);
   const generatedAt = new Date().toISOString();
   const initialReturnedSections = [...params.plan.sections];
   let returnedSections = [...initialReturnedSections];

--- a/src/shared/gpt/gptControlResponseShape.ts
+++ b/src/shared/gpt/gptControlResponseShape.ts
@@ -270,6 +270,7 @@ function buildRuntimeInspectionEnvelope(params: {
   rawResult: Record<string, unknown>;
   plan: GptExecutionPlan<'runtime.inspect'>;
   routeMeta: Record<string, unknown>;
+  generatedAt: string;
   returnedSections: string[];
   omittedSections: string[];
   truncated: boolean;
@@ -295,6 +296,7 @@ function buildRuntimeInspectionEnvelope(params: {
     },
     meta: buildGptControlResponseMeta({
       plan: params.plan,
+      generatedAt: params.generatedAt,
       availableSections: getGptExecutionPlanAvailableSections(params.action),
       truncated: params.truncated,
       returnedSections: actualReturnedSections,
@@ -310,6 +312,7 @@ function buildSelfHealEnvelope(params: {
   rawResult: Record<string, unknown>;
   plan: GptExecutionPlan<'self_heal.status'>;
   routeMeta: Record<string, unknown>;
+  generatedAt: string;
   returnedSections: string[];
   omittedSections: string[];
   truncated: boolean;
@@ -350,6 +353,7 @@ function buildSelfHealEnvelope(params: {
     },
     meta: buildGptControlResponseMeta({
       plan: params.plan,
+      generatedAt: params.generatedAt,
       availableSections: getGptExecutionPlanAvailableSections(params.action),
       truncated: params.truncated,
       returnedSections: actualReturnedSections,
@@ -365,6 +369,7 @@ function buildMinimalPartialEnvelope(params: {
   rawResult: Record<string, unknown>;
   plan: GptExecutionPlan<ShapableControlAction>;
   routeMeta: Record<string, unknown>;
+  generatedAt: string;
   omittedSections: string[];
 }): Record<string, unknown> {
   if (params.action === 'runtime.inspect') {
@@ -385,6 +390,7 @@ function buildMinimalPartialEnvelope(params: {
       },
       meta: buildGptControlResponseMeta({
         plan: params.plan,
+        generatedAt: params.generatedAt,
         availableSections: getGptExecutionPlanAvailableSections(params.action),
         truncated: true,
         omittedSections: params.omittedSections,
@@ -410,6 +416,7 @@ function buildMinimalPartialEnvelope(params: {
     },
     meta: buildGptControlResponseMeta({
       plan: params.plan,
+      generatedAt: params.generatedAt,
       availableSections: getGptExecutionPlanAvailableSections(params.action),
       truncated: true,
       omittedSections: params.omittedSections,
@@ -424,6 +431,7 @@ function buildEnvelope(params: {
   rawResult: Record<string, unknown>;
   plan: GptExecutionPlan<ShapableControlAction>;
   routeMeta: Record<string, unknown>;
+  generatedAt: string;
   returnedSections: string[];
   omittedSections: string[];
   truncated: boolean;
@@ -434,6 +442,7 @@ function buildEnvelope(params: {
         rawResult: params.rawResult,
         plan: params.plan as GptExecutionPlan<'runtime.inspect'>,
         routeMeta: params.routeMeta,
+        generatedAt: params.generatedAt,
         returnedSections: params.returnedSections,
         omittedSections: params.omittedSections,
         truncated: params.truncated,
@@ -443,6 +452,7 @@ function buildEnvelope(params: {
         rawResult: params.rawResult,
         plan: params.plan as GptExecutionPlan<'self_heal.status'>,
         routeMeta: params.routeMeta,
+        generatedAt: params.generatedAt,
         returnedSections: params.returnedSections,
         omittedSections: params.omittedSections,
         truncated: params.truncated,
@@ -458,6 +468,7 @@ export function prepareShapedControlResponse(params: {
   logEvent?: string;
 }): PlannedControlPreparedResponse {
   const maxResponseBytes = resolveClientResponseMaxBytes();
+  const generatedAt = new Date().toISOString();
   const initialReturnedSections = [...params.plan.sections];
   let returnedSections = [...initialReturnedSections];
   let omittedSections: string[] = [];
@@ -467,6 +478,7 @@ export function prepareShapedControlResponse(params: {
     rawResult: params.rawResult,
     plan: params.plan,
     routeMeta: params.routeMeta,
+    generatedAt,
     returnedSections,
     omittedSections,
     truncated: false,
@@ -483,6 +495,7 @@ export function prepareShapedControlResponse(params: {
       rawResult: params.rawResult,
       plan: params.plan,
       routeMeta: params.routeMeta,
+      generatedAt,
       returnedSections,
       omittedSections,
       truncated: true,
@@ -498,6 +511,7 @@ export function prepareShapedControlResponse(params: {
       rawResult: params.rawResult,
       plan: params.plan,
       routeMeta: params.routeMeta,
+      generatedAt,
       omittedSections,
     });
   }
@@ -516,6 +530,7 @@ export function prepareShapedControlResponse(params: {
         rawResult: params.rawResult,
         plan: params.plan,
         routeMeta: params.routeMeta,
+        generatedAt,
         omittedSections: [...initialReturnedSections],
       }),
       {

--- a/src/shared/gpt/gptControlResponseShape.ts
+++ b/src/shared/gpt/gptControlResponseShape.ts
@@ -1,0 +1,533 @@
+import type { PreparedClientJsonPayload } from '@shared/http/clientResponseCommon.js';
+import {
+  isRecord,
+  measureJsonBytes,
+  readBoolean,
+  readString,
+  resolveClientResponseMaxBytes,
+  truncateText,
+} from '@shared/http/clientResponseCommon.js';
+import { prepareBoundedClientJsonPayload } from '@shared/http/clientJsonPayload.js';
+import type { RequestScopedLogger } from '@shared/http/types.js';
+
+import {
+  buildGptControlResponseMeta,
+  getGptExecutionPlanAvailableSections,
+  type GptExecutionPlan,
+  type GptExecutionPlanDetail,
+} from './gptExecutionPlanner.js';
+
+type ShapableControlAction = 'runtime.inspect' | 'self_heal.status';
+
+type DetailPruneBudget = {
+  maxDepth: number;
+  maxArrayItems: number;
+  maxStringBytes: number;
+};
+
+const DETAIL_PRUNE_BUDGETS: Record<GptExecutionPlanDetail, DetailPruneBudget> = {
+  summary: {
+    maxDepth: 2,
+    maxArrayItems: 4,
+    maxStringBytes: 240,
+  },
+  standard: {
+    maxDepth: 3,
+    maxArrayItems: 8,
+    maxStringBytes: 1_024,
+  },
+  full: {
+    maxDepth: 5,
+    maxArrayItems: 24,
+    maxStringBytes: 4_096,
+  },
+};
+
+const PARTIAL_RESPONSE_MESSAGE =
+  'Response exceeded public route bounds. Narrow sections or use a less verbose detail level.';
+
+type PlannedControlPreparedResponse = PreparedClientJsonPayload<Record<string, unknown>> & {
+  explicitTruncated: boolean;
+};
+
+function pruneForDetail(value: unknown, detail: GptExecutionPlanDetail, depth = 0): unknown {
+  const budget = DETAIL_PRUNE_BUDGETS[detail];
+
+  if (typeof value === 'string') {
+    return truncateText(value, budget.maxStringBytes);
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean' || value === null) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    if (depth >= budget.maxDepth) {
+      return { total: value.length };
+    }
+
+    return value
+      .slice(0, budget.maxArrayItems)
+      .map((entry) => pruneForDetail(entry, detail, depth + 1))
+      .filter((entry) => entry !== undefined);
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  if (depth >= budget.maxDepth) {
+    return undefined;
+  }
+
+  const output: Record<string, unknown> = {};
+  for (const [key, entryValue] of Object.entries(value)) {
+    const normalized = pruneForDetail(entryValue, detail, depth + 1);
+    if (normalized !== undefined) {
+      output[key] = normalized;
+    }
+  }
+
+  return Object.keys(output).length > 0 ? output : undefined;
+}
+
+function mapSourceRecord(source: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...(readString(source.sourceType) ? { sourceType: readString(source.sourceType) } : {}),
+    ...(readString(source.tool) ? { tool: readString(source.tool) } : {}),
+    ...(Object.prototype.hasOwnProperty.call(source, 'data') ? { data: source.data } : {}),
+  };
+}
+
+function buildRuntimeInspectionSectionCatalog(
+  runtimeInspection: Record<string, unknown>,
+): Record<string, unknown> {
+  const sources = Array.isArray(runtimeInspection.sources)
+    ? runtimeInspection.sources.filter(isRecord).map(mapSourceRecord)
+    : [];
+
+  const workerSources = sources.filter((source) => {
+    const tool = readString(source.tool) ?? '';
+    return tool === '/workers/status' ||
+      tool === '/worker-helper/health' ||
+      tool === 'cli:workers';
+  });
+  const memorySources = sources.filter((source) => (readString(source.tool) ?? '') === 'system.metrics');
+  const eventSources = sources.filter((source) => {
+    const tool = readString(source.tool) ?? '';
+    return tool === '/api/self-heal/events' || tool === 'cli:logs_recent';
+  });
+  const traceSources = sources.filter((source) => (readString(source.tool) ?? '') === '/api/self-heal/inspection');
+
+  return {
+    workers: {
+      sources: workerSources,
+    },
+    queues: {
+      sources: workerSources,
+    },
+    memory: {
+      metrics: memorySources,
+    },
+    incidents: {
+      failures: Array.isArray(runtimeInspection.failures) ? runtimeInspection.failures : [],
+      workerSources,
+    },
+    events: {
+      eventSources,
+    },
+    trace: {
+      detectedIntent: runtimeInspection.detectedIntent,
+      matchedKeywords: runtimeInspection.matchedKeywords,
+      toolsSelected: runtimeInspection.toolsSelected,
+      runtimeEndpointsQueried: runtimeInspection.runtimeEndpointsQueried,
+      repoInspectionDisabled: runtimeInspection.repoInspectionDisabled,
+      onlyReturnRuntimeValues: runtimeInspection.onlyReturnRuntimeValues,
+      evidence: runtimeInspection.evidence,
+      traceSources,
+    },
+  };
+}
+
+function buildSelfHealSectionCatalog(
+  selfHealStatus: Record<string, unknown>,
+): Record<string, unknown> {
+  const predictiveHealing = isRecord(selfHealStatus.predictiveHealing)
+    ? selfHealStatus.predictiveHealing
+    : null;
+  const recentObservations = Array.isArray(predictiveHealing?.recentObservations)
+    ? predictiveHealing.recentObservations
+    : [];
+  const latestObservation = recentObservations.length > 0
+    ? recentObservations[recentObservations.length - 1]
+    : null;
+  const inspection = isRecord(selfHealStatus.inspection)
+    ? selfHealStatus.inspection
+    : null;
+
+  return {
+    system: {
+      status: selfHealStatus.status,
+      enabled: selfHealStatus.enabled,
+      active: selfHealStatus.active,
+      isHealing: selfHealStatus.isHealing,
+      systemState: selfHealStatus.systemState,
+      trinity: selfHealStatus.trinity,
+    },
+    workers: {
+      loopRunning: selfHealStatus.loopRunning,
+      inFlight: selfHealStatus.inFlight,
+      lastDiagnosis: selfHealStatus.lastDiagnosis,
+      lastAction: selfHealStatus.lastAction,
+      lastActionAt: selfHealStatus.lastActionAt,
+      inspection: inspection
+        ? {
+            lastDispatchAttempt: inspection.lastDispatchAttempt,
+            lastDispatchTarget: inspection.lastDispatchTarget,
+            lastWorkerReceipt: inspection.lastWorkerReceipt,
+            lastHealResult: inspection.lastHealResult,
+          }
+        : null,
+    },
+    memory: {
+      latestObservation,
+      aiProvider: predictiveHealing?.aiProvider ?? null,
+      trends: predictiveHealing?.trends ?? null,
+    },
+    incidents: {
+      degradedModeReason: selfHealStatus.degradedModeReason,
+      activeMitigation: selfHealStatus.activeMitigation,
+      recentTimeoutCounts: selfHealStatus.recentTimeoutCounts,
+      lastError: selfHealStatus.lastError,
+      lastFailure: selfHealStatus.lastFailure,
+      lastFallback: selfHealStatus.lastFallback,
+      promptRouteMitigation: selfHealStatus.promptRouteMitigation,
+    },
+    events: {
+      recentEvents: Array.isArray(selfHealStatus.recentEvents) ? selfHealStatus.recentEvents : [],
+    },
+    trace: {
+      inspection,
+      loop: selfHealStatus.loop,
+      controlLoop: selfHealStatus.controlLoop,
+      lastVerificationResult: selfHealStatus.lastVerificationResult,
+    },
+    predictive: predictiveHealing,
+  };
+}
+
+function buildRuntimeInspectionSummary(runtimeInspection: Record<string, unknown>): string {
+  const explicitSummary = readString(runtimeInspection.summary);
+  if (explicitSummary) {
+    return explicitSummary;
+  }
+
+  const selectedTools = Array.isArray(runtimeInspection.toolsSelected)
+    ? runtimeInspection.toolsSelected.length
+    : 0;
+  return `Collected live runtime state from ${selectedTools} runtime sources.`;
+}
+
+function buildSelfHealSummary(selfHealStatus: Record<string, unknown>): string {
+  const status = readString(selfHealStatus.status) ?? 'ok';
+  const enabled = readBoolean(selfHealStatus.enabled);
+  const active = readBoolean(selfHealStatus.active);
+  const isHealing = readBoolean(selfHealStatus.isHealing);
+  const lastAction = readString(selfHealStatus.lastHealAction) ?? readString(selfHealStatus.lastAction);
+  const systemState = isRecord(selfHealStatus.systemState)
+    ? readString(selfHealStatus.systemState.status)
+    : null;
+
+  return truncateText(
+    `Self-heal status is ${status}; enabled=${enabled === true}; active=${active === true}; healing=${isHealing === true}; lastAction=${lastAction ?? 'unknown'}; systemState=${systemState ?? 'unknown'}.`,
+    240,
+  );
+}
+
+function buildShapedSections(
+  catalog: Record<string, unknown>,
+  sections: string[],
+  detail: GptExecutionPlanDetail,
+): Record<string, unknown> {
+  const shapedSections: Record<string, unknown> = {};
+
+  for (const section of sections) {
+    if (!Object.prototype.hasOwnProperty.call(catalog, section)) {
+      continue;
+    }
+
+    const pruned = pruneForDetail(catalog[section], detail);
+    if (pruned !== undefined) {
+      shapedSections[section] = pruned;
+    }
+  }
+
+  return shapedSections;
+}
+
+function buildRuntimeInspectionEnvelope(params: {
+  action: 'runtime.inspect';
+  rawResult: Record<string, unknown>;
+  plan: GptExecutionPlan<'runtime.inspect'>;
+  routeMeta: Record<string, unknown>;
+  returnedSections: string[];
+  omittedSections: string[];
+  truncated: boolean;
+}): Record<string, unknown> {
+  const runtimeInspection = isRecord(params.rawResult.runtimeInspection)
+    ? params.rawResult.runtimeInspection
+    : {};
+  const catalog = buildRuntimeInspectionSectionCatalog(runtimeInspection);
+  const shapedSections = buildShapedSections(catalog, params.returnedSections, params.plan.detail);
+  const actualReturnedSections = Object.keys(shapedSections);
+
+  return {
+    ok: true,
+    action: params.action,
+    ...(params.truncated ? { status: 'partial' } : {}),
+    result: {
+      handledBy: readString(params.rawResult.handledBy) ?? 'runtime-inspection',
+      runtimeInspection: {
+        status: readString(runtimeInspection.status) ?? 'ok',
+        summary: buildRuntimeInspectionSummary(runtimeInspection),
+        ...(actualReturnedSections.length > 0 ? { sections: shapedSections } : {}),
+      },
+    },
+    meta: buildGptControlResponseMeta({
+      plan: params.plan,
+      availableSections: getGptExecutionPlanAvailableSections(params.action),
+      truncated: params.truncated,
+      returnedSections: actualReturnedSections,
+      omittedSections: params.omittedSections,
+    }),
+    ...(params.truncated ? { message: PARTIAL_RESPONSE_MESSAGE } : {}),
+    _route: params.routeMeta,
+  };
+}
+
+function buildSelfHealEnvelope(params: {
+  action: 'self_heal.status';
+  rawResult: Record<string, unknown>;
+  plan: GptExecutionPlan<'self_heal.status'>;
+  routeMeta: Record<string, unknown>;
+  returnedSections: string[];
+  omittedSections: string[];
+  truncated: boolean;
+}): Record<string, unknown> {
+  const catalog = buildSelfHealSectionCatalog(params.rawResult);
+  const shapedSections = buildShapedSections(catalog, params.returnedSections, params.plan.detail);
+  const actualReturnedSections = Object.keys(shapedSections);
+
+  return {
+    ok: true,
+    action: params.action,
+    ...(params.truncated ? { status: 'partial' } : {}),
+    result: {
+      status: readString(params.rawResult.status) ?? 'ok',
+      ...(readBoolean(params.rawResult.enabled) !== undefined
+        ? { enabled: readBoolean(params.rawResult.enabled) }
+        : {}),
+      ...(readBoolean(params.rawResult.active) !== undefined
+        ? { active: readBoolean(params.rawResult.active) }
+        : {}),
+      ...(readBoolean(params.rawResult.isHealing) !== undefined
+        ? { isHealing: readBoolean(params.rawResult.isHealing) }
+        : {}),
+      ...(readString(params.rawResult.lastHealAction)
+        ? { lastHealAction: readString(params.rawResult.lastHealAction) }
+        : {}),
+      ...(readString(params.rawResult.lastHealRun)
+        ? { lastHealRun: readString(params.rawResult.lastHealRun) }
+        : {}),
+      ...(readString(params.rawResult.lastTriggerReason)
+        ? { lastTriggerReason: readString(params.rawResult.lastTriggerReason) }
+        : {}),
+      ...(readString(params.rawResult.lastHealedComponent)
+        ? { lastHealedComponent: readString(params.rawResult.lastHealedComponent) }
+        : {}),
+      summary: buildSelfHealSummary(params.rawResult),
+      ...(actualReturnedSections.length > 0 ? { sections: shapedSections } : {}),
+    },
+    meta: buildGptControlResponseMeta({
+      plan: params.plan,
+      availableSections: getGptExecutionPlanAvailableSections(params.action),
+      truncated: params.truncated,
+      returnedSections: actualReturnedSections,
+      omittedSections: params.omittedSections,
+    }),
+    ...(params.truncated ? { message: PARTIAL_RESPONSE_MESSAGE } : {}),
+    _route: params.routeMeta,
+  };
+}
+
+function buildMinimalPartialEnvelope(params: {
+  action: ShapableControlAction;
+  rawResult: Record<string, unknown>;
+  plan: GptExecutionPlan<ShapableControlAction>;
+  routeMeta: Record<string, unknown>;
+  omittedSections: string[];
+}): Record<string, unknown> {
+  if (params.action === 'runtime.inspect') {
+    const runtimeInspection = isRecord(params.rawResult.runtimeInspection)
+      ? params.rawResult.runtimeInspection
+      : {};
+
+    return {
+      ok: true,
+      action: params.action,
+      status: 'partial',
+      result: {
+        handledBy: readString(params.rawResult.handledBy) ?? 'runtime-inspection',
+        runtimeInspection: {
+          status: readString(runtimeInspection.status) ?? 'ok',
+          summary: buildRuntimeInspectionSummary(runtimeInspection),
+        },
+      },
+      meta: buildGptControlResponseMeta({
+        plan: params.plan,
+        availableSections: getGptExecutionPlanAvailableSections(params.action),
+        truncated: true,
+        omittedSections: params.omittedSections,
+      }),
+      message: PARTIAL_RESPONSE_MESSAGE,
+      _route: params.routeMeta,
+    };
+  }
+
+  return {
+    ok: true,
+    action: params.action,
+    status: 'partial',
+    result: {
+      status: readString(params.rawResult.status) ?? 'ok',
+      ...(readBoolean(params.rawResult.enabled) !== undefined
+        ? { enabled: readBoolean(params.rawResult.enabled) }
+        : {}),
+      ...(readBoolean(params.rawResult.active) !== undefined
+        ? { active: readBoolean(params.rawResult.active) }
+        : {}),
+      summary: buildSelfHealSummary(params.rawResult),
+    },
+    meta: buildGptControlResponseMeta({
+      plan: params.plan,
+      availableSections: getGptExecutionPlanAvailableSections(params.action),
+      truncated: true,
+      omittedSections: params.omittedSections,
+    }),
+    message: PARTIAL_RESPONSE_MESSAGE,
+    _route: params.routeMeta,
+  };
+}
+
+function buildEnvelope(params: {
+  action: ShapableControlAction;
+  rawResult: Record<string, unknown>;
+  plan: GptExecutionPlan<ShapableControlAction>;
+  routeMeta: Record<string, unknown>;
+  returnedSections: string[];
+  omittedSections: string[];
+  truncated: boolean;
+}): Record<string, unknown> {
+  return params.action === 'runtime.inspect'
+    ? buildRuntimeInspectionEnvelope({
+        action: params.action,
+        rawResult: params.rawResult,
+        plan: params.plan as GptExecutionPlan<'runtime.inspect'>,
+        routeMeta: params.routeMeta,
+        returnedSections: params.returnedSections,
+        omittedSections: params.omittedSections,
+        truncated: params.truncated,
+      })
+    : buildSelfHealEnvelope({
+        action: params.action,
+        rawResult: params.rawResult,
+        plan: params.plan as GptExecutionPlan<'self_heal.status'>,
+        routeMeta: params.routeMeta,
+        returnedSections: params.returnedSections,
+        omittedSections: params.omittedSections,
+        truncated: params.truncated,
+      });
+}
+
+export function prepareShapedControlResponse(params: {
+  action: ShapableControlAction;
+  rawResult: Record<string, unknown>;
+  plan: GptExecutionPlan<ShapableControlAction>;
+  routeMeta: Record<string, unknown>;
+  logger?: RequestScopedLogger;
+  logEvent?: string;
+}): PlannedControlPreparedResponse {
+  const maxResponseBytes = resolveClientResponseMaxBytes();
+  const initialReturnedSections = [...params.plan.sections];
+  let returnedSections = [...initialReturnedSections];
+  let omittedSections: string[] = [];
+  let explicitTruncated = false;
+  let envelope = buildEnvelope({
+    action: params.action,
+    rawResult: params.rawResult,
+    plan: params.plan,
+    routeMeta: params.routeMeta,
+    returnedSections,
+    omittedSections,
+    truncated: false,
+  });
+
+  while (measureJsonBytes(envelope) > maxResponseBytes && returnedSections.length > 0) {
+    explicitTruncated = true;
+    const removedSection = returnedSections.pop();
+    if (removedSection) {
+      omittedSections = [...omittedSections, removedSection];
+    }
+    envelope = buildEnvelope({
+      action: params.action,
+      rawResult: params.rawResult,
+      plan: params.plan,
+      routeMeta: params.routeMeta,
+      returnedSections,
+      omittedSections,
+      truncated: true,
+    });
+  }
+
+  if (measureJsonBytes(envelope) > maxResponseBytes) {
+    explicitTruncated = true;
+    omittedSections = [...initialReturnedSections];
+    returnedSections = [];
+    envelope = buildMinimalPartialEnvelope({
+      action: params.action,
+      rawResult: params.rawResult,
+      plan: params.plan,
+      routeMeta: params.routeMeta,
+      omittedSections,
+    });
+  }
+
+  let preparedPayload = prepareBoundedClientJsonPayload(envelope, {
+    logger: params.logger,
+    logEvent: params.logEvent,
+    maxBytes: maxResponseBytes,
+  });
+
+  if (preparedPayload.truncated) {
+    explicitTruncated = true;
+    preparedPayload = prepareBoundedClientJsonPayload(
+      buildMinimalPartialEnvelope({
+        action: params.action,
+        rawResult: params.rawResult,
+        plan: params.plan,
+        routeMeta: params.routeMeta,
+        omittedSections: [...initialReturnedSections],
+      }),
+      {
+        logger: params.logger,
+        logEvent: params.logEvent,
+        maxBytes: maxResponseBytes,
+      },
+    );
+  }
+
+  return {
+    ...preparedPayload,
+    explicitTruncated,
+  };
+}

--- a/src/shared/gpt/gptExecutionPlanner.ts
+++ b/src/shared/gpt/gptExecutionPlanner.ts
@@ -340,10 +340,10 @@ export function buildGptControlResponseMeta(params: {
     detail: params.plan.detail,
     truncated: params.truncated,
     availableSections: [...params.availableSections],
-    ...(params.returnedSections && params.returnedSections.length > 0
+    ...(params.returnedSections
       ? { returnedSections: [...params.returnedSections] }
       : {}),
-    ...(params.omittedSections && params.omittedSections.length > 0
+    ...(params.omittedSections
       ? { omittedSections: [...params.omittedSections] }
       : {}),
     generatedAt: params.generatedAt ?? new Date().toISOString(),

--- a/src/shared/gpt/gptExecutionPlanner.ts
+++ b/src/shared/gpt/gptExecutionPlanner.ts
@@ -297,7 +297,7 @@ function normalizeSections(
       sections
         .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
         .map((value) => value.trim().toLowerCase())
-    ).values()
+    )
   );
 
   const unsupportedSections = normalizedSections.filter(

--- a/src/shared/gpt/gptExecutionPlanner.ts
+++ b/src/shared/gpt/gptExecutionPlanner.ts
@@ -1,0 +1,414 @@
+import type { GptDirectControlAction } from './gptControlActions.js';
+
+export const GPT_EXECUTION_PLAN_DETAILS = ['summary', 'standard', 'full'] as const;
+
+export type GptExecutionPlanDetail = (typeof GPT_EXECUTION_PLAN_DETAILS)[number];
+export type GptExecutionPlanSource = 'explicit' | 'planner';
+export type GptPlannableControlAction =
+  | 'runtime.inspect'
+  | 'workers.status'
+  | 'queue.inspect'
+  | 'self_heal.status';
+
+export interface GptExecutionPlan<Action extends GptPlannableControlAction = GptPlannableControlAction> {
+  action: Action;
+  detail: GptExecutionPlanDetail;
+  sections: string[];
+  shouldUseAsync: boolean;
+  source: GptExecutionPlanSource;
+}
+
+export interface GptControlResponseMeta {
+  detail: GptExecutionPlanDetail;
+  truncated: boolean;
+  availableSections: string[];
+  returnedSections?: string[];
+  omittedSections?: string[];
+  generatedAt: string;
+  source: GptExecutionPlanSource;
+}
+
+type PlannerErrorCode = 'INVALID_GPT_DETAIL' | 'INVALID_GPT_SECTIONS';
+
+type PlannerErrorResult = {
+  ok: false;
+  error: {
+    code: PlannerErrorCode;
+    message: string;
+  };
+  canonical: Record<string, unknown>;
+};
+
+type PlannerSuccessResult<Action extends GptPlannableControlAction> = {
+  ok: true;
+  plan: GptExecutionPlan<Action>;
+  availableSections: string[];
+};
+
+export type GptExecutionPlannerResult<Action extends GptPlannableControlAction> =
+  | PlannerSuccessResult<Action>
+  | PlannerErrorResult;
+
+export interface GptExecutionPlannerInput<Action extends GptPlannableControlAction = GptPlannableControlAction> {
+  action: Action;
+  promptText?: string | null;
+  payload?: unknown;
+}
+
+export interface GptExecutionPlanner {
+  plan<Action extends GptPlannableControlAction>(
+    input: GptExecutionPlannerInput<Action>
+  ): GptExecutionPlannerResult<Action>;
+}
+
+const GPT_EXECUTION_PLAN_SECTION_ALLOWLIST: Record<GptPlannableControlAction, readonly string[]> = {
+  'runtime.inspect': ['workers', 'queues', 'memory', 'incidents', 'events', 'trace'],
+  'workers.status': ['workers', 'queues', 'incidents'],
+  'queue.inspect': ['queues', 'incidents'],
+  'self_heal.status': ['system', 'workers', 'memory', 'incidents', 'events', 'trace', 'predictive'],
+};
+
+const SUMMARY_DETAIL_PATTERN =
+  /\b(?:brief|briefly|summary|summarize|overview|healthy|health|compact|high[-\s]?level)\b/i;
+const INVESTIGATIVE_DETAIL_PATTERN =
+  /\b(?:why|analy[sz]e|analysis|investigat(?:e|ion|ing)|debug|issue|problem|incident|failure|failing|stuck|degraded|degradation|triage)\b/i;
+const FULL_DETAIL_PATTERN =
+  /\b(?:full|complete|raw|everything|all\s+details|near[-\s]?complete)\b/i;
+
+const SECTION_CUE_PATTERNS: Array<{
+  section: string;
+  pattern: RegExp;
+}> = [
+  { section: 'workers', pattern: /\bworkers?\b/i },
+  { section: 'queues', pattern: /\bqueues?\b|\bqueue\b/i },
+  { section: 'memory', pattern: /\bmemory\b|\bheap\b|\brss\b/i },
+  { section: 'incidents', pattern: /\bincident(?:s)?\b|\bfailure(?:s)?\b|\berror(?:s)?\b|\balerts?\b/i },
+  { section: 'events', pattern: /\bevents?\b|\blogs?\b/i },
+  { section: 'trace', pattern: /\btrace\b|\btimeline\b|\bhistory\b/i },
+  { section: 'system', pattern: /\bsystem\b|\bhealth\b/i },
+  { section: 'predictive', pattern: /\bpredictive\b|\bforecast\b|\btrend(?:s)?\b/i },
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizePrompt(promptText: string | null | undefined): string {
+  return typeof promptText === 'string' ? promptText.trim() : '';
+}
+
+function normalizeDetail(detail: unknown): GptExecutionPlanDetail | null {
+  return typeof detail === 'string' && detail.trim().length > 0
+    ? (GPT_EXECUTION_PLAN_DETAILS.find((value) => value === detail.trim().toLowerCase()) ?? null)
+    : null;
+}
+
+function normalizeBooleanLike(value: unknown): boolean | null {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'true' || normalized === '1' || normalized === 'yes') {
+    return true;
+  }
+  if (normalized === 'false' || normalized === '0' || normalized === 'no') {
+    return false;
+  }
+
+  return null;
+}
+
+function readPlannerPayloadRecord(payload: unknown): Record<string, unknown> | null {
+  return isRecord(payload) ? payload : null;
+}
+
+function inferDetailFromPrompt(
+  action: GptPlannableControlAction,
+  promptText: string,
+): GptExecutionPlanDetail {
+  if (FULL_DETAIL_PATTERN.test(promptText)) {
+    return 'full';
+  }
+
+  if (SUMMARY_DETAIL_PATTERN.test(promptText) && !INVESTIGATIVE_DETAIL_PATTERN.test(promptText)) {
+    return 'summary';
+  }
+
+  const inferredSections = inferSectionsFromPrompt(action, promptText);
+  if (INVESTIGATIVE_DETAIL_PATTERN.test(promptText) || inferredSections.length > 0) {
+    return 'standard';
+  }
+
+  if (action === 'runtime.inspect' || action === 'self_heal.status') {
+    return 'summary';
+  }
+
+  return 'standard';
+}
+
+function inferSectionsFromPrompt(
+  action: GptPlannableControlAction,
+  promptText: string,
+): string[] {
+  const availableSections = getGptExecutionPlanAvailableSections(action);
+  if (availableSections.length === 0 || !promptText) {
+    return [];
+  }
+
+  const matchedSections = SECTION_CUE_PATTERNS
+    .filter((entry) => entry.pattern.test(promptText))
+    .map((entry) => entry.section)
+    .filter((section) => availableSections.includes(section));
+
+  return Array.from(new Set(matchedSections));
+}
+
+function defaultSectionsForPlan(
+  action: GptPlannableControlAction,
+  detail: GptExecutionPlanDetail,
+): string[] {
+  switch (action) {
+    case 'runtime.inspect':
+      if (detail === 'summary') {
+        return ['workers', 'queues', 'memory', 'incidents'];
+      }
+      if (detail === 'standard') {
+        return ['workers', 'queues', 'memory', 'incidents', 'events'];
+      }
+      return [...GPT_EXECUTION_PLAN_SECTION_ALLOWLIST[action]];
+    case 'self_heal.status':
+      if (detail === 'summary') {
+        return ['system', 'incidents', 'workers', 'memory'];
+      }
+      if (detail === 'standard') {
+        return ['system', 'incidents', 'workers', 'memory', 'events', 'trace'];
+      }
+      return [...GPT_EXECUTION_PLAN_SECTION_ALLOWLIST[action]];
+    case 'workers.status':
+      return detail === 'summary'
+        ? ['workers', 'queues', 'incidents']
+        : [...GPT_EXECUTION_PLAN_SECTION_ALLOWLIST[action]];
+    case 'queue.inspect':
+      return detail === 'summary'
+        ? ['queues', 'incidents']
+        : [...GPT_EXECUTION_PLAN_SECTION_ALLOWLIST[action]];
+  }
+}
+
+function inferShouldUseAsync(
+  action: GptPlannableControlAction,
+  detail: GptExecutionPlanDetail,
+  sections: string[],
+  promptText: string,
+): boolean {
+  if (detail !== 'full') {
+    return false;
+  }
+
+  if (action !== 'runtime.inspect' && action !== 'self_heal.status') {
+    return false;
+  }
+
+  return sections.includes('events') ||
+    sections.includes('trace') ||
+    /\b(?:full|complete|raw|everything|history|trace|timeline)\b/i.test(promptText);
+}
+
+function readExplicitShouldUseAsync(payloadRecord: Record<string, unknown> | null): boolean | null {
+  if (!payloadRecord) {
+    return null;
+  }
+
+  const executionMode = payloadRecord.executionMode;
+  if (typeof executionMode === 'string') {
+    const normalizedExecutionMode = executionMode.trim().toLowerCase();
+    if (normalizedExecutionMode === 'async') {
+      return true;
+    }
+    if (normalizedExecutionMode === 'sync') {
+      return false;
+    }
+  }
+
+  return normalizeBooleanLike(payloadRecord.async);
+}
+
+function invalidDetailResult(
+  action: GptPlannableControlAction,
+  availableSections: string[],
+  detail: unknown,
+): PlannerErrorResult {
+  return {
+    ok: false,
+    error: {
+      code: 'INVALID_GPT_DETAIL',
+      message: `Unsupported detail '${String(detail)}'. Supported detail values: ${GPT_EXECUTION_PLAN_DETAILS.join(', ')}.`,
+    },
+    canonical: {
+      action,
+      supportedDetail: GPT_EXECUTION_PLAN_DETAILS.join(', '),
+      availableSections,
+    },
+  };
+}
+
+function invalidSectionsResult(
+  action: GptPlannableControlAction,
+  availableSections: string[],
+  sections: unknown,
+): PlannerErrorResult {
+  return {
+    ok: false,
+    error: {
+      code: 'INVALID_GPT_SECTIONS',
+      message: `Unsupported sections for action '${action}'. Supported sections: ${availableSections.join(', ') || '(none)'}.`,
+    },
+    canonical: {
+      action,
+      supportedSections: availableSections,
+      receivedSections: sections,
+    },
+  };
+}
+
+function normalizeSections(
+  action: GptPlannableControlAction,
+  sections: unknown,
+): { ok: true; sections: string[] } | PlannerErrorResult {
+  const availableSections = getGptExecutionPlanAvailableSections(action);
+  if (sections === undefined || sections === null) {
+    return {
+      ok: true,
+      sections: [],
+    };
+  }
+
+  if (!Array.isArray(sections)) {
+    return invalidSectionsResult(action, availableSections, sections);
+  }
+
+  const normalizedSections = Array.from(
+    new Set(
+      sections
+        .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+        .map((value) => value.trim().toLowerCase())
+    ).values()
+  );
+
+  const unsupportedSections = normalizedSections.filter(
+    (section) => !availableSections.includes(section)
+  );
+  if (unsupportedSections.length > 0) {
+    return invalidSectionsResult(action, availableSections, normalizedSections);
+  }
+
+  return {
+    ok: true,
+    sections: normalizedSections,
+  };
+}
+
+export function isPlannableGptControlAction(
+  action: GptDirectControlAction
+): action is GptPlannableControlAction {
+  return action === 'runtime.inspect' ||
+    action === 'workers.status' ||
+    action === 'queue.inspect' ||
+    action === 'self_heal.status';
+}
+
+export function getGptExecutionPlanAvailableSections(
+  action: GptPlannableControlAction,
+): string[] {
+  return [...GPT_EXECUTION_PLAN_SECTION_ALLOWLIST[action]];
+}
+
+export function buildGptControlResponseMeta(params: {
+  plan: GptExecutionPlan;
+  generatedAt?: string;
+  availableSections: string[];
+  truncated: boolean;
+  returnedSections?: string[];
+  omittedSections?: string[];
+}): GptControlResponseMeta {
+  return {
+    detail: params.plan.detail,
+    truncated: params.truncated,
+    availableSections: [...params.availableSections],
+    ...(params.returnedSections && params.returnedSections.length > 0
+      ? { returnedSections: [...params.returnedSections] }
+      : {}),
+    ...(params.omittedSections && params.omittedSections.length > 0
+      ? { omittedSections: [...params.omittedSections] }
+      : {}),
+    generatedAt: params.generatedAt ?? new Date().toISOString(),
+    source: params.plan.source,
+  };
+}
+
+function planWithRules<Action extends GptPlannableControlAction>(
+  input: GptExecutionPlannerInput<Action>
+): GptExecutionPlannerResult<Action> {
+  const payloadRecord = readPlannerPayloadRecord(input.payload);
+  const normalizedPrompt = normalizePrompt(input.promptText);
+  const availableSections = getGptExecutionPlanAvailableSections(input.action);
+  const explicitDetail = payloadRecord ? payloadRecord.detail : undefined;
+  const normalizedExplicitDetail = normalizeDetail(explicitDetail);
+
+  if (explicitDetail !== undefined && normalizedExplicitDetail === null) {
+    return invalidDetailResult(input.action, availableSections, explicitDetail);
+  }
+
+  const explicitSections = normalizeSections(input.action, payloadRecord?.sections);
+  if (!explicitSections.ok) {
+    return explicitSections;
+  }
+
+  const inferredDetail =
+    normalizedExplicitDetail ??
+    inferDetailFromPrompt(input.action, normalizedPrompt);
+  const inferredSections =
+    explicitSections.sections.length > 0
+      ? explicitSections.sections
+      : inferSectionsFromPrompt(input.action, normalizedPrompt);
+  const plannedSections =
+    inferredSections.length > 0
+      ? inferredSections
+      : defaultSectionsForPlan(input.action, inferredDetail);
+  const explicitShouldUseAsync = readExplicitShouldUseAsync(payloadRecord);
+  const plan: GptExecutionPlan<Action> = {
+    action: input.action,
+    detail: inferredDetail,
+    sections: plannedSections,
+    shouldUseAsync:
+      explicitShouldUseAsync ??
+      inferShouldUseAsync(input.action, inferredDetail, plannedSections, normalizedPrompt),
+    source:
+      normalizedExplicitDetail !== null || explicitSections.sections.length > 0
+        ? 'explicit'
+        : 'planner',
+  };
+
+  return {
+    ok: true,
+    plan,
+    availableSections,
+  };
+}
+
+const ruleBasedGptExecutionPlanner: GptExecutionPlanner = {
+  plan: planWithRules,
+};
+
+export function planGptControlExecution<Action extends GptPlannableControlAction>(
+  input: GptExecutionPlannerInput<Action>
+): GptExecutionPlannerResult<Action> {
+  // TODO: Allow an AI-assisted planner to implement the same interface after allowlist validation,
+  // response guards, and direct-control safety checks stay fixed at this boundary.
+  return ruleBasedGptExecutionPlanner.plan(input);
+}

--- a/src/shared/http/clientResponseCommon.ts
+++ b/src/shared/http/clientResponseCommon.ts
@@ -84,15 +84,24 @@ export function truncateText(text: string, maxBytes: number): string {
   return `${text.slice(0, end).trimEnd()}${TRUNCATION_MARKER}`;
 }
 
-export function resolveClientResponseMaxBytes(explicitMaxBytes?: number): number {
-  const envValue = Number.parseInt(process.env.CLIENT_RESPONSE_MAX_BYTES ?? '', 10);
-  const candidate = explicitMaxBytes ?? envValue;
+function readPositiveIntegerEnv(name: string): number | undefined {
+  const value = Number.parseInt(process.env[name] ?? '', 10);
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}
 
-  if (!Number.isFinite(candidate) || candidate <= 0) {
+export function resolveClientResponseMaxBytes(explicitMaxBytes?: number): number {
+  const candidate = explicitMaxBytes ?? readPositiveIntegerEnv('CLIENT_RESPONSE_MAX_BYTES');
+
+  if (candidate === undefined || !Number.isFinite(candidate) || candidate <= 0) {
     return DEFAULT_CLIENT_RESPONSE_MAX_BYTES;
   }
 
   return Math.min(MAX_CLIENT_RESPONSE_MAX_BYTES, Math.max(MIN_CLIENT_RESPONSE_MAX_BYTES, candidate));
+}
+
+export function resolveGptPublicResponseMaxBytes(explicitMaxBytes?: number): number {
+  const gptPublicMaxBytes = readPositiveIntegerEnv('GPT_PUBLIC_RESPONSE_MAX_BYTES');
+  return resolveClientResponseMaxBytes(explicitMaxBytes ?? gptPublicMaxBytes);
 }
 
 export function emitClientResponseTruncationWarning(

--- a/src/workers/jobRunner.ts
+++ b/src/workers/jobRunner.ts
@@ -67,6 +67,8 @@ interface JobExecutionOutcome {
 
 type OpenAIClient = ReturnType<typeof initOpenAIClient>;
 
+const QUEUED_GPT_PROMPT_KEYS = ['prompt', 'message', 'query', 'text', 'content', 'userInput'] as const;
+
 function initOpenAIClient() {
   const unified = getConfig();
   const apiKey = unified.openaiApiKey?.trim() || '';
@@ -96,6 +98,47 @@ function isProviderRuntimeError(message: string): boolean {
     normalizedMessage.includes('provider probe') ||
     normalizedMessage.includes('circuit breaker')
   );
+}
+
+function hasQueuedGptPromptField(body: Record<string, unknown>): boolean {
+  for (const key of QUEUED_GPT_PROMPT_KEYS) {
+    const candidate = body[key];
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return true;
+    }
+  }
+
+  if (!Array.isArray(body.messages)) {
+    return false;
+  }
+
+  return body.messages.some((entry) => {
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+      return false;
+    }
+
+    const candidate = entry as Record<string, unknown>;
+
+    return (
+      candidate.role === 'user' &&
+      typeof candidate.content === 'string' &&
+      candidate.content.trim().length > 0
+    );
+  });
+}
+
+function hydrateQueuedGptBodyPrompt(
+  body: Record<string, unknown>,
+  prompt: string | undefined
+): Record<string, unknown> {
+  if (!prompt || hasQueuedGptPromptField(body)) {
+    return body;
+  }
+
+  return {
+    ...body,
+    prompt
+  };
 }
 
 function resolveProviderPauseMs(nextRetryAt: string | null, fallbackMs: number): number {
@@ -301,7 +344,8 @@ async function executeQueuedGptRequest(params: {
   }
 
   const routeStartedAtMs = Date.now();
-  const { gptId, body, requestId } = parsedGptJobInput.value;
+  const { gptId, body, requestId, prompt, bypassIntentRouting } = parsedGptJobInput.value;
+  const hydratedBody = hydrateQueuedGptBodyPrompt(body, prompt);
   const latestJob = await getJobById(params.jobId);
   const resolveCancellationReason = async (
     fallbackMessage: string,
@@ -341,9 +385,10 @@ async function executeQueuedGptRequest(params: {
   try {
     envelope = await routeGptRequest({
       gptId,
-      body,
+      body: hydratedBody,
       requestId,
       logger: routeLogger,
+      bypassIntentRouting,
       runtimeExecutionMode: 'background',
       parentAbortSignal: params.cancellationSignal
     });

--- a/tests/gpt-async-idempotency.route.test.ts
+++ b/tests/gpt-async-idempotency.route.test.ts
@@ -966,6 +966,56 @@ describe('async /gpt idempotency', () => {
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
+  it('keeps the exact prompt on async query jobs when callers provide transport hints inside payload', async () => {
+    findOrCreateGptJobMock.mockResolvedValue({
+      job: {
+        id: 'job-query-payload-async',
+        status: 'pending'
+      },
+      created: true,
+      deduped: false,
+      dedupeReason: 'new_job'
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'query',
+        prompt: 'Reply with exactly OK.',
+        payload: {
+          executionMode: 'async'
+        }
+      });
+
+    expect(response.status).toBe(202);
+    expect(response.body).toMatchObject({
+      ok: true,
+      action: 'query',
+      status: 'pending',
+      jobId: 'job-query-payload-async',
+      jobStatus: 'pending',
+      lifecycleStatus: 'queued'
+    });
+    expect(findOrCreateGptJobMock).toHaveBeenCalledTimes(1);
+    expect(findOrCreateGptJobMock.mock.calls[0]?.[0]).toMatchObject({
+      input: {
+        gptId: 'arcanos-core',
+        prompt: 'Reply with exactly OK.',
+        bypassIntentRouting: true,
+        body: {
+          action: 'query',
+          prompt: 'Reply with exactly OK.',
+          payload: {
+            executionMode: 'async'
+          }
+        },
+        routeHint: 'query'
+      }
+    });
+    expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
   it('returns query_and_wait timeout guidance with the same job id and one job creation only', async () => {
     findOrCreateGptJobMock.mockResolvedValue({
       job: {

--- a/tests/gpt-async-idempotency.route.test.ts
+++ b/tests/gpt-async-idempotency.route.test.ts
@@ -81,6 +81,7 @@ describe('async /gpt idempotency', () => {
     delete process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT;
     delete process.env.GPT_ASYNC_HEAVY_WAIT_FOR_RESULT_MS;
     delete process.env.GPT_ROUTE_HARD_TIMEOUT_MS;
+    delete process.env.GPT_PUBLIC_RESPONSE_MAX_BYTES;
     planAutonomousWorkerJobMock.mockResolvedValue({
       status: 'pending',
       retryCount: 0,
@@ -913,6 +914,66 @@ describe('async /gpt idempotency', () => {
       }
     });
     expect((findOrCreateGptJobMock.mock.calls[0]?.[0] as { input?: { body?: Record<string, unknown> } }).input?.body?.action).toBeUndefined();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('keeps query_and_wait prompt execution isolated from GPT control truncation limits', async () => {
+    process.env.GPT_PUBLIC_RESPONSE_MAX_BYTES = '5000';
+    findOrCreateGptJobMock.mockResolvedValue({
+      job: {
+        id: 'job-query-and-wait-ok',
+        status: 'completed'
+      },
+      created: true,
+      deduped: false,
+      dedupeReason: 'new_job'
+    });
+    waitForQueuedGptJobCompletionMock.mockResolvedValue({
+      state: 'completed',
+      job: {
+        id: 'job-query-and-wait-ok',
+        status: 'completed',
+        output: {
+          ok: true,
+          result: 'OK',
+          _route: {
+            gptId: 'arcanos-core',
+            module: 'ARCANOS:CORE',
+            route: 'core',
+            action: 'query',
+            timestamp: '2026-04-11T10:00:03.000Z'
+          }
+        }
+      }
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'query_and_wait',
+        prompt: 'Reply with OK'
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['x-response-truncated']).toBeUndefined();
+    expect(response.body).toMatchObject({
+      ok: true,
+      jobId: 'job-query-and-wait-ok',
+      status: 'completed',
+      lifecycleStatus: 'completed',
+      result: 'OK'
+    });
+    expect(response.body.meta).toBeUndefined();
+    expect(findOrCreateGptJobMock.mock.calls[0]?.[0]).toMatchObject({
+      input: {
+        gptId: 'arcanos-core',
+        body: {
+          prompt: 'Reply with OK',
+          executionMode: 'async'
+        },
+        routeHint: 'query'
+      }
+    });
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 

--- a/tests/gpt-dispatch-compatibility.test.ts
+++ b/tests/gpt-dispatch-compatibility.test.ts
@@ -155,4 +155,30 @@ describe('gpt dispatch compatibility', () => {
       })
     );
   });
+
+  it('preserves the exact top-level prompt when query callers also send an explicit payload wrapper', async () => {
+    const response = await routeGptRequest({
+      gptId: 'arcanos-core',
+      body: {
+        action: 'query',
+        prompt: 'Reply with exactly OK.',
+        payload: {
+          executionMode: 'async',
+          extra: 'kept'
+        }
+      },
+      requestId: 'req_payload_prompt_query'
+    });
+
+    expect(response.ok).toBe(true);
+    expect(mockDispatchModuleAction).toHaveBeenCalledWith(
+      'ARCANOS:CORE',
+      'query',
+      expect.objectContaining({
+        prompt: 'Reply with exactly OK.',
+        executionMode: 'async',
+        extra: 'kept'
+      })
+    );
+  });
 });

--- a/tests/gpt-execution-planner.test.ts
+++ b/tests/gpt-execution-planner.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { planGptControlExecution } from '../src/shared/gpt/gptExecutionPlanner.js';
+
+describe('gpt execution planner', () => {
+  it('honors an explicit summary override for runtime inspection', () => {
+    const result = planGptControlExecution({
+      action: 'runtime.inspect',
+      promptText: 'full raw runtime inspection with everything included',
+      payload: {
+        detail: 'summary',
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.plan).toEqual(
+      expect.objectContaining({
+        action: 'runtime.inspect',
+        detail: 'summary',
+        source: 'explicit',
+        shouldUseAsync: false,
+      }),
+    );
+    expect(result.plan.sections).toEqual(
+      expect.arrayContaining(['workers', 'queues', 'memory', 'incidents']),
+    );
+  });
+
+  it('infers summary detail from broad health prompts', () => {
+    const result = planGptControlExecution({
+      action: 'runtime.inspect',
+      promptText: 'brief health overview',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.plan.detail).toBe('summary');
+    expect(result.plan.source).toBe('planner');
+  });
+
+  it('infers standard detail and relevant sections for investigative prompts', () => {
+    const result = planGptControlExecution({
+      action: 'runtime.inspect',
+      promptText: 'Investigate workers queues and memory issues in the live runtime',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.plan).toEqual(
+      expect.objectContaining({
+        action: 'runtime.inspect',
+        detail: 'standard',
+        source: 'planner',
+      }),
+    );
+    expect(result.plan.sections).toEqual(
+      expect.arrayContaining(['workers', 'queues', 'memory']),
+    );
+  });
+
+  it('keeps explicit full detail and explicit section filtering', () => {
+    const result = planGptControlExecution({
+      action: 'runtime.inspect',
+      payload: {
+        detail: 'full',
+        sections: ['workers', 'memory', 'workers'],
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.plan).toEqual(
+      expect.objectContaining({
+        action: 'runtime.inspect',
+        detail: 'full',
+        source: 'explicit',
+      }),
+    );
+    expect(result.plan.sections).toEqual(['workers', 'memory']);
+  });
+
+  it('defaults workers.status investigations to standard detail', () => {
+    const result = planGptControlExecution({
+      action: 'workers.status',
+      promptText: 'Why are workers unhealthy and stuck?',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.plan).toEqual(
+      expect.objectContaining({
+        action: 'workers.status',
+        detail: 'standard',
+      }),
+    );
+  });
+
+  it('rejects invalid explicit detail values with a typed error', () => {
+    const result = planGptControlExecution({
+      action: 'runtime.inspect',
+      payload: {
+        detail: 'verbose',
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+
+    expect(result.error).toEqual(
+      expect.objectContaining({
+        code: 'INVALID_GPT_DETAIL',
+      }),
+    );
+    expect(result.canonical).toEqual(
+      expect.objectContaining({
+        supportedDetail: 'summary, standard, full',
+      }),
+    );
+  });
+});

--- a/tests/gpt-router-universal-dispatch.test.ts
+++ b/tests/gpt-router-universal-dispatch.test.ts
@@ -347,6 +347,29 @@ describe('gpt router universal dispatch', () => {
     expect(mockExecuteRuntimeInspection).not.toHaveBeenCalled();
   });
 
+  it('routes explicit query actions directly through the module dispatcher without intent rewrites', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'query',
+        prompt: 'Reply with exactly OK.',
+        executionMode: 'sync'
+      });
+
+    expect(response.status).toBe(200);
+    expect(mockRouteGptRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gptId: 'arcanos-core',
+        bypassIntentRouting: true,
+        body: expect.objectContaining({
+          action: 'query',
+          prompt: 'Reply with exactly OK.'
+        })
+      })
+    );
+    expect(mockExecuteRuntimeInspection).not.toHaveBeenCalled();
+  });
+
   it('keeps diagnostics working through POST /gpt/{gptId}', async () => {
     const response = await request(buildApp())
       .post('/gpt/arcanos-core')
@@ -654,10 +677,13 @@ describe('gpt router universal dispatch', () => {
           detail: 'full',
           truncated: true,
           source: 'explicit',
+          returnedSections: expect.any(Array),
           omittedSections: expect.any(Array),
+          availableSections: expect.arrayContaining(['workers', 'queues', 'memory', 'incidents']),
         }),
       }),
     );
+    expect(response.body.meta.returnedSections.length).toBeGreaterThan(0);
     expect(response.body.meta.omittedSections.length).toBeGreaterThan(0);
   });
 

--- a/tests/gpt-router-universal-dispatch.test.ts
+++ b/tests/gpt-router-universal-dispatch.test.ts
@@ -1,0 +1,690 @@
+import express from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockRouteGptRequest = jest.fn();
+const mockExecuteSystemStateRequest = jest.fn();
+const mockExecuteRuntimeInspection = jest.fn();
+const mockGetWorkerControlStatus = jest.fn();
+const mockBuildSafetySelfHealSnapshot = jest.fn();
+const mockGetDiagnosticsSnapshot = jest.fn();
+
+class MockSystemStateConflictError extends Error {
+  readonly code = 'SYSTEM_STATE_CONFLICT';
+
+  constructor(readonly conflict: Record<string, unknown>) {
+    super('system_state update conflict');
+  }
+}
+
+jest.unstable_mockModule('../src/routes/_core/gptDispatch.js', () => ({
+  routeGptRequest: mockRouteGptRequest,
+}));
+
+jest.unstable_mockModule('../src/platform/logging/gptLogger.js', () => ({
+  logGptConnection: jest.fn(),
+  logGptConnectionFailed: jest.fn(),
+  logGptAckSent: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/services/systemState.js', () => ({
+  executeSystemStateRequest: mockExecuteSystemStateRequest,
+  SystemStateConflictError: MockSystemStateConflictError,
+}));
+
+jest.unstable_mockModule('../src/services/runtimeInspectionRoutingService.js', () => ({
+  executeRuntimeInspection: mockExecuteRuntimeInspection,
+  classifyRuntimeInspectionPrompt: jest.fn(() => ({
+    detectedIntent: 'STANDARD',
+    matchedKeywords: [],
+    repoInspectionDisabled: false,
+    onlyReturnRuntimeValues: false,
+  })),
+}));
+
+jest.unstable_mockModule('../src/services/workerControlService.js', () => ({
+  getWorkerControlStatus: mockGetWorkerControlStatus,
+}));
+
+jest.unstable_mockModule('../src/services/selfHealRuntimeInspectionService.js', () => ({
+  buildSafetySelfHealSnapshot: mockBuildSafetySelfHealSnapshot,
+}));
+
+jest.unstable_mockModule('../src/core/diagnostics.js', () => ({
+  getDiagnosticsSnapshot: mockGetDiagnosticsSnapshot,
+}));
+
+const { default: requestContext } = await import('../src/middleware/requestContext.js');
+const { default: gptRouter } = await import('../src/routes/gptRouter.js');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(requestContext);
+  app.use('/gpt', gptRouter);
+  return app;
+}
+
+describe('gpt router universal dispatch', () => {
+  const originalGptRouteAsyncCoreDefault = process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT;
+  const originalClientResponseMaxBytes = process.env.CLIENT_RESPONSE_MAX_BYTES;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT = 'false';
+    delete process.env.CLIENT_RESPONSE_MAX_BYTES;
+
+    mockRouteGptRequest.mockResolvedValue({
+      ok: true,
+      result: { handledBy: 'module-dispatch' },
+      _route: {
+        gptId: 'arcanos-core',
+        module: 'ARCANOS:CORE',
+        route: 'core',
+        action: 'query',
+        timestamp: '2026-04-15T00:00:00.000Z',
+      },
+    });
+
+    mockGetDiagnosticsSnapshot.mockResolvedValue({
+      ok: true,
+      registered_gpts: ['arcanos-core'],
+      active_routes: ['/gpt/arcanos-core'],
+    });
+
+    mockExecuteRuntimeInspection.mockResolvedValue({
+      ok: true,
+      responsePayload: {
+        handledBy: 'runtime-inspection',
+        runtimeInspection: {
+          status: 'ok',
+          summary: 'Collected live runtime state from 5 runtime sources.',
+          detectedIntent: 'RUNTIME_INSPECTION_REQUIRED',
+          matchedKeywords: ['runtime', 'workers'],
+          repoInspectionDisabled: false,
+          onlyReturnRuntimeValues: false,
+          toolsSelected: [
+            '/worker-helper/health',
+            '/workers/status',
+            'system.metrics',
+            '/api/self-heal/events',
+            '/api/self-heal/inspection',
+          ],
+          runtimeEndpointsQueried: ['/worker-helper/health', '/workers/status'],
+          evidence: {
+            traceId: 'trace-1',
+            collectedAt: '2026-04-15T00:00:00.000Z',
+          },
+          sources: [
+            {
+              sourceType: 'worker-health',
+              tool: '/worker-helper/health',
+              data: {
+                overallStatus: 'healthy',
+                pending: 2,
+                running: 1,
+                alerts: [],
+              },
+            },
+            {
+              sourceType: 'worker-health',
+              tool: '/workers/status',
+              data: {
+                status: 'ok',
+                arcanosWorkers: {
+                  count: 1,
+                  status: 'Active',
+                },
+              },
+            },
+            {
+              sourceType: 'metrics',
+              tool: 'system.metrics',
+              data: {
+                health: {
+                  status: 'ok',
+                  memory: {
+                    rss_mb: 128,
+                    heap_used_mb: 64,
+                  },
+                },
+                diagnostics: {
+                  requests_total: 42,
+                },
+              },
+            },
+            {
+              sourceType: 'runtime-endpoint',
+              tool: '/api/self-heal/events',
+              data: {
+                events: [
+                  {
+                    id: 'evt-1',
+                    type: 'HEAL_RESULT',
+                  },
+                ],
+              },
+            },
+            {
+              sourceType: 'runtime-endpoint',
+              tool: '/api/self-heal/inspection',
+              data: {
+                summary: 'inspection summary',
+                evidence: {
+                  node: 'trace-node-1',
+                },
+              },
+            },
+          ],
+          failures: [
+            {
+              tool: 'cli:workers',
+              error: 'timeout',
+            },
+          ],
+        },
+      },
+      routingDebug: {
+        requestId: 'req-runtime-1',
+        timestamp: '2026-04-15T00:00:00.000Z',
+        rawPrompt: 'runtime inspect live runtime status',
+        normalizedPrompt: 'runtime inspect live runtime status',
+        detectedIntent: 'RUNTIME_INSPECTION_REQUIRED',
+        routingDecision: 'runtime_inspection_completed',
+        toolsAvailable: ['system.metrics'],
+        toolsSelected: ['system.metrics'],
+        cliUsed: false,
+        runtimeEndpointsQueried: ['/workers/status'],
+        repoFallbackUsed: false,
+        constraintViolations: [],
+      },
+      repoFallbackAllowed: false,
+      selectedTools: ['system.metrics'],
+      runtimeEndpointsQueried: ['/workers/status'],
+      cliUsed: false,
+    });
+
+    mockGetWorkerControlStatus.mockResolvedValue({
+      timestamp: '2026-04-15T00:00:00.000Z',
+      mainApp: {
+        connected: true,
+        workerId: 'main-app',
+        runtime: {
+          enabled: true,
+          started: true,
+          configuredCount: 1,
+          model: 'gpt-4o',
+        },
+      },
+      workerService: {
+        observationMode: 'queue-observed',
+        database: {
+          connected: true,
+        },
+        queueSummary: {
+          pending: 2,
+          running: 1,
+        },
+        queueSemantics: {
+          failedCountMode: 'retained_terminal_jobs',
+        },
+        retryPolicy: {
+          defaultMaxRetries: 3,
+        },
+        recentFailedJobs: [],
+        latestJob: {
+          id: 'job-1',
+        },
+        health: {
+          overallStatus: 'healthy',
+          alerts: [],
+          diagnosticAlerts: [],
+          operationalHealth: {},
+          historicalDebt: {},
+          workers: [],
+        },
+      },
+    });
+
+    mockBuildSafetySelfHealSnapshot.mockReturnValue({
+      status: 'ok',
+      enabled: true,
+      active: false,
+      isHealing: false,
+      lastTriggerReason: 'steady_state',
+      lastHealedComponent: 'worker-service',
+      lastHealAction: 'restart_worker',
+      lastHealRun: '2026-04-15T00:00:00.000Z',
+      systemState: {
+        status: 'healthy',
+        latency: 12,
+      },
+      loopRunning: true,
+      inFlight: false,
+      lastDiagnosis: 'healthy',
+      lastAction: 'restart_worker',
+      lastActionAt: '2026-04-15T00:00:00.000Z',
+      lastError: null,
+      activeMitigation: null,
+      degradedModeReason: null,
+      recentTimeoutCounts: {
+        prompt: 0,
+      },
+      lastVerificationResult: {
+        status: 'ok',
+      },
+      lastFailure: null,
+      lastFallback: null,
+      recentEvents: [
+        {
+          id: 'evt-1',
+          type: 'HEAL_RESULT',
+        },
+      ],
+      promptRouteMitigation: {
+        active: false,
+      },
+      trinity: {
+        enabled: true,
+      },
+      predictiveHealing: {
+        recentObservations: [
+          {
+            memory: {
+              rssMb: 128,
+              heapUsedMb: 64,
+            },
+          },
+        ],
+        trends: {
+          memoryGrowthMb: 0,
+        },
+        aiProvider: {
+          configured: false,
+        },
+      },
+      inspection: {
+        lastDispatchAttempt: {
+          at: '2026-04-15T00:00:00.000Z',
+        },
+        lastWorkerReceipt: {
+          at: '2026-04-15T00:00:00.000Z',
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (originalGptRouteAsyncCoreDefault === undefined) {
+      delete process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT;
+    } else {
+      process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT = originalGptRouteAsyncCoreDefault;
+    }
+
+    if (originalClientResponseMaxBytes === undefined) {
+      delete process.env.CLIENT_RESPONSE_MAX_BYTES;
+      return;
+    }
+
+    process.env.CLIENT_RESPONSE_MAX_BYTES = originalClientResponseMaxBytes;
+  });
+
+  it('keeps normal GPT module requests on the writing dispatcher', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({ prompt: 'Explain how the queue and worker fit together.' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        result: {
+          handledBy: 'module-dispatch',
+        },
+      })
+    );
+    expect(mockRouteGptRequest).toHaveBeenCalledTimes(1);
+    expect(mockExecuteRuntimeInspection).not.toHaveBeenCalled();
+  });
+
+  it('keeps diagnostics working through POST /gpt/{gptId}', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({ action: 'diagnostics' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      ok: true,
+      registered_gpts: ['arcanos-core'],
+      active_routes: ['/gpt/arcanos-core'],
+    });
+    expect(mockGetDiagnosticsSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('routes runtime.inspect through the universal public dispatcher', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({ action: 'runtime.inspect' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        action: 'runtime.inspect',
+        meta: expect.objectContaining({
+          detail: 'summary',
+          truncated: false,
+          source: 'planner',
+          availableSections: expect.arrayContaining(['workers', 'queues', 'memory', 'incidents']),
+          returnedSections: expect.arrayContaining(['workers', 'queues', 'memory', 'incidents']),
+        }),
+        result: {
+          handledBy: 'runtime-inspection',
+          runtimeInspection: expect.objectContaining({
+            status: 'ok',
+            summary: 'Collected live runtime state from 5 runtime sources.',
+            sections: expect.objectContaining({
+              workers: expect.any(Object),
+              queues: expect.any(Object),
+              memory: expect.any(Object),
+              incidents: expect.any(Object),
+            }),
+          }),
+        },
+        _route: expect.objectContaining({
+          gptId: 'arcanos-core',
+          action: 'runtime.inspect',
+          route: 'runtime_inspect',
+        }),
+      })
+    );
+    expect(mockExecuteRuntimeInspection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rawPrompt: 'runtime inspect live runtime status',
+        normalizedPrompt: 'runtime inspect live runtime status',
+      })
+    );
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('honors explicit full detail and section filtering for runtime.inspect', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'runtime.inspect',
+        payload: {
+          detail: 'full',
+          sections: ['workers', 'memory'],
+        },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        action: 'runtime.inspect',
+        meta: expect.objectContaining({
+          detail: 'full',
+          truncated: false,
+          source: 'explicit',
+          returnedSections: ['workers', 'memory'],
+        }),
+        result: {
+          handledBy: 'runtime-inspection',
+          runtimeInspection: expect.objectContaining({
+            sections: {
+              workers: expect.any(Object),
+              memory: expect.any(Object),
+            },
+          }),
+        },
+      }),
+    );
+    expect(response.body.result.runtimeInspection.sections.queues).toBeUndefined();
+    expect(response.body.result.runtimeInspection.sections.incidents).toBeUndefined();
+  });
+
+  it('defaults self_heal.status to a shaped summary response', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({ action: 'self_heal.status' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        action: 'self_heal.status',
+        meta: expect.objectContaining({
+          detail: 'summary',
+          truncated: false,
+          source: 'planner',
+          availableSections: expect.arrayContaining(['system', 'workers', 'memory', 'incidents']),
+        }),
+        result: expect.objectContaining({
+          status: 'ok',
+          enabled: true,
+          active: false,
+          summary: expect.any(String),
+          sections: expect.objectContaining({
+            system: expect.any(Object),
+            incidents: expect.any(Object),
+            workers: expect.any(Object),
+            memory: expect.any(Object),
+          }),
+        }),
+        _route: expect.objectContaining({
+          gptId: 'arcanos-core',
+          action: 'self_heal.status',
+          route: 'self_heal_status',
+        }),
+      }),
+    );
+  });
+
+  it('routes workers.status through the universal public dispatcher', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({ action: 'workers.status' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        action: 'workers.status',
+        meta: expect.objectContaining({
+          detail: 'standard',
+          truncated: false,
+          source: 'planner',
+        }),
+        result: expect.objectContaining({
+          timestamp: '2026-04-15T00:00:00.000Z',
+          workerService: expect.objectContaining({
+            queueSummary: expect.objectContaining({
+              pending: 2,
+              running: 1,
+            }),
+          }),
+        }),
+        _route: expect.objectContaining({
+          gptId: 'arcanos-core',
+          action: 'workers.status',
+          route: 'workers_status',
+        }),
+      })
+    );
+    expect(mockGetWorkerControlStatus).toHaveBeenCalledTimes(1);
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid explicit detail values with a typed 400 error', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'runtime.inspect',
+        payload: {
+          detail: 'verbose',
+        },
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: false,
+        action: 'runtime.inspect',
+        error: expect.objectContaining({
+          code: 'INVALID_GPT_DETAIL',
+        }),
+        canonical: expect.objectContaining({
+          supportedDetail: 'summary, standard, full',
+        }),
+      }),
+    );
+    expect(mockExecuteRuntimeInspection).not.toHaveBeenCalled();
+  });
+
+  it('marks truncated runtime inspection responses explicitly before the public response guard', async () => {
+    process.env.CLIENT_RESPONSE_MAX_BYTES = '950';
+    mockExecuteRuntimeInspection.mockResolvedValueOnce({
+      ok: true,
+      responsePayload: {
+        handledBy: 'runtime-inspection',
+        runtimeInspection: {
+          status: 'ok',
+          summary: 'Collected live runtime state from 5 runtime sources.',
+          detectedIntent: 'RUNTIME_INSPECTION_REQUIRED',
+          toolsSelected: [
+            '/worker-helper/health',
+            '/workers/status',
+            'system.metrics',
+            '/api/self-heal/events',
+            '/api/self-heal/inspection',
+          ],
+          runtimeEndpointsQueried: ['/worker-helper/health', '/workers/status'],
+          sources: [
+            {
+              sourceType: 'worker-health',
+              tool: '/worker-helper/health',
+              data: {
+                alerts: Array.from({ length: 20 }, (_, index) => `alert-${index}`),
+                workers: Array.from({ length: 20 }, (_, index) => ({
+                  workerId: `worker-${index}`,
+                  healthStatus: 'healthy',
+                })),
+              },
+            },
+            {
+              sourceType: 'metrics',
+              tool: 'system.metrics',
+              data: {
+                diagnostics: {
+                  recent_latency_ms: Array.from({ length: 40 }, (_, index) => index),
+                },
+              },
+            },
+            {
+              sourceType: 'runtime-endpoint',
+              tool: '/api/self-heal/events',
+              data: {
+                events: Array.from({ length: 50 }, (_, index) => ({
+                  id: `evt-${index}`,
+                  type: 'HEAL_RESULT',
+                  message: 'x'.repeat(200),
+                })),
+              },
+            },
+            {
+              sourceType: 'runtime-endpoint',
+              tool: '/api/self-heal/inspection',
+              data: {
+                evidence: {
+                  traces: Array.from({ length: 40 }, (_, index) => ({
+                    id: `trace-${index}`,
+                    detail: 'y'.repeat(200),
+                  })),
+                },
+              },
+            },
+          ],
+          failures: Array.from({ length: 20 }, (_, index) => ({
+            tool: `tool-${index}`,
+            error: 'z'.repeat(160),
+          })),
+        },
+      },
+      routingDebug: {
+        requestId: 'req-runtime-oversized',
+        timestamp: '2026-04-15T00:00:00.000Z',
+        rawPrompt: 'full raw runtime inspection with everything included',
+        normalizedPrompt: 'full raw runtime inspection with everything included',
+        detectedIntent: 'RUNTIME_INSPECTION_REQUIRED',
+        routingDecision: 'runtime_inspection_completed',
+        toolsAvailable: ['system.metrics'],
+        toolsSelected: ['system.metrics'],
+        cliUsed: false,
+        runtimeEndpointsQueried: ['/workers/status'],
+        repoFallbackUsed: false,
+        constraintViolations: [],
+      },
+      repoFallbackAllowed: false,
+      selectedTools: ['system.metrics'],
+      runtimeEndpointsQueried: ['/workers/status'],
+      cliUsed: false,
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'runtime.inspect',
+        payload: {
+          detail: 'full',
+          sections: ['workers', 'queues', 'memory', 'incidents', 'events', 'trace'],
+        },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['x-response-truncated']).toBe('true');
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        action: 'runtime.inspect',
+        status: 'partial',
+        message: 'Response exceeded public route bounds. Narrow sections or use a less verbose detail level.',
+        meta: expect.objectContaining({
+          detail: 'full',
+          truncated: true,
+          source: 'explicit',
+          omittedSections: expect.any(Array),
+        }),
+      }),
+    );
+    expect(response.body.meta.omittedSections.length).toBeGreaterThan(0);
+  });
+
+  it('rejects unknown reserved control actions with a typed 400 error', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({ action: 'runtime.unknown' });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: false,
+        action: 'runtime.unknown',
+        error: expect.objectContaining({
+          code: 'UNSUPPORTED_GPT_ACTION',
+        }),
+        canonical: expect.objectContaining({
+          supportedActions: expect.stringContaining('runtime.inspect'),
+        }),
+        _route: expect.objectContaining({
+          gptId: 'arcanos-core',
+          route: 'control_guard',
+          action: 'runtime.unknown',
+        }),
+      })
+    );
+    expect(mockExecuteRuntimeInspection).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+});

--- a/tests/gpt-router-universal-dispatch.test.ts
+++ b/tests/gpt-router-universal-dispatch.test.ts
@@ -65,14 +65,197 @@ function buildApp() {
   return app;
 }
 
+function buildOversizedRuntimeInspectionResponse() {
+  return {
+    ok: true,
+    responsePayload: {
+      handledBy: 'runtime-inspection',
+      runtimeInspection: {
+        status: 'ok',
+        summary: 'Collected live runtime state from 5 runtime sources.',
+        detectedIntent: 'RUNTIME_INSPECTION_REQUIRED',
+        toolsSelected: [
+          '/worker-helper/health',
+          '/workers/status',
+          'system.metrics',
+          '/api/self-heal/events',
+          '/api/self-heal/inspection',
+        ],
+        runtimeEndpointsQueried: ['/worker-helper/health', '/workers/status'],
+        sources: [
+          {
+            sourceType: 'worker-health',
+            tool: '/worker-helper/health',
+            data: {
+              alerts: Array.from({ length: 40 }, (_, index) => `alert-${index}-${'a'.repeat(160)}`),
+              workers: Array.from({ length: 40 }, (_, index) => ({
+                workerId: `worker-${index}`,
+                healthStatus: 'healthy',
+                diagnostics: 'w'.repeat(240),
+              })),
+            },
+          },
+          {
+            sourceType: 'worker-health',
+            tool: '/workers/status',
+            data: {
+              queueDetails: Array.from({ length: 40 }, (_, index) => ({
+                id: `queue-${index}`,
+                detail: 'q'.repeat(240),
+              })),
+            },
+          },
+          {
+            sourceType: 'metrics',
+            tool: 'system.metrics',
+            data: {
+              diagnostics: {
+                recent_latency_ms: Array.from({ length: 80 }, (_, index) => index),
+                memorySamples: Array.from({ length: 40 }, (_, index) => ({
+                  index,
+                  heap: 'm'.repeat(220),
+                })),
+              },
+            },
+          },
+          {
+            sourceType: 'runtime-endpoint',
+            tool: '/api/self-heal/events',
+            data: {
+              events: Array.from({ length: 80 }, (_, index) => ({
+                id: `evt-${index}`,
+                type: 'HEAL_RESULT',
+                message: 'e'.repeat(260),
+              })),
+            },
+          },
+          {
+            sourceType: 'runtime-endpoint',
+            tool: '/api/self-heal/inspection',
+            data: {
+              evidence: {
+                traces: Array.from({ length: 80 }, (_, index) => ({
+                  id: `trace-${index}`,
+                  detail: 't'.repeat(260),
+                })),
+              },
+            },
+          },
+        ],
+        failures: Array.from({ length: 40 }, (_, index) => ({
+          tool: `tool-${index}`,
+          error: 'z'.repeat(220),
+        })),
+      },
+    },
+    routingDebug: {
+      requestId: 'req-runtime-oversized',
+      timestamp: '2026-04-15T00:00:00.000Z',
+      rawPrompt: 'full raw runtime inspection with everything included',
+      normalizedPrompt: 'full raw runtime inspection with everything included',
+      detectedIntent: 'RUNTIME_INSPECTION_REQUIRED',
+      routingDecision: 'runtime_inspection_completed',
+      toolsAvailable: ['system.metrics'],
+      toolsSelected: ['system.metrics'],
+      cliUsed: false,
+      runtimeEndpointsQueried: ['/workers/status'],
+      repoFallbackUsed: false,
+      constraintViolations: [],
+    },
+    repoFallbackAllowed: false,
+    selectedTools: ['system.metrics'],
+    runtimeEndpointsQueried: ['/workers/status'],
+    cliUsed: false,
+  };
+}
+
+function buildOversizedSelfHealSnapshot() {
+  return {
+    status: 'ok',
+    enabled: true,
+    active: false,
+    isHealing: false,
+    lastTriggerReason: 'steady_state',
+    lastHealedComponent: 'worker-service',
+    lastHealAction: 'restart_worker',
+    lastHealRun: '2026-04-15T00:00:00.000Z',
+    systemState: {
+      status: 'healthy',
+      detail: 's'.repeat(500),
+    },
+    loopRunning: true,
+    inFlight: false,
+    lastDiagnosis: 'healthy',
+    lastAction: 'restart_worker',
+    lastActionAt: '2026-04-15T00:00:00.000Z',
+    lastError: null,
+    activeMitigation: null,
+    degradedModeReason: null,
+    recentTimeoutCounts: {
+      prompt: 0,
+    },
+    lastVerificationResult: {
+      status: 'ok',
+      evidence: 'v'.repeat(800),
+    },
+    recentEvents: Array.from({ length: 80 }, (_, index) => ({
+      id: `evt-${index}`,
+      type: 'HEAL_RESULT',
+      message: 'h'.repeat(260),
+    })),
+    promptRouteMitigation: {
+      active: false,
+      diagnostics: 'p'.repeat(800),
+    },
+    trinity: {
+      enabled: true,
+      diagnostics: 'r'.repeat(800),
+    },
+    predictiveHealing: {
+      recentObservations: Array.from({ length: 80 }, (_, index) => ({
+        id: `obs-${index}`,
+        memory: {
+          rssMb: 128 + index,
+          heapUsedMb: 64 + index,
+          detail: 'o'.repeat(260),
+        },
+      })),
+      trends: {
+        memoryGrowthMb: 0,
+        detail: 'n'.repeat(800),
+      },
+      aiProvider: {
+        configured: false,
+        detail: 'a'.repeat(800),
+      },
+    },
+    inspection: {
+      lastDispatchAttempt: {
+        at: '2026-04-15T00:00:00.000Z',
+        detail: 'd'.repeat(800),
+      },
+      lastWorkerReceipt: {
+        at: '2026-04-15T00:00:00.000Z',
+        detail: 'w'.repeat(800),
+      },
+    },
+  };
+}
+
 describe('gpt router universal dispatch', () => {
   const originalGptRouteAsyncCoreDefault = process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT;
   const originalClientResponseMaxBytes = process.env.CLIENT_RESPONSE_MAX_BYTES;
+  const originalGptPublicResponseMaxBytes = process.env.GPT_PUBLIC_RESPONSE_MAX_BYTES;
+  const originalDebugGptControls = process.env.ARCANOS_ENABLE_DEBUG_GPT_CONTROLS;
+  const originalNodeEnv = process.env.NODE_ENV;
 
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT = 'false';
     delete process.env.CLIENT_RESPONSE_MAX_BYTES;
+    delete process.env.GPT_PUBLIC_RESPONSE_MAX_BYTES;
+    delete process.env.ARCANOS_ENABLE_DEBUG_GPT_CONTROLS;
+    process.env.NODE_ENV = originalNodeEnv;
 
     mockRouteGptRequest.mockResolvedValue({
       ok: true,
@@ -323,10 +506,27 @@ describe('gpt router universal dispatch', () => {
 
     if (originalClientResponseMaxBytes === undefined) {
       delete process.env.CLIENT_RESPONSE_MAX_BYTES;
-      return;
+    } else {
+      process.env.CLIENT_RESPONSE_MAX_BYTES = originalClientResponseMaxBytes;
     }
 
-    process.env.CLIENT_RESPONSE_MAX_BYTES = originalClientResponseMaxBytes;
+    if (originalGptPublicResponseMaxBytes === undefined) {
+      delete process.env.GPT_PUBLIC_RESPONSE_MAX_BYTES;
+    } else {
+      process.env.GPT_PUBLIC_RESPONSE_MAX_BYTES = originalGptPublicResponseMaxBytes;
+    }
+
+    if (originalDebugGptControls === undefined) {
+      delete process.env.ARCANOS_ENABLE_DEBUG_GPT_CONTROLS;
+    } else {
+      process.env.ARCANOS_ENABLE_DEBUG_GPT_CONTROLS = originalDebugGptControls;
+    }
+
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
   });
 
   it('keeps normal GPT module requests on the writing dispatcher', async () => {
@@ -567,7 +767,7 @@ describe('gpt router universal dispatch', () => {
   });
 
   it('marks truncated runtime inspection responses explicitly before the public response guard', async () => {
-    process.env.CLIENT_RESPONSE_MAX_BYTES = '950';
+    process.env.GPT_PUBLIC_RESPONSE_MAX_BYTES = '5000';
     mockExecuteRuntimeInspection.mockResolvedValueOnce({
       ok: true,
       responsePayload: {
@@ -672,7 +872,7 @@ describe('gpt router universal dispatch', () => {
         ok: true,
         action: 'runtime.inspect',
         status: 'partial',
-        message: 'Response exceeded public route bounds. Narrow sections or use a less verbose detail level.',
+        message: 'Response exceeded public route bounds. Narrow sections or reduce detail.',
         meta: expect.objectContaining({
           detail: 'full',
           truncated: true,
@@ -685,6 +885,109 @@ describe('gpt router universal dispatch', () => {
     );
     expect(response.body.meta.returnedSections.length).toBeGreaterThan(0);
     expect(response.body.meta.omittedSections.length).toBeGreaterThan(0);
+  });
+
+  it('keeps section filtering bounded when a filtered runtime inspection response is truncated', async () => {
+    process.env.GPT_PUBLIC_RESPONSE_MAX_BYTES = '5000';
+    mockExecuteRuntimeInspection.mockResolvedValueOnce(buildOversizedRuntimeInspectionResponse());
+    const requestedSections = ['workers', 'queues'];
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'runtime.inspect',
+        payload: {
+          detail: 'full',
+          sections: requestedSections,
+        },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['x-response-truncated']).toBe('true');
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        action: 'runtime.inspect',
+        status: 'partial',
+        meta: expect.objectContaining({
+          detail: 'full',
+          truncated: true,
+          source: 'explicit',
+          returnedSections: expect.any(Array),
+          omittedSections: expect.any(Array),
+          availableSections: expect.arrayContaining(['workers', 'queues']),
+        }),
+      }),
+    );
+
+    const returnedSections = response.body.meta.returnedSections as string[];
+    const omittedSections = response.body.meta.omittedSections as string[];
+    expect(returnedSections.every((section) => requestedSections.includes(section))).toBe(true);
+    expect(omittedSections.every((section) => requestedSections.includes(section))).toBe(true);
+    expect(new Set([...returnedSections, ...omittedSections])).toEqual(new Set(requestedSections));
+  });
+
+  it('marks truncated self_heal.status responses explicitly before the public response guard', async () => {
+    process.env.GPT_PUBLIC_RESPONSE_MAX_BYTES = '5000';
+    mockBuildSafetySelfHealSnapshot.mockReturnValueOnce(buildOversizedSelfHealSnapshot());
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'self_heal.status',
+        payload: {
+          detail: 'full',
+        },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['x-response-truncated']).toBe('true');
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        action: 'self_heal.status',
+        status: 'partial',
+        message: 'Response exceeded public route bounds. Narrow sections or reduce detail.',
+        meta: expect.objectContaining({
+          detail: 'full',
+          truncated: true,
+          source: 'explicit',
+          returnedSections: expect.any(Array),
+          omittedSections: expect.any(Array),
+          availableSections: expect.arrayContaining(['system', 'workers', 'memory', 'incidents']),
+        }),
+      }),
+    );
+    expect(response.body.meta.omittedSections.length).toBeGreaterThan(0);
+  });
+
+  it('allows guarded non-production debug headers to lower GPT control response bounds', async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.ARCANOS_ENABLE_DEBUG_GPT_CONTROLS = 'true';
+    mockExecuteRuntimeInspection.mockResolvedValueOnce(buildOversizedRuntimeInspectionResponse());
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .set('X-Debug-Max-Bytes', '5000')
+      .send({
+        action: 'runtime.inspect',
+        payload: {
+          detail: 'full',
+        },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['x-response-truncated']).toBe('true');
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        action: 'runtime.inspect',
+        status: 'partial',
+        meta: expect.objectContaining({
+          truncated: true,
+        }),
+      }),
+    );
   });
 
   it('rejects unknown reserved control actions with a typed 400 error', async () => {


### PR DESCRIPTION
## Summary
- add a deterministic GPT execution planner on top of the universal `/gpt/{gptId}` dispatcher
- shape `runtime.inspect` and `self_heal.status` responses before the public JSON guard with explicit truncation metadata
- update the OpenAPI contract and add planner-focused coverage for explicit, inferred, and bounded response profiles

## Details
- introduce a typed execution plan with validated `detail`, `sections`, and async heuristics
- keep allowlist enforcement in place so planner output cannot invent unsupported actions
- preserve existing `query`, `query_and_wait`, `get_status`, `get_result`, and `diagnostics` behavior
- attach planner metadata to shaped control responses and keep partial responses explicit when bounds are hit

## Validation
- `node --disable-warning=ExperimentalWarning --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --coverage=false --runTestsByPath tests/gpt-execution-planner.test.ts tests/gpt-router-universal-dispatch.test.ts tests/gpt-router-auth-logging.test.ts tests/gpt-dispatch.mcp.test.ts packages/cli/__tests__/gpt-client.test.ts tests/introspection-openapi-contract.route.test.ts`
- `npm run type-check`
- `railway up --ci --service "ARCANOS V2" -m "Add GPT execution planner and bounded control shaping"`
- production smoke through `/gpt/arcanos-core` for `runtime.inspect`, `workers.status`, and `self_heal.status`
- repo-local ARCANOS CLI smoke for `status`, `workers`, and `inspect self-heal`
