### PR TITLE
[codex] fix GPT core default routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,9 @@ GPT_FAST_PATH_ENABLED=true
 # GPT_FAST_PATH_MAX_WORDS=350
 # Optional comma-separated GPT IDs allowed to use the fast path. Empty means all GPT IDs.
 # GPT_FAST_PATH_GPT_ALLOWLIST=arcanos-core,core
+# Optional legacy bridge for small unadorned core queries. Leave false so the bounded
+# request-mode core path can return inline unless the request explicitly asks for async work.
+# GPT_ROUTE_ASYNC_CORE_DEFAULT=false
 
 # Feature flags
 # ENABLE_ACTION_PLANS=false

--- a/docs/GPT_FAST_PATH.md
+++ b/docs/GPT_FAST_PATH.md
@@ -4,7 +4,7 @@
 `POST /gpt/:gptId` now has two execution modes:
 
 - `fast_path`: inline prompt generation for small requests that look like prompt-generation work. It bypasses job creation, worker orchestration, DAG planning, memory overlays, research overlays, and audit overlays.
-- `orchestrated_path`: existing async or module-dispatch behavior for durable jobs, complex prompts, explicit actions, DAG/research/tool requests, idempotent retries, and long-running work.
+- `orchestrated_path`: non-fast-path behavior. Execution planning may still return through bounded module dispatch, or it may use durable async jobs for explicit async requests, complex prompts, explicit actions, idempotent retries, and long-running work.
 
 The route keeps a single public endpoint so existing Custom GPT integrations do not need a new URL. The router branches internally before async job planning. Explicit async bridge actions (`query`, `query_and_wait`, `get_status`, `get_result`) always keep their current job-backed behavior; fast path is for prompt-generation requests that omit `action`.
 
@@ -16,7 +16,7 @@ A request is eligible when all of these are true:
 - `GPT_FAST_PATH_ENABLED` is not disabled.
 - The request has a prompt.
 - The prompt looks like prompt-generation work.
-- General short-form generation that does not ask for a prompt, such as `Generate a launch email`, stays orchestrated by design.
+- General short-form generation that does not ask for a prompt, such as `Generate a launch email`, stays out of the fast path by design. Small unadorned core requests then use the bounded direct path unless explicit async mode, heavy-request thresholds, idempotency, or `GPT_ROUTE_ASYNC_CORE_DEFAULT=true` require a durable job.
 - If the caller explicitly sets fast mode, all other eligibility checks still apply.
 - There is no explicit idempotency key.
 - The action is omitted. Explicit async bridge actions stay orchestrated even if `executionMode` is `fast`.
@@ -34,6 +34,7 @@ Configuration:
 | `GPT_FAST_PATH_MAX_MESSAGE_COUNT` | `3` | Maximum `messages[]` count. |
 | `GPT_FAST_PATH_MAX_WORDS` | `350` | Maximum requested output size from `maxWords` / `max_words`. |
 | `GPT_FAST_PATH_GPT_ALLOWLIST` | empty | Optional comma-separated GPT IDs allowed to use the fast path. Empty means all GPT IDs. |
+| `GPT_ROUTE_ASYNC_CORE_DEFAULT` | `false` | Legacy opt-in for routing small unadorned core queries through async jobs by default. Explicit async requests and heavy requests still use async jobs without this flag. |
 
 ## HTTP Usage
 Fast path:
@@ -202,8 +203,9 @@ If a request unexpectedly falls back to async, check:
 
 - The response header `x-gpt-route-decision-reason`.
 - Whether the prompt actually matches prompt-generation intent.
-- Whether the request is general generation instead of prompt generation. `Generate a launch email` is orchestrated; `Generate a prompt for a launch email` can be fast path.
+- Whether the request is general generation instead of prompt generation. `Generate a launch email` is not fast path; `Generate a prompt for a launch email` can be fast path.
 - Whether `executionMode` was set to `async` / `orchestrated`.
+- Whether `GPT_ROUTE_ASYNC_CORE_DEFAULT=true` is forcing small core queries into async jobs.
 - Whether the request has `action`, non-empty `payload`, `tools`, `dag`, `files`, `research`, or other heavy fields.
 - Whether an `Idempotency-Key` header was provided.
 - Whether `GPT_FAST_PATH_ENABLED=false` or `GPT_FAST_PATH_GPT_ALLOWLIST` excludes the GPT ID.

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -619,7 +619,7 @@ function shouldDefaultCoreQueriesToAsync(
   }
 
   return ARCANOS_CORE_GPT_IDS.has(gptId) &&
-    readBooleanEnv('GPT_ROUTE_ASYNC_CORE_DEFAULT', true);
+    readBooleanEnv('GPT_ROUTE_ASYNC_CORE_DEFAULT', false);
 }
 
 function resolveGptExecutionPlan(params: {

--- a/tests/gpt-async-idempotency.route.test.ts
+++ b/tests/gpt-async-idempotency.route.test.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import request from 'supertest';
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const mockRouteGptRequest = jest.fn();
 const findOrCreateGptJobMock = jest.fn();
@@ -76,9 +76,11 @@ function buildApp() {
 }
 
 describe('async /gpt idempotency', () => {
+  const originalGptRouteAsyncCoreDefault = process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT;
+
   beforeEach(() => {
     jest.clearAllMocks();
-    delete process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT;
+    process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT = 'true';
     delete process.env.GPT_ASYNC_HEAVY_WAIT_FOR_RESULT_MS;
     delete process.env.GPT_ROUTE_HARD_TIMEOUT_MS;
     delete process.env.GPT_PUBLIC_RESPONSE_MAX_BYTES;
@@ -94,6 +96,14 @@ describe('async /gpt idempotency', () => {
       },
       planningReasons: []
     });
+  });
+
+  afterEach(() => {
+    if (originalGptRouteAsyncCoreDefault === undefined) {
+      delete process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT;
+    } else {
+      process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT = originalGptRouteAsyncCoreDefault;
+    }
   });
 
   it('returns the canonical in-flight job when an equivalent async request is deduped', async () => {

--- a/tests/gpt-async-idempotency.route.test.ts
+++ b/tests/gpt-async-idempotency.route.test.ts
@@ -67,6 +67,30 @@ jest.unstable_mockModule('../src/services/queuedGptCompletionService.js', () => 
 const { default: requestContext } = await import('../src/middleware/requestContext.js');
 const { default: gptRouter } = await import('../src/routes/gptRouter.js');
 
+const ASYNC_IDEMPOTENCY_ENV_KEYS = [
+  'GPT_ASYNC_HEAVY_PROMPT_CHARS',
+  'GPT_ASYNC_HEAVY_MESSAGE_COUNT',
+  'GPT_ASYNC_HEAVY_MAX_WORDS',
+  'GPT_ASYNC_HEAVY_WAIT_FOR_RESULT_MS',
+  'GPT_PUBLIC_RESPONSE_MAX_BYTES',
+  'GPT_ROUTE_ASYNC_CORE_DEFAULT',
+  'GPT_ROUTE_HARD_TIMEOUT_MS',
+] as const;
+
+function captureEnv(keys: readonly string[]): Map<string, string | undefined> {
+  return new Map(keys.map((key) => [key, process.env[key]]));
+}
+
+function restoreEnv(snapshot: ReadonlyMap<string, string | undefined>): void {
+  for (const [key, originalValue] of snapshot) {
+    if (originalValue === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = originalValue;
+    }
+  }
+}
+
 function buildApp() {
   const app = express();
   app.use(express.json());
@@ -76,14 +100,14 @@ function buildApp() {
 }
 
 describe('async /gpt idempotency', () => {
-  const originalGptRouteAsyncCoreDefault = process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT;
+  const originalAsyncIdempotencyEnv = captureEnv(ASYNC_IDEMPOTENCY_ENV_KEYS);
 
   beforeEach(() => {
     jest.clearAllMocks();
+    for (const key of ASYNC_IDEMPOTENCY_ENV_KEYS) {
+      delete process.env[key];
+    }
     process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT = 'true';
-    delete process.env.GPT_ASYNC_HEAVY_WAIT_FOR_RESULT_MS;
-    delete process.env.GPT_ROUTE_HARD_TIMEOUT_MS;
-    delete process.env.GPT_PUBLIC_RESPONSE_MAX_BYTES;
     planAutonomousWorkerJobMock.mockResolvedValue({
       status: 'pending',
       retryCount: 0,
@@ -99,11 +123,7 @@ describe('async /gpt idempotency', () => {
   });
 
   afterEach(() => {
-    if (originalGptRouteAsyncCoreDefault === undefined) {
-      delete process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT;
-    } else {
-      process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT = originalGptRouteAsyncCoreDefault;
-    }
+    restoreEnv(originalAsyncIdempotencyEnv);
   });
 
   it('returns the canonical in-flight job when an equivalent async request is deduped', async () => {

--- a/tests/gpt-fast-path.route.test.ts
+++ b/tests/gpt-fast-path.route.test.ts
@@ -204,7 +204,60 @@ describe('GPT fast-path route branching', () => {
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
-  it('keeps non-prompt-generation requests on the existing async job path', async () => {
+  it('keeps small non-prompt-generation core requests on the bounded direct path by default', async () => {
+    mockRouteGptRequest.mockResolvedValueOnce({
+      ok: true,
+      result: {
+        result: 'Direct core response.',
+      },
+      _route: {
+        requestId: 'req-core-direct',
+        gptId: 'arcanos-core',
+        module: 'ARCANOS:CORE',
+        action: 'query',
+        route: 'core',
+        matchMethod: 'direct',
+        availableActions: [],
+        timestamp: '2026-04-21T12:00:00.000Z',
+      },
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        prompt: 'Analyze this deployment timeout.',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['x-gpt-route-decision']).toBe('orchestrated_path');
+    expect(response.headers['x-gpt-route-decision-reason']).toBe('no_prompt_generation_intent');
+    expect(response.headers['x-gpt-fast-path-queue-bypassed']).toBe('false');
+    expect(response.headers['x-gpt-queue-bypassed']).toBe('true');
+    expect(response.body).toMatchObject({
+      ok: true,
+      result: {
+        result: 'Direct core response.',
+      },
+      _route: {
+        gptId: 'arcanos-core',
+        route: 'core',
+      },
+    });
+    expect(executeFastGptPromptMock).not.toHaveBeenCalled();
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gptId: 'arcanos-core',
+        body: {
+          prompt: 'Analyze this deployment timeout.',
+        },
+      })
+    );
+  });
+
+  it('preserves the legacy async core default when explicitly enabled', async () => {
+    process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT = 'true';
+
     const response = await request(buildApp())
       .post('/gpt/arcanos-core')
       .send({
@@ -226,8 +279,80 @@ describe('GPT fast-path route branching', () => {
         route: 'async',
       },
     });
-    expect(executeFastGptPromptMock).not.toHaveBeenCalled();
+    expect(planAutonomousWorkerJobMock).toHaveBeenCalledWith(
+      'gpt',
+      expect.objectContaining({
+        executionModeReason: 'core_query_async_default',
+      })
+    );
     expect(findOrCreateGptJobMock).toHaveBeenCalledTimes(1);
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('keeps explicit async core requests on the job path', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        prompt: 'Analyze this deployment timeout.',
+        executionMode: 'async',
+      });
+
+    expect(response.status).toBe(202);
+    expect(response.headers['x-gpt-route-decision']).toBe('orchestrated_path');
+    expect(response.headers['x-gpt-route-decision-reason']).toBe('explicit_orchestrated_mode');
+    expect(response.headers['x-gpt-fast-path-queue-bypassed']).toBe('false');
+    expect(response.headers['x-gpt-queue-bypassed']).toBe('false');
+    expect(response.body).toMatchObject({
+      ok: true,
+      action: 'query',
+      status: 'pending',
+      jobId: 'job-orchestrated',
+      _route: {
+        gptId: 'arcanos-core',
+        route: 'async',
+      },
+    });
+    expect(planAutonomousWorkerJobMock).toHaveBeenCalledWith(
+      'gpt',
+      expect.objectContaining({
+        executionModeReason: 'explicit_async_request',
+      })
+    );
+    expect(findOrCreateGptJobMock).toHaveBeenCalledTimes(1);
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('keeps heavy core requests on the async job path without the legacy default', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        prompt: 'Analyze this deployment timeout.',
+        maxWords: 900,
+      });
+
+    expect(response.status).toBe(202);
+    expect(response.headers['x-gpt-route-decision']).toBe('orchestrated_path');
+    expect(response.headers['x-gpt-route-decision-reason']).toBe('no_prompt_generation_intent');
+    expect(response.headers['x-gpt-fast-path-queue-bypassed']).toBe('false');
+    expect(response.headers['x-gpt-queue-bypassed']).toBe('false');
+    expect(response.body).toMatchObject({
+      ok: true,
+      action: 'query',
+      status: 'pending',
+      jobId: 'job-orchestrated',
+      _route: {
+        gptId: 'arcanos-core',
+        route: 'async',
+      },
+    });
+    expect(planAutonomousWorkerJobMock).toHaveBeenCalledWith(
+      'gpt',
+      expect.objectContaining({
+        executionModeReason: 'heavy_prompt_auto_async',
+      })
+    );
+    expect(findOrCreateGptJobMock).toHaveBeenCalledTimes(1);
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
   it('reports actual queue bypass for sync module-dispatch responses', async () => {
@@ -275,6 +400,23 @@ describe('GPT fast-path route branching', () => {
   });
 
   it('does not fast-path non-prompt-generation requests even when fast mode is requested', async () => {
+    mockRouteGptRequest.mockResolvedValueOnce({
+      ok: true,
+      result: {
+        result: 'Direct core response.',
+      },
+      _route: {
+        requestId: 'req-core-fast-rejected',
+        gptId: 'arcanos-core',
+        module: 'ARCANOS:CORE',
+        action: 'query',
+        route: 'core',
+        matchMethod: 'direct',
+        availableActions: [],
+        timestamp: '2026-04-21T12:00:00.000Z',
+      },
+    });
+
     const response = await request(buildApp())
       .post('/gpt/arcanos-core')
       .send({
@@ -282,19 +424,24 @@ describe('GPT fast-path route branching', () => {
         executionMode: 'fast',
       });
 
-    expect(response.status).toBe(202);
+    expect(response.status).toBe(200);
     expect(response.headers['x-gpt-route-decision']).toBe('orchestrated_path');
     expect(response.headers['x-gpt-route-decision-reason']).toBe('no_prompt_generation_intent');
     expect(response.headers['x-gpt-fast-path-queue-bypassed']).toBe('false');
-    expect(response.headers['x-gpt-queue-bypassed']).toBe('false');
+    expect(response.headers['x-gpt-queue-bypassed']).toBe('true');
     expect(response.body).toMatchObject({
       ok: true,
-      action: 'query',
-      status: 'pending',
-      jobId: 'job-orchestrated',
+      result: {
+        result: 'Direct core response.',
+      },
+      _route: {
+        gptId: 'arcanos-core',
+        route: 'core',
+      },
     });
     expect(executeFastGptPromptMock).not.toHaveBeenCalled();
-    expect(findOrCreateGptJobMock).toHaveBeenCalledTimes(1);
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).toHaveBeenCalledTimes(1);
   });
 
   it('rejects malformed payload shapes before queue submission', async () => {

--- a/tests/gpt-fast-path.route.test.ts
+++ b/tests/gpt-fast-path.route.test.ts
@@ -118,24 +118,42 @@ function buildFastPathEnvelope() {
   };
 }
 
-const GPT_FAST_PATH_ENV_KEYS = [
+const GPT_ROUTE_TEST_ENV_KEYS = [
+  'GPT_ASYNC_HEAVY_PROMPT_CHARS',
+  'GPT_ASYNC_HEAVY_MESSAGE_COUNT',
+  'GPT_ASYNC_HEAVY_MAX_WORDS',
+  'GPT_ASYNC_HEAVY_WAIT_FOR_RESULT_MS',
   'GPT_FAST_PATH_ENABLED',
   'GPT_FAST_PATH_GPT_ALLOWLIST',
   'GPT_FAST_PATH_MAX_PROMPT_CHARS',
   'GPT_FAST_PATH_MAX_MESSAGE_COUNT',
   'GPT_FAST_PATH_MAX_WORDS',
   'GPT_FAST_PATH_TIMEOUT_MS',
+  'GPT_PUBLIC_RESPONSE_MAX_BYTES',
   'GPT_ROUTE_ASYNC_CORE_DEFAULT',
+  'GPT_ROUTE_HARD_TIMEOUT_MS',
 ] as const;
 
-const originalFastPathEnv = new Map(
-  GPT_FAST_PATH_ENV_KEYS.map((key) => [key, process.env[key]])
-);
+function captureEnv(keys: readonly string[]): Map<string, string | undefined> {
+  return new Map(keys.map((key) => [key, process.env[key]]));
+}
+
+function restoreEnv(snapshot: ReadonlyMap<string, string | undefined>): void {
+  for (const [key, originalValue] of snapshot) {
+    if (originalValue === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = originalValue;
+    }
+  }
+}
+
+const originalRouteTestEnv = captureEnv(GPT_ROUTE_TEST_ENV_KEYS);
 
 describe('GPT fast-path route branching', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    for (const key of GPT_FAST_PATH_ENV_KEYS) {
+    for (const key of GPT_ROUTE_TEST_ENV_KEYS) {
       delete process.env[key];
     }
     executeFastGptPromptMock.mockResolvedValue(buildFastPathEnvelope());
@@ -170,14 +188,7 @@ describe('GPT fast-path route branching', () => {
   });
 
   afterEach(() => {
-    for (const key of GPT_FAST_PATH_ENV_KEYS) {
-      const originalValue = originalFastPathEnv.get(key);
-      if (originalValue === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = originalValue;
-      }
-    }
+    restoreEnv(originalRouteTestEnv);
   });
 
   it('returns eligible prompt-generation requests inline without queue submission', async () => {

--- a/tests/gpt-fast-path.route.test.ts
+++ b/tests/gpt-fast-path.route.test.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import request from 'supertest';
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const mockRouteGptRequest = jest.fn();
 const executeFastGptPromptMock = jest.fn();
@@ -118,16 +118,26 @@ function buildFastPathEnvelope() {
   };
 }
 
+const GPT_FAST_PATH_ENV_KEYS = [
+  'GPT_FAST_PATH_ENABLED',
+  'GPT_FAST_PATH_GPT_ALLOWLIST',
+  'GPT_FAST_PATH_MAX_PROMPT_CHARS',
+  'GPT_FAST_PATH_MAX_MESSAGE_COUNT',
+  'GPT_FAST_PATH_MAX_WORDS',
+  'GPT_FAST_PATH_TIMEOUT_MS',
+  'GPT_ROUTE_ASYNC_CORE_DEFAULT',
+] as const;
+
+const originalFastPathEnv = new Map(
+  GPT_FAST_PATH_ENV_KEYS.map((key) => [key, process.env[key]])
+);
+
 describe('GPT fast-path route branching', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    delete process.env.GPT_FAST_PATH_ENABLED;
-    delete process.env.GPT_FAST_PATH_GPT_ALLOWLIST;
-    delete process.env.GPT_FAST_PATH_MAX_PROMPT_CHARS;
-    delete process.env.GPT_FAST_PATH_MAX_MESSAGE_COUNT;
-    delete process.env.GPT_FAST_PATH_MAX_WORDS;
-    delete process.env.GPT_FAST_PATH_TIMEOUT_MS;
-    delete process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT;
+    for (const key of GPT_FAST_PATH_ENV_KEYS) {
+      delete process.env[key];
+    }
     executeFastGptPromptMock.mockResolvedValue(buildFastPathEnvelope());
     planAutonomousWorkerJobMock.mockResolvedValue({
       status: 'pending',
@@ -157,6 +167,17 @@ describe('GPT fast-path route branching', () => {
         status: 'pending',
       },
     });
+  });
+
+  afterEach(() => {
+    for (const key of GPT_FAST_PATH_ENV_KEYS) {
+      const originalValue = originalFastPathEnv.get(key);
+      if (originalValue === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalValue;
+      }
+    }
   });
 
   it('returns eligible prompt-generation requests inline without queue submission', async () => {


### PR DESCRIPTION
## Summary

- Change `GPT_ROUTE_ASYNC_CORE_DEFAULT` to default to `false` so small unadorned `/gpt/arcanos-core` requests use the bounded direct path unless async is explicitly requested.
- Preserve backwards compatibility for explicit async flows, heavy requests, idempotent requests, and the legacy default-async behavior when `GPT_ROUTE_ASYNC_CORE_DEFAULT=true`.
- Add route regression coverage and update fast-path docs/config examples for the new default.

## Root Cause

Production had `GPT_ROUTE_ASYNC_CORE_DEFAULT` unset, while the router defaulted that flag to `true`. Small non-prompt core requests that missed prompt-generation intent were therefore forced into the async worker path as `core_query_async_default`. Prior tracing showed queue wait was low and most latency was spent in the core Trinity/model pipeline, not DB or pool acquisition.

## Validation

- `npm test -- --runTestsByPath tests/gpt-fast-path.route.test.ts tests/gpt-async-idempotency.route.test.ts tests/gpt-fast-path-classification.test.ts --coverage=false`
- `npm test -- --runTestsByPath tests/gpt-router-universal-dispatch.test.ts tests/gpt-router-auth-logging.test.ts --coverage=false`
- `npm run type-check`
- `npm run validate:railway`
- `git diff --check`

## Railway Notes

- Verified Railway CLI `4.30.2` and authenticated account.
- Current linked Railway context is project `Arcanos`, environment `production`, service `None`.
- Runtime probe for production `ARCANOS V2` showed `GPT_ROUTE_ASYNC_CORE_DEFAULT` is unset, which this code change hardens after deploy.
- No production variable was mutated and no deploy was run from this branch.