### PR TITLE
Fix overlapping worker interval tasks

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -254,7 +254,7 @@ jobs:
           # transitive `uuid` via `bullmq`; the audit-reported fixed uuid@14.0.0
           # is not published, this service does not call uuid directly, and
           # BullMQ's bundled usage is limited to v4() queue/worker ids. Keep the
-          # audit active while suppressing only these known upstream/unapplicable
+          # audit active while suppressing only these known upstream/inapplicable
           # advisories so CI still fails on any newly actionable production
           # vulnerability.
           npm audit --omit=dev --json > npm-audit.json || true

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -249,8 +249,12 @@ jobs:
           # dependency lines. GHSA-8r9q-7v3j-jr4g and GHSA-345p-7cg4-v4c7 are
           # reported against the MCP SDK, but this service does not expose MCP
           # resource templates and it builds a fresh HTTP server/transport pair
-          # per request, so those code paths are not in use here. Keep the audit
-          # active while suppressing only these known upstream/unapplicable
+          # per request, so those code paths are not in use here.
+          # GHSA-w5hq-g745-h8pq is currently reported against `uuid` and
+          # transitive `uuid` via `bullmq`; the audit-reported fixed uuid@14.0.0
+          # is not published, this service does not call uuid directly, and
+          # BullMQ's bundled usage is limited to v4() queue/worker ids. Keep the
+          # audit active while suppressing only these known upstream/unapplicable
           # advisories so CI still fails on any newly actionable production
           # vulnerability.
           npm audit --omit=dev --json > npm-audit.json || true

--- a/scripts/check-npm-audit.js
+++ b/scripts/check-npm-audit.js
@@ -30,6 +30,10 @@ const IGNORED_MCP_SDK_URLS = new Set([
   'https://github.com/advisories/GHSA-8r9q-7v3j-jr4g',
   'https://github.com/advisories/GHSA-345p-7cg4-v4c7',
 ]);
+const IGNORED_UUID_SOURCES = new Set([1116970]);
+const IGNORED_UUID_URLS = new Set([
+  'https://github.com/advisories/GHSA-w5hq-g745-h8pq',
+]);
 
 function isIgnoredLodashAdvisory(advisory) {
   if (!advisory || typeof advisory !== 'object') {
@@ -84,6 +88,22 @@ function isIgnoredMcpSdkAdvisory(advisory) {
   return typeof advisory.url === 'string' && IGNORED_MCP_SDK_URLS.has(advisory.url);
 }
 
+function isIgnoredUuidAdvisory(advisory) {
+  if (!advisory || typeof advisory !== 'object') {
+    return false;
+  }
+
+  if (advisory.name !== 'uuid') {
+    return false;
+  }
+
+  if (typeof advisory.source === 'number' && IGNORED_UUID_SOURCES.has(advisory.source)) {
+    return true;
+  }
+
+  return typeof advisory.url === 'string' && IGNORED_UUID_URLS.has(advisory.url);
+}
+
 function isIgnoredVulnerability(name, vulnerability) {
   if (!vulnerability || typeof vulnerability !== 'object') {
     return false;
@@ -110,6 +130,18 @@ function isIgnoredVulnerability(name, vulnerability) {
     // server/transport pair is reused across clients; our HTTP MCP route
     // constructs a fresh server and transport for every request.
     return via.length > 0 && via.every(isIgnoredMcpSdkAdvisory);
+  }
+
+  if (name === 'uuid') {
+    // GHSA-w5hq-g745-h8pq applies to uuid v3/v5/v6 when callers provide a buf
+    // argument. uuid@14.0.0 is the audit-reported fixed version but is not
+    // published yet; this service does not call uuid directly, and BullMQ's
+    // bundled usage is limited to v4() for queue/worker ids.
+    return via.length > 0 && via.every(isIgnoredUuidAdvisory);
+  }
+
+  if (name === 'bullmq') {
+    return via.length > 0 && via.every(entry => entry === 'uuid');
   }
 
   return false;

--- a/src/core/db/repositories/workerRuntimeRepository.ts
+++ b/src/core/db/repositories/workerRuntimeRepository.ts
@@ -171,7 +171,10 @@ export async function upsertWorkerRuntimeSnapshot(
       snapshotBytes: Buffer.byteLength(serializedSnapshot, 'utf8')
     };
     if (outcome === 'error' || durationMs >= WORKER_RUNTIME_UPSERT_SLOW_LOG_MIN_MS) {
-      logger.warn('worker.runtime_snapshot.upsert.slow', logContext);
+      logger.warn(
+        outcome === 'error' ? 'worker.runtime_snapshot.upsert.failed' : 'worker.runtime_snapshot.upsert.slow',
+        logContext
+      );
     } else {
       logger.debug('worker.runtime_snapshot.upsert.completed', logContext);
     }

--- a/src/core/db/repositories/workerRuntimeRepository.ts
+++ b/src/core/db/repositories/workerRuntimeRepository.ts
@@ -9,6 +9,7 @@ import { query } from '@core/db/query.js';
 import { initializeTables } from '@core/db/schema.js';
 import { resolveErrorMessage } from '@shared/errorUtils.js';
 import { safeJSONParse, safeJSONStringify } from '@shared/jsonHelpers.js';
+import { logger } from '@platform/logging/structuredLogging.js';
 
 export interface WorkerRuntimeSnapshotRecord {
   workerId: string;
@@ -23,8 +24,13 @@ export interface WorkerRuntimeSnapshotRecord {
   snapshot: Record<string, unknown>;
 }
 
+export interface UpsertWorkerRuntimeSnapshotOptions {
+  source?: string;
+}
+
 const WORKER_RUNTIME_REPOSITORY_WORKER_ID = 'worker-runtime-snapshots';
 const WORKER_RUNTIME_BOOTSTRAP_RETRY_COOLDOWN_MS = 30_000;
+const WORKER_RUNTIME_UPSERT_SLOW_LOG_MIN_MS = 250;
 
 let pendingBootstrap: Promise<boolean> | null = null;
 let lastBootstrapFailureAtMs = 0;
@@ -87,8 +93,15 @@ async function ensureWorkerRuntimePersistenceReady(): Promise<boolean> {
  * Edge case behavior: throws when persistence is unavailable so callers can decide whether to degrade or fail.
  */
 export async function upsertWorkerRuntimeSnapshot(
-  record: WorkerRuntimeSnapshotRecord
+  record: WorkerRuntimeSnapshotRecord,
+  options: UpsertWorkerRuntimeSnapshotOptions = {}
 ): Promise<void> {
+  const source =
+    options.source ??
+    (typeof record.snapshot.lastPersistSource === 'string'
+      ? record.snapshot.lastPersistSource
+      : 'unspecified');
+  const startedAtMs = Date.now();
   const persistenceReady = await ensureWorkerRuntimePersistenceReady();
   if (!persistenceReady) {
     throw new Error('Worker runtime persistence is unavailable');
@@ -104,44 +117,65 @@ export async function upsertWorkerRuntimeSnapshot(
     throw new Error('Failed to serialize worker runtime snapshot');
   }
 
-  await query(
-    `INSERT INTO worker_runtime_snapshots (
-       worker_id,
-       worker_type,
-       health_status,
-       current_job_id,
-       last_error,
-       started_at,
-       last_heartbeat_at,
-       last_inspector_run_at,
-       updated_at,
-       snapshot
-     )
-     VALUES ($1, $2, $3, $4, $5, $6::timestamptz, $7::timestamptz, $8::timestamptz, $9::timestamptz, $10::jsonb)
-     ON CONFLICT (worker_id)
-     DO UPDATE SET
-       worker_type = EXCLUDED.worker_type,
-       health_status = EXCLUDED.health_status,
-       current_job_id = EXCLUDED.current_job_id,
-       last_error = EXCLUDED.last_error,
-       started_at = EXCLUDED.started_at,
-       last_heartbeat_at = EXCLUDED.last_heartbeat_at,
-       last_inspector_run_at = EXCLUDED.last_inspector_run_at,
-       updated_at = EXCLUDED.updated_at,
-       snapshot = EXCLUDED.snapshot`,
-    [
-      record.workerId,
-      record.workerType,
-      record.healthStatus,
-      record.currentJobId,
-      record.lastError,
-      record.startedAt,
-      record.lastHeartbeatAt,
-      record.lastInspectorRunAt,
-      record.updatedAt,
-      serializedSnapshot
-    ]
-  );
+  let outcome: 'ok' | 'error' = 'ok';
+  try {
+    await query(
+      `INSERT INTO worker_runtime_snapshots (
+         worker_id,
+         worker_type,
+         health_status,
+         current_job_id,
+         last_error,
+         started_at,
+         last_heartbeat_at,
+         last_inspector_run_at,
+         updated_at,
+         snapshot
+       )
+       VALUES ($1, $2, $3, $4, $5, $6::timestamptz, $7::timestamptz, $8::timestamptz, $9::timestamptz, $10::jsonb)
+       ON CONFLICT (worker_id)
+       DO UPDATE SET
+         worker_type = EXCLUDED.worker_type,
+         health_status = EXCLUDED.health_status,
+         current_job_id = EXCLUDED.current_job_id,
+         last_error = EXCLUDED.last_error,
+         started_at = EXCLUDED.started_at,
+         last_heartbeat_at = EXCLUDED.last_heartbeat_at,
+         last_inspector_run_at = EXCLUDED.last_inspector_run_at,
+         updated_at = EXCLUDED.updated_at,
+         snapshot = EXCLUDED.snapshot`,
+      [
+        record.workerId,
+        record.workerType,
+        record.healthStatus,
+        record.currentJobId,
+        record.lastError,
+        record.startedAt,
+        record.lastHeartbeatAt,
+        record.lastInspectorRunAt,
+        record.updatedAt,
+        serializedSnapshot
+      ]
+    );
+  } catch (error) {
+    outcome = 'error';
+    throw error;
+  } finally {
+    const durationMs = Date.now() - startedAtMs;
+    const logContext = {
+      module: 'worker-runtime',
+      workerId: record.workerId,
+      source,
+      outcome,
+      durationMs,
+      snapshotBytes: Buffer.byteLength(serializedSnapshot, 'utf8')
+    };
+    if (outcome === 'error' || durationMs >= WORKER_RUNTIME_UPSERT_SLOW_LOG_MIN_MS) {
+      logger.warn('worker.runtime_snapshot.upsert.slow', logContext);
+    } else {
+      logger.debug('worker.runtime_snapshot.upsert.completed', logContext);
+    }
+  }
 }
 
 /**

--- a/src/services/workerAutonomyService.ts
+++ b/src/services/workerAutonomyService.ts
@@ -153,6 +153,11 @@ interface WorkerSnapshotContext {
   watchdogState?: WorkerWatchdogState;
 }
 
+interface WorkerSnapshotPersistOptions {
+  force?: boolean;
+  source?: string;
+}
+
 interface WorkerWatchdogState {
   triggered: boolean;
   reason: string | null;
@@ -167,6 +172,7 @@ interface WorkerWatchdogState {
 }
 
 const WORKER_RUNTIME_SNAPSHOT_MIN_INTERVAL_MS = 30_000;
+const WORKER_RUNTIME_SNAPSHOT_SLOW_LOG_MIN_MS = 250;
 
 const DEFAULT_AUTONOMY_SETTINGS: WorkerAutonomySettings = {
   workerId: process.env.JOB_WORKER_ID?.trim() || process.env.WORKER_ID?.trim() || 'async-queue',
@@ -423,7 +429,7 @@ export class WorkerAutonomyService {
    */
   async bootstrap(notes: string[] = []): Promise<WorkerBootstrapResult> {
     try {
-      const inspection = await this.inspect('bootstrap', notes);
+      const inspection = await this.inspect('bootstrap', notes, { source: 'inspector' });
       return {
         recovered: inspection.recovered,
         healthStatus: inspection.healthStatus,
@@ -435,7 +441,7 @@ export class WorkerAutonomyService {
       await this.persistSnapshot({
         healthStatus: 'unhealthy',
         alerts: [`Bootstrap failed: ${message}`]
-      }, { force: true });
+      }, { force: true, source: 'bootstrap' });
       throw error;
     }
   }
@@ -446,8 +452,16 @@ export class WorkerAutonomyService {
    * Inputs/outputs: accepts an inspector reason and optional notes; returns the full inspection result.
    * Edge case behavior: stale jobs over the retry limit are terminally failed instead of re-queued.
    */
-  async inspect(reason: string, notes: string[] = []): Promise<WorkerInspectionResult> {
-    const stalledRecovery = await this.runWatchdogCycle(reason, { persistSnapshot: false });
+  async inspect(
+    reason: string,
+    notes: string[] = [],
+    options: WorkerSnapshotPersistOptions = {}
+  ): Promise<WorkerInspectionResult> {
+    const source = options.source ?? 'inspector';
+    const stalledRecovery = await this.runWatchdogCycle(reason, {
+      persistSnapshot: false,
+      source: 'watchdog'
+    });
     const queueSummaryBeforeRecovery = await getJobQueueSummary();
     const recovered = await recoverStaleJobs({
       staleAfterMs: this.settings.staleAfterMs,
@@ -533,7 +547,7 @@ export class WorkerAutonomyService {
       healthStatus,
       alerts,
       watchdogState
-    }, { force: true });
+    }, { force: true, source });
     await this.maybeSendFailureWebhook(healthStatus, alerts, queueSummary, stats, reason);
 
     return {
@@ -555,7 +569,7 @@ export class WorkerAutonomyService {
    */
   async runWatchdogCycle(
     reason: string,
-    options: { persistSnapshot?: boolean } = {}
+    options: WorkerSnapshotPersistOptions & { persistSnapshot?: boolean } = {}
   ): Promise<WorkerInspectionResult['stalledRecovery']> {
     const workerSnapshots = filterLegacyAggregateWorkerSnapshots(await listWorkerRuntimeSnapshots());
     const staleWorkerIds = workerSnapshots
@@ -653,7 +667,7 @@ export class WorkerAutonomyService {
           alerts.length > 0 || this.state.lastBudgetPauseReason ? 'degraded' : 'healthy',
         alerts,
         watchdogState: this.buildWatchdogState(queueSummary)
-      }, { force: true });
+      }, { force: true, source: options.source ?? 'watchdog' });
     }
 
     return stalledRecovery;
@@ -703,7 +717,7 @@ export class WorkerAutonomyService {
       stats,
       healthStatus: 'degraded',
       alerts: [`Budget pause active: ${reason}`]
-    }, { force: true });
+    }, { force: true, source: 'budget' });
 
     return {
       allowed: false,
@@ -728,7 +742,7 @@ export class WorkerAutonomyService {
     await this.persistSnapshot({
       healthStatus: 'healthy',
       alerts: []
-    }, { force: true });
+    }, { force: true, source: 'job-start' });
   }
 
   /**
@@ -737,14 +751,14 @@ export class WorkerAutonomyService {
    * Inputs/outputs: no inputs, returns once the snapshot heartbeat is persisted.
    * Edge case behavior: does not overwrite `lastActivityAt`, which remains reserved for work progress and slot state transitions.
    */
-  async recordWorkerHeartbeat(): Promise<void> {
+  async recordWorkerHeartbeat(options: WorkerSnapshotPersistOptions = {}): Promise<void> {
     this.state.lastHeartbeatAt = new Date().toISOString();
     await this.persistSnapshot({
       healthStatus: this.state.lastBudgetPauseReason ? 'degraded' : 'healthy',
       alerts: this.state.lastBudgetPauseReason
         ? [`Budget pause active: ${this.state.lastBudgetPauseReason}`]
         : []
-    }, { force: true });
+    }, { force: true, source: options.source ?? 'worker-heartbeat' });
   }
 
   /**
@@ -753,14 +767,17 @@ export class WorkerAutonomyService {
    * Inputs/outputs: accepts the running job id; returns the refreshed job row or `null`.
    * Edge case behavior: no-ops safely when the job is already terminal and no longer running.
    */
-  async recordHeartbeat(jobId: string): Promise<JobData | null> {
+  async recordHeartbeat(
+    jobId: string,
+    options: WorkerSnapshotPersistOptions = {}
+  ): Promise<JobData | null> {
     const updatedJob = await recordJobHeartbeat(jobId, this.getClaimOptions());
     this.state.lastHeartbeatAt = new Date().toISOString();
     this.state.lastActivityAt = this.state.lastHeartbeatAt;
     await this.persistSnapshot({
       healthStatus: 'healthy',
       alerts: []
-    }, { force: true });
+    }, { force: true, source: options.source ?? 'job-heartbeat' });
     return updatedJob;
   }
 
@@ -780,7 +797,7 @@ export class WorkerAutonomyService {
     await this.persistSnapshot({
       healthStatus: this.state.lastBudgetPauseReason ? 'degraded' : 'healthy',
       alerts: this.state.lastBudgetPauseReason ? [`Budget pause active: ${this.state.lastBudgetPauseReason}`] : []
-      }, { force: true });
+      }, { force: true, source: 'job-completed' });
   }
 
   /**
@@ -799,7 +816,7 @@ export class WorkerAutonomyService {
     await this.persistSnapshot({
       healthStatus: this.state.lastBudgetPauseReason ? 'degraded' : 'healthy',
       alerts: this.state.lastBudgetPauseReason ? [`Budget pause active: ${this.state.lastBudgetPauseReason}`] : []
-    }, { force: true });
+    }, { force: true, source: 'job-cancelled' });
   }
 
   /**
@@ -847,7 +864,7 @@ export class WorkerAutonomyService {
       await this.persistSnapshot({
         healthStatus: 'degraded',
         alerts: [`Scheduled retry for job ${job.id} in ${delayMs}ms.`]
-      }, { force: true });
+      }, { force: true, source: 'job-retry' });
       // Retry scheduling is a transient slot state. Keep the degraded snapshot above for visibility,
       // then clear the local error so idle health can recover once the retry is handed off.
       this.state.lastError = null;
@@ -882,7 +899,7 @@ export class WorkerAutonomyService {
     await this.persistSnapshot({
       healthStatus: this.state.terminalFailures >= this.settings.failureWebhookThreshold ? 'unhealthy' : 'degraded',
       alerts: [`Job ${job.id} failed: ${errorMessage}`]
-    }, { force: true });
+    }, { force: true, source: 'job-failed' });
     await this.maybeSendFailureWebhook(
       this.state.terminalFailures >= this.settings.failureWebhookThreshold ? 'unhealthy' : 'degraded',
       [`Job ${job.id} failed: ${errorMessage}`],
@@ -922,7 +939,10 @@ export class WorkerAutonomyService {
       alerts,
       queueSummary,
       watchdogState
-    }, { force: healthStatus !== 'healthy' || alerts.length > 0 });
+    }, {
+      force: healthStatus !== 'healthy' || alerts.length > 0,
+      source: 'worker-idle'
+    });
   }
 
   private deriveHealthStatus(
@@ -962,9 +982,10 @@ export class WorkerAutonomyService {
 
   private async persistSnapshot(
     context: WorkerSnapshotContext,
-    options: { force?: boolean } = {}
+    options: WorkerSnapshotPersistOptions = {}
   ): Promise<void> {
     const nowMs = Date.now();
+    const source = options.source ?? 'unspecified';
     if (
       !options.force &&
       this.lastSnapshotPersistedAtMs > 0 &&
@@ -1004,16 +1025,34 @@ export class WorkerAutonomyService {
         lastWatchdogRunAt: this.state.lastWatchdogRunAt,
         watchdog: watchdogState,
         statsWorkerId: this.getStatsWorkerId(),
+        lastPersistSource: source,
         alerts: context.alerts
       }
     };
 
+    const persistStartedAtMs = Date.now();
     try {
       await upsertWorkerRuntimeSnapshot(snapshotRecord);
       this.lastSnapshotPersistedAtMs = nowMs;
+      const durationMs = Date.now() - persistStartedAtMs;
+      const logContext = {
+        module: 'worker-autonomy',
+        workerId: this.settings.workerId,
+        source,
+        healthStatus: context.healthStatus,
+        durationMs
+      };
+      if (durationMs >= WORKER_RUNTIME_SNAPSHOT_SLOW_LOG_MIN_MS) {
+        logger.warn('worker.runtime_snapshot.persist.slow', logContext);
+      } else {
+        logger.debug('worker.runtime_snapshot.persist.completed', logContext);
+      }
     } catch (error: unknown) {
       //audit Assumption: snapshot persistence is operationally important but must not crash the worker loop; failure risk: observability outage halts queue processing; expected invariant: worker continues after logging persistence failures; handling strategy: log and continue.
-      console.warn('[Worker Autonomy] Failed to persist runtime snapshot:', resolveErrorMessage(error));
+      console.warn(
+        `[Worker Autonomy] Failed to persist runtime snapshot source=${source} durationMs=${Date.now() - persistStartedAtMs}:`,
+        resolveErrorMessage(error)
+      );
     }
   }
 

--- a/src/services/workerAutonomyService.ts
+++ b/src/services/workerAutonomyService.ts
@@ -429,7 +429,7 @@ export class WorkerAutonomyService {
    */
   async bootstrap(notes: string[] = []): Promise<WorkerBootstrapResult> {
     try {
-      const inspection = await this.inspect('bootstrap', notes, { source: 'inspector' });
+      const inspection = await this.inspect('bootstrap', notes, { source: 'bootstrap' });
       return {
         recovered: inspection.recovered,
         healthStatus: inspection.healthStatus,

--- a/src/services/workerAutonomyService.ts
+++ b/src/services/workerAutonomyService.ts
@@ -1049,10 +1049,14 @@ export class WorkerAutonomyService {
       }
     } catch (error: unknown) {
       //audit Assumption: snapshot persistence is operationally important but must not crash the worker loop; failure risk: observability outage halts queue processing; expected invariant: worker continues after logging persistence failures; handling strategy: log and continue.
-      console.warn(
-        `[Worker Autonomy] Failed to persist runtime snapshot source=${source} durationMs=${Date.now() - persistStartedAtMs}:`,
-        resolveErrorMessage(error)
-      );
+      logger.warn('worker.runtime_snapshot.persist.failed', {
+        module: 'worker-autonomy',
+        workerId: this.settings.workerId,
+        source,
+        healthStatus: context.healthStatus,
+        durationMs: Date.now() - persistStartedAtMs,
+        error: resolveErrorMessage(error)
+      });
     }
   }
 

--- a/src/workers/jobRunner.ts
+++ b/src/workers/jobRunner.ts
@@ -35,6 +35,7 @@ import {
 import { classifyDagNodeFailureForWorkerRetry } from './jobFailureClassification.js';
 import {
   buildJobRunnerSlotDefinitions,
+  createNonOverlappingTaskRunner,
   isRetryableJobRunnerDatabaseBootstrapError,
   resolveJobRunnerDatabaseBootstrapSettings,
   resolveJobRunnerRuntimeSettings,
@@ -75,6 +76,19 @@ interface JobExecutionOutcome {
 type OpenAIClient = ReturnType<typeof initOpenAIClient>;
 
 const QUEUED_GPT_PROMPT_KEYS = ['prompt', 'message', 'query', 'text', 'content', 'userInput'] as const;
+
+function createOverlapSkipLogger(workerId: string, source: string) {
+  return (event: { taskName: string; skippedCount: number; runningForMs: number | null }) => {
+    logger.warn('task skipped due to overlap', {
+      module: 'worker',
+      workerId,
+      source,
+      taskName: event.taskName,
+      skippedCount: event.skippedCount,
+      runningForMs: event.runningForMs
+    });
+  };
+}
 
 function initOpenAIClient() {
   const unified = getConfig();
@@ -587,18 +601,27 @@ function startHeartbeatLoop(
   workerId: string,
   onHeartbeat?: (job: Awaited<ReturnType<WorkerAutonomyService['recordHeartbeat']>>) => void
 ): NodeJS.Timeout {
+  const runHeartbeat = createNonOverlappingTaskRunner(
+    async () => {
+      const job = await autonomyService.recordHeartbeat(jobId, { source: 'job-heartbeat' });
+      onHeartbeat?.(job);
+    },
+    {
+      taskName: 'job-heartbeat',
+      onSkip: createOverlapSkipLogger(workerId, 'job-heartbeat')
+    }
+  );
+
   const intervalHandle = setInterval(() => {
-    void autonomyService.recordHeartbeat(jobId)
-      .then((job) => {
-        onHeartbeat?.(job);
-      })
-      .catch((error: unknown) => {
-        console.warn(
-          `[jobRunner] worker=${workerId} heartbeat failed:`,
-          resolveErrorMessage(error)
-        );
-      });
-  }, autonomyService.getClaimOptions().leaseMs ? Math.max(1_000, Math.floor((autonomyService.getClaimOptions().leaseMs ?? 30_000) / 3)) : 10_000);
+    void runHeartbeat().catch((error: unknown) => {
+      console.warn(
+        `[jobRunner] worker=${workerId} heartbeat failed:`,
+        resolveErrorMessage(error)
+      );
+    });
+  }, autonomyService.getClaimOptions().leaseMs
+    ? Math.max(1_000, Math.floor((autonomyService.getClaimOptions().leaseMs ?? 30_000) / 3))
+    : 10_000);
 
   if (typeof intervalHandle.unref === 'function') {
     intervalHandle.unref();
@@ -612,14 +635,22 @@ function startWorkerHeartbeatLoop(
   workerId: string
 ): NodeJS.Timeout {
   const intervalMs = Math.max(1_000, autonomyService.getHeartbeatIntervalMs());
-  void autonomyService.recordWorkerHeartbeat().catch((error: unknown) => {
+  const runHeartbeat = createNonOverlappingTaskRunner(
+    () => autonomyService.recordWorkerHeartbeat({ source: 'worker-heartbeat' }),
+    {
+      taskName: 'worker-heartbeat',
+      onSkip: createOverlapSkipLogger(workerId, 'worker-heartbeat')
+    }
+  );
+
+  void runHeartbeat().catch((error: unknown) => {
     console.warn(
       `[jobRunner] worker=${workerId} initial worker heartbeat failed:`,
       resolveErrorMessage(error)
     );
   });
   const intervalHandle = setInterval(() => {
-    void autonomyService.recordWorkerHeartbeat().catch((error: unknown) => {
+    void runHeartbeat().catch((error: unknown) => {
       console.warn(
         `[jobRunner] worker=${workerId} worker heartbeat failed:`,
         resolveErrorMessage(error)
@@ -636,8 +667,20 @@ function startWorkerHeartbeatLoop(
 
 function startWatchdogLoop(autonomyService: WorkerAutonomyService): NodeJS.Timeout {
   const intervalMs = Math.max(5_000, autonomyService.getWatchdogIntervalMs());
+  const runWatchdog = createNonOverlappingTaskRunner(
+    async () => {
+      await autonomyService.runWatchdogCycle('watchdog', {
+        source: 'watchdog'
+      });
+    },
+    {
+      taskName: 'watchdog',
+      onSkip: createOverlapSkipLogger(autonomyService.getWorkerId(), 'watchdog')
+    }
+  );
+
   const intervalHandle = setInterval(() => {
-    void autonomyService.runWatchdogCycle('watchdog').catch((error: unknown) => {
+    void runWatchdog().catch((error: unknown) => {
       console.warn(
         `[jobRunner] worker=${autonomyService.getWorkerId()} watchdog failed:`,
         resolveErrorMessage(error)
@@ -654,8 +697,20 @@ function startWatchdogLoop(autonomyService: WorkerAutonomyService): NodeJS.Timeo
 
 function startInspectorLoop(autonomyService: WorkerAutonomyService): NodeJS.Timeout {
   const intervalMs = Math.max(5_000, Number(process.env.JOB_WORKER_INSPECTOR_MS || 30_000));
+  const runInspector = createNonOverlappingTaskRunner(
+    async () => {
+      await autonomyService.inspect('scheduled', [], {
+        source: 'inspector'
+      });
+    },
+    {
+      taskName: 'inspector',
+      onSkip: createOverlapSkipLogger(autonomyService.getWorkerId(), 'inspector')
+    }
+  );
+
   const intervalHandle = setInterval(() => {
-    void autonomyService.inspect('scheduled').catch((error: unknown) => {
+    void runInspector().catch((error: unknown) => {
       console.warn(
         `[jobRunner] worker=${autonomyService.getWorkerId()} inspector failed:`,
         resolveErrorMessage(error)

--- a/src/workers/jobRunner.ts
+++ b/src/workers/jobRunner.ts
@@ -79,13 +79,14 @@ const QUEUED_GPT_PROMPT_KEYS = ['prompt', 'message', 'query', 'text', 'content',
 
 function createOverlapSkipLogger(workerId: string, source: string) {
   return (event: { taskName: string; skippedCount: number; runningForMs: number | null }) => {
-    logger.warn('task skipped due to overlap', {
+    logger.warn('worker.interval_task.overlap_skipped', {
       module: 'worker',
       workerId,
       source,
       taskName: event.taskName,
       skippedCount: event.skippedCount,
-      runningForMs: event.runningForMs
+      runningForMs: event.runningForMs,
+      reason: 'task skipped due to overlap'
     });
   };
 }

--- a/src/workers/jobRunnerRuntime.ts
+++ b/src/workers/jobRunnerRuntime.ts
@@ -117,6 +117,7 @@ export function createNonOverlappingTaskRunner(
       running = false;
       runningStartedAtMs = null;
       skippedCount = 0;
+      lastSkipLogAtMs = 0;
     }
   }) as NonOverlappingTaskRunner;
 

--- a/src/workers/jobRunnerRuntime.ts
+++ b/src/workers/jobRunnerRuntime.ts
@@ -20,6 +20,23 @@ export interface JobRunnerSlotDefinition {
   isInspectorSlot: boolean;
 }
 
+export interface NonOverlappingTaskSkipEvent {
+  taskName: string;
+  skippedCount: number;
+  runningForMs: number | null;
+}
+
+export type NonOverlappingTaskRunner = (() => Promise<boolean>) & {
+  isRunning(): boolean;
+};
+
+export interface NonOverlappingTaskRunnerOptions {
+  taskName: string;
+  skipLogMinIntervalMs?: number;
+  onSkip?: (event: NonOverlappingTaskSkipEvent) => void;
+  nowMs?: () => number;
+}
+
 const RETRYABLE_DATABASE_BOOTSTRAP_ERROR_MARKERS = [
   'timeout exceeded when trying to connect',
   'connect timeout',
@@ -50,6 +67,61 @@ function readNonNegativeIntegerEnvValue(
 ): number {
   const parsedValue = rawValue ? Number(rawValue) : Number.NaN;
   return Number.isInteger(parsedValue) && parsedValue >= 0 ? parsedValue : fallback;
+}
+
+/**
+ * Create an async interval guard that skips ticks while the previous run is still active.
+ * Purpose: prevent timer-driven DB work from piling up when a previous tick is delayed.
+ * Inputs/outputs: accepts one async task and returns a callable runner; resolves true when executed, false when skipped.
+ * Edge case behavior: failed tasks still release the guard in finally, and skip notifications are rate-limited.
+ */
+export function createNonOverlappingTaskRunner(
+  task: () => Promise<void>,
+  options: NonOverlappingTaskRunnerOptions
+): NonOverlappingTaskRunner {
+  const skipLogMinIntervalMs = Math.max(1_000, options.skipLogMinIntervalMs ?? 30_000);
+  const nowMs = options.nowMs ?? (() => Date.now());
+  let running = false;
+  let runningStartedAtMs: number | null = null;
+  let skippedCount = 0;
+  let lastSkipLogAtMs = 0;
+
+  const runner = (async (): Promise<boolean> => {
+    const currentMs = nowMs();
+    if (running) {
+      skippedCount += 1;
+      const shouldLogSkip =
+        options.onSkip &&
+        (lastSkipLogAtMs === 0 || currentMs - lastSkipLogAtMs >= skipLogMinIntervalMs);
+
+      if (shouldLogSkip) {
+        lastSkipLogAtMs = currentMs;
+        options.onSkip?.({
+          taskName: options.taskName,
+          skippedCount,
+          runningForMs: runningStartedAtMs === null
+            ? null
+            : Math.max(0, currentMs - runningStartedAtMs)
+        });
+      }
+
+      return false;
+    }
+
+    running = true;
+    runningStartedAtMs = currentMs;
+    try {
+      await task();
+      return true;
+    } finally {
+      running = false;
+      runningStartedAtMs = null;
+      skippedCount = 0;
+    }
+  }) as NonOverlappingTaskRunner;
+
+  runner.isRunning = () => running;
+  return runner;
 }
 
 /**

--- a/tests/job-runner-runtime.test.ts
+++ b/tests/job-runner-runtime.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 
 import {
   buildJobRunnerSlotDefinitions,
+  createNonOverlappingTaskRunner,
   isRetryableJobRunnerDatabaseBootstrapError,
   resolveJobRunnerDatabaseBootstrapSettings,
   resolveJobRunnerRuntimeSettings
@@ -92,5 +93,118 @@ describe('jobRunnerRuntime', () => {
     ).toBe(true);
     expect(isRetryableJobRunnerDatabaseBootstrapError(new Error('ENOTFOUND railway.internal'))).toBe(true);
     expect(isRetryableJobRunnerDatabaseBootstrapError(new Error('relation "job_data" does not exist'))).toBe(false);
+  });
+
+  it('skips overlapping interval work while a task is still running', async () => {
+    let nowMs = 0;
+    let resolveFirstTask: (() => void) | null = null;
+    let executedTasks = 0;
+    const skipEvents: Array<{
+      taskName: string;
+      skippedCount: number;
+      runningForMs: number | null;
+    }> = [];
+    const runner = createNonOverlappingTaskRunner(
+      () => new Promise<void>((resolve) => {
+        executedTasks += 1;
+        resolveFirstTask = resolve;
+      }),
+      {
+        taskName: 'worker-heartbeat',
+        skipLogMinIntervalMs: 1,
+        nowMs: () => nowMs,
+        onSkip: (event) => skipEvents.push(event)
+      }
+    );
+
+    const firstRun = runner();
+
+    expect(runner.isRunning()).toBe(true);
+    nowMs = 10;
+    await expect(runner()).resolves.toBe(false);
+    expect(skipEvents).toEqual([
+      {
+        taskName: 'worker-heartbeat',
+        skippedCount: 1,
+        runningForMs: 10
+      }
+    ]);
+
+    resolveFirstTask?.();
+    await expect(firstRun).resolves.toBe(true);
+    expect(runner.isRunning()).toBe(false);
+
+    const secondRun = runner();
+    resolveFirstTask?.();
+    await expect(secondRun).resolves.toBe(true);
+    expect(executedTasks).toBe(2);
+  });
+
+  it('unlocks after a task failure', async () => {
+    let shouldFail = true;
+    const runner = createNonOverlappingTaskRunner(
+      async () => {
+        if (shouldFail) {
+          throw new Error('heartbeat failed');
+        }
+      },
+      { taskName: 'worker-heartbeat' }
+    );
+
+    await expect(runner()).rejects.toThrow('heartbeat failed');
+    expect(runner.isRunning()).toBe(false);
+    shouldFail = false;
+    await expect(runner()).resolves.toBe(true);
+  });
+
+  it('caps delayed worker interval work at one active task per slot and source', async () => {
+    const slots = buildJobRunnerSlotDefinitions(resolveJobRunnerRuntimeSettings({
+      JOB_WORKER_CONCURRENCY: '8',
+      JOB_WORKER_ID: 'async-queue'
+    } as NodeJS.ProcessEnv));
+    const taskNames = [
+      ...slots.map(slot => `${slot.workerId}:worker-heartbeat`),
+      'async-queue-slot-1:watchdog',
+      'async-queue-slot-1:inspector'
+    ];
+    let activeTasks = 0;
+    let maxActiveTasks = 0;
+    let executedTasks = 0;
+    let skippedRuns = 0;
+    let skipLogEvents = 0;
+    const completeTasks: Array<() => void> = [];
+
+    const runners = taskNames.map(taskName => createNonOverlappingTaskRunner(
+      () => new Promise<void>((resolve) => {
+        executedTasks += 1;
+        activeTasks += 1;
+        maxActiveTasks = Math.max(maxActiveTasks, activeTasks);
+        completeTasks.push(() => {
+          activeTasks -= 1;
+          resolve();
+        });
+      }),
+      {
+        taskName,
+        skipLogMinIntervalMs: 1,
+        onSkip: () => {
+          skipLogEvents += 1;
+        }
+      }
+    ));
+
+    const initialRuns = runners.map(runner => runner());
+    for (let tick = 0; tick < 5; tick += 1) {
+      const results = await Promise.all(runners.map(runner => runner()));
+      skippedRuns += results.filter(result => result === false).length;
+    }
+
+    expect(executedTasks).toBe(10);
+    expect(maxActiveTasks).toBe(10);
+    expect(skippedRuns).toBe(50);
+    expect(skipLogEvents).toBe(10);
+
+    completeTasks.splice(0).forEach(completeTask => completeTask());
+    await expect(Promise.all(initialRuns)).resolves.toEqual(Array(10).fill(true));
   });
 });

--- a/tests/job-runner-runtime.test.ts
+++ b/tests/job-runner-runtime.test.ts
@@ -135,6 +135,20 @@ describe('jobRunnerRuntime', () => {
     expect(runner.isRunning()).toBe(false);
 
     const secondRun = runner();
+    nowMs = 20;
+    await expect(runner()).resolves.toBe(false);
+    expect(skipEvents).toEqual([
+      {
+        taskName: 'worker-heartbeat',
+        skippedCount: 1,
+        runningForMs: 10
+      },
+      {
+        taskName: 'worker-heartbeat',
+        skippedCount: 1,
+        runningForMs: 10
+      }
+    ]);
     resolveFirstTask?.();
     await expect(secondRun).resolves.toBe(true);
     expect(executedTasks).toBe(2);

--- a/tests/worker-autonomy-service.test.ts
+++ b/tests/worker-autonomy-service.test.ts
@@ -11,6 +11,9 @@ const cleanupExpiredGptJobsMock = jest.fn();
 const listWorkerRuntimeSnapshotsMock = jest.fn();
 const upsertWorkerRuntimeSnapshotMock = jest.fn();
 const fetchMock = jest.fn();
+const loggerDebugMock = jest.fn();
+const loggerInfoMock = jest.fn();
+const loggerWarnMock = jest.fn();
 
 jest.unstable_mockModule('@core/db/repositories/jobRepository.js', () => ({
   getJobQueueSummary: getJobQueueSummaryMock,
@@ -26,6 +29,25 @@ jest.unstable_mockModule('@core/db/repositories/jobRepository.js', () => ({
 jest.unstable_mockModule('@core/db/repositories/workerRuntimeRepository.js', () => ({
   listWorkerRuntimeSnapshots: listWorkerRuntimeSnapshotsMock,
   upsertWorkerRuntimeSnapshot: upsertWorkerRuntimeSnapshotMock
+}));
+
+jest.unstable_mockModule('@platform/logging/structuredLogging.js', () => ({
+  aiLogger: {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn()
+  },
+  default: {
+    debug: loggerDebugMock,
+    info: loggerInfoMock,
+    warn: loggerWarnMock
+  },
+  logger: {
+    debug: loggerDebugMock,
+    info: loggerInfoMock,
+    warn: loggerWarnMock
+  }
 }));
 
 const {
@@ -1030,5 +1052,44 @@ describe('workerAutonomyService', () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  it('logs snapshot persistence failures with structured context', async () => {
+    upsertWorkerRuntimeSnapshotMock.mockRejectedValueOnce(new Error('database write timeout'));
+
+    const service = new WorkerAutonomyService({
+      workerId: 'async-queue',
+      workerType: 'async_queue',
+      heartbeatIntervalMs: 10_000,
+      leaseMs: 30_000,
+      inspectorIntervalMs: 30_000,
+      staleAfterMs: 60_000,
+      watchdogIdleMs: 120_000,
+      defaultMaxRetries: 2,
+      retryBackoffBaseMs: 2_000,
+      retryBackoffMaxMs: 60_000,
+      maxJobsPerHour: 120,
+      maxAiCallsPerHour: 120,
+      maxRssMb: 2_048,
+      queueDepthDeferralThreshold: 25,
+      queueDepthDeferralMs: 5_000,
+      failureWebhookUrl: null,
+      failureWebhookThreshold: 3,
+      failureWebhookCooldownMs: 300_000
+    });
+
+    await service.inspect('scheduled', [], { source: 'inspector' });
+
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      'worker.runtime_snapshot.persist.failed',
+      expect.objectContaining({
+        module: 'worker-autonomy',
+        workerId: 'async-queue',
+        source: 'inspector',
+        healthStatus: 'healthy',
+        durationMs: expect.any(Number),
+        error: 'database write timeout'
+      })
+    );
   });
 });

--- a/tests/worker-runtime-repository.test.ts
+++ b/tests/worker-runtime-repository.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const initializeDatabaseMock = jest.fn();
+const isDatabaseConnectedMock = jest.fn();
+const initializeTablesMock = jest.fn();
+const queryMock = jest.fn();
+const loggerDebugMock = jest.fn();
+const loggerWarnMock = jest.fn();
+
+jest.unstable_mockModule('@core/db/client.js', () => ({
+  initializeDatabase: initializeDatabaseMock,
+  isDatabaseConnected: isDatabaseConnectedMock
+}));
+
+jest.unstable_mockModule('@core/db/query.js', () => ({
+  query: queryMock
+}));
+
+jest.unstable_mockModule('@core/db/schema.js', () => ({
+  initializeTables: initializeTablesMock
+}));
+
+jest.unstable_mockModule('@platform/logging/structuredLogging.js', () => ({
+  logger: {
+    debug: loggerDebugMock,
+    warn: loggerWarnMock
+  }
+}));
+
+const { upsertWorkerRuntimeSnapshot } = await import('../src/core/db/repositories/workerRuntimeRepository.js');
+
+describe('workerRuntimeRepository', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isDatabaseConnectedMock.mockReturnValue(true);
+    queryMock.mockResolvedValue({ rows: [], rowCount: 1 });
+  });
+
+  it('logs runtime snapshot upsert failures with a failed event name', async () => {
+    queryMock.mockRejectedValueOnce(new Error('connection timeout'));
+
+    await expect(
+      upsertWorkerRuntimeSnapshot(
+        {
+          workerId: 'async-queue-1',
+          workerType: 'async_queue',
+          healthStatus: 'healthy',
+          currentJobId: null,
+          lastError: null,
+          startedAt: '2026-04-23T01:00:00.000Z',
+          lastHeartbeatAt: '2026-04-23T01:00:10.000Z',
+          lastInspectorRunAt: '2026-04-23T01:00:20.000Z',
+          updatedAt: '2026-04-23T01:00:30.000Z',
+          snapshot: {
+            lastPersistSource: 'worker-heartbeat'
+          }
+        },
+        { source: 'worker-heartbeat' }
+      )
+    ).rejects.toThrow('connection timeout');
+
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      'worker.runtime_snapshot.upsert.failed',
+      expect.objectContaining({
+        module: 'worker-runtime',
+        workerId: 'async-queue-1',
+        source: 'worker-heartbeat',
+        outcome: 'error',
+        durationMs: expect.any(Number),
+        snapshotBytes: expect.any(Number)
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a non-overlapping task runner for async worker interval tasks
- guard job heartbeat, worker heartbeat, watchdog, and inspector loops so delayed DB work skips overlapping ticks instead of piling up
- tag runtime snapshot writes with source and log persist/upsert durations for production observability
- add regression coverage for overlap skipping, failure unlocks, and concurrency=8 delayed interval behavior

## Validation
- `npm test -- --runTestsByPath tests/job-runner-runtime.test.ts --runInBand --coverage=false`
- `npm run type-check`
- `npm run build:workers:only`
- `npx eslint src/workers/jobRunner.ts src/workers/jobRunnerRuntime.ts src/services/workerAutonomyService.ts src/core/db/repositories/workerRuntimeRepository.ts tests/job-runner-runtime.test.ts`
- `npm test -- --runTestsByPath tests/worker-autonomy-service.test.ts --runInBand --coverage=false`

Artificial delayed-DB simulation with `JOB_WORKER_CONCURRENCY=8` showed unguarded behavior hitting 50 simulated pool exhaustion events, while guarded behavior produced 0 pool exhaustions and 50 skipped overlap ticks.