### PR TITLE
[codex] Add priority scheduler layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,6 +149,14 @@ GPT_FAST_PATH_ENABLED=true
 # Optional legacy bridge for small unadorned core queries. Leave false so the bounded
 # request-mode core path can return inline unless the request explicitly asks for async work.
 # GPT_ROUTE_ASYNC_CORE_DEFAULT=false
+# Priority GPT async execution and queue lane.
+# PRIORITY_GPT_IDS=arcanos-core,arcanos-audit,arcanos-build,arcanos-research,arcanos-write,arcanos-guide,arcanos-sim,arcanos-tracker,arcanos-tutor,arcanos-daemon,core,audit,build,research,write,guide,sim,tracker,tutor
+PRIORITY_QUEUE_ENABLED=true
+PRIORITY_QUEUE_WEIGHT=5
+GPT_DIRECT_EXECUTION_THRESHOLD_MS=8000
+GPT_WAIT_TIMEOUT_MS=24000
+GPT_JOB_MAX_RETRIES=1
+# GPT_PRIORITY_DIRECT_EXECUTION_CONCURRENCY=1
 
 # Feature flags
 # ENABLE_ACTION_PLANS=false

--- a/.github/workflows/arcanos-pr-assistant.yml
+++ b/.github/workflows/arcanos-pr-assistant.yml
@@ -37,6 +37,11 @@ jobs:
       - name: 📦 Install dependencies
         run: npm ci
 
+      - name: 🐍 Install Python protocol runtime dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install jsonschema referencing
+
       - name: 🧹 Lint code
         run: npm run lint
 

--- a/src/core/db/repositories/jobRepository.ts
+++ b/src/core/db/repositories/jobRepository.ts
@@ -1132,11 +1132,12 @@ export async function claimNextPendingJob(
       lane: firstLane
     });
 
-    if (!claimedJob && firstLane === 'normal') {
+    if (!claimedJob) {
+      const secondLane = firstLane === 'normal' ? 'priority' : 'normal';
       claimedJob = await claimPendingJobWithLane(client, {
         leaseMs,
         workerId: options.workerId ?? null,
-        lane: 'priority'
+        lane: secondLane
       });
     }
 

--- a/src/core/db/repositories/jobRepository.ts
+++ b/src/core/db/repositories/jobRepository.ts
@@ -1011,11 +1011,20 @@ async function withPriorityQueueFairnessLock<T>(operation: () => Promise<T>): Pr
   });
 
   await previousLock;
+
+  let operationPromise: Promise<T>;
   try {
-    return await operation();
-  } finally {
+    // Run the callback while holding the lock so any synchronous fairness-state
+    // reads/updates remain serialized, but release the lock before awaiting the
+    // returned promise so DB round-trips can proceed concurrently.
+    operationPromise = operation();
+  } catch (error) {
     releaseLock();
+    throw error;
   }
+
+  releaseLock();
+  return await operationPromise;
 }
 
 function toRepositoryClaimLane(lane: QueueLane): PriorityQueueClaimLane {

--- a/src/core/db/repositories/jobRepository.ts
+++ b/src/core/db/repositories/jobRepository.ts
@@ -1012,19 +1012,13 @@ async function withPriorityQueueFairnessLock<T>(operation: () => Promise<T>): Pr
 
   await previousLock;
 
-  let operationPromise: Promise<T>;
   try {
-    // Run the callback while holding the lock so any synchronous fairness-state
-    // reads/updates remain serialized, but release the lock before awaiting the
-    // returned promise so DB round-trips can proceed concurrently.
-    operationPromise = operation();
+    return await operation();
   } catch (error) {
-    releaseLock();
     throw error;
+  } finally {
+    releaseLock();
   }
-
-  releaseLock();
-  return await operationPromise;
 }
 
 function toRepositoryClaimLane(lane: QueueLane): PriorityQueueClaimLane {

--- a/src/core/db/repositories/jobRepository.ts
+++ b/src/core/db/repositories/jobRepository.ts
@@ -15,6 +15,17 @@ import {
   resolveGptExpiredCompactionMs,
   resolveGptPendingMaxAgeMs
 } from '@shared/gpt/gptJobLifecycle.js';
+import {
+  PRIORITY_QUEUE_LANE_MAX_PRIORITY,
+  isPriorityQueueEnabled,
+  isPriorityQueueLaneJob,
+  resolvePriorityQueueWeight
+} from '@shared/gpt/priorityGpt.js';
+import {
+  resolveSchedulerClaimLane,
+  updateSchedulerClaimState
+} from '@core/scheduler/scheduler.js';
+import type { QueueLane, SchedulerClaimOptions } from '@core/scheduler/types.js';
 
 export type JobFailureCategory =
   | 'authentication'
@@ -63,6 +74,11 @@ export interface JobQueueSummary {
   recentCompleted?: number;
   recentFailed?: number;
   recentTotalTerminal?: number;
+  priorityPending: number;
+  priorityRunning: number;
+  priorityTotal: number;
+  normalPending: number;
+  priorityJobCount: number;
   lastUpdatedAt?: string;
 }
 
@@ -96,10 +112,7 @@ export interface UpdateJobMetadata {
   cancelReason?: string | null;
 }
 
-export interface ClaimNextPendingJobOptions {
-  workerId?: string;
-  leaseMs?: number;
-}
+export interface ClaimNextPendingJobOptions extends SchedulerClaimOptions {}
 
 export interface ScheduleJobRetryOptions {
   workerId?: string;
@@ -986,6 +999,108 @@ export async function requestJobCancellation(
   }
 }
 
+type PriorityQueueClaimLane = 'priority' | 'normal';
+
+let priorityClaimsSinceNormal = 0;
+
+function toRepositoryClaimLane(lane: QueueLane): PriorityQueueClaimLane {
+  return lane === 'standard' ? 'normal' : 'priority';
+}
+
+export function resolvePriorityQueueClaimLane(options: {
+  priorityQueueEnabled?: boolean;
+  priorityQueueWeight?: number;
+  priorityClaimsSinceNormal?: number;
+  env?: NodeJS.ProcessEnv;
+} = {}): PriorityQueueClaimLane {
+  const enabled =
+    options.priorityQueueEnabled ??
+    isPriorityQueueEnabled(options.env ?? process.env);
+  if (!enabled) {
+    return 'priority';
+  }
+
+  const weight = Math.max(
+    1,
+    Math.trunc(
+      options.priorityQueueWeight ??
+      resolvePriorityQueueWeight(options.env ?? process.env)
+    )
+  );
+  const claimsSinceNormal = Math.max(
+    0,
+    Math.trunc(options.priorityClaimsSinceNormal ?? priorityClaimsSinceNormal)
+  );
+
+  return toRepositoryClaimLane(resolveSchedulerClaimLane({
+    policy: {
+      priorityQueueEnabled: enabled,
+      priorityQueueWeight: weight,
+      priorityLaneMaxPriority: PRIORITY_QUEUE_LANE_MAX_PRIORITY
+    },
+    state: {
+      priorityClaimsSinceStandard: claimsSinceNormal
+    }
+  }).lane);
+}
+
+export function resetPriorityQueueFairnessState(): void {
+  priorityClaimsSinceNormal = 0;
+}
+
+async function claimPendingJobWithLane(
+  client: { query: (sql: string, params?: unknown[]) => Promise<{ rows: unknown[] }> },
+  params: {
+    leaseMs: number;
+    workerId?: string | null;
+    lane: PriorityQueueClaimLane;
+  }
+): Promise<JobData | null> {
+  const queryParams: unknown[] = [params.leaseMs, params.workerId ?? null];
+  const normalLaneFilter = params.lane === 'normal'
+    ? `AND NOT (job_type = 'gpt' AND priority <= $3)`
+    : '';
+  if (params.lane === 'normal') {
+    queryParams.push(PRIORITY_QUEUE_LANE_MAX_PRIORITY);
+  }
+
+  const result = await client.query(
+    `UPDATE job_data
+     SET
+       status = 'running',
+       updated_at = NOW(),
+       started_at = COALESCE(started_at, NOW()),
+       last_heartbeat_at = NOW(),
+       lease_expires_at = NOW() + ($1::bigint * INTERVAL '1 millisecond'),
+       last_worker_id = COALESCE($2, last_worker_id)
+     WHERE id = (
+       SELECT id
+       FROM job_data
+       WHERE status = 'pending'
+         AND next_run_at <= NOW()
+         ${normalLaneFilter}
+       ORDER BY priority ASC, next_run_at ASC, created_at ASC
+       FOR UPDATE SKIP LOCKED
+       LIMIT 1
+     )
+     RETURNING *`,
+    queryParams
+  );
+
+  return (result.rows[0] as JobData | undefined) ?? null;
+}
+
+function updatePriorityQueueFairnessAfterClaim(job: JobData | null): void {
+  if (!job) {
+    return;
+  }
+
+  priorityClaimsSinceNormal = updateSchedulerClaimState(
+    { priorityClaimsSinceStandard: priorityClaimsSinceNormal },
+    isPriorityQueueLaneJob(job) ? 'priority' : 'standard'
+  ).priorityClaimsSinceStandard;
+}
+
 /**
  * Atomically claim the next runnable pending job using SKIP LOCKED.
  * Purpose: lease due queue work to one worker while respecting scheduling and priority.
@@ -1007,30 +1122,27 @@ export async function claimNextPendingJob(
   try {
     await client.query('BEGIN');
 
-    const result = await client.query(
-      `UPDATE job_data
-       SET
-         status = 'running',
-         updated_at = NOW(),
-         started_at = COALESCE(started_at, NOW()),
-         last_heartbeat_at = NOW(),
-         lease_expires_at = NOW() + ($1::bigint * INTERVAL '1 millisecond'),
-         last_worker_id = COALESCE($2, last_worker_id)
-       WHERE id = (
-         SELECT id
-         FROM job_data
-         WHERE status = 'pending'
-           AND next_run_at <= NOW()
-         ORDER BY priority ASC, next_run_at ASC, created_at ASC
-         FOR UPDATE SKIP LOCKED
-         LIMIT 1
-       )
-       RETURNING *`,
-      [leaseMs, options.workerId ?? null]
-    );
+    const firstLane = resolvePriorityQueueClaimLane({
+      priorityQueueEnabled: options.priorityQueueEnabled,
+      priorityQueueWeight: options.priorityQueueWeight
+    });
+    let claimedJob = await claimPendingJobWithLane(client, {
+      leaseMs,
+      workerId: options.workerId ?? null,
+      lane: firstLane
+    });
+
+    if (!claimedJob && firstLane === 'normal') {
+      claimedJob = await claimPendingJobWithLane(client, {
+        leaseMs,
+        workerId: options.workerId ?? null,
+        lane: 'priority'
+      });
+    }
 
     await client.query('COMMIT');
-    return (result.rows[0] as JobData | undefined) ?? null;
+    updatePriorityQueueFairnessAfterClaim(claimedJob);
+    return claimedJob;
   } catch (error: unknown) {
     await client.query('ROLLBACK');
     console.error('Error claiming pending job:', resolveErrorMessage(error));
@@ -1622,6 +1734,28 @@ export async function getJobQueueSummary(): Promise<JobQueueSummary | null> {
            COUNT(*) FILTER (WHERE status = 'running')::int AS running_count,
            COUNT(*) FILTER (WHERE status = 'completed')::int AS completed_count,
            COUNT(*) FILTER (WHERE status = 'failed')::int AS failed_count,
+           COUNT(*) FILTER (
+             WHERE status = 'pending'
+               AND job_type = 'gpt'
+               AND priority <= $3
+           )::int AS priority_pending_count,
+           COUNT(*) FILTER (
+             WHERE status = 'running'
+               AND job_type = 'gpt'
+               AND priority <= $3
+           )::int AS priority_running_count,
+           COUNT(*) FILTER (
+             WHERE job_type = 'gpt'
+               AND priority <= $3
+           )::int AS priority_total_count,
+           COUNT(*) FILTER (
+             WHERE status = 'pending'
+               AND NOT (job_type = 'gpt' AND priority <= $3)
+           )::int AS normal_pending_count,
+           COUNT(*) FILTER (
+             WHERE job_type = 'gpt'
+               AND priority <= $3
+           )::int AS priority_job_count,
            COUNT(*)::int AS total_count,
            COUNT(*) FILTER (WHERE status = 'pending' AND next_run_at > NOW())::int AS delayed_count,
            COUNT(*) FILTER (
@@ -1690,6 +1824,11 @@ export async function getJobQueueSummary(): Promise<JobQueueSummary | null> {
          summary.running_count,
          summary.completed_count,
          summary.failed_count,
+         summary.priority_pending_count,
+         summary.priority_running_count,
+         summary.priority_total_count,
+         summary.normal_pending_count,
+         summary.priority_job_count,
          summary.total_count,
          summary.delayed_count,
          summary.stalled_running_count,
@@ -1727,7 +1866,7 @@ export async function getJobQueueSummary(): Promise<JobQueueSummary | null> {
          ) AS recent_failure_reasons
        FROM summary
        CROSS JOIN failure_breakdown`,
-      [recentTerminalWindowMs, staleAfterMs]
+      [recentTerminalWindowMs, staleAfterMs, PRIORITY_QUEUE_LANE_MAX_PRIORITY]
     );
 
     const summaryRow = result.rows[0] as {
@@ -1735,6 +1874,11 @@ export async function getJobQueueSummary(): Promise<JobQueueSummary | null> {
       running_count: number;
       completed_count: number;
       failed_count: number;
+      priority_pending_count: number;
+      priority_running_count: number;
+      priority_total_count: number;
+      normal_pending_count: number;
+      priority_job_count: number;
       total_count: number;
       delayed_count: number;
       stalled_running_count: number;
@@ -1773,7 +1917,12 @@ export async function getJobQueueSummary(): Promise<JobQueueSummary | null> {
         recentTerminalWindowMs,
         recentCompleted: 0,
         recentFailed: 0,
-        recentTotalTerminal: 0
+        recentTotalTerminal: 0,
+        priorityPending: 0,
+        priorityRunning: 0,
+        priorityTotal: 0,
+        normalPending: 0,
+        priorityJobCount: 0
       };
     }
 
@@ -1804,7 +1953,12 @@ export async function getJobQueueSummary(): Promise<JobQueueSummary | null> {
       recentTerminalWindowMs,
       recentCompleted: Number(summaryRow.recent_completed_count ?? 0),
       recentFailed: Number(summaryRow.recent_failed_count ?? 0),
-      recentTotalTerminal: Number(summaryRow.recent_terminal_count ?? 0)
+      recentTotalTerminal: Number(summaryRow.recent_terminal_count ?? 0),
+      priorityPending: Number(summaryRow.priority_pending_count ?? 0),
+      priorityRunning: Number(summaryRow.priority_running_count ?? 0),
+      priorityTotal: Number(summaryRow.priority_total_count ?? 0),
+      normalPending: Number(summaryRow.normal_pending_count ?? 0),
+      priorityJobCount: Number(summaryRow.priority_job_count ?? 0)
     };
 
     if (summaryRow.last_updated_at) {

--- a/src/core/db/repositories/jobRepository.ts
+++ b/src/core/db/repositories/jobRepository.ts
@@ -76,7 +76,6 @@ export interface JobQueueSummary {
   recentTotalTerminal?: number;
   priorityPending: number;
   priorityRunning: number;
-  priorityTotal: number;
   normalPending: number;
   priorityJobCount: number;
   lastUpdatedAt?: string;
@@ -1002,14 +1001,40 @@ export async function requestJobCancellation(
 type PriorityQueueClaimLane = 'priority' | 'normal';
 
 let priorityClaimsSinceNormal = 0;
+let priorityQueueFairnessLock: Promise<void> = Promise.resolve();
+
+async function withPriorityQueueFairnessLock<T>(operation: () => Promise<T>): Promise<T> {
+  const previousLock = priorityQueueFairnessLock;
+  let releaseLock: () => void = () => {};
+  priorityQueueFairnessLock = new Promise<void>(resolve => {
+    releaseLock = resolve;
+  });
+
+  await previousLock;
+  try {
+    return await operation();
+  } finally {
+    releaseLock();
+  }
+}
 
 function toRepositoryClaimLane(lane: QueueLane): PriorityQueueClaimLane {
   return lane === 'standard' ? 'normal' : 'priority';
 }
 
+function normalizePriorityLaneMaxPriority(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return PRIORITY_QUEUE_LANE_MAX_PRIORITY;
+  }
+
+  const normalized = Math.trunc(value);
+  return normalized > 0 ? normalized : PRIORITY_QUEUE_LANE_MAX_PRIORITY;
+}
+
 export function resolvePriorityQueueClaimLane(options: {
   priorityQueueEnabled?: boolean;
   priorityQueueWeight?: number;
+  priorityLaneMaxPriority?: number;
   priorityClaimsSinceNormal?: number;
   env?: NodeJS.ProcessEnv;
 } = {}): PriorityQueueClaimLane {
@@ -1031,12 +1056,15 @@ export function resolvePriorityQueueClaimLane(options: {
     0,
     Math.trunc(options.priorityClaimsSinceNormal ?? priorityClaimsSinceNormal)
   );
+  const priorityLaneMaxPriority = normalizePriorityLaneMaxPriority(
+    options.priorityLaneMaxPriority
+  );
 
   return toRepositoryClaimLane(resolveSchedulerClaimLane({
     policy: {
       priorityQueueEnabled: enabled,
       priorityQueueWeight: weight,
-      priorityLaneMaxPriority: PRIORITY_QUEUE_LANE_MAX_PRIORITY
+      priorityLaneMaxPriority
     },
     state: {
       priorityClaimsSinceStandard: claimsSinceNormal
@@ -1054,6 +1082,7 @@ async function claimPendingJobWithLane(
     leaseMs: number;
     workerId?: string | null;
     lane: PriorityQueueClaimLane;
+    priorityLaneMaxPriority: number;
   }
 ): Promise<JobData | null> {
   const queryParams: unknown[] = [params.leaseMs, params.workerId ?? null];
@@ -1061,7 +1090,7 @@ async function claimPendingJobWithLane(
     ? `AND NOT (job_type = 'gpt' AND priority <= $3)`
     : '';
   if (params.lane === 'normal') {
-    queryParams.push(PRIORITY_QUEUE_LANE_MAX_PRIORITY);
+    queryParams.push(params.priorityLaneMaxPriority);
   }
 
   const result = await client.query(
@@ -1090,14 +1119,17 @@ async function claimPendingJobWithLane(
   return (result.rows[0] as JobData | undefined) ?? null;
 }
 
-function updatePriorityQueueFairnessAfterClaim(job: JobData | null): void {
+function updatePriorityQueueFairnessAfterClaim(
+  job: JobData | null,
+  priorityLaneMaxPriority: number
+): void {
   if (!job) {
     return;
   }
 
   priorityClaimsSinceNormal = updateSchedulerClaimState(
     { priorityClaimsSinceStandard: priorityClaimsSinceNormal },
-    isPriorityQueueLaneJob(job) ? 'priority' : 'standard'
+    isPriorityQueueLaneJob(job, priorityLaneMaxPriority) ? 'priority' : 'standard'
   ).priorityClaimsSinceStandard;
 }
 
@@ -1118,39 +1150,56 @@ export async function claimNextPendingJob(
   }
 
   const leaseMs = Math.max(1_000, options.leaseMs ?? 30_000);
-  const client = await pool.connect();
-  try {
-    await client.query('BEGIN');
+  const priorityQueueEnabled = options.priorityQueueEnabled ?? isPriorityQueueEnabled();
+  const priorityLaneMaxPriority = normalizePriorityLaneMaxPriority(
+    options.priorityLaneMaxPriority
+  );
+  const claimOperation = async (): Promise<JobData | null> => {
+    const client = await pool.connect();
+    let claimedJob: JobData | null = null;
 
-    const firstLane = resolvePriorityQueueClaimLane({
-      priorityQueueEnabled: options.priorityQueueEnabled,
-      priorityQueueWeight: options.priorityQueueWeight
-    });
-    let claimedJob = await claimPendingJobWithLane(client, {
-      leaseMs,
-      workerId: options.workerId ?? null,
-      lane: firstLane
-    });
+    try {
+      await client.query('BEGIN');
 
-    if (!claimedJob) {
-      const secondLane = firstLane === 'normal' ? 'priority' : 'normal';
+      const firstLane = resolvePriorityQueueClaimLane({
+        priorityQueueEnabled,
+        priorityQueueWeight: options.priorityQueueWeight,
+        priorityLaneMaxPriority
+      });
       claimedJob = await claimPendingJobWithLane(client, {
         leaseMs,
         workerId: options.workerId ?? null,
-        lane: secondLane
+        lane: firstLane,
+        priorityLaneMaxPriority
       });
+
+      if (!claimedJob && firstLane === 'normal') {
+        claimedJob = await claimPendingJobWithLane(client, {
+          leaseMs,
+          workerId: options.workerId ?? null,
+          lane: 'priority',
+          priorityLaneMaxPriority
+        });
+      }
+
+      await client.query('COMMIT');
+    } catch (error: unknown) {
+      await client.query('ROLLBACK');
+      console.error('Error claiming pending job:', resolveErrorMessage(error));
+      throw error;
+    } finally {
+      client.release();
     }
 
-    await client.query('COMMIT');
-    updatePriorityQueueFairnessAfterClaim(claimedJob);
+    if (priorityQueueEnabled) {
+      updatePriorityQueueFairnessAfterClaim(claimedJob, priorityLaneMaxPriority);
+    }
     return claimedJob;
-  } catch (error: unknown) {
-    await client.query('ROLLBACK');
-    console.error('Error claiming pending job:', resolveErrorMessage(error));
-    throw error;
-  } finally {
-    client.release();
-  }
+  };
+
+  return priorityQueueEnabled
+    ? withPriorityQueueFairnessLock(claimOperation)
+    : claimOperation();
 }
 
 /**
@@ -1746,10 +1795,6 @@ export async function getJobQueueSummary(): Promise<JobQueueSummary | null> {
                AND priority <= $3
            )::int AS priority_running_count,
            COUNT(*) FILTER (
-             WHERE job_type = 'gpt'
-               AND priority <= $3
-           )::int AS priority_total_count,
-           COUNT(*) FILTER (
              WHERE status = 'pending'
                AND NOT (job_type = 'gpt' AND priority <= $3)
            )::int AS normal_pending_count,
@@ -1827,7 +1872,6 @@ export async function getJobQueueSummary(): Promise<JobQueueSummary | null> {
          summary.failed_count,
          summary.priority_pending_count,
          summary.priority_running_count,
-         summary.priority_total_count,
          summary.normal_pending_count,
          summary.priority_job_count,
          summary.total_count,
@@ -1877,7 +1921,6 @@ export async function getJobQueueSummary(): Promise<JobQueueSummary | null> {
       failed_count: number;
       priority_pending_count: number;
       priority_running_count: number;
-      priority_total_count: number;
       normal_pending_count: number;
       priority_job_count: number;
       total_count: number;
@@ -1921,7 +1964,6 @@ export async function getJobQueueSummary(): Promise<JobQueueSummary | null> {
         recentTotalTerminal: 0,
         priorityPending: 0,
         priorityRunning: 0,
-        priorityTotal: 0,
         normalPending: 0,
         priorityJobCount: 0
       };
@@ -1957,7 +1999,6 @@ export async function getJobQueueSummary(): Promise<JobQueueSummary | null> {
       recentTotalTerminal: Number(summaryRow.recent_terminal_count ?? 0),
       priorityPending: Number(summaryRow.priority_pending_count ?? 0),
       priorityRunning: Number(summaryRow.priority_running_count ?? 0),
-      priorityTotal: Number(summaryRow.priority_total_count ?? 0),
       normalPending: Number(summaryRow.normal_pending_count ?? 0),
       priorityJobCount: Number(summaryRow.priority_job_count ?? 0)
     };

--- a/src/core/scheduler/index.ts
+++ b/src/core/scheduler/index.ts
@@ -1,0 +1,4 @@
+export * from './types.js';
+export * from './scheduler.js';
+export * from './postgresAdapter.js';
+export * from './redisAdapter.js';

--- a/src/core/scheduler/postgresAdapter.ts
+++ b/src/core/scheduler/postgresAdapter.ts
@@ -49,7 +49,10 @@ function readGptId(input: unknown): string {
   return typeof gptId === 'string' ? gptId.trim() : '';
 }
 
-export function toJobSchedulingMetadata(job: JobData): JobSchedulingMetadata {
+export function toJobSchedulingMetadata(
+  job: JobData,
+  options: { priorityLaneMaxPriority?: number } = {}
+): JobSchedulingMetadata {
   const priority = job.priority ?? Number.MAX_SAFE_INTEGER;
 
   return {
@@ -58,7 +61,7 @@ export function toJobSchedulingMetadata(job: JobData): JobSchedulingMetadata {
     priority,
     lane: classifyQueueLane({
       priority,
-      priorityLaneMaxPriority: PRIORITY_QUEUE_LANE_MAX_PRIORITY
+      priorityLaneMaxPriority: options.priorityLaneMaxPriority ?? PRIORITY_QUEUE_LANE_MAX_PRIORITY
     }),
     createdAt: coerceDate(job.created_at, new Date(0)),
     attempts: job.retry_count ?? 0,
@@ -98,7 +101,9 @@ export class PostgresQueueSchedulerAdapter implements QueueSchedulerAdapter<JobD
     return {
       adapter: this.adapter,
       job,
-      lane: job ? toJobSchedulingMetadata(job).lane : null
+      lane: job ? toJobSchedulingMetadata(job, {
+        priorityLaneMaxPriority: options.priorityLaneMaxPriority
+      }).lane : null
     };
   }
 

--- a/src/core/scheduler/postgresAdapter.ts
+++ b/src/core/scheduler/postgresAdapter.ts
@@ -1,0 +1,116 @@
+import type { JobData } from '@core/db/schema.js';
+import {
+  claimNextPendingJob,
+  getJobQueueSummary,
+  type JobQueueSummary
+} from '@core/db/repositories/jobRepository.js';
+import { PRIORITY_QUEUE_LANE_MAX_PRIORITY } from '@shared/gpt/priorityGpt.js';
+import { classifyQueueLane } from './scheduler.js';
+import type {
+  JobSchedulingMetadata,
+  LeaseState,
+  QueueSchedulerAdapter,
+  RetryState,
+  SchedulerClaimOptions,
+  SchedulerClaimResult
+} from './types.js';
+
+export interface PostgresSchedulerRepository {
+  claimNextPendingJob(options?: SchedulerClaimOptions): Promise<JobData | null>;
+  getJobQueueSummary(): Promise<JobQueueSummary | null>;
+}
+
+const defaultRepository: PostgresSchedulerRepository = {
+  claimNextPendingJob,
+  getJobQueueSummary
+};
+
+function coerceDate(value: string | Date | null | undefined, fallback: Date): Date {
+  if (value instanceof Date) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed;
+    }
+  }
+
+  return fallback;
+}
+
+function readGptId(input: unknown): string {
+  if (!input || typeof input !== 'object') {
+    return '';
+  }
+
+  const gptId = (input as { gptId?: unknown }).gptId;
+  return typeof gptId === 'string' ? gptId.trim() : '';
+}
+
+export function toJobSchedulingMetadata(job: JobData): JobSchedulingMetadata {
+  const priority = job.priority ?? Number.MAX_SAFE_INTEGER;
+
+  return {
+    jobId: job.id,
+    gptId: job.job_type === 'gpt' ? readGptId(job.input) : '',
+    priority,
+    lane: classifyQueueLane({
+      priority,
+      priorityLaneMaxPriority: PRIORITY_QUEUE_LANE_MAX_PRIORITY
+    }),
+    createdAt: coerceDate(job.created_at, new Date(0)),
+    attempts: job.retry_count ?? 0,
+    maxRetries: job.max_retries ?? 0
+  };
+}
+
+export function toLeaseState(job: JobData): LeaseState | null {
+  if (!job.last_worker_id || !job.lease_expires_at) {
+    return null;
+  }
+
+  return {
+    workerId: job.last_worker_id,
+    leaseExpiresAt: coerceDate(job.lease_expires_at, new Date(0))
+  };
+}
+
+export function toRetryState(job: JobData): RetryState {
+  return {
+    attempts: job.retry_count ?? 0,
+    ...(job.error_message ? { lastError: job.error_message } : {}),
+    ...(job.next_run_at ? { nextRetryAt: coerceDate(job.next_run_at, new Date(0)) } : {})
+  };
+}
+
+export class PostgresQueueSchedulerAdapter implements QueueSchedulerAdapter<JobData> {
+  readonly adapter = 'postgres' as const;
+
+  constructor(private readonly repository: PostgresSchedulerRepository = defaultRepository) {}
+
+  async claimNext(
+    options: SchedulerClaimOptions = {}
+  ): Promise<SchedulerClaimResult<JobData>> {
+    const job = await this.repository.claimNextPendingJob(options);
+
+    return {
+      adapter: this.adapter,
+      job,
+      lane: job ? toJobSchedulingMetadata(job).lane : null
+    };
+  }
+
+  async getQueueSummary(): Promise<JobQueueSummary | null> {
+    return this.repository.getJobQueueSummary();
+  }
+}
+
+export function createPostgresQueueSchedulerAdapter(
+  repository: PostgresSchedulerRepository = defaultRepository
+): PostgresQueueSchedulerAdapter {
+  return new PostgresQueueSchedulerAdapter(repository);
+}
+
+export const postgresQueueSchedulerAdapter = createPostgresQueueSchedulerAdapter();

--- a/src/core/scheduler/redisAdapter.ts
+++ b/src/core/scheduler/redisAdapter.ts
@@ -1,0 +1,28 @@
+import type {
+  QueueSchedulerAdapter,
+  SchedulerClaimOptions,
+  SchedulerClaimResult
+} from './types.js';
+
+export interface RedisQueueSchedulerAdapterOptions {
+  redisUrl?: string;
+  keyPrefix?: string;
+}
+
+export class RedisQueueSchedulerAdapter<TJob = unknown> implements QueueSchedulerAdapter<TJob> {
+  readonly adapter = 'redis' as const;
+
+  constructor(readonly options: RedisQueueSchedulerAdapterOptions = {}) {}
+
+  async claimNext(_options: SchedulerClaimOptions = {}): Promise<SchedulerClaimResult<TJob>> {
+    throw new Error(
+      'RedisQueueSchedulerAdapter is a future adapter stub. The active scheduler remains Postgres-backed.'
+    );
+  }
+}
+
+export function createRedisQueueSchedulerAdapter<TJob = unknown>(
+  options: RedisQueueSchedulerAdapterOptions = {}
+): RedisQueueSchedulerAdapter<TJob> {
+  return new RedisQueueSchedulerAdapter<TJob>(options);
+}

--- a/src/core/scheduler/scheduler.ts
+++ b/src/core/scheduler/scheduler.ts
@@ -1,0 +1,112 @@
+import type {
+  QueueLane,
+  RetryState,
+  SchedulerClaimDecision,
+  SchedulerPolicy,
+  SchedulerState
+} from './types.js';
+
+const DEFAULT_PRIORITY_QUEUE_WEIGHT = 5;
+const DEFAULT_PRIORITY_LANE_MAX_PRIORITY = 10;
+
+function normalizePositiveInteger(value: number | undefined, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  const normalized = Math.trunc(value);
+  return normalized > 0 ? normalized : fallback;
+}
+
+export function buildSchedulerPolicy(input: Partial<SchedulerPolicy> = {}): SchedulerPolicy {
+  return {
+    priorityQueueEnabled: input.priorityQueueEnabled ?? true,
+    priorityQueueWeight: normalizePositiveInteger(
+      input.priorityQueueWeight,
+      DEFAULT_PRIORITY_QUEUE_WEIGHT
+    ),
+    priorityLaneMaxPriority: normalizePositiveInteger(
+      input.priorityLaneMaxPriority,
+      DEFAULT_PRIORITY_LANE_MAX_PRIORITY
+    )
+  };
+}
+
+export function classifyQueueLane(input: {
+  priority: number | undefined;
+  priorityLaneMaxPriority?: number;
+}): QueueLane {
+  const priority = Number.isFinite(input.priority)
+    ? Math.trunc(input.priority as number)
+    : Number.MAX_SAFE_INTEGER;
+  const priorityLaneMaxPriority = normalizePositiveInteger(
+    input.priorityLaneMaxPriority,
+    DEFAULT_PRIORITY_LANE_MAX_PRIORITY
+  );
+
+  return priority <= priorityLaneMaxPriority ? 'priority' : 'standard';
+}
+
+export function resolveSchedulerClaimLane(input: {
+  policy?: Partial<SchedulerPolicy>;
+  state?: Partial<SchedulerState>;
+} = {}): SchedulerClaimDecision {
+  const policy = buildSchedulerPolicy(input.policy);
+  const priorityClaimsSinceStandard = Math.max(
+    0,
+    Math.trunc(input.state?.priorityClaimsSinceStandard ?? 0)
+  );
+
+  if (!policy.priorityQueueEnabled) {
+    return {
+      lane: 'priority',
+      reason: 'priority_queue_disabled',
+      priorityQueueWeight: policy.priorityQueueWeight,
+      priorityClaimsSinceStandard
+    };
+  }
+
+  if (priorityClaimsSinceStandard >= policy.priorityQueueWeight) {
+    return {
+      lane: 'standard',
+      reason: 'standard_weight_due',
+      priorityQueueWeight: policy.priorityQueueWeight,
+      priorityClaimsSinceStandard
+    };
+  }
+
+  return {
+    lane: 'priority',
+    reason: 'priority_weight_available',
+    priorityQueueWeight: policy.priorityQueueWeight,
+    priorityClaimsSinceStandard
+  };
+}
+
+export function updateSchedulerClaimState(
+  state: SchedulerState,
+  claimedLane: QueueLane | null
+): SchedulerState {
+  if (!claimedLane) {
+    return state;
+  }
+
+  if (claimedLane === 'priority') {
+    return {
+      priorityClaimsSinceStandard: Math.max(0, state.priorityClaimsSinceStandard) + 1
+    };
+  }
+
+  return {
+    priorityClaimsSinceStandard: 0
+  };
+}
+
+export function shouldRetryJob(
+  retryState: RetryState,
+  maxRetries: number
+): boolean {
+  const attempts = Math.max(0, Math.trunc(retryState.attempts));
+  const retryLimit = Math.max(0, Math.trunc(maxRetries));
+  return attempts < retryLimit;
+}

--- a/src/core/scheduler/types.ts
+++ b/src/core/scheduler/types.ts
@@ -1,4 +1,4 @@
-export type QueueLane = "priority" | "standard";
+export type QueueLane = 'priority' | 'standard';
 
 export interface JobSchedulingMetadata {
   jobId: string;
@@ -47,14 +47,14 @@ export interface SchedulerClaimOptions {
   priorityLaneMaxPriority?: number;
 }
 
-export type SchedulerBackendKind = "postgres" | "redis";
+export type SchedulerBackendKind = 'postgres' | 'redis';
 
 export interface SchedulerClaimDecision {
   lane: QueueLane;
   reason:
-    | "priority_queue_disabled"
-    | "priority_weight_available"
-    | "standard_weight_due";
+    | 'priority_queue_disabled'
+    | 'priority_weight_available'
+    | 'standard_weight_due';
   priorityQueueWeight: number;
   priorityClaimsSinceStandard: number;
 }

--- a/src/core/scheduler/types.ts
+++ b/src/core/scheduler/types.ts
@@ -1,0 +1,70 @@
+export type QueueLane = "priority" | "standard";
+
+export interface JobSchedulingMetadata {
+  jobId: string;
+  gptId: string;
+  priority: number;
+  lane: QueueLane;
+  createdAt: Date;
+  attempts: number;
+  maxRetries: number;
+}
+
+export interface LeaseState {
+  workerId: string;
+  leaseExpiresAt: Date;
+}
+
+export interface RetryState {
+  attempts: number;
+  lastError?: string;
+  nextRetryAt?: Date;
+}
+
+export interface DagNodeTiming {
+  nodeId: string;
+  durationMs: number;
+  retries: number;
+  provider?: string;
+  timestamp: Date;
+}
+
+export interface SchedulerPolicy {
+  priorityQueueEnabled: boolean;
+  priorityQueueWeight: number;
+  priorityLaneMaxPriority: number;
+}
+
+export interface SchedulerState {
+  priorityClaimsSinceStandard: number;
+}
+
+export interface SchedulerClaimOptions {
+  workerId?: string;
+  leaseMs?: number;
+  priorityQueueEnabled?: boolean;
+  priorityQueueWeight?: number;
+}
+
+export type SchedulerBackendKind = "postgres" | "redis";
+
+export interface SchedulerClaimDecision {
+  lane: QueueLane;
+  reason:
+    | "priority_queue_disabled"
+    | "priority_weight_available"
+    | "standard_weight_due";
+  priorityQueueWeight: number;
+  priorityClaimsSinceStandard: number;
+}
+
+export interface SchedulerClaimResult<TJob = unknown> {
+  adapter: SchedulerBackendKind;
+  lane: QueueLane | null;
+  job: TJob | null;
+}
+
+export interface QueueSchedulerAdapter<TJob = unknown> {
+  readonly adapter: SchedulerBackendKind;
+  claimNext(options?: SchedulerClaimOptions): Promise<SchedulerClaimResult<TJob>>;
+}

--- a/src/core/scheduler/types.ts
+++ b/src/core/scheduler/types.ts
@@ -44,6 +44,7 @@ export interface SchedulerClaimOptions {
   leaseMs?: number;
   priorityQueueEnabled?: boolean;
   priorityQueueWeight?: number;
+  priorityLaneMaxPriority?: number;
 }
 
 export type SchedulerBackendKind = "postgres" | "redis";

--- a/src/platform/runtime/writingPlaneContract.ts
+++ b/src/platform/runtime/writingPlaneContract.ts
@@ -229,7 +229,7 @@ export function classifyWritingPlaneInput(input: {
       errorCode: 'TRINITY_CONTROL_LEAK',
       message: 'Job status retrieval is control-plane only and must bypass the Trinity writing pipeline.',
       canonical: {
-        poll: '/jobs/{jobId}',
+        poll: '/jobs/{jobId}/result',
       },
     };
   }
@@ -311,7 +311,7 @@ export function classifyWritingPlaneInput(input: {
     if (jobLookup) {
       const canonical = jobLookup.ok
         ? {
-            poll: `/jobs/${jobLookup.jobId}`,
+            poll: `/jobs/${jobLookup.jobId}/result`,
             result: `/jobs/${jobLookup.jobId}/result`,
           }
         : {

--- a/src/routes/api-arcanos-verification.ts
+++ b/src/routes/api-arcanos-verification.ts
@@ -219,7 +219,7 @@ router.get(
     const asyncQueueSnapshot = workerStatus.workerService.health.workers[0];
     const activeQueueWorkers = workerStatus.workerService.health.workers
       .filter(worker => worker.healthStatus !== 'offline').length;
-    const activeWorkerSlots = Math.max(1, activeQueueWorkers);
+    const activeWorkerSlots = activeQueueWorkers;
     const queueRunning = queueSummary?.running ?? 0;
     const data: WorkersStatusData = {
       workers: [
@@ -268,7 +268,7 @@ router.get(
     const queueSummary = workerStatus.workerService.queueSummary;
     const activeQueueWorkers = workerStatus.workerService.health.workers
       .filter(worker => worker.healthStatus !== 'offline').length;
-    const activeWorkerSlots = Math.max(1, activeQueueWorkers);
+    const activeWorkerSlots = activeQueueWorkers;
     const data: QueueStatusData = {
       queue: {
         name: 'job_data',

--- a/src/routes/api-arcanos-verification.ts
+++ b/src/routes/api-arcanos-verification.ts
@@ -217,6 +217,10 @@ router.get(
     const queueSummary = workerStatus.workerService.queueSummary;
     const now = new Date().toISOString();
     const asyncQueueSnapshot = workerStatus.workerService.health.workers[0];
+    const activeQueueWorkers = workerStatus.workerService.health.workers
+      .filter(worker => worker.healthStatus !== 'offline').length;
+    const activeWorkerSlots = Math.max(1, activeQueueWorkers);
+    const queueRunning = queueSummary?.running ?? 0;
     const data: WorkersStatusData = {
       workers: [
         {
@@ -244,7 +248,12 @@ router.get(
           activeJobs: queueSummary?.running ?? 0,
           lastHeartbeatAt: asyncQueueSnapshot?.lastHeartbeatAt || queueSummary?.lastUpdatedAt || now
         }
-      ]
+      ],
+      activeWorkers: activeQueueWorkers,
+      activeWorkerSlots,
+      availableWorkerSlots: Math.max(0, activeWorkerSlots - queueRunning),
+      queueDepth: (queueSummary?.pending ?? 0) + queueRunning,
+      priorityQueueDepth: queueSummary?.priorityPending ?? 0
     };
 
     sendVerificationEnvelope(req, res, data, 'verification.workers_status.response');
@@ -257,6 +266,9 @@ router.get(
   asyncHandler(async (req, res) => {
     const workerStatus = await getWorkerControlStatus();
     const queueSummary = workerStatus.workerService.queueSummary;
+    const activeQueueWorkers = workerStatus.workerService.health.workers
+      .filter(worker => worker.healthStatus !== 'offline').length;
+    const activeWorkerSlots = Math.max(1, activeQueueWorkers);
     const data: QueueStatusData = {
       queue: {
         name: 'job_data',
@@ -266,7 +278,13 @@ router.get(
         failed: queueSummary?.failed ?? 0,
         delayed: queueSummary?.delayed ?? 0,
         oldestWaitingJobAgeMs: queueSummary?.oldestPendingJobAgeMs ?? 0,
-        stalledJobs: queueSummary?.stalledRunning ?? 0
+        stalledJobs: queueSummary?.stalledRunning ?? 0,
+        priorityDepth: queueSummary?.priorityPending ?? 0,
+        priorityRunning: queueSummary?.priorityRunning ?? 0,
+        normalWaiting: queueSummary?.normalPending ?? 0,
+        activeWorkers: activeQueueWorkers,
+        availableWorkerSlots: Math.max(0, activeWorkerSlots - (queueSummary?.running ?? 0)),
+        priorityJobCount: queueSummary?.priorityJobCount ?? 0
       }
     };
 

--- a/src/routes/ask/index.ts
+++ b/src/routes/ask/index.ts
@@ -43,6 +43,7 @@ import {
   buildQueuedAskPendingResponse,
   type CompletedQueuedAskJobOutput
 } from '@shared/ask/asyncAskJob.js';
+import { buildJobResultPollPath } from '@shared/jobs/jobLinks.js';
 import { buildTrinityOutputControlOptions } from '@shared/ask/trinityRequestOptions.js';
 import {
   getActiveIntentSnapshot,
@@ -504,7 +505,7 @@ function buildAsyncAskFailurePayload(jobId: string, errorMessage?: string | null
     error: 'ASYNC_ASK_JOB_FAILED',
     message: errorMessage?.trim() || 'Async ask job failed.',
     jobId,
-    poll: `/jobs/${jobId}`
+    poll: buildJobResultPollPath(jobId)
   };
 }
 
@@ -1145,7 +1146,7 @@ export const handleAIRequest = async (
             error: 'ASYNC_ASK_JOB_OUTPUT_INVALID',
             message: 'Async ask job completed without a structured output payload.',
             jobId: job.id,
-            poll: `/jobs/${job.id}`
+            poll: buildJobResultPollPath(job.id)
           }, `${endpointName}.async_completed_invalid`, 500);
         }
 
@@ -1227,7 +1228,7 @@ export const handleAIRequest = async (
           error: 'ASYNC_ASK_JOB_MISSING',
           message: 'Async ask job disappeared before completion.',
           jobId: job.id,
-          poll: `/jobs/${job.id}`
+          poll: buildJobResultPollPath(job.id)
         }, `${endpointName}.async_missing`, 500);
       }
 

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 import express from "express";
-import { routeGptRequest } from "./_core/gptDispatch.js";
+import { resolveGptRouting, routeGptRequest } from "./_core/gptDispatch.js";
 import { buildArcanosCoreTimeoutFallbackEnvelope } from "@services/arcanos-core.js";
 import {
   logGptConnection,
@@ -34,7 +34,8 @@ import {
   recordGptJobEvent,
   recordGptJobLookup,
   recordGptRequestEvent,
-  recordGptRouteDecision
+  recordGptRouteDecision,
+  recordUnknownGpt
 } from '@platform/observability/appMetrics.js';
 import { shouldTreatPromptAsDagExecution } from '@shared/dag/dagExecutionRouting.js';
 import {
@@ -1571,6 +1572,33 @@ router.post("/:gptId", async (req, res, next) => {
           gptId: incomingGptId,
           ...buildGptRequestAuthState(req),
         });
+
+        const routingValidation = await resolveGptRouting(incomingGptId, requestId);
+        if (!routingValidation.ok) {
+          const statusCode = routingValidation.error.code === 'UNKNOWN_GPT' ? 404 : 400;
+          requestLogger?.warn?.('gpt.request.route_result', {
+            endpoint: req.originalUrl,
+            gptId: incomingGptId,
+            statusCode,
+            ok: false,
+            errorCode: routingValidation.error.code,
+            queueBypassed: true
+          });
+          if (routingValidation.error.code === 'UNKNOWN_GPT') {
+            logGptConnectionFailed(incomingGptId);
+            recordUnknownGpt({
+              gptId: incomingGptId,
+              outcome: 'not_registered'
+            });
+          }
+          return sendGuardedGptJsonResponse(
+            req,
+            res,
+            routingValidation,
+            'gpt.response.route_error',
+            statusCode
+          );
+        }
 
         if (queryAndWaitRequested && !normalizedBody) {
           requestLogger?.warn?.('integration.job.query_and_wait_invalid_body', {

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -2852,7 +2852,7 @@ router.post("/:gptId", async (req, res, next) => {
           buildDirectReturnTimeoutResponse({
             pendingResponse,
             jobId: queuedJobId ?? pendingResponse.jobId,
-            waitForResultMs: routeTimeoutMs,
+            waitForResultMs: resolvedAsyncWaitForResultMs ?? routeTimeoutMs,
             pollIntervalMs: resolveAsyncGptPollIntervalMs(explicitAsyncPollIntervalMs)
           }),
           'gpt.response.timeout_pending',

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -1508,7 +1508,7 @@ router.post("/:gptId", async (req, res, next) => {
       async () => {
         const incomingGptId = req.params.gptId;
         const requestLogger = (req as any).logger;
-        const priorityQueueActive = priorityGpt && isPriorityQueueEnabled();
+        const priorityQueueConfigured = priorityGpt && isPriorityQueueEnabled();
         const normalizedBody = normalizeGptRequestBody(req.body);
         const bodyGptId = resolveBodyGptId(req.body);
         const effectiveRequestedAction = queryAndWaitRequested ? 'query' : requestedAction;
@@ -1541,7 +1541,7 @@ router.post("/:gptId", async (req, res, next) => {
           gptId: incomingGptId,
           action: requestedAction,
           priorityGpt,
-          priorityQueueActive
+          priorityQueueConfigured
         });
 
         if (bodyGptId) {
@@ -2055,6 +2055,13 @@ router.post("/:gptId", async (req, res, next) => {
           requestedAction: effectiveRequestedAction,
           routeTimeoutProfile
         });
+        const priorityJobBackedExecutionRequested =
+          queryAndWaitRequested ||
+          executionPlan.mode === 'async' ||
+          fastPathFallbackToOrchestrated ||
+          Boolean(explicitIdempotencyKey);
+        const priorityQueueActive =
+          priorityQueueConfigured && priorityJobBackedExecutionRequested;
         const priorityDirectReturnRequested = priorityQueueActive;
         const directReturnRequested =
           queryAndWaitRequested ||
@@ -2131,7 +2138,6 @@ router.post("/:gptId", async (req, res, next) => {
         }
 
         const shouldUseJobBackedExecution =
-          priorityDirectReturnRequested ||
           queryAndWaitRequested ||
           executionPlan.mode === 'async' ||
           fastPathFallbackToOrchestrated ||

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -63,6 +63,19 @@ import {
   resolveGptJobLifecycleStatus,
   summarizeGptJobTimings
 } from '@shared/gpt/gptJobLifecycle.js';
+import {
+  PRIORITY_GPT_JOB_PRIORITY,
+  isPriorityGpt,
+  isPriorityQueueEnabled,
+  mapGptJobStatusToClientStatus,
+  resolveGptDirectExecutionThresholdMs,
+  resolveGptWaitTimeoutMs
+} from '@shared/gpt/priorityGpt.js';
+import {
+  startReservedPriorityGptDirectExecution,
+  tryAcquirePriorityGptDirectExecutionSlot,
+  type PriorityGptDirectExecutionSlot
+} from '@services/priorityGptDirectExecutionService.js';
 import { getRequestActorKey } from '@platform/runtime/security.js';
 import {
   GPT_QUERY_ACTION,
@@ -107,10 +120,7 @@ const DEFAULT_GPT_ASYNC_HEAVY_PROMPT_CHARS = 1_200;
 const DEFAULT_GPT_ASYNC_HEAVY_MESSAGE_COUNT = 8;
 const DEFAULT_GPT_ASYNC_HEAVY_MAX_WORDS = 700;
 const DEFAULT_GPT_ASYNC_HEAVY_WAIT_FOR_RESULT_MS = 500;
-const DEFAULT_GPT_QUERY_AND_WAIT_TIMEOUT_MS = 25_000;
 const DIRECT_RETURN_ROUTE_TIMEOUT_HEADROOM_MS = 750;
-const DEFAULT_GPT_QUERY_AND_WAIT_ROUTE_TIMEOUT_MS =
-  DEFAULT_GPT_QUERY_AND_WAIT_TIMEOUT_MS + DIRECT_RETURN_ROUTE_TIMEOUT_HEADROOM_MS;
 const DEBUG_GPT_MAX_BYTES_HEADER = 'x-debug-max-bytes';
 const DIRECT_RETURN_WAIT_KEYS = [
   'waitForResultMs',
@@ -755,16 +765,24 @@ function buildDirectReturnTimeoutResponse(params: {
 }) {
   return {
     ...params.pendingResponse,
+    status: 'timeout' as const,
+    result: {},
+    poll: `/jobs/${params.jobId}/result`,
+    timedOut: true,
     instruction: `Direct wait timed out after ${params.waitForResultMs}ms. Use GET /jobs/${params.jobId}/result to retrieve the final result.`,
     directReturn: {
       requested: true,
       timedOut: true,
       waitForResultMs: params.waitForResultMs,
       pollIntervalMs: params.pollIntervalMs,
-      poll: `/jobs/${params.jobId}`,
+      poll: `/jobs/${params.jobId}/result`,
       result: `/jobs/${params.jobId}/result`
     }
   };
+}
+
+function resolveDefaultGptQueryAndWaitRouteTimeoutMs(): number {
+  return resolveGptWaitTimeoutMs() + DIRECT_RETURN_ROUTE_TIMEOUT_HEADROOM_MS;
 }
 
 function sendGuardedGptJsonResponse(
@@ -1408,10 +1426,12 @@ function buildAsyncJobResponseMetadata(input: {
   return {
     action: input.action,
     jobId: input.jobId,
-    status: input.jobStatus,
+    status: mapGptJobStatusToClientStatus(input.jobStatus),
+    jobStatus: input.jobStatus,
     lifecycleStatus: resolveGptJobLifecycleStatus(input.jobStatus),
-    poll: `/jobs/${input.jobId}`,
+    poll: `/jobs/${input.jobId}/result`,
     stream: `/jobs/${input.jobId}/stream`,
+    timedOut: false,
     ...(input.deduped ? { deduped: true } : {}),
     idempotencyKey: input.idempotencyKey,
     idempotencySource: input.idempotencySource
@@ -1436,6 +1456,8 @@ function applyGptQueueBypassedHeader(
 }
 
 router.post("/:gptId", async (req, res, next) => {
+  const routeGptId = req.params.gptId;
+  const priorityGpt = isPriorityGpt(routeGptId);
   const requestedAction = resolveRequestedAction(req.body);
   const queryRequested = requestedAction === GPT_QUERY_ACTION;
   const queryAndWaitRequested = requestedAction === GPT_QUERY_AND_WAIT_ACTION;
@@ -1448,13 +1470,13 @@ router.post("/:gptId", async (req, res, next) => {
   const explicitAsyncWaitForResultMs = readRequestedAsyncGptWaitForResultMs(req, req.body);
   const explicitAsyncPollIntervalMs = readRequestedAsyncGptPollIntervalMs(req, req.body);
   const queryAndWaitRequestedTimeoutMs =
-    explicitAsyncWaitForResultMs ?? DEFAULT_GPT_QUERY_AND_WAIT_TIMEOUT_MS;
+    explicitAsyncWaitForResultMs ?? resolveGptWaitTimeoutMs();
   const routeTimeoutMs = resolveGptRouteHardTimeoutMs({
     profile: routeTimeoutProfile,
     ...(queryAndWaitRequested && routeTimeoutProfile === 'default'
       ? {
           defaultMsOverride: Math.max(
-            DEFAULT_GPT_QUERY_AND_WAIT_ROUTE_TIMEOUT_MS,
+            resolveDefaultGptQueryAndWaitRouteTimeoutMs(),
             queryAndWaitRequestedTimeoutMs + DIRECT_RETURN_ROUTE_TIMEOUT_HEADROOM_MS
           )
         }
@@ -1486,6 +1508,7 @@ router.post("/:gptId", async (req, res, next) => {
       async () => {
         const incomingGptId = req.params.gptId;
         const requestLogger = (req as any).logger;
+        const priorityQueueActive = priorityGpt && isPriorityQueueEnabled();
         const normalizedBody = normalizeGptRequestBody(req.body);
         const bodyGptId = resolveBodyGptId(req.body);
         const effectiveRequestedAction = queryAndWaitRequested ? 'query' : requestedAction;
@@ -1516,7 +1539,9 @@ router.post("/:gptId", async (req, res, next) => {
         requestLogger?.info?.('gpt.request.action', {
           endpoint: req.originalUrl,
           gptId: incomingGptId,
-          action: requestedAction
+          action: requestedAction,
+          priorityGpt,
+          priorityQueueActive
         });
 
         if (bodyGptId) {
@@ -2030,19 +2055,26 @@ router.post("/:gptId", async (req, res, next) => {
           requestedAction: effectiveRequestedAction,
           routeTimeoutProfile
         });
+        const priorityDirectReturnRequested = priorityQueueActive;
         const directReturnRequested =
           queryAndWaitRequested ||
+          priorityDirectReturnRequested ||
           (
             !queryRequested &&
             explicitAsyncWaitForResultMs !== undefined &&
             executionPlan.mode === 'async'
           );
         let requestedAsyncWaitForResultMs = explicitAsyncWaitForResultMs;
-        if (queryRequested) {
+        if (priorityDirectReturnRequested && requestedAsyncWaitForResultMs === undefined) {
+          requestedAsyncWaitForResultMs = Math.min(
+            resolveGptDirectExecutionThresholdMs(),
+            resolveGptWaitTimeoutMs()
+          );
+        } else if (queryRequested) {
           requestedAsyncWaitForResultMs = 0;
         } else if (requestedAsyncWaitForResultMs === undefined) {
           if (queryAndWaitRequested) {
-            requestedAsyncWaitForResultMs = DEFAULT_GPT_QUERY_AND_WAIT_TIMEOUT_MS;
+            requestedAsyncWaitForResultMs = resolveGptWaitTimeoutMs();
           } else if (executionPlan.heavyPrompt) {
             requestedAsyncWaitForResultMs = readPositiveIntegerEnv(
               'GPT_ASYNC_HEAVY_WAIT_FOR_RESULT_MS',
@@ -2070,7 +2102,9 @@ router.post("/:gptId", async (req, res, next) => {
           requestedAsyncWaitForResultMs: requestedAsyncWaitForResultMs ?? null,
           requestedAsyncPollIntervalMs: explicitAsyncPollIntervalMs ?? null,
           asyncWaitForResultMs,
-          asyncPollIntervalMs
+          asyncPollIntervalMs,
+          priorityGpt,
+          priorityQueueActive
         });
         if (explicitAsyncWaitForResultMs !== undefined && !directReturnRequested) {
           requestLogger?.info?.('gpt.request.direct_return_ignored', {
@@ -2097,6 +2131,7 @@ router.post("/:gptId", async (req, res, next) => {
         }
 
         const shouldUseJobBackedExecution =
+          priorityDirectReturnRequested ||
           queryAndWaitRequested ||
           executionPlan.mode === 'async' ||
           fastPathFallbackToOrchestrated ||
@@ -2170,7 +2205,37 @@ router.post("/:gptId", async (req, res, next) => {
               requestPath: req.originalUrl,
               executionModeReason: executionPlan.reason
             });
-            const plannedJob = await planAutonomousWorkerJob('gpt', queuedGptJobInput);
+            const priorityDirectWorkerId = `${process.env.WORKER_ID || 'api'}:priority-gpt-direct`;
+            let priorityDirectSlot: PriorityGptDirectExecutionSlot | null = priorityQueueActive
+              ? tryAcquirePriorityGptDirectExecutionSlot()
+              : null;
+            const plannedJobBase = await planAutonomousWorkerJob('gpt', queuedGptJobInput);
+            const plannedJob = priorityQueueActive
+              ? {
+                  ...plannedJobBase,
+                  status: priorityDirectSlot ? 'running' : plannedJobBase.status,
+                  startedAt: priorityDirectSlot ? new Date() : plannedJobBase.startedAt,
+                  lastHeartbeatAt: priorityDirectSlot ? new Date() : plannedJobBase.lastHeartbeatAt,
+                  leaseExpiresAt: priorityDirectSlot
+                    ? new Date(
+                        Date.now() +
+                        Math.max(resolveGptWaitTimeoutMs(), asyncWaitForResultMs) +
+                        DIRECT_RETURN_ROUTE_TIMEOUT_HEADROOM_MS
+                      )
+                    : plannedJobBase.leaseExpiresAt,
+                  priority: PRIORITY_GPT_JOB_PRIORITY,
+                  lastWorkerId: priorityDirectSlot ? priorityDirectWorkerId : plannedJobBase.lastWorkerId,
+                  autonomyState: {
+                    ...(plannedJobBase.autonomyState ?? {}),
+                    priorityQueue: {
+                      enabled: true,
+                      gptId: incomingGptId,
+                      directExecution: priorityDirectSlot ? 'reserved' : 'queued',
+                      requestedAt: new Date().toISOString()
+                    }
+                  }
+                }
+              : plannedJobBase;
             let createResult;
             try {
               createResult = await findOrCreateGptJob({
@@ -2185,6 +2250,8 @@ router.post("/:gptId", async (req, res, next) => {
                 createOptions: plannedJob
               });
             } catch (error: unknown) {
+              priorityDirectSlot?.release();
+              priorityDirectSlot = null;
               if (error instanceof IdempotencyKeyConflictError) {
                 return sendGuardedGptJsonResponse(req, res, {
                   ok: false,
@@ -2246,6 +2313,27 @@ router.post("/:gptId", async (req, res, next) => {
             if (createResult) {
               const job = createResult.job;
               queuedJobId = job.id;
+              if (priorityDirectSlot) {
+                if (createResult.created) {
+                  startReservedPriorityGptDirectExecution({
+                    jobId: job.id,
+                    rawInput: queuedGptJobInput,
+                    workerId: priorityDirectWorkerId,
+                    slot: priorityDirectSlot,
+                    requestLogger
+                  });
+                  requestLogger?.info?.('gpt.priority_direct.reserved', {
+                    endpoint: req.originalUrl,
+                    gptId: incomingGptId,
+                    requestId,
+                    jobId: job.id,
+                    waitForResultMs: asyncWaitForResultMs
+                  });
+                } else {
+                  priorityDirectSlot.release();
+                }
+                priorityDirectSlot = null;
+              }
               queuedPendingResponse = buildQueuedGptPendingResponse({
                 action: asyncBridgeAction,
                 jobId: job.id,
@@ -2346,7 +2434,7 @@ router.post("/:gptId", async (req, res, next) => {
                       message: 'Async GPT job completed without a valid envelope.'
                     },
                     jobId: job.id,
-                    poll: `/jobs/${job.id}`,
+                    poll: `/jobs/${job.id}/result`,
                     stream: `/jobs/${job.id}/stream`,
                     _route: {
                       requestId,
@@ -2545,7 +2633,7 @@ router.post("/:gptId", async (req, res, next) => {
                     message: 'Async GPT job disappeared before completion.'
                   },
                   jobId: job.id,
-                  poll: `/jobs/${job.id}`,
+                  poll: `/jobs/${job.id}/result`,
                   stream: `/jobs/${job.id}/stream`,
                   _route: {
                     requestId,
@@ -2744,6 +2832,7 @@ router.post("/:gptId", async (req, res, next) => {
       });
       const responseOpen = !res.headersSent && !res.writableEnded && !res.destroyed;
       if (routeTimedOut && responseOpen && queuedPendingResponse) {
+        const pendingResponse = queuedPendingResponse as ReturnType<typeof buildQueuedGptPendingResponse>;
         req.logger?.warn?.('gpt.request.timeout_pending', {
           endpoint: req.originalUrl,
           gptId,
@@ -2754,7 +2843,12 @@ router.post("/:gptId", async (req, res, next) => {
         return sendGuardedGptJsonResponse(
           req,
           res,
-          queuedPendingResponse,
+          buildDirectReturnTimeoutResponse({
+            pendingResponse,
+            jobId: queuedJobId ?? pendingResponse.jobId,
+            waitForResultMs: routeTimeoutMs,
+            pollIntervalMs: resolveAsyncGptPollIntervalMs(explicitAsyncPollIntervalMs)
+          }),
           'gpt.response.timeout_pending',
           202
         );

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -1487,6 +1487,8 @@ router.post("/:gptId", async (req, res, next) => {
   let queuedPendingResponse:
     | ReturnType<typeof buildQueuedGptPendingResponse>
     | null = null;
+  let queuedAsyncWaitForResultMs: number | null = null;
+  let queuedAsyncPollIntervalMs: number | null = null;
   const timeoutMessage = `GPT route timeout after ${routeTimeoutMs}ms`;
   const clientAbortController = new AbortController();
   const abortForClosedClient = () => {
@@ -2094,6 +2096,8 @@ router.post("/:gptId", async (req, res, next) => {
           routeTimeoutMs
         );
         const asyncPollIntervalMs = resolveAsyncGptPollIntervalMs(explicitAsyncPollIntervalMs);
+        queuedAsyncWaitForResultMs = asyncWaitForResultMs;
+        queuedAsyncPollIntervalMs = asyncPollIntervalMs;
         requestLogger?.info?.('gpt.request.execution_plan', {
           endpoint: req.originalUrl,
           gptId: incomingGptId,
@@ -2852,8 +2856,8 @@ router.post("/:gptId", async (req, res, next) => {
           buildDirectReturnTimeoutResponse({
             pendingResponse,
             jobId: queuedJobId ?? pendingResponse.jobId,
-            waitForResultMs: resolvedAsyncWaitForResultMs ?? routeTimeoutMs,
-            pollIntervalMs: resolveAsyncGptPollIntervalMs(explicitAsyncPollIntervalMs)
+            waitForResultMs: queuedAsyncWaitForResultMs ?? routeTimeoutMs,
+            pollIntervalMs: queuedAsyncPollIntervalMs ?? resolveAsyncGptPollIntervalMs(explicitAsyncPollIntervalMs)
           }),
           'gpt.response.timeout_pending',
           202

--- a/src/routes/jobs.ts
+++ b/src/routes/jobs.ts
@@ -18,6 +18,7 @@ import {
   buildGptJobResultLookupPayload,
   buildStoredJobStatusPayload
 } from '@shared/gpt/gptJobResult.js';
+import { buildJobResultPollPath } from '@shared/jobs/jobLinks.js';
 import { sendBoundedJsonResponse } from '@shared/http/sendBoundedJsonResponse.js';
 
 const router = express.Router();
@@ -324,7 +325,7 @@ router.get(
           writeSseEvent(res, 'timeout', {
             jobId: id,
             status: job.status,
-            poll: `/jobs/${id}`
+            poll: buildJobResultPollPath(id)
           });
           return;
         }

--- a/src/routes/status.ts
+++ b/src/routes/status.ts
@@ -14,16 +14,18 @@ import { sendJsonError } from "@transport/http/responseHelpers.js";
 import { assessCoreServiceReadiness, mapReadinessToHealthStatus } from "@platform/resilience/healthChecks.js";
 import { resolveErrorMessage } from "@core/lib/errors/index.js";
 import { getConfig } from "@platform/runtime/unifiedConfig.js";
+import { writePublicHealthResponse } from "@core/diagnostics.js";
 
 const router = express.Router();
 
 /**
- * GET /status - Retrieve current system state
+ * GET /status - Legacy health alias
  */
-router.get('/status', (_: Request, res: Response) => {
+router.get('/status', async (req: Request, res: Response) => {
   try {
-    const state = loadState();
-    res.json(state);
+    res.setHeader('x-status-endpoint', 'deprecated');
+    res.setHeader('x-status-replacement', '/health');
+    await writePublicHealthResponse(req, res);
   } catch (error) {
     //audit Assumption: state load failures should return 500; risk: leaking internal details; invariant: client gets structured error; handling: log and return error response.
     console.error('[STATUS] Error retrieving system state:', error);

--- a/src/services/arcanosDagRunService.ts
+++ b/src/services/arcanosDagRunService.ts
@@ -22,6 +22,7 @@ import type {
   DagEventsData,
   DagLineageData,
   DagMetricsData,
+  DagNodeTraceEntry,
   DagRunError,
   DagRunMetrics,
   DagRunSummary,
@@ -107,6 +108,7 @@ const TRINITY_PIPELINE_NAME = 'trinity' as const;
 const TRINITY_PIPELINE_VERSION = '1.0' as const;
 const DEFAULT_DAG_TRACE_MAX_EVENTS = 200;
 const MAX_DAG_TRACE_MAX_EVENTS = 1000;
+const DAG_SLOW_NODE_THRESHOLD_MS = 5_000;
 
 export interface WaitForDagRunUpdateOptions {
   updatedAfter?: string;
@@ -256,6 +258,93 @@ function extractNodeDuration(metrics: NodeMetrics | undefined, output: Record<st
   return typeof resultMetrics?.durationMs === 'number' ? resultMetrics.durationMs : undefined;
 }
 
+function readTraceString(
+  source: Record<string, unknown> | undefined,
+  keys: string[]
+): string | null {
+  if (!source) {
+    return null;
+  }
+
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+
+  return null;
+}
+
+function extractTraceModuleName(node: StoredNodeDetail): string {
+  return (
+    readTraceString(node.input, ['moduleName', 'module_name', 'module', 'name']) ??
+    readTraceString(node.output, ['moduleName', 'module_name', 'module']) ??
+    `${node.agentRole}:${node.jobType}`
+  );
+}
+
+function extractExternalProvider(node: StoredNodeDetail): string | null {
+  const outputMeta = node.output?.meta;
+  const outputMetaRecord =
+    outputMeta && typeof outputMeta === 'object' && !Array.isArray(outputMeta)
+      ? outputMeta as Record<string, unknown>
+      : undefined;
+
+  return (
+    readTraceString(node.input, ['externalProvider', 'external_provider', 'provider']) ??
+    readTraceString(node.output, ['externalProvider', 'external_provider', 'provider']) ??
+    readTraceString(outputMetaRecord, ['externalProvider', 'external_provider', 'provider']) ??
+    null
+  );
+}
+
+function calculateNodeDurationMs(node: StoredNodeDetail, snapshotUpdatedAt?: string): number | null {
+  const metricDuration = extractNodeDuration(node.metrics, node.output);
+  if (typeof metricDuration === 'number' && Number.isFinite(metricDuration)) {
+    return Math.max(0, Math.trunc(metricDuration));
+  }
+
+  const startedAtMs = toEpochMilliseconds(node.startedAt);
+  if (startedAtMs <= 0) {
+    return null;
+  }
+
+  const completedAtMs = node.completedAt
+    ? toEpochMilliseconds(node.completedAt)
+    : toEpochMilliseconds(snapshotUpdatedAt);
+  if (completedAtMs <= 0) {
+    return null;
+  }
+
+  return Math.max(0, completedAtMs - startedAtMs);
+}
+
+export function buildDagNodeTraceEntries(
+  nodes: StoredNodeDetail[],
+  options: { updatedAt?: string; slowThresholdMs?: number } = {}
+): DagNodeTraceEntry[] {
+  const slowThresholdMs = Math.max(1, options.slowThresholdMs ?? DAG_SLOW_NODE_THRESHOLD_MS);
+
+  return nodes.map((node) => {
+    const durationMs = calculateNodeDurationMs(node, options.updatedAt);
+    const moduleName = extractTraceModuleName(node);
+
+    return {
+      nodeId: node.nodeId,
+      moduleName,
+      module_name: moduleName,
+      start_time: node.startedAt ?? null,
+      end_time: node.completedAt ?? null,
+      duration_ms: durationMs,
+      retries: Math.max(0, (node.attempt ?? 1) - 1),
+      error: node.error ?? null,
+      external_provider: extractExternalProvider(node),
+      slow: durationMs !== null && durationMs > slowThresholdMs
+    };
+  });
+}
+
 function normalizeNodeStatus(status: NodeStatus): NodeStatus {
   return status;
 }
@@ -272,7 +361,8 @@ function createDefaultMetrics(totalNodes: number): DagRunMetrics {
     wallClockDurationMs: 0,
     sumNodeDurationMs: 0,
     queueWaitMsP50: 0,
-    queueWaitMsP95: 0
+    queueWaitMsP95: 0,
+    slowNodeCount: 0
   };
 }
 
@@ -701,8 +791,9 @@ function calculateLineageEntriesFromNodes(
 
 function recalculateMetrics(record: StoredDagRunRecord): DagRunMetrics {
   const nodeList = Array.from(record.nodesById.values());
+  const nodeTrace = buildDagNodeTraceEntries(nodeList, { updatedAt: record.updatedAt });
   const durationValues = nodeList
-    .map(node => node.metrics?.durationMs)
+    .map(node => calculateNodeDurationMs(node, record.updatedAt))
     .filter((value): value is number => typeof value === 'number');
   const queueWaitValues = nodeList
     .map(node => {
@@ -736,7 +827,8 @@ function recalculateMetrics(record: StoredDagRunRecord): DagRunMetrics {
     wallClockDurationMs,
     sumNodeDurationMs: durationValues.reduce((sum, value) => sum + value, 0),
     queueWaitMsP50: percentile(queueWaitValues, 50),
-    queueWaitMsP95: percentile(queueWaitValues, 95)
+    queueWaitMsP95: percentile(queueWaitValues, 95),
+    slowNodeCount: nodeTrace.filter(node => node.slow).length
   };
 }
 
@@ -1064,6 +1156,10 @@ export class ArcanosDagRunService {
       }))
     };
     buildMs.tree = Date.now() - treeStartedAtMs;
+    const nodeTrace = buildDagNodeTraceEntries(snapshot.nodes, {
+      updatedAt: snapshot.updatedAt
+    });
+    const slowNodes = nodeTrace.filter(node => node.slow);
 
     const eventsStartedAtMs = Date.now();
     const totalEvents = snapshot.events.length;
@@ -1083,9 +1179,13 @@ export class ArcanosDagRunService {
     const metricsStartedAtMs = Date.now();
     const metrics: DagMetricsData = {
       runId: snapshot.runId,
-      metrics: cloneSerializable(snapshot.metrics),
+      metrics: {
+        ...cloneSerializable(snapshot.metrics),
+        slowNodeCount: slowNodes.length
+      },
       limits: cloneSerializable(snapshot.limits),
-      guardViolations: cloneSerializable(snapshot.guardViolations)
+      guardViolations: cloneSerializable(snapshot.guardViolations),
+      slowNodes: cloneSerializable(slowNodes)
     };
     buildMs.metrics = Date.now() - metricsStartedAtMs;
 
@@ -1118,6 +1218,8 @@ export class ArcanosDagRunService {
         ...createTrinityRuntimeMetadata(),
         run,
         tree,
+        nodeTrace: cloneSerializable(nodeTrace),
+        slowNodes: cloneSerializable(slowNodes),
         events,
         metrics,
         errors,
@@ -1760,11 +1862,19 @@ export class ArcanosDagRunService {
     }
 
     const buildStartedAtMs = Date.now();
-    const response = {
+    const nodeTrace = buildDagNodeTraceEntries(snapshot.nodes, {
+      updatedAt: snapshot.updatedAt
+    });
+    const slowNodes = nodeTrace.filter(node => node.slow);
+    const response: DagMetricsData = {
       runId,
-      metrics: cloneSerializable(snapshot.metrics),
+      metrics: {
+        ...cloneSerializable(snapshot.metrics),
+        slowNodeCount: slowNodes.length
+      },
       limits: cloneSerializable(snapshot.limits),
-      guardViolations: cloneSerializable(snapshot.guardViolations)
+      guardViolations: cloneSerializable(snapshot.guardViolations),
+      slowNodes: cloneSerializable(slowNodes)
     };
     recordDagRunRequest({
       handler: 'metrics',

--- a/src/services/customGptBridgeService.ts
+++ b/src/services/customGptBridgeService.ts
@@ -449,7 +449,8 @@ function buildPendingPayload(input: {
       idempotencyKey: input.idempotencyKey,
       idempotencySource: input.idempotencySource,
     }),
-    poll: pending.poll,
+    poll: pollUrl(input.job.id),
+    stream: pending.stream,
     result: {
       method: 'GET',
       url: resultUrl(input.job.id),

--- a/src/services/customGptBridgeService.ts
+++ b/src/services/customGptBridgeService.ts
@@ -145,7 +145,7 @@ function extractBearerToken(authorization?: string | null): string | null {
 }
 
 function pollUrl(jobId: string): string {
-  return `/jobs/${encodeURIComponent(jobId)}`;
+  return `/jobs/${encodeURIComponent(jobId)}/result`;
 }
 
 function resultUrl(jobId: string): string {

--- a/src/services/priorityGptDirectExecutionService.ts
+++ b/src/services/priorityGptDirectExecutionService.ts
@@ -157,7 +157,15 @@ async function executeReservedPriorityGptDirectExecution(params: {
 
     const { gptId, body, prompt, requestId, bypassIntentRouting } = parsedGptJobInput.value;
     const latestJob = await getJobById(params.jobId);
-    if (latestJob?.cancel_requested_at) {
+    if (!latestJob) {
+      params.requestLogger?.warn?.('gpt.priority_direct.job_missing', {
+        jobId: params.jobId,
+        workerId: params.workerId
+      });
+      return;
+    }
+
+    if (latestJob.cancel_requested_at) {
       await updateJob(
         params.jobId,
         'cancelled',

--- a/src/services/priorityGptDirectExecutionService.ts
+++ b/src/services/priorityGptDirectExecutionService.ts
@@ -9,7 +9,7 @@ import {
   recordGptJobEvent,
   recordGptJobTiming
 } from '@platform/observability/appMetrics.js';
-import { routeGptRequest } from '@routes/_core/gptDispatch.js';
+import type { routeGptRequest as routeGptRequestType } from '@routes/_core/gptDispatch.js';
 import { parseQueuedGptJobInput } from '@shared/gpt/asyncGptJob.js';
 import { computeGptJobLifecycleDeadlines } from '@shared/gpt/gptJobLifecycle.js';
 import {
@@ -30,6 +30,14 @@ export interface PriorityGptDirectExecutionSnapshot {
 
 const DIRECT_HEARTBEAT_INTERVAL_MS = 5_000;
 let activePriorityDirectExecutions = 0;
+let routeGptRequestLoader: Promise<typeof routeGptRequestType> | null = null;
+
+async function loadRouteGptRequest(): Promise<typeof routeGptRequestType> {
+  routeGptRequestLoader ??= import('@routes/_core/gptDispatch.js').then(
+    (module) => module.routeGptRequest
+  );
+  return routeGptRequestLoader;
+}
 
 function hydrateQueuedGptBodyPrompt(
   body: Record<string, unknown>,
@@ -199,6 +207,7 @@ async function executeReservedPriorityGptDirectExecution(params: {
       workerId: params.workerId
     });
 
+    const routeGptRequest = await loadRouteGptRequest();
     const envelope = await routeGptRequest({
       gptId,
       body: hydrateQueuedGptBodyPrompt(body, prompt),

--- a/src/services/priorityGptDirectExecutionService.ts
+++ b/src/services/priorityGptDirectExecutionService.ts
@@ -1,0 +1,307 @@
+import {
+  getJobById,
+  recordJobHeartbeat,
+  updateJob
+} from '@core/db/repositories/jobRepository.js';
+import { resolveErrorMessage } from '@core/lib/errors/index.js';
+import { logger } from '@platform/logging/structuredLogging.js';
+import {
+  recordGptJobEvent,
+  recordGptJobTiming
+} from '@platform/observability/appMetrics.js';
+import { routeGptRequest } from '@routes/_core/gptDispatch.js';
+import { parseQueuedGptJobInput } from '@shared/gpt/asyncGptJob.js';
+import { computeGptJobLifecycleDeadlines } from '@shared/gpt/gptJobLifecycle.js';
+import {
+  resolveGptWaitTimeoutMs,
+  resolvePriorityGptDirectExecutionConcurrency
+} from '@shared/gpt/priorityGpt.js';
+import { isAbortError } from '@arcanos/runtime';
+
+export interface PriorityGptDirectExecutionSlot {
+  release: () => void;
+}
+
+export interface PriorityGptDirectExecutionSnapshot {
+  active: number;
+  capacity: number;
+  available: number;
+}
+
+const DIRECT_HEARTBEAT_INTERVAL_MS = 5_000;
+let activePriorityDirectExecutions = 0;
+
+function hydrateQueuedGptBodyPrompt(
+  body: Record<string, unknown>,
+  prompt: string | undefined
+): Record<string, unknown> {
+  if (!prompt) {
+    return body;
+  }
+
+  if (
+    typeof body.prompt === 'string' ||
+    typeof body.message === 'string' ||
+    typeof body.query === 'string' ||
+    typeof body.text === 'string' ||
+    typeof body.content === 'string'
+  ) {
+    return body;
+  }
+
+  return {
+    ...body,
+    prompt
+  };
+}
+
+export function getPriorityGptDirectExecutionSnapshot(
+  env: NodeJS.ProcessEnv = process.env
+): PriorityGptDirectExecutionSnapshot {
+  const capacity = resolvePriorityGptDirectExecutionConcurrency(env);
+  const active = Math.min(activePriorityDirectExecutions, capacity);
+
+  return {
+    active,
+    capacity,
+    available: Math.max(0, capacity - active)
+  };
+}
+
+export function tryAcquirePriorityGptDirectExecutionSlot(
+  env: NodeJS.ProcessEnv = process.env
+): PriorityGptDirectExecutionSlot | null {
+  const capacity = resolvePriorityGptDirectExecutionConcurrency(env);
+  if (activePriorityDirectExecutions >= capacity) {
+    return null;
+  }
+
+  activePriorityDirectExecutions += 1;
+  let released = false;
+
+  return {
+    release: () => {
+      if (released) {
+        return;
+      }
+
+      released = true;
+      activePriorityDirectExecutions = Math.max(0, activePriorityDirectExecutions - 1);
+    }
+  };
+}
+
+/**
+ * Start API-process execution for a reserved priority GPT job.
+ * Purpose: let custom GPT requests use immediate worker capacity without entering the normal queue lane.
+ * Inputs/outputs: accepts a pre-created running job plus the reserved slot; persists terminal job state.
+ * Edge case behavior: failures are logged and converted to terminal job rows, avoiding hidden retry loops.
+ */
+export function startReservedPriorityGptDirectExecution(params: {
+  jobId: string;
+  rawInput: unknown;
+  workerId: string;
+  slot: PriorityGptDirectExecutionSlot;
+  requestLogger?: { info?: (...args: unknown[]) => void; warn?: (...args: unknown[]) => void; error?: (...args: unknown[]) => void };
+}): void {
+  void executeReservedPriorityGptDirectExecution(params)
+    .catch((error: unknown) => {
+      logger.error('gpt.priority_direct.unhandled_error', {
+        jobId: params.jobId,
+        workerId: params.workerId,
+        error: resolveErrorMessage(error)
+      });
+    });
+}
+
+async function executeReservedPriorityGptDirectExecution(params: {
+  jobId: string;
+  rawInput: unknown;
+  workerId: string;
+  slot: PriorityGptDirectExecutionSlot;
+  requestLogger?: { info?: (...args: unknown[]) => void; warn?: (...args: unknown[]) => void; error?: (...args: unknown[]) => void };
+}): Promise<void> {
+  const parsedGptJobInput = parseQueuedGptJobInput(params.rawInput ?? {});
+  const startedAtMs = Date.now();
+  const leaseMs = Math.max(15_000, resolveGptWaitTimeoutMs() + 5_000);
+  const heartbeatHandle = setInterval(() => {
+    void recordJobHeartbeat(params.jobId, {
+      workerId: params.workerId,
+      leaseMs
+    }).catch((error: unknown) => {
+      logger.warn('gpt.priority_direct.heartbeat_failed', {
+        jobId: params.jobId,
+        workerId: params.workerId,
+        error: resolveErrorMessage(error)
+      });
+    });
+  }, DIRECT_HEARTBEAT_INTERVAL_MS);
+
+  try {
+    if (!parsedGptJobInput.ok) {
+      await updateJob(
+        params.jobId,
+        'failed',
+        null,
+        `Invalid GPT job.input: ${parsedGptJobInput.error}`,
+        {
+          priorityDirectExecution: {
+            completedAt: new Date().toISOString(),
+            failure: 'invalid_input'
+          }
+        },
+        computeGptJobLifecycleDeadlines('failed')
+      );
+      return;
+    }
+
+    const { gptId, body, prompt, requestId, bypassIntentRouting } = parsedGptJobInput.value;
+    const latestJob = await getJobById(params.jobId);
+    if (latestJob?.cancel_requested_at) {
+      await updateJob(
+        params.jobId,
+        'cancelled',
+        null,
+        latestJob.cancel_reason ?? 'Job cancellation requested before priority GPT execution started.',
+        {
+          priorityDirectExecution: {
+            completedAt: new Date().toISOString(),
+            cancelledBeforeStart: true
+          }
+        },
+        {
+          ...computeGptJobLifecycleDeadlines('cancelled'),
+          cancelRequestedAt: new Date().toISOString(),
+          cancelReason: latestJob.cancel_reason ?? 'Priority GPT direct execution cancelled.'
+        }
+      );
+      return;
+    }
+
+    const routeLogger = logger.child({
+      module: 'priority-gpt-direct',
+      gptId,
+      requestId,
+      jobId: params.jobId
+    });
+    params.requestLogger?.info?.('gpt.priority_direct.started', {
+      gptId,
+      requestId,
+      jobId: params.jobId,
+      workerId: params.workerId
+    });
+
+    const envelope = await routeGptRequest({
+      gptId,
+      body: hydrateQueuedGptBodyPrompt(body, prompt),
+      requestId,
+      logger: routeLogger,
+      bypassIntentRouting,
+      runtimeExecutionMode: 'background'
+    });
+
+    if (!envelope.ok) {
+      const errorMessage = `${envelope.error.code}: ${envelope.error.message}`;
+      await updateJob(
+        params.jobId,
+        'failed',
+        envelope,
+        errorMessage,
+        {
+          priorityDirectExecution: {
+            completedAt: new Date().toISOString(),
+            durationMs: Date.now() - startedAtMs,
+            retryable:
+              envelope.error.code === 'MODULE_TIMEOUT' ||
+              envelope.error.code === 'MODULE_ERROR'
+          },
+          lastFailure: {
+            at: new Date().toISOString(),
+            reason: errorMessage,
+            retryable:
+              envelope.error.code === 'MODULE_TIMEOUT' ||
+              envelope.error.code === 'MODULE_ERROR',
+            retryExhausted: true,
+            priorityDirectExecution: true
+          }
+        },
+        computeGptJobLifecycleDeadlines('failed')
+      );
+      recordGptJobEvent({
+        event:
+          envelope.error.code === 'MODULE_TIMEOUT' || envelope.error.code === 'MODULE_ERROR'
+            ? 'retryable_failure'
+            : 'non_retryable_failure',
+        status: 'failed',
+        retryable:
+          envelope.error.code === 'MODULE_TIMEOUT' ||
+          envelope.error.code === 'MODULE_ERROR'
+      });
+      return;
+    }
+
+    await updateJob(
+      params.jobId,
+      'completed',
+      envelope,
+      null,
+      {
+        priorityDirectExecution: {
+          completedAt: new Date().toISOString(),
+          durationMs: Date.now() - startedAtMs
+        }
+      },
+      computeGptJobLifecycleDeadlines('completed')
+    );
+    recordGptJobEvent({
+      event: 'completed',
+      status: 'completed',
+      retryable: false
+    });
+    recordGptJobTiming({
+      phase: 'execution',
+      outcome: 'completed',
+      durationMs: Date.now() - startedAtMs
+    });
+    params.requestLogger?.info?.('gpt.priority_direct.completed', {
+      gptId,
+      requestId,
+      jobId: params.jobId,
+      durationMs: Date.now() - startedAtMs
+    });
+  } catch (error: unknown) {
+    const errorMessage = resolveErrorMessage(error);
+    const aborted = isAbortError(error);
+    await updateJob(
+      params.jobId,
+      aborted ? 'cancelled' : 'failed',
+      null,
+      errorMessage,
+      {
+        priorityDirectExecution: {
+          completedAt: new Date().toISOString(),
+          durationMs: Date.now() - startedAtMs,
+          thrown: true,
+          aborted
+        },
+        lastFailure: {
+          at: new Date().toISOString(),
+          reason: errorMessage,
+          retryable: false,
+          retryExhausted: true,
+          priorityDirectExecution: true
+        }
+      },
+      computeGptJobLifecycleDeadlines(aborted ? 'cancelled' : 'failed')
+    );
+    params.requestLogger?.warn?.('gpt.priority_direct.failed', {
+      jobId: params.jobId,
+      workerId: params.workerId,
+      durationMs: Date.now() - startedAtMs,
+      error: errorMessage
+    });
+  } finally {
+    clearInterval(heartbeatHandle);
+    params.slot.release();
+  }
+}

--- a/src/services/runtimeDiagnosticsService.ts
+++ b/src/services/runtimeDiagnosticsService.ts
@@ -43,7 +43,10 @@ export interface DiagnosticsSnapshot {
   public_metrics_request_count: number;
   public_metrics_error_count: number;
   avg_latency_ms: number | `DATA NOT EXPOSED: ${string}`;
+  p95_latency_ms: number | `DATA NOT EXPOSED: ${string}`;
   recent_latency_ms: number[] | `DATA NOT EXPOSED: ${string}`;
+  timeout_count: number;
+  recent_slow_routes: RuntimeSlowRouteSnapshot[];
   top_error_routes: DiagnosticsRouteErrorSnapshot[];
   modules: Record<string, ModuleStatus>;
 }
@@ -54,6 +57,15 @@ export interface DiagnosticsRouteErrorSnapshot {
   errorCount: number;
   timeoutCount: number;
   errorRate: number;
+}
+
+export interface RuntimeSlowRouteSnapshot {
+  route: string;
+  slowRequestCount: number;
+  avgLatencyMs: number;
+  p95LatencyMs: number;
+  maxLatencyMs: number;
+  timeoutCount: number;
 }
 
 export interface RequestSample {
@@ -260,6 +272,7 @@ class RuntimeDiagnosticsService {
 
   async getDiagnosticsSnapshot(app: Application): Promise<DiagnosticsSnapshot> {
     const metricsSnapshot = await this.getMetricsSnapshot();
+    const requestWindow = this.getRollingRequestWindow(PUBLIC_ERROR_RATE_WINDOW_MS);
     const activeRoutes = this.getActiveRoutes(app);
     const registry = await this.getRegistrySnapshot();
 
@@ -276,7 +289,20 @@ class RuntimeDiagnosticsService {
       public_metrics_request_count: metricsSnapshot.publicMetricsRequestCount,
       public_metrics_error_count: metricsSnapshot.publicMetricsErrorCount,
       avg_latency_ms: metricsSnapshot.avgLatencyMs,
+      p95_latency_ms: requestWindow.p95LatencyMs,
       recent_latency_ms: metricsSnapshot.recentLatencyMs,
+      timeout_count: requestWindow.timeoutCount,
+      recent_slow_routes: requestWindow.routes
+        .filter(route => route.slowRequestCount > 0)
+        .slice(0, 10)
+        .map(route => ({
+          route: route.route,
+          slowRequestCount: route.slowRequestCount,
+          avgLatencyMs: route.avgLatencyMs,
+          p95LatencyMs: route.p95LatencyMs,
+          maxLatencyMs: route.maxLatencyMs,
+          timeoutCount: route.timeoutCount
+        })),
       top_error_routes: metricsSnapshot.topErrorRoutes,
       modules: this.resolveModuleStatuses(registry.loadedModules)
     };

--- a/src/services/workerAutonomyService.ts
+++ b/src/services/workerAutonomyService.ts
@@ -8,17 +8,24 @@ import {
   recoverStaleJobs,
   scheduleJobRetry,
   updateJob,
-  type ClaimNextPendingJobOptions,
   type CreateJobOptions,
   type JobExecutionStats,
   type JobQueueSummary,
   type RecoverStaleJobsResult
 } from '@core/db/repositories/jobRepository.js';
+import type { SchedulerClaimOptions } from '@core/scheduler/types.js';
 import { computeGptJobLifecycleDeadlines } from '@shared/gpt/gptJobLifecycle.js';
 import {
+  PRIORITY_GPT_JOB_PRIORITY,
+  isPriorityGpt,
+  isPriorityQueueEnabled,
+  resolveGptJobMaxRetries,
+  resolvePriorityQueueWeight
+} from '@shared/gpt/priorityGpt.js';
+import {
+  listWorkerRuntimeSnapshots,
   listWorkerLiveness,
   listWorkerRuntimeStateSnapshots,
-  listWorkerRuntimeSnapshots,
   upsertWorkerRuntimeSnapshot,
   type WorkerLivenessSnapshotRecord,
   type WorkerRuntimeSnapshotRecord
@@ -257,6 +264,10 @@ export async function planAutonomousWorkerJob(
   const queueSummary = await getJobQueueSummary();
   const planningReasons: string[] = [];
   const basePriority = overrides.priority ?? determineJobPriority(jobType, input);
+  const defaultMaxRetries =
+    jobType === 'gpt'
+      ? resolveGptJobMaxRetries()
+      : settings.defaultMaxRetries;
   let priority = basePriority;
   let nextRunAt = overrides.nextRunAt;
 
@@ -286,7 +297,7 @@ export async function planAutonomousWorkerJob(
   return {
     status: overrides.status ?? 'pending',
     retryCount: overrides.retryCount ?? 0,
-    maxRetries: overrides.maxRetries ?? settings.defaultMaxRetries,
+    maxRetries: overrides.maxRetries ?? defaultMaxRetries,
     nextRunAt,
     startedAt: overrides.startedAt ?? null,
     lastHeartbeatAt: overrides.lastHeartbeatAt ?? null,
@@ -430,10 +441,12 @@ export class WorkerAutonomyService {
    * Inputs/outputs: no inputs, returns normalized claim options.
    * Edge case behavior: always includes a non-empty worker id and positive lease duration.
    */
-  getClaimOptions(): ClaimNextPendingJobOptions {
+  getClaimOptions(): SchedulerClaimOptions {
     return {
       workerId: this.settings.workerId,
-      leaseMs: this.settings.leaseMs
+      leaseMs: this.settings.leaseMs,
+      priorityQueueEnabled: isPriorityQueueEnabled(),
+      priorityQueueWeight: resolvePriorityQueueWeight()
     };
   }
 
@@ -1553,8 +1566,8 @@ function determineJobPriority(jobType: string, input: unknown): number {
 
   if (jobType === 'gpt') {
     const gptId = readStringPath(input, ['gptId']);
-    if (gptId === 'arcanos-core' || gptId === 'core' || gptId === 'arcanos-daemon') {
-      return 85;
+    if (isPriorityGpt(gptId)) {
+      return PRIORITY_GPT_JOB_PRIORITY;
     }
     return 95;
   }

--- a/src/shared/ask/asyncAskJob.ts
+++ b/src/shared/ask/asyncAskJob.ts
@@ -14,6 +14,7 @@ import {
   buildTrinityUserVisibleResponse,
   type TrinityUserVisibleResponse
 } from './trinityResponseSerializer.js';
+import { buildJobResultPollPath } from '../jobs/jobLinks.js';
 
 const ASYNC_ASK_ENDPOINT_FALLBACK = 'ask';
 
@@ -274,7 +275,7 @@ export function buildQueuedAskPendingResponse(jobId: string): QueuedAskPendingRe
     ok: true,
     status: 'pending',
     jobId,
-    poll: `/jobs/${jobId}`
+    poll: buildJobResultPollPath(jobId)
   };
 }
 

--- a/src/shared/gpt/asyncGptJob.ts
+++ b/src/shared/gpt/asyncGptJob.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { GptAsyncWriteAction } from './gptJobResult.js';
+import { mapGptJobStatusToClientStatus } from './priorityGpt.js';
 import {
   GPT_ECHO_ACTION,
   GPT_HEALTH_ECHO_ACTION,
@@ -47,10 +48,12 @@ export interface QueuedGptJobInput {
 export interface QueuedGptPendingResponse {
   ok: true;
   action: GptAsyncWriteAction;
-  status: 'pending';
+  status: 'queued' | 'running' | 'timeout';
   jobId: string;
+  result: Record<string, never>;
   poll: string;
   stream: string;
+  timedOut: boolean;
   jobStatus?: string;
   lifecycleStatus?: string;
   deduped?: boolean;
@@ -182,10 +185,14 @@ export function buildQueuedGptPendingResponse(input: {
   return {
     ok: true,
     action: input.action ?? 'query',
-    status: 'pending',
+    status: mapGptJobStatusToClientStatus(input.jobStatus) === 'running'
+      ? 'running'
+      : 'queued',
     jobId: input.jobId,
-    poll: `/jobs/${input.jobId}`,
+    result: {},
+    poll: `/jobs/${input.jobId}/result`,
     stream: `/jobs/${input.jobId}/stream`,
+    timedOut: false,
     ...(normalizeOptionalString(input.jobStatus ?? undefined)
       ? { jobStatus: normalizeOptionalString(input.jobStatus ?? undefined)! }
       : {}),

--- a/src/shared/gpt/gptJobResult.ts
+++ b/src/shared/gpt/gptJobResult.ts
@@ -248,6 +248,7 @@ export function parseGptJobStatusRequest(body: unknown): ParsedGptJobStatusReque
 export function buildStoredJobStatusPayload(job: JobData) {
   return {
     id: job.id,
+    jobId: job.id,
     job_type: job.job_type,
     status: job.status,
     lifecycle_status: resolveGptJobLifecycleStatus(job.status),
@@ -259,6 +260,8 @@ export function buildStoredJobStatusPayload(job: JobData) {
     retention_until: serializeJobTimestamp(job.retention_until),
     idempotency_until: serializeJobTimestamp(job.idempotency_until),
     expires_at: serializeJobTimestamp(job.expires_at),
+    poll: buildJobResultPollPath(job.id),
+    stream: `/jobs/${job.id}/stream`,
     error_message: job.error_message ?? null,
     output: job.output ?? null,
     result: job.output ?? null

--- a/src/shared/gpt/gptJobResult.ts
+++ b/src/shared/gpt/gptJobResult.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { JobData } from '@core/db/schema.js';
+import { buildJobResultPollPath } from '@shared/jobs/jobLinks.js';
 import { resolveGptJobLifecycleStatus } from './gptJobLifecycle.js';
 import type { GptBridgeSmokeAction } from './bridgeSmoke.js';
 
@@ -124,7 +125,7 @@ function buildPendingJobLookupPayload(job: JobData): GptJobResultLookupPayload {
     retentionUntil: serializeJobTimestamp(job.retention_until),
     idempotencyUntil: serializeJobTimestamp(job.idempotency_until),
     expiresAt: serializeJobTimestamp(job.expires_at),
-    poll: `/jobs/${job.id}`,
+    poll: buildJobResultPollPath(job.id),
     stream: `/jobs/${job.id}/stream`,
     result: null,
     error: null
@@ -143,7 +144,7 @@ function buildCompletedJobLookupPayload(job: JobData): GptJobResultLookupPayload
     retentionUntil: serializeJobTimestamp(job.retention_until),
     idempotencyUntil: serializeJobTimestamp(job.idempotency_until),
     expiresAt: serializeJobTimestamp(job.expires_at),
-    poll: `/jobs/${job.id}`,
+    poll: buildJobResultPollPath(job.id),
     stream: `/jobs/${job.id}/stream`,
     result: job.output ?? null,
     error: null
@@ -166,7 +167,7 @@ function buildFailedJobLookupPayload(
     retentionUntil: serializeJobTimestamp(job.retention_until),
     idempotencyUntil: serializeJobTimestamp(job.idempotency_until),
     expiresAt: serializeJobTimestamp(job.expires_at),
-    poll: `/jobs/${job.id}`,
+    poll: buildJobResultPollPath(job.id),
     stream: `/jobs/${job.id}/stream`,
     result: job.output ?? null,
     error: buildJobFailurePayload(
@@ -193,7 +194,7 @@ function buildExpiredJobLookupPayload(job: JobData): GptJobResultLookupPayload {
     retentionUntil: serializeJobTimestamp(job.retention_until),
     idempotencyUntil: serializeJobTimestamp(job.idempotency_until),
     expiresAt: serializeJobTimestamp(job.expires_at),
-    poll: `/jobs/${job.id}`,
+    poll: buildJobResultPollPath(job.id),
     stream: `/jobs/${job.id}/stream`,
     result: job.output ?? null,
     error: buildJobFailurePayload(
@@ -291,7 +292,7 @@ export function buildGptJobResultLookupPayload(
       retentionUntil: null,
       idempotencyUntil: null,
       expiresAt: null,
-      poll: `/jobs/${jobId}`,
+      poll: buildJobResultPollPath(jobId),
       stream: `/jobs/${jobId}/stream`,
       result: null,
       error: buildJobFailurePayload('JOB_NOT_FOUND', 'Async GPT job was not found.')

--- a/src/shared/gpt/priorityGpt.ts
+++ b/src/shared/gpt/priorityGpt.ts
@@ -1,0 +1,181 @@
+const DEFAULT_PRIORITY_GPT_IDS = [
+  'arcanos-core',
+  'arcanos-audit',
+  'arcanos-build',
+  'arcanos-research',
+  'arcanos-write',
+  'arcanos-guide',
+  'arcanos-sim',
+  'arcanos-tracker',
+  'arcanos-tutor',
+  'arcanos-daemon',
+  'core',
+  'audit',
+  'build',
+  'research',
+  'write',
+  'guide',
+  'sim',
+  'tracker',
+  'tutor'
+] as const;
+
+export const PRIORITY_GPT_JOB_PRIORITY = 0;
+export const PRIORITY_QUEUE_LANE_MAX_PRIORITY = 10;
+export const DEFAULT_PRIORITY_QUEUE_WEIGHT = 5;
+export const DEFAULT_GPT_DIRECT_EXECUTION_THRESHOLD_MS = 8_000;
+export const DEFAULT_GPT_WAIT_TIMEOUT_MS = 24_000;
+export const DEFAULT_GPT_JOB_MAX_RETRIES = 1;
+export const DEFAULT_PRIORITY_GPT_DIRECT_EXECUTION_CONCURRENCY = 1;
+
+function normalizeId(value: string | null | undefined): string | null {
+  const normalizedValue = value?.trim().toLowerCase();
+  return normalizedValue && normalizedValue.length > 0 ? normalizedValue : null;
+}
+
+function parseCsv(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+
+  return value
+    .split(',')
+    .map(entry => normalizeId(entry))
+    .filter((entry): entry is string => Boolean(entry));
+}
+
+function readPositiveInteger(
+  env: NodeJS.ProcessEnv,
+  name: string,
+  fallback: number,
+  options: { min?: number; max?: number } = {}
+): number {
+  const parsedValue = Number(env[name]);
+  const min = options.min ?? 1;
+  const max = options.max ?? Number.MAX_SAFE_INTEGER;
+
+  if (!Number.isFinite(parsedValue) || parsedValue < min) {
+    return fallback;
+  }
+
+  return Math.min(max, Math.max(min, Math.trunc(parsedValue)));
+}
+
+function readNonNegativeInteger(
+  env: NodeJS.ProcessEnv,
+  name: string,
+  fallback: number,
+  options: { max?: number } = {}
+): number {
+  const parsedValue = Number(env[name]);
+  const max = options.max ?? Number.MAX_SAFE_INTEGER;
+
+  if (!Number.isFinite(parsedValue) || parsedValue < 0) {
+    return fallback;
+  }
+
+  return Math.min(max, Math.trunc(parsedValue));
+}
+
+export function getPriorityGptIds(env: NodeJS.ProcessEnv = process.env): string[] {
+  return Array.from(
+    new Set([
+      ...DEFAULT_PRIORITY_GPT_IDS,
+      ...parseCsv(env.PRIORITY_GPT_IDS)
+    ])
+  );
+}
+
+export function isPriorityGpt(
+  gptId: string | null | undefined,
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  const normalizedGptId = normalizeId(gptId);
+  if (!normalizedGptId) {
+    return false;
+  }
+
+  return getPriorityGptIds(env).includes(normalizedGptId);
+}
+
+export function isPriorityQueueEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.PRIORITY_QUEUE_ENABLED?.trim().toLowerCase() !== 'false';
+}
+
+export function resolvePriorityQueueWeight(env: NodeJS.ProcessEnv = process.env): number {
+  return readPositiveInteger(env, 'PRIORITY_QUEUE_WEIGHT', DEFAULT_PRIORITY_QUEUE_WEIGHT, {
+    min: 1,
+    max: 100
+  });
+}
+
+export function resolveGptDirectExecutionThresholdMs(
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  return readPositiveInteger(
+    env,
+    'GPT_DIRECT_EXECUTION_THRESHOLD_MS',
+    DEFAULT_GPT_DIRECT_EXECUTION_THRESHOLD_MS,
+    {
+      min: 250,
+      max: DEFAULT_GPT_WAIT_TIMEOUT_MS
+    }
+  );
+}
+
+export function resolveGptWaitTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  return readPositiveInteger(env, 'GPT_WAIT_TIMEOUT_MS', DEFAULT_GPT_WAIT_TIMEOUT_MS, {
+    min: 1_000,
+    max: 120_000
+  });
+}
+
+export function resolveGptJobMaxRetries(env: NodeJS.ProcessEnv = process.env): number {
+  return readNonNegativeInteger(env, 'GPT_JOB_MAX_RETRIES', DEFAULT_GPT_JOB_MAX_RETRIES, {
+    max: 10
+  });
+}
+
+export function resolvePriorityGptDirectExecutionConcurrency(
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  return readPositiveInteger(
+    env,
+    'GPT_PRIORITY_DIRECT_EXECUTION_CONCURRENCY',
+    DEFAULT_PRIORITY_GPT_DIRECT_EXECUTION_CONCURRENCY,
+    {
+      min: 1,
+      max: 20
+    }
+  );
+}
+
+export function mapGptJobStatusToClientStatus(
+  jobStatus: string | null | undefined
+): 'queued' | 'running' | 'completed' | 'timeout' {
+  switch (jobStatus) {
+    case 'completed':
+      return 'completed';
+    case 'running':
+      return 'running';
+    case 'failed':
+    case 'cancelled':
+    case 'expired':
+      return 'completed';
+    case 'pending':
+    default:
+      return 'queued';
+  }
+}
+
+export function isPriorityQueueLaneJob(job: {
+  job_type?: string | null;
+  priority?: number | string | null;
+}): boolean {
+  const priority = Number(job.priority ?? Number.NaN);
+  return (
+    job.job_type === 'gpt' &&
+    Number.isFinite(priority) &&
+    priority <= PRIORITY_QUEUE_LANE_MAX_PRIORITY
+  );
+}

--- a/src/shared/gpt/priorityGpt.ts
+++ b/src/shared/gpt/priorityGpt.ts
@@ -152,30 +152,40 @@ export function resolvePriorityGptDirectExecutionConcurrency(
 
 export function mapGptJobStatusToClientStatus(
   jobStatus: string | null | undefined
-): 'queued' | 'running' | 'completed' | 'timeout' {
+): 'queued' | 'running' | 'completed' | 'timeout' | 'failed' | 'cancelled' {
   switch (jobStatus) {
     case 'completed':
       return 'completed';
     case 'running':
       return 'running';
-    case 'failed':
-    case 'cancelled':
+    case 'timeout':
     case 'expired':
-      return 'completed';
+      return 'timeout';
+    case 'failed':
+      return 'failed';
+    case 'cancelled':
+      return 'cancelled';
     case 'pending':
     default:
       return 'queued';
   }
 }
 
-export function isPriorityQueueLaneJob(job: {
-  job_type?: string | null;
-  priority?: number | string | null;
-}): boolean {
+export function isPriorityQueueLaneJob(
+  job: {
+    job_type?: string | null;
+    priority?: number | string | null;
+  },
+  priorityLaneMaxPriority: number = PRIORITY_QUEUE_LANE_MAX_PRIORITY
+): boolean {
   const priority = Number(job.priority ?? Number.NaN);
+  const maxPriority =
+    Number.isFinite(priorityLaneMaxPriority) && priorityLaneMaxPriority > 0
+      ? Math.trunc(priorityLaneMaxPriority)
+      : PRIORITY_QUEUE_LANE_MAX_PRIORITY;
   return (
     job.job_type === 'gpt' &&
     Number.isFinite(priority) &&
-    priority <= PRIORITY_QUEUE_LANE_MAX_PRIORITY
+    priority <= maxPriority
   );
 }

--- a/src/shared/jobs/jobLinks.ts
+++ b/src/shared/jobs/jobLinks.ts
@@ -1,0 +1,3 @@
+export function buildJobResultPollPath(jobId: string): string {
+  return `/jobs/${jobId}/result`;
+}

--- a/src/shared/types/arcanos-verification-contract.types.ts
+++ b/src/shared/types/arcanos-verification-contract.types.ts
@@ -140,6 +140,11 @@ export interface WorkerInfo {
 
 export interface WorkersStatusData {
   workers: WorkerInfo[];
+  activeWorkers: number;
+  activeWorkerSlots: number;
+  availableWorkerSlots: number;
+  queueDepth: number;
+  priorityQueueDepth: number;
 }
 
 export type WorkersStatusResponse = ApiEnvelope<WorkersStatusData>;
@@ -153,6 +158,12 @@ export interface QueueSnapshot {
   delayed: number;
   oldestWaitingJobAgeMs: number;
   stalledJobs: number;
+  priorityDepth: number;
+  priorityRunning: number;
+  normalWaiting: number;
+  activeWorkers: number;
+  availableWorkerSlots: number;
+  priorityJobCount: number;
 }
 
 export interface QueueStatusData {
@@ -266,6 +277,19 @@ export interface NodeDetail extends TrinityNodeMetadata {
   error: ErrorInfo | null;
 }
 
+export interface DagNodeTraceEntry {
+  nodeId: string;
+  moduleName: string;
+  module_name: string;
+  start_time: ISODateString | null;
+  end_time: ISODateString | null;
+  duration_ms: number | null;
+  retries: number;
+  error: ErrorInfo | null;
+  external_provider: string | null;
+  slow: boolean;
+}
+
 export interface NodeDetailData {
   node: NodeDetail;
 }
@@ -306,6 +330,7 @@ export interface DagRunMetrics {
   sumNodeDurationMs: number;
   queueWaitMsP50: number;
   queueWaitMsP95: number;
+  slowNodeCount: number;
 }
 
 export interface DagMetricsData {
@@ -313,6 +338,7 @@ export interface DagMetricsData {
   metrics: DagRunMetrics;
   limits: ExecutionLimits;
   guardViolations: GuardViolation[];
+  slowNodes: DagNodeTraceEntry[];
 }
 
 export type DagMetricsResponse = ApiEnvelope<DagMetricsData>;
@@ -391,6 +417,8 @@ export type DagVerificationResponse = ApiEnvelope<DagVerificationData>;
 export interface DagTraceData extends TrinityRuntimeMetadata {
   run: DagRunSummary;
   tree: DagTreeData;
+  nodeTrace: DagNodeTraceEntry[];
+  slowNodes: DagNodeTraceEntry[];
   events: DagEventsData;
   metrics: DagMetricsData;
   errors: DagErrorsData;

--- a/src/workers/jobRunner.ts
+++ b/src/workers/jobRunner.ts
@@ -8,7 +8,8 @@
  * - Persists worker health snapshots for cross-instance inspection
  */
 
-import { claimNextPendingJob, getJobById, updateJob } from '@core/db/repositories/jobRepository.js';
+import { getJobById, updateJob } from '@core/db/repositories/jobRepository.js';
+import { postgresQueueSchedulerAdapter } from '@core/scheduler/postgresAdapter.js';
 import {
   initializeDatabaseWithSchema as initializeDatabase,
   getStatus as getDatabaseStatus
@@ -855,7 +856,9 @@ async function runWorkerConsumerSlot(
         continue;
       }
 
-      const job = await claimNextPendingJob(autonomyService.getClaimOptions());
+      const { job } = await postgresQueueSchedulerAdapter.claimNext(
+        autonomyService.getClaimOptions()
+      );
 
       if (!job) {
         await autonomyService.markIdle();

--- a/tests/arcanos-dag-run-service.test.ts
+++ b/tests/arcanos-dag-run-service.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import {
   ArcanosDagRunService,
+  buildDagNodeTraceEntries,
   type DagRunWaitResult
 } from '../src/services/arcanosDagRunService.js';
 import { runWithRequestAbortTimeout } from '@arcanos/runtime';
@@ -45,7 +46,8 @@ function buildStoredRunRecord(updatedAt: string) {
       wallClockDurationMs: 0,
       sumNodeDurationMs: 0,
       queueWaitMsP50: 0,
-      queueWaitMsP95: 0
+      queueWaitMsP95: 0,
+      slowNodeCount: 0
     },
     verification: {
       runCompleted: false,
@@ -83,8 +85,57 @@ function buildStoredRunRecord(updatedAt: string) {
       updatedAtIso: updatedAt
     },
     loopDetected: false
-  } as any;
+} as any;
 }
+
+describe('DAG node trace formatting', () => {
+  it('marks nodes slower than 5000ms with module, retry, error, and provider details', () => {
+    const [trace] = buildDagNodeTraceEntries([
+      {
+        nodeId: 'research-1',
+        runId: 'run-1',
+        parentNodeId: null,
+        agentRole: 'research',
+        jobType: 'analyze',
+        status: 'complete',
+        dependencyIds: [],
+        childNodeIds: [],
+        spawnDepth: 0,
+        attempt: 2,
+        maxRetries: 2,
+        input: {
+          moduleName: 'ARCANOS:RESEARCH'
+        },
+        output: {
+          provider: 'openai'
+        },
+        startedAt: '2026-03-07T00:00:00.000Z',
+        completedAt: '2026-03-07T00:00:06.250Z',
+        metrics: {
+          durationMs: 6250
+        },
+        error: {
+          message: 'retry recovered'
+        }
+      } as any
+    ]);
+
+    expect(trace).toEqual(expect.objectContaining({
+      nodeId: 'research-1',
+      moduleName: 'ARCANOS:RESEARCH',
+      module_name: 'ARCANOS:RESEARCH',
+      start_time: '2026-03-07T00:00:00.000Z',
+      end_time: '2026-03-07T00:00:06.250Z',
+      duration_ms: 6250,
+      retries: 1,
+      external_provider: 'openai',
+      slow: true,
+      error: {
+        message: 'retry recovered'
+      }
+    }));
+  });
+});
 
 describe('ArcanosDagRunService.waitForRunUpdate', () => {
   beforeEach(() => {

--- a/tests/ask-async-route.test.ts
+++ b/tests/ask-async-route.test.ts
@@ -133,7 +133,7 @@ describe('async /brain queue contract', () => {
       ok: true,
       status: 'pending',
       jobId: 'job-123',
-      poll: '/jobs/job-123'
+      poll: '/jobs/job-123/result'
     });
     expect(createJobMock).toHaveBeenCalledWith(
       'api',
@@ -227,7 +227,7 @@ describe('async /brain queue contract', () => {
       error: 'ASYNC_ASK_JOB_FAILED',
       message: 'OpenAI upstream timed out',
       jobId: 'job-123',
-      poll: '/jobs/job-123'
+      poll: '/jobs/job-123/result'
     });
   });
 
@@ -250,7 +250,7 @@ describe('async /brain queue contract', () => {
       error: 'ASYNC_ASK_JOB_OUTPUT_INVALID',
       message: 'Async ask job completed without a structured output payload.',
       jobId: 'job-123',
-      poll: '/jobs/job-123'
+      poll: '/jobs/job-123/result'
     });
   });
 
@@ -269,7 +269,7 @@ describe('async /brain queue contract', () => {
       error: 'ASYNC_ASK_JOB_MISSING',
       message: 'Async ask job disappeared before completion.',
       jobId: 'job-123',
-      poll: '/jobs/job-123'
+      poll: '/jobs/job-123/result'
     });
   });
 });

--- a/tests/ask-validation.test.ts
+++ b/tests/ask-validation.test.ts
@@ -2,8 +2,10 @@ import express from 'express';
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const mockRouteGptRequest = jest.fn();
+const mockResolveGptRouting = jest.fn();
 
 jest.unstable_mockModule('../src/routes/_core/gptDispatch.js', () => ({
+  resolveGptRouting: mockResolveGptRouting,
   routeGptRequest: mockRouteGptRequest,
 }));
 
@@ -28,6 +30,26 @@ function buildApp() {
 describe('canonical GPT route validation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockResolveGptRouting.mockImplementation(async (gptId: string) => ({
+      ok: true,
+      plan: {
+        matchedId: gptId,
+        module: 'ARCANOS:CORE',
+        route: 'core',
+        action: 'query',
+        availableActions: ['query'],
+        moduleVersion: null,
+        moduleDescription: null,
+        matchMethod: 'exact'
+      },
+      _route: {
+        gptId,
+        route: 'core',
+        module: 'ARCANOS:CORE',
+        action: 'query',
+        timestamp: '2026-04-24T00:00:00.000Z'
+      }
+    }));
   });
 
   afterEach(() => {

--- a/tests/async-ask-job.test.ts
+++ b/tests/async-ask-job.test.ts
@@ -162,7 +162,7 @@ describe('async ask job helpers', () => {
       ok: true,
       status: 'pending',
       jobId: 'job-123',
-      poll: '/jobs/job-123'
+      poll: '/jobs/job-123/result'
     });
   });
 });

--- a/tests/client-response-guards.test.ts
+++ b/tests/client-response-guards.test.ts
@@ -508,7 +508,7 @@ describe('client response guards', () => {
       status: 'completed',
       jobStatus: 'completed',
       lifecycleStatus: 'completed',
-      poll: '/jobs/job-123',
+      poll: '/jobs/job-123/result',
       stream: '/jobs/job-123/stream',
       result: {
         answer: 'x'.repeat(16_000),
@@ -525,7 +525,7 @@ describe('client response guards', () => {
       status: 'completed',
       jobStatus: 'completed',
       lifecycleStatus: 'completed',
-      poll: '/jobs/job-123',
+      poll: '/jobs/job-123/result',
       stream: '/jobs/job-123/stream',
       truncated: true,
       result: expect.stringContaining('[truncated]'),

--- a/tests/custom-gpt-bridge-smoke.route.test.ts
+++ b/tests/custom-gpt-bridge-smoke.route.test.ts
@@ -172,9 +172,9 @@ describe('Custom GPT bridge smoke action', () => {
       status: 'pending',
       action: 'health_echo',
       jobId: SMOKE_PENDING_JOB_ID,
-      poll_url: `/jobs/${SMOKE_PENDING_JOB_ID}`,
+      poll_url: `/jobs/${SMOKE_PENDING_JOB_ID}/result`,
       result_url: `/jobs/${SMOKE_PENDING_JOB_ID}/result`,
-      poll: `/jobs/${SMOKE_PENDING_JOB_ID}`,
+      poll: `/jobs/${SMOKE_PENDING_JOB_ID}/result`,
       result: {
         method: 'GET',
         url: `/jobs/${SMOKE_PENDING_JOB_ID}/result`,
@@ -220,7 +220,7 @@ describe('Custom GPT bridge smoke action', () => {
       status: 'pending',
       action: 'echo',
       jobId: ECHO_PENDING_JOB_ID,
-      poll_url: `/jobs/${ECHO_PENDING_JOB_ID}`,
+      poll_url: `/jobs/${ECHO_PENDING_JOB_ID}/result`,
       result_url: `/jobs/${ECHO_PENDING_JOB_ID}/result`,
       result: {
         method: 'GET',

--- a/tests/custom-gpt-bridge.route.test.ts
+++ b/tests/custom-gpt-bridge.route.test.ts
@@ -123,7 +123,7 @@ describe('Custom GPT bridge route', () => {
         ok: true,
         status: 'pending',
         jobId: 'job-pending-123',
-        poll_url: '/jobs/job-pending-123',
+        poll_url: '/jobs/job-pending-123/result',
         result_url: '/jobs/job-pending-123/result',
         action: 'query',
       }),
@@ -256,7 +256,7 @@ describe('Custom GPT bridge route', () => {
         ok: true,
         status: 'completed',
         jobId: 'job-completed-123',
-        poll_url: '/jobs/job-completed-123',
+        poll_url: '/jobs/job-completed-123/result',
         result_url: '/jobs/job-completed-123/result',
         output: {
           answer: 'Deployment is healthy.',

--- a/tests/gpt-async-idempotency.route.test.ts
+++ b/tests/gpt-async-idempotency.route.test.ts
@@ -234,7 +234,7 @@ describe('async /gpt idempotency', () => {
       retentionUntil: null,
       idempotencyUntil: null,
       expiresAt: null,
-      poll: '/jobs/job-lookup-complete',
+      poll: '/jobs/job-lookup-complete/result',
       stream: '/jobs/job-lookup-complete/stream',
       output: {
         ok: true,
@@ -254,7 +254,7 @@ describe('async /gpt idempotency', () => {
         retentionUntil: null,
         idempotencyUntil: null,
         expiresAt: null,
-        poll: '/jobs/job-lookup-complete',
+        poll: '/jobs/job-lookup-complete/result',
         stream: '/jobs/job-lookup-complete/stream',
         result: {
           ok: true,
@@ -547,7 +547,7 @@ describe('async /gpt idempotency', () => {
       retentionUntil: null,
       idempotencyUntil: null,
       expiresAt: null,
-      poll: '/jobs/missing-job',
+      poll: '/jobs/missing-job/result',
       stream: '/jobs/missing-job/stream',
       output: null,
       error: {
@@ -565,7 +565,7 @@ describe('async /gpt idempotency', () => {
         retentionUntil: null,
         idempotencyUntil: null,
         expiresAt: null,
-        poll: '/jobs/missing-job',
+        poll: '/jobs/missing-job/result',
         stream: '/jobs/missing-job/stream',
         result: null,
         error: {

--- a/tests/gpt-async-idempotency.route.test.ts
+++ b/tests/gpt-async-idempotency.route.test.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const mockRouteGptRequest = jest.fn();
+const mockResolveGptRouting = jest.fn();
 const findOrCreateGptJobMock = jest.fn();
 const getJobByIdMock = jest.fn();
 const planAutonomousWorkerJobMock = jest.fn();
@@ -15,6 +16,7 @@ class MockIdempotencyKeyConflictError extends Error {}
 class MockJobRepositoryUnavailableError extends Error {}
 
 jest.unstable_mockModule('../src/routes/_core/gptDispatch.js', () => ({
+  resolveGptRouting: mockResolveGptRouting,
   routeGptRequest: mockRouteGptRequest,
 }));
 
@@ -124,6 +126,26 @@ describe('async /gpt idempotency', () => {
     }
     process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT = 'true';
     process.env.PRIORITY_QUEUE_ENABLED = 'false';
+    mockResolveGptRouting.mockImplementation(async (gptId: string) => ({
+      ok: true,
+      plan: {
+        matchedId: gptId,
+        module: 'ARCANOS:CORE',
+        route: 'core',
+        action: 'query',
+        availableActions: ['query'],
+        moduleVersion: null,
+        moduleDescription: null,
+        matchMethod: 'exact'
+      },
+      _route: {
+        gptId,
+        route: 'core',
+        module: 'ARCANOS:CORE',
+        action: 'query',
+        timestamp: '2026-04-24T00:00:00.000Z'
+      }
+    }));
     planAutonomousWorkerJobMock.mockResolvedValue({
       status: 'pending',
       retryCount: 0,
@@ -140,6 +162,42 @@ describe('async /gpt idempotency', () => {
 
   afterEach(() => {
     restoreEnv(originalAsyncIdempotencyEnv);
+  });
+
+  it('rejects unknown GPT IDs before creating async jobs', async () => {
+    mockResolveGptRouting.mockResolvedValueOnce({
+      ok: false,
+      error: {
+        code: 'UNKNOWN_GPT',
+        message: "gptId 'invalid-id' is not registered"
+      },
+      _route: {
+        gptId: 'invalid-id',
+        timestamp: '2026-04-24T00:00:00.000Z'
+      }
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/invalid-id')
+      .send({
+        action: 'query',
+        prompt: 'This should not enter the queue.'
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'UNKNOWN_GPT'
+      },
+      _route: {
+        gptId: 'invalid-id'
+      }
+    });
+    expect(planAutonomousWorkerJobMock).not.toHaveBeenCalled();
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
   it('returns the canonical in-flight job when an equivalent async request is deduped', async () => {

--- a/tests/gpt-async-idempotency.route.test.ts
+++ b/tests/gpt-async-idempotency.route.test.ts
@@ -9,6 +9,8 @@ const planAutonomousWorkerJobMock = jest.fn();
 const waitForQueuedGptJobCompletionMock = jest.fn();
 const resolveAsyncGptPollIntervalMsMock = jest.fn(() => 250);
 const resolveAsyncGptWaitForResultMsMock = jest.fn((requested?: number) => requested ?? 3500);
+const tryAcquirePriorityGptDirectExecutionSlotMock = jest.fn(() => null);
+const startReservedPriorityGptDirectExecutionMock = jest.fn();
 class MockIdempotencyKeyConflictError extends Error {}
 class MockJobRepositoryUnavailableError extends Error {}
 
@@ -64,6 +66,16 @@ jest.unstable_mockModule('../src/services/queuedGptCompletionService.js', () => 
   resolveAsyncGptWaitForResultMs: resolveAsyncGptWaitForResultMsMock
 }));
 
+jest.unstable_mockModule('../src/services/priorityGptDirectExecutionService.js', () => ({
+  tryAcquirePriorityGptDirectExecutionSlot: tryAcquirePriorityGptDirectExecutionSlotMock,
+  startReservedPriorityGptDirectExecution: startReservedPriorityGptDirectExecutionMock,
+  getPriorityGptDirectExecutionSnapshot: jest.fn(() => ({
+    active: 0,
+    capacity: 1,
+    available: 1
+  }))
+}));
+
 const { default: requestContext } = await import('../src/middleware/requestContext.js');
 const { default: gptRouter } = await import('../src/routes/gptRouter.js');
 
@@ -75,6 +87,9 @@ const ASYNC_IDEMPOTENCY_ENV_KEYS = [
   'GPT_PUBLIC_RESPONSE_MAX_BYTES',
   'GPT_ROUTE_ASYNC_CORE_DEFAULT',
   'GPT_ROUTE_HARD_TIMEOUT_MS',
+  'PRIORITY_QUEUE_ENABLED',
+  'GPT_DIRECT_EXECUTION_THRESHOLD_MS',
+  'GPT_WAIT_TIMEOUT_MS',
 ] as const;
 
 function captureEnv(keys: readonly string[]): Map<string, string | undefined> {
@@ -108,6 +123,7 @@ describe('async /gpt idempotency', () => {
       delete process.env[key];
     }
     process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT = 'true';
+    process.env.PRIORITY_QUEUE_ENABLED = 'false';
     planAutonomousWorkerJobMock.mockResolvedValue({
       status: 'pending',
       retryCount: 0,
@@ -154,10 +170,12 @@ describe('async /gpt idempotency', () => {
     expect(response.body).toEqual({
       ok: true,
       action: 'query',
-      status: 'pending',
+      status: 'running',
       jobId: 'job-123',
-      poll: '/jobs/job-123',
+      result: {},
+      poll: '/jobs/job-123/result',
       stream: '/jobs/job-123/stream',
+      timedOut: false,
       jobStatus: 'running',
       lifecycleStatus: 'running',
       deduped: true,
@@ -861,8 +879,12 @@ describe('async /gpt idempotency', () => {
     expect(response.status).toBe(202);
     expect(response.body).toMatchObject({
       ok: true,
-      status: 'pending',
+      status: 'timeout',
       jobId: 'job-timeout',
+      result: {},
+      poll: '/jobs/job-timeout/result',
+      stream: '/jobs/job-timeout/stream',
+      timedOut: true,
       jobStatus: 'running',
       lifecycleStatus: 'running',
       instruction: 'Direct wait timed out after 5250ms. Use GET /jobs/job-timeout/result to retrieve the final result.',
@@ -871,7 +893,7 @@ describe('async /gpt idempotency', () => {
         timedOut: true,
         waitForResultMs: 5_250,
         pollIntervalMs: 250,
-        poll: '/jobs/job-timeout',
+        poll: '/jobs/job-timeout/result',
         result: '/jobs/job-timeout/result'
       }
     });
@@ -924,11 +946,11 @@ describe('async /gpt idempotency', () => {
       lifecycleStatus: 'completed',
       result: 'Seth Rollins promo prompt'
     });
-    expect(resolveAsyncGptWaitForResultMsMock).toHaveBeenCalledWith(25_000);
+    expect(resolveAsyncGptWaitForResultMsMock).toHaveBeenCalledWith(24_000);
     expect(waitForQueuedGptJobCompletionMock).toHaveBeenCalledWith(
       'job-query-and-wait',
       expect.objectContaining({
-        waitForResultMs: 25_000,
+        waitForResultMs: 24_000,
         pollIntervalMs: 250
       })
     );
@@ -1036,8 +1058,11 @@ describe('async /gpt idempotency', () => {
     expect(response.body).toMatchObject({
       ok: true,
       action: 'query',
-      status: 'pending',
+      status: 'queued',
       jobId: 'job-query',
+      result: {},
+      poll: '/jobs/job-query/result',
+      timedOut: false,
       jobStatus: 'pending',
       lifecycleStatus: 'queued'
     });
@@ -1082,8 +1107,11 @@ describe('async /gpt idempotency', () => {
     expect(response.body).toMatchObject({
       ok: true,
       action: 'query',
-      status: 'pending',
+      status: 'queued',
       jobId: 'job-query-payload-async',
+      result: {},
+      poll: '/jobs/job-query-payload-async/result',
+      timedOut: false,
       jobStatus: 'pending',
       lifecycleStatus: 'queued'
     });
@@ -1137,8 +1165,11 @@ describe('async /gpt idempotency', () => {
     expect(response.status).toBe(202);
     expect(response.body).toMatchObject({
       ok: true,
-      status: 'pending',
+      status: 'timeout',
       jobId: 'job-query-and-wait-timeout',
+      result: {},
+      poll: '/jobs/job-query-and-wait-timeout/result',
+      timedOut: true,
       jobStatus: 'running',
       lifecycleStatus: 'running',
       instruction: 'Direct wait timed out after 1ms. Use GET /jobs/job-query-and-wait-timeout/result to retrieve the final result.',
@@ -1147,7 +1178,7 @@ describe('async /gpt idempotency', () => {
         timedOut: true,
         waitForResultMs: 1,
         pollIntervalMs: 250,
-        poll: '/jobs/job-query-and-wait-timeout',
+        poll: '/jobs/job-query-and-wait-timeout/result',
         result: '/jobs/job-query-and-wait-timeout/result'
       }
     });
@@ -1221,7 +1252,7 @@ describe('async /gpt idempotency', () => {
     expect(response.body).toMatchObject({
       ok: true,
       action: 'query',
-      status: 'pending',
+      status: 'queued',
       jobId: 'job-query-ignore-wait'
     });
     expect(response.body).not.toHaveProperty('directReturn');
@@ -1325,8 +1356,10 @@ describe('async /gpt idempotency', () => {
       jobId: 'job-456',
       status: 'completed',
       lifecycleStatus: 'completed',
-      poll: '/jobs/job-456',
+      jobStatus: 'completed',
+      poll: '/jobs/job-456/result',
       stream: '/jobs/job-456/stream',
+      timedOut: false,
       deduped: true,
       result: {
         answer: 'done'

--- a/tests/gpt-fast-path.route.test.ts
+++ b/tests/gpt-fast-path.route.test.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const mockRouteGptRequest = jest.fn();
+const mockResolveGptRouting = jest.fn();
 const executeFastGptPromptMock = jest.fn();
 const findOrCreateGptJobMock = jest.fn();
 const getJobByIdMock = jest.fn();
@@ -15,6 +16,7 @@ class MockIdempotencyKeyConflictError extends Error {}
 class MockJobRepositoryUnavailableError extends Error {}
 
 jest.unstable_mockModule('../src/routes/_core/gptDispatch.js', () => ({
+  resolveGptRouting: mockResolveGptRouting,
   routeGptRequest: mockRouteGptRequest,
 }));
 
@@ -158,6 +160,26 @@ describe('GPT fast-path route branching', () => {
       delete process.env[key];
     }
     process.env.PRIORITY_QUEUE_ENABLED = 'false';
+    mockResolveGptRouting.mockImplementation(async (gptId: string) => ({
+      ok: true,
+      plan: {
+        matchedId: gptId,
+        module: 'ARCANOS:CORE',
+        route: 'core',
+        action: 'query',
+        availableActions: ['query'],
+        moduleVersion: null,
+        moduleDescription: null,
+        matchMethod: 'exact'
+      },
+      _route: {
+        gptId,
+        route: 'core',
+        module: 'ARCANOS:CORE',
+        action: 'query',
+        timestamp: '2026-04-24T00:00:00.000Z'
+      }
+    }));
     executeFastGptPromptMock.mockResolvedValue(buildFastPathEnvelope());
     planAutonomousWorkerJobMock.mockResolvedValue({
       status: 'pending',

--- a/tests/gpt-fast-path.route.test.ts
+++ b/tests/gpt-fast-path.route.test.ts
@@ -306,7 +306,7 @@ describe('GPT fast-path route branching', () => {
     expect(response.body).toMatchObject({
       ok: true,
       action: 'query',
-      status: 'pending',
+      status: 'queued',
       jobId: 'job-orchestrated',
       _route: {
         gptId: 'arcanos-core',
@@ -339,7 +339,7 @@ describe('GPT fast-path route branching', () => {
     expect(response.body).toMatchObject({
       ok: true,
       action: 'query',
-      status: 'pending',
+      status: 'queued',
       jobId: 'job-orchestrated',
       _route: {
         gptId: 'arcanos-core',
@@ -372,7 +372,7 @@ describe('GPT fast-path route branching', () => {
     expect(response.body).toMatchObject({
       ok: true,
       action: 'query',
-      status: 'pending',
+      status: 'queued',
       jobId: 'job-orchestrated',
       _route: {
         gptId: 'arcanos-core',
@@ -527,7 +527,7 @@ describe('GPT fast-path route branching', () => {
     expect(response.body).toMatchObject({
       ok: true,
       action: 'query',
-      status: 'pending',
+      status: 'queued',
       jobId: 'job-orchestrated',
     });
     expect(executeFastGptPromptMock).toHaveBeenCalledTimes(1);
@@ -549,7 +549,7 @@ describe('GPT fast-path route branching', () => {
     expect(response.body).toMatchObject({
       ok: true,
       action: 'query',
-      status: 'pending',
+      status: 'queued',
       jobId: 'job-orchestrated',
     });
     expect(executeFastGptPromptMock).not.toHaveBeenCalled();

--- a/tests/gpt-fast-path.route.test.ts
+++ b/tests/gpt-fast-path.route.test.ts
@@ -132,6 +132,7 @@ const GPT_ROUTE_TEST_ENV_KEYS = [
   'GPT_PUBLIC_RESPONSE_MAX_BYTES',
   'GPT_ROUTE_ASYNC_CORE_DEFAULT',
   'GPT_ROUTE_HARD_TIMEOUT_MS',
+  'PRIORITY_QUEUE_ENABLED',
 ] as const;
 
 function captureEnv(keys: readonly string[]): Map<string, string | undefined> {
@@ -156,6 +157,7 @@ describe('GPT fast-path route branching', () => {
     for (const key of GPT_ROUTE_TEST_ENV_KEYS) {
       delete process.env[key];
     }
+    process.env.PRIORITY_QUEUE_ENABLED = 'false';
     executeFastGptPromptMock.mockResolvedValue(buildFastPathEnvelope());
     planAutonomousWorkerJobMock.mockResolvedValue({
       status: 'pending',

--- a/tests/gpt-job-lookup-guard.route.test.ts
+++ b/tests/gpt-job-lookup-guard.route.test.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const mockRouteGptRequest = jest.fn();
+const mockResolveGptRouting = jest.fn();
 const findOrCreateGptJobMock = jest.fn();
 const getJobByIdMock = jest.fn();
 const planAutonomousWorkerJobMock = jest.fn();
@@ -13,6 +14,7 @@ class MockIdempotencyKeyConflictError extends Error {}
 class MockJobRepositoryUnavailableError extends Error {}
 
 jest.unstable_mockModule('../src/routes/_core/gptDispatch.js', () => ({
+  resolveGptRouting: mockResolveGptRouting,
   routeGptRequest: mockRouteGptRequest,
 }));
 
@@ -78,6 +80,26 @@ function buildApp() {
 describe('natural-language job lookup guard on /gpt/:gptId', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockResolveGptRouting.mockImplementation(async (gptId: string) => ({
+      ok: true,
+      plan: {
+        matchedId: gptId,
+        module: 'ARCANOS:CORE',
+        route: 'core',
+        action: 'query',
+        availableActions: ['query'],
+        moduleVersion: null,
+        moduleDescription: null,
+        matchMethod: 'exact'
+      },
+      _route: {
+        gptId,
+        route: 'core',
+        module: 'ARCANOS:CORE',
+        action: 'query',
+        timestamp: '2026-04-24T00:00:00.000Z'
+      }
+    }));
   });
 
   it('rejects result retrieval prompts and points callers to the canonical jobs result route', async () => {

--- a/tests/gpt-job-lookup-guard.route.test.ts
+++ b/tests/gpt-job-lookup-guard.route.test.ts
@@ -97,7 +97,7 @@ describe('natural-language job lookup guard on /gpt/:gptId', () => {
         message: 'Job retrieval requests must use the jobs API. Do not send result or status lookups through POST /gpt/{gptId}.'
       },
       canonical: {
-        poll: '/jobs/job-123',
+        poll: '/jobs/job-123/result',
         result: '/jobs/job-123/result'
       },
       _route: expect.objectContaining({
@@ -130,7 +130,7 @@ describe('natural-language job lookup guard on /gpt/:gptId', () => {
         message: 'Job retrieval requests must use the jobs API. Do not send result or status lookups through POST /gpt/{gptId}.'
       },
       canonical: {
-        poll: '/jobs/job-123',
+        poll: '/jobs/job-123/result',
         result: '/jobs/job-123/result'
       },
       _route: expect.objectContaining({
@@ -163,7 +163,7 @@ describe('natural-language job lookup guard on /gpt/:gptId', () => {
         message: 'Job retrieval requests must use the jobs API. Do not send result or status lookups through POST /gpt/{gptId}.'
       },
       canonical: {
-        poll: '/jobs/job-456',
+        poll: '/jobs/job-456/result',
         result: '/jobs/job-456/result'
       },
       _route: expect.objectContaining({
@@ -196,7 +196,7 @@ describe('natural-language job lookup guard on /gpt/:gptId', () => {
         message: 'Job retrieval requests must use the jobs API. Do not send result or status lookups through POST /gpt/{gptId}.'
       },
       canonical: {
-        poll: '/jobs/job-789',
+        poll: '/jobs/job-789/result',
         result: '/jobs/job-789/result'
       },
       _route: expect.objectContaining({

--- a/tests/gpt-router-auth-logging.test.ts
+++ b/tests/gpt-router-auth-logging.test.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const mockRouteGptRequest = jest.fn();
+const mockResolveGptRouting = jest.fn();
 const mockExecuteSystemStateRequest = jest.fn();
 
 class MockSystemStateConflictError extends Error {
@@ -14,6 +15,7 @@ class MockSystemStateConflictError extends Error {
 }
 
 jest.unstable_mockModule('../src/routes/_core/gptDispatch.js', () => ({
+  resolveGptRouting: mockResolveGptRouting,
   routeGptRequest: mockRouteGptRequest,
 }));
 
@@ -64,6 +66,26 @@ describe('gpt router auth logging', () => {
     consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
     jest.clearAllMocks();
     process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT = 'false';
+    mockResolveGptRouting.mockImplementation(async (gptId: string) => ({
+      ok: true,
+      plan: {
+        matchedId: gptId,
+        module: 'ARCANOS:CORE',
+        route: 'core',
+        action: 'query',
+        availableActions: ['query'],
+        moduleVersion: null,
+        moduleDescription: null,
+        matchMethod: 'exact'
+      },
+      _route: {
+        gptId,
+        route: 'core',
+        module: 'ARCANOS:CORE',
+        action: 'query',
+        timestamp: '2026-04-24T00:00:00.000Z'
+      }
+    }));
   });
 
   afterEach(() => {
@@ -178,7 +200,7 @@ describe('gpt router auth logging', () => {
   });
 
   it('logs anonymous GPT requests so UI-auth mismatches are visible in traces', async () => {
-    mockRouteGptRequest.mockResolvedValue({
+    mockResolveGptRouting.mockResolvedValueOnce({
       ok: false,
       error: {
         code: 'UNKNOWN_GPT',
@@ -199,6 +221,7 @@ describe('gpt router auth logging', () => {
       .send({ prompt: 'Ping the backend anonymously' });
 
     expect(response.status).toBe(404);
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
 
     const logs = collectStructuredLogs(consoleLogSpy.mock.calls);
     const authLog = logs.find((entry) => entry.event === 'gpt.request.auth_state');

--- a/tests/gpt-router-universal-dispatch.test.ts
+++ b/tests/gpt-router-universal-dispatch.test.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const mockRouteGptRequest = jest.fn();
+const mockResolveGptRouting = jest.fn();
 const mockExecuteSystemStateRequest = jest.fn();
 const mockExecuteRuntimeInspection = jest.fn();
 const mockGetWorkerControlStatus = jest.fn();
@@ -18,6 +19,7 @@ class MockSystemStateConflictError extends Error {
 }
 
 jest.unstable_mockModule('../src/routes/_core/gptDispatch.js', () => ({
+  resolveGptRouting: mockResolveGptRouting,
   routeGptRequest: mockRouteGptRequest,
 }));
 
@@ -256,6 +258,27 @@ describe('gpt router universal dispatch', () => {
     delete process.env.GPT_PUBLIC_RESPONSE_MAX_BYTES;
     delete process.env.ARCANOS_ENABLE_DEBUG_GPT_CONTROLS;
     process.env.NODE_ENV = originalNodeEnv;
+
+    mockResolveGptRouting.mockImplementation(async (gptId: string) => ({
+      ok: true,
+      plan: {
+        matchedId: gptId,
+        module: 'ARCANOS:CORE',
+        route: 'core',
+        action: 'query',
+        availableActions: ['query'],
+        moduleVersion: null,
+        moduleDescription: null,
+        matchMethod: 'exact'
+      },
+      _route: {
+        gptId,
+        route: 'core',
+        module: 'ARCANOS:CORE',
+        action: 'query',
+        timestamp: '2026-04-24T00:00:00.000Z'
+      }
+    }));
 
     mockRouteGptRequest.mockResolvedValue({
       ok: true,

--- a/tests/job-repository.claimNextPendingJob.test.ts
+++ b/tests/job-repository.claimNextPendingJob.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const getPoolMock = jest.fn();
+const isDatabaseConnectedMock = jest.fn();
+const queryMock = jest.fn();
+const clientQueryMock = jest.fn();
+const clientReleaseMock = jest.fn();
+const poolConnectMock = jest.fn();
+
+jest.unstable_mockModule('@core/db/client.js', () => ({
+  getPool: getPoolMock,
+  isDatabaseConnected: isDatabaseConnectedMock
+}));
+
+jest.unstable_mockModule('@core/db/query.js', () => ({
+  query: queryMock
+}));
+
+const {
+  claimNextPendingJob,
+  resetPriorityQueueFairnessState
+} = await import('../src/core/db/repositories/jobRepository.js');
+
+describe('jobRepository.claimNextPendingJob', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetPriorityQueueFairnessState();
+    isDatabaseConnectedMock.mockReturnValue(true);
+    clientQueryMock.mockResolvedValue({ rows: [] });
+    poolConnectMock.mockResolvedValue({
+      query: clientQueryMock,
+      release: clientReleaseMock
+    });
+    getPoolMock.mockReturnValue({
+      connect: poolConnectMock
+    });
+  });
+
+  it('does not bind the priority lane threshold when the SQL does not reference it', async () => {
+    await claimNextPendingJob({
+      workerId: 'worker-1',
+      leaseMs: 12_000,
+      priorityQueueEnabled: false
+    });
+
+    const updateCall = clientQueryMock.mock.calls.find(([sql]) =>
+      typeof sql === 'string' && sql.includes('UPDATE job_data')
+    );
+
+    expect(updateCall).toBeDefined();
+    expect(updateCall?.[0]).not.toContain('$3');
+    expect(updateCall?.[1]).toEqual([12_000, 'worker-1']);
+  });
+});

--- a/tests/job-repository.claimNextPendingJob.test.ts
+++ b/tests/job-repository.claimNextPendingJob.test.ts
@@ -51,4 +51,113 @@ describe('jobRepository.claimNextPendingJob', () => {
     expect(updateCall?.[0]).not.toContain('$3');
     expect(updateCall?.[1]).toEqual([12_000, 'worker-1']);
   });
+
+  it('does not run a redundant normal-lane fallback after an empty priority-lane claim', async () => {
+    await claimNextPendingJob({
+      workerId: 'worker-1',
+      leaseMs: 12_000,
+      priorityQueueEnabled: true,
+      priorityQueueWeight: 5
+    });
+
+    const updateCalls = clientQueryMock.mock.calls.filter(([sql]) =>
+      typeof sql === 'string' && sql.includes('UPDATE job_data')
+    );
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]?.[0]).not.toContain('$3');
+  });
+
+  it('uses the configured priority lane threshold when claiming the normal lane', async () => {
+    let updateQueryCount = 0;
+    clientQueryMock.mockImplementation(async (sql: unknown) => {
+      if (typeof sql === 'string' && sql.includes('UPDATE job_data')) {
+        updateQueryCount += 1;
+        return updateQueryCount === 1
+          ? { rows: [{ id: 'priority-job', job_type: 'gpt', priority: 0 }] }
+          : { rows: [] };
+      }
+
+      return { rows: [] };
+    });
+
+    await claimNextPendingJob({
+      workerId: 'worker-1',
+      leaseMs: 12_000,
+      priorityQueueEnabled: true,
+      priorityQueueWeight: 1,
+      priorityLaneMaxPriority: 3
+    });
+
+    clientQueryMock.mockClear();
+
+    await claimNextPendingJob({
+      workerId: 'worker-1',
+      leaseMs: 12_000,
+      priorityQueueEnabled: true,
+      priorityQueueWeight: 1,
+      priorityLaneMaxPriority: 3
+    });
+
+    const updateCalls = clientQueryMock.mock.calls.filter(([sql]) =>
+      typeof sql === 'string' && sql.includes('UPDATE job_data')
+    );
+
+    expect(updateCalls).toHaveLength(2);
+    expect(updateCalls[0]?.[0]).toContain('$3');
+    expect(updateCalls[0]?.[1]).toEqual([12_000, 'worker-1', 3]);
+    expect(updateCalls[1]?.[0]).not.toContain('$3');
+    expect(updateCalls[1]?.[1]).toEqual([12_000, 'worker-1']);
+  });
+
+  it('serializes priority queue claims until fairness state is updated', async () => {
+    let updateQueryCount = 0;
+    let resolveFirstUpdateStarted: () => void = () => {};
+    let resolveFirstUpdate: () => void = () => {};
+    const firstUpdateStarted = new Promise<void>(resolve => {
+      resolveFirstUpdateStarted = resolve;
+    });
+    const firstUpdateAllowed = new Promise<void>(resolve => {
+      resolveFirstUpdate = resolve;
+    });
+
+    clientQueryMock.mockImplementation(async (sql: unknown) => {
+      if (typeof sql === 'string' && sql.includes('UPDATE job_data')) {
+        updateQueryCount += 1;
+
+        if (updateQueryCount === 1) {
+          resolveFirstUpdateStarted();
+          await firstUpdateAllowed;
+          return { rows: [{ id: 'priority-job', job_type: 'gpt', priority: 0 }] };
+        }
+
+        return { rows: [] };
+      }
+
+      return { rows: [] };
+    });
+
+    const firstClaim = claimNextPendingJob({
+      workerId: 'worker-1',
+      leaseMs: 12_000,
+      priorityQueueEnabled: true,
+      priorityQueueWeight: 1
+    });
+    await firstUpdateStarted;
+
+    const secondClaim = claimNextPendingJob({
+      workerId: 'worker-2',
+      leaseMs: 12_000,
+      priorityQueueEnabled: true,
+      priorityQueueWeight: 1
+    });
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(updateQueryCount).toBe(1);
+
+    resolveFirstUpdate();
+    await Promise.all([firstClaim, secondClaim]);
+
+    expect(updateQueryCount).toBe(3);
+  });
 });

--- a/tests/job-repository.claimNextPendingJob.test.ts
+++ b/tests/job-repository.claimNextPendingJob.test.ts
@@ -110,7 +110,7 @@ describe('jobRepository.claimNextPendingJob', () => {
     expect(updateCalls[1]?.[1]).toEqual([12_000, 'worker-1']);
   });
 
-  it('serializes priority queue claims until fairness state is updated', async () => {
+  it('does not serialize database claim round-trips when priority queue fairness is enabled', async () => {
     let updateQueryCount = 0;
     let resolveFirstUpdateStarted: () => void = () => {};
     let resolveFirstUpdate: () => void = () => {};
@@ -153,11 +153,11 @@ describe('jobRepository.claimNextPendingJob', () => {
     });
     await new Promise(resolve => setTimeout(resolve, 0));
 
-    expect(updateQueryCount).toBe(1);
+    expect(updateQueryCount).toBe(2);
 
     resolveFirstUpdate();
     await Promise.all([firstClaim, secondClaim]);
 
-    expect(updateQueryCount).toBe(3);
+    expect(updateQueryCount).toBe(2);
   });
 });

--- a/tests/job-repository.claimNextPendingJob.test.ts
+++ b/tests/job-repository.claimNextPendingJob.test.ts
@@ -110,7 +110,53 @@ describe('jobRepository.claimNextPendingJob', () => {
     expect(updateCalls[1]?.[1]).toEqual([12_000, 'worker-1']);
   });
 
-  it('does not serialize database claim round-trips when priority queue fairness is enabled', async () => {
+  it('claims five priority jobs before one normal job when both lanes have backlog', async () => {
+    const laneClaims: string[] = [];
+    clientQueryMock.mockImplementation(async (sql: unknown) => {
+      if (typeof sql === 'string' && sql.includes('UPDATE job_data')) {
+        const lane = sql.includes('$3') ? 'normal' : 'priority';
+        laneClaims.push(lane);
+        return {
+          rows: [{
+            id: `${lane}-job-${laneClaims.length}`,
+            job_type: lane === 'priority' ? 'gpt' : 'task',
+            priority: lane === 'priority' ? 0 : 85
+          }]
+        };
+      }
+
+      return { rows: [] };
+    });
+
+    const claimedJobs = [];
+    for (let index = 0; index < 6; index += 1) {
+      claimedJobs.push(await claimNextPendingJob({
+        workerId: `worker-${index}`,
+        leaseMs: 12_000,
+        priorityQueueEnabled: true,
+        priorityQueueWeight: 5
+      }));
+    }
+
+    expect(laneClaims).toEqual([
+      'priority',
+      'priority',
+      'priority',
+      'priority',
+      'priority',
+      'normal'
+    ]);
+    expect(claimedJobs.map(job => job?.id)).toEqual([
+      'priority-job-1',
+      'priority-job-2',
+      'priority-job-3',
+      'priority-job-4',
+      'priority-job-5',
+      'normal-job-6'
+    ]);
+  });
+
+  it('serializes database claims while updating priority fairness state', async () => {
     let updateQueryCount = 0;
     let resolveFirstUpdateStarted: () => void = () => {};
     let resolveFirstUpdate: () => void = () => {};
@@ -129,6 +175,10 @@ describe('jobRepository.claimNextPendingJob', () => {
           resolveFirstUpdateStarted();
           await firstUpdateAllowed;
           return { rows: [{ id: 'priority-job', job_type: 'gpt', priority: 0 }] };
+        }
+
+        if (updateQueryCount === 2) {
+          return { rows: [{ id: 'normal-job', job_type: 'task', priority: 85 }] };
         }
 
         return { rows: [] };
@@ -153,7 +203,8 @@ describe('jobRepository.claimNextPendingJob', () => {
     });
     await new Promise(resolve => setTimeout(resolve, 0));
 
-    expect(updateQueryCount).toBe(2);
+    expect(poolConnectMock).toHaveBeenCalledTimes(1);
+    expect(updateQueryCount).toBe(1);
 
     resolveFirstUpdate();
     await Promise.all([firstClaim, secondClaim]);

--- a/tests/jobs.route.test.ts
+++ b/tests/jobs.route.test.ts
@@ -177,8 +177,11 @@ describe('/jobs routes', () => {
     expect(response.headers['x-response-bytes']).toBeTruthy();
     expect(response.body).toMatchObject({
       id: EXPIRED_JOB_ID,
+      jobId: EXPIRED_JOB_ID,
       status: 'expired',
       lifecycle_status: 'expired',
+      poll: `/jobs/${EXPIRED_JOB_ID}/result`,
+      stream: `/jobs/${EXPIRED_JOB_ID}/stream`,
       retention_until: '2026-04-06T10:04:00.000Z',
       idempotency_until: '2026-04-06T10:03:00.000Z',
       expires_at: '2026-04-06T10:05:00.000Z'

--- a/tests/jobs.route.test.ts
+++ b/tests/jobs.route.test.ts
@@ -76,7 +76,7 @@ describe('/jobs routes', () => {
       retentionUntil: '2026-04-07T10:01:00.000Z',
       idempotencyUntil: '2026-04-07T10:01:00.000Z',
       expiresAt: null,
-      poll: `/jobs/${COMPLETED_JOB_ID}`,
+      poll: `/jobs/${COMPLETED_JOB_ID}/result`,
       stream: `/jobs/${COMPLETED_JOB_ID}/stream`,
       result: {
         ok: true,
@@ -106,7 +106,7 @@ describe('/jobs routes', () => {
       retentionUntil: null,
       idempotencyUntil: null,
       expiresAt: null,
-      poll: `/jobs/${MISSING_JOB_ID}`,
+      poll: `/jobs/${MISSING_JOB_ID}/result`,
       stream: `/jobs/${MISSING_JOB_ID}/stream`,
       result: null,
       error: {
@@ -415,7 +415,7 @@ describe('/jobs routes', () => {
         status: 'completed',
         jobStatus: 'completed',
         lifecycleStatus: 'completed',
-        poll: `/jobs/${TRUNCATED_JOB_ID}`,
+        poll: `/jobs/${TRUNCATED_JOB_ID}/result`,
         stream: `/jobs/${TRUNCATED_JOB_ID}/stream`,
         truncated: true,
         result: expect.stringContaining('[truncated]')

--- a/tests/priority-gpt.test.ts
+++ b/tests/priority-gpt.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from '@jest/globals';
 import {
+  isPriorityQueueLaneJob,
   isPriorityGpt,
+  mapGptJobStatusToClientStatus,
   resolveGptDirectExecutionThresholdMs,
   resolveGptJobMaxRetries,
   resolveGptWaitTimeoutMs,
@@ -50,5 +52,26 @@ describe('priority GPT classification and scheduling config', () => {
       priorityQueueWeight: 5,
       priorityClaimsSinceNormal: 99
     })).toBe('priority');
+  });
+
+  it('maps terminal GPT job statuses without reporting failures as completed', () => {
+    expect(mapGptJobStatusToClientStatus('completed')).toBe('completed');
+    expect(mapGptJobStatusToClientStatus('running')).toBe('running');
+    expect(mapGptJobStatusToClientStatus('pending')).toBe('queued');
+    expect(mapGptJobStatusToClientStatus('timeout')).toBe('timeout');
+    expect(mapGptJobStatusToClientStatus('expired')).toBe('timeout');
+    expect(mapGptJobStatusToClientStatus('failed')).toBe('failed');
+    expect(mapGptJobStatusToClientStatus('cancelled')).toBe('cancelled');
+  });
+
+  it('classifies priority queue lane jobs with the configured priority threshold', () => {
+    expect(isPriorityQueueLaneJob({
+      job_type: 'gpt',
+      priority: 3
+    }, 3)).toBe(true);
+    expect(isPriorityQueueLaneJob({
+      job_type: 'gpt',
+      priority: 4
+    }, 3)).toBe(false);
   });
 });

--- a/tests/priority-gpt.test.ts
+++ b/tests/priority-gpt.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  isPriorityGpt,
+  resolveGptDirectExecutionThresholdMs,
+  resolveGptJobMaxRetries,
+  resolveGptWaitTimeoutMs,
+  resolvePriorityQueueWeight
+} from '../src/shared/gpt/priorityGpt.js';
+import {
+  resolvePriorityQueueClaimLane
+} from '../src/core/db/repositories/jobRepository.js';
+
+describe('priority GPT classification and scheduling config', () => {
+  it('classifies built-in and configured GPT IDs as priority', () => {
+    expect(isPriorityGpt('arcanos-build', {} as NodeJS.ProcessEnv)).toBe(true);
+    expect(isPriorityGpt('GUIDE', {} as NodeJS.ProcessEnv)).toBe(true);
+    expect(isPriorityGpt('custom-ops', {
+      PRIORITY_GPT_IDS: 'custom-ops'
+    } as NodeJS.ProcessEnv)).toBe(true);
+    expect(isPriorityGpt('ordinary-gpt', {} as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  it('normalizes priority queue env defaults', () => {
+    const env = {
+      PRIORITY_QUEUE_WEIGHT: '7',
+      GPT_DIRECT_EXECUTION_THRESHOLD_MS: '9000',
+      GPT_WAIT_TIMEOUT_MS: '24000',
+      GPT_JOB_MAX_RETRIES: '1'
+    } as NodeJS.ProcessEnv;
+
+    expect(resolvePriorityQueueWeight(env)).toBe(7);
+    expect(resolveGptDirectExecutionThresholdMs(env)).toBe(9000);
+    expect(resolveGptWaitTimeoutMs(env)).toBe(24000);
+    expect(resolveGptJobMaxRetries(env)).toBe(1);
+  });
+
+  it('uses weighted fair scheduling after priority jobs reach the configured weight', () => {
+    expect(resolvePriorityQueueClaimLane({
+      priorityQueueEnabled: true,
+      priorityQueueWeight: 5,
+      priorityClaimsSinceNormal: 4
+    })).toBe('priority');
+    expect(resolvePriorityQueueClaimLane({
+      priorityQueueEnabled: true,
+      priorityQueueWeight: 5,
+      priorityClaimsSinceNormal: 5
+    })).toBe('normal');
+    expect(resolvePriorityQueueClaimLane({
+      priorityQueueEnabled: false,
+      priorityQueueWeight: 5,
+      priorityClaimsSinceNormal: 99
+    })).toBe('priority');
+  });
+});

--- a/tests/railway-async-job-probe.test.js
+++ b/tests/railway-async-job-probe.test.js
@@ -39,7 +39,7 @@ describe('railway-async-job-probe', () => {
           ok: true,
           status: 'pending',
           jobId: 'job-123',
-          poll: '/jobs/job-123'
+          poll: '/jobs/job-123/result'
         })
       },
       {
@@ -165,7 +165,7 @@ describe('railway-async-job-probe', () => {
             ok: true,
             status: 'pending',
             jobId: 'job-456',
-            poll: '/jobs/job-456'
+            poll: '/jobs/job-456/result'
           })
         })
       }
@@ -193,7 +193,7 @@ describe('railway-async-job-probe', () => {
             ok: true,
             status: 'pending',
             jobId: 'job-789',
-            poll: 'https://example.com/jobs/job-789?trace=abc123'
+            poll: 'https://example.com/jobs/job-789/result?trace=abc123'
           })
         })
       }

--- a/tests/scheduler-postgres-adapter.test.ts
+++ b/tests/scheduler-postgres-adapter.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import type { JobData } from '../src/core/db/schema.js';
+import {
+  createPostgresQueueSchedulerAdapter,
+  toJobSchedulingMetadata,
+  toLeaseState,
+  toRetryState
+} from '../src/core/scheduler/postgresAdapter.js';
+
+function buildJob(overrides: Partial<JobData> = {}): JobData {
+  return {
+    id: 'job-1',
+    worker_id: 'worker-origin',
+    job_type: 'gpt',
+    status: 'running',
+    input: {
+      gptId: 'arcanos-build'
+    },
+    retry_count: 0,
+    max_retries: 1,
+    next_run_at: new Date('2026-04-24T10:01:00.000Z'),
+    started_at: new Date('2026-04-24T10:00:00.000Z'),
+    last_heartbeat_at: new Date('2026-04-24T10:00:02.000Z'),
+    lease_expires_at: new Date('2026-04-24T10:00:30.000Z'),
+    priority: 0,
+    last_worker_id: 'worker-1',
+    created_at: new Date('2026-04-24T09:59:00.000Z'),
+    updated_at: new Date('2026-04-24T10:00:00.000Z'),
+    ...overrides
+  };
+}
+
+describe('PostgresQueueSchedulerAdapter', () => {
+  it('delegates claims to the existing repository and reports scheduler lane metadata', async () => {
+    const job = buildJob();
+    const claimNextPendingJob = jest.fn(async () => job);
+    const adapter = createPostgresQueueSchedulerAdapter({
+      claimNextPendingJob,
+      getJobQueueSummary: jest.fn(async () => null)
+    });
+
+    const result = await adapter.claimNext({
+      workerId: 'worker-1',
+      leaseMs: 15_000,
+      priorityQueueEnabled: true,
+      priorityQueueWeight: 5
+    });
+
+    expect(claimNextPendingJob).toHaveBeenCalledWith({
+      workerId: 'worker-1',
+      leaseMs: 15_000,
+      priorityQueueEnabled: true,
+      priorityQueueWeight: 5
+    });
+    expect(result).toEqual({
+      adapter: 'postgres',
+      lane: 'priority',
+      job
+    });
+  });
+
+  it('maps JobData into the formal scheduler contract', () => {
+    const job = buildJob({
+      retry_count: 1,
+      error_message: 'provider timeout'
+    });
+
+    expect(toJobSchedulingMetadata(job)).toEqual({
+      jobId: 'job-1',
+      gptId: 'arcanos-build',
+      priority: 0,
+      lane: 'priority',
+      createdAt: new Date('2026-04-24T09:59:00.000Z'),
+      attempts: 1,
+      maxRetries: 1
+    });
+    expect(toLeaseState(job)).toEqual({
+      workerId: 'worker-1',
+      leaseExpiresAt: new Date('2026-04-24T10:00:30.000Z')
+    });
+    expect(toRetryState(job)).toEqual({
+      attempts: 1,
+      lastError: 'provider timeout',
+      nextRetryAt: new Date('2026-04-24T10:01:00.000Z')
+    });
+  });
+});

--- a/tests/scheduler-postgres-adapter.test.ts
+++ b/tests/scheduler-postgres-adapter.test.ts
@@ -43,14 +43,16 @@ describe('PostgresQueueSchedulerAdapter', () => {
       workerId: 'worker-1',
       leaseMs: 15_000,
       priorityQueueEnabled: true,
-      priorityQueueWeight: 5
+      priorityQueueWeight: 5,
+      priorityLaneMaxPriority: 3
     });
 
     expect(claimNextPendingJob).toHaveBeenCalledWith({
       workerId: 'worker-1',
       leaseMs: 15_000,
       priorityQueueEnabled: true,
-      priorityQueueWeight: 5
+      priorityQueueWeight: 5,
+      priorityLaneMaxPriority: 3
     });
     expect(result).toEqual({
       adapter: 'postgres',

--- a/tests/scheduler-postgres-adapter.test.ts
+++ b/tests/scheduler-postgres-adapter.test.ts
@@ -61,6 +61,23 @@ describe('PostgresQueueSchedulerAdapter', () => {
     });
   });
 
+  it('uses the effective claim threshold when reporting claimed job lanes', async () => {
+    const job = buildJob({ priority: 8 });
+    const claimNextPendingJob = jest.fn(async () => job);
+    const adapter = createPostgresQueueSchedulerAdapter({
+      claimNextPendingJob,
+      getJobQueueSummary: jest.fn(async () => null)
+    });
+
+    await expect(adapter.claimNext({
+      priorityQueueEnabled: true,
+      priorityLaneMaxPriority: 3
+    })).resolves.toMatchObject({
+      lane: 'standard',
+      job
+    });
+  });
+
   it('maps JobData into the formal scheduler contract', () => {
     const job = buildJob({
       retry_count: 1,

--- a/tests/scheduler.test.ts
+++ b/tests/scheduler.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  classifyQueueLane,
+  resolveSchedulerClaimLane,
+  shouldRetryJob,
+  updateSchedulerClaimState
+} from '../src/core/scheduler/scheduler.js';
+
+describe('scheduler pure policy', () => {
+  it('routes claims through priority until the configured weight is reached', () => {
+    expect(resolveSchedulerClaimLane({
+      policy: {
+        priorityQueueEnabled: true,
+        priorityQueueWeight: 5,
+        priorityLaneMaxPriority: 10
+      },
+      state: {
+        priorityClaimsSinceStandard: 4
+      }
+    })).toEqual(expect.objectContaining({
+      lane: 'priority',
+      reason: 'priority_weight_available'
+    }));
+
+    expect(resolveSchedulerClaimLane({
+      policy: {
+        priorityQueueEnabled: true,
+        priorityQueueWeight: 5,
+        priorityLaneMaxPriority: 10
+      },
+      state: {
+        priorityClaimsSinceStandard: 5
+      }
+    })).toEqual(expect.objectContaining({
+      lane: 'standard',
+      reason: 'standard_weight_due'
+    }));
+  });
+
+  it('classifies low numeric priorities into the priority lane', () => {
+    expect(classifyQueueLane({ priority: 0, priorityLaneMaxPriority: 10 })).toBe('priority');
+    expect(classifyQueueLane({ priority: 95, priorityLaneMaxPriority: 10 })).toBe('standard');
+  });
+
+  it('updates fairness state without storing database details', () => {
+    expect(updateSchedulerClaimState({ priorityClaimsSinceStandard: 2 }, 'priority'))
+      .toEqual({ priorityClaimsSinceStandard: 3 });
+    expect(updateSchedulerClaimState({ priorityClaimsSinceStandard: 3 }, 'standard'))
+      .toEqual({ priorityClaimsSinceStandard: 0 });
+  });
+
+  it('caps retries using attempts and max retries only', () => {
+    expect(shouldRetryJob({ attempts: 0 }, 1)).toBe(true);
+    expect(shouldRetryJob({ attempts: 1, lastError: 'timeout' }, 1)).toBe(false);
+  });
+});

--- a/tests/status.route.test.ts
+++ b/tests/status.route.test.ts
@@ -1,0 +1,45 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const writePublicHealthResponseMock = jest.fn();
+
+jest.unstable_mockModule('../src/core/diagnostics.js', () => ({
+  writePublicHealthResponse: writePublicHealthResponseMock
+}));
+
+const { default: statusRouter } = await import('../src/routes/status.js');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/', statusRouter);
+  return app;
+}
+
+describe('/status route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    writePublicHealthResponseMock.mockImplementation(async (_req, res) => {
+      res.status(200).json({
+        status: 'ok',
+        service: 'arcanos-backend',
+        version: '1.0.0'
+      });
+    });
+  });
+
+  it('aliases GET /status to the public health response without stale state', async () => {
+    const response = await request(buildApp()).get('/status');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['x-status-endpoint']).toBe('deprecated');
+    expect(response.headers['x-status-replacement']).toBe('/health');
+    expect(response.body).toEqual({
+      status: 'ok',
+      service: 'arcanos-backend',
+      version: '1.0.0'
+    });
+    expect(writePublicHealthResponseMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/worker-autonomy-service.test.ts
+++ b/tests/worker-autonomy-service.test.ts
@@ -170,6 +170,29 @@ describe('workerAutonomyService', () => {
     expect(plannedJob.planningReasons).toContain('queue_depth_deferred');
   });
 
+  it('plans priority GPT jobs ahead of normal queue work and caps retries', async () => {
+    const originalMaxRetries = process.env.GPT_JOB_MAX_RETRIES;
+    process.env.GPT_JOB_MAX_RETRIES = '1';
+
+    try {
+      const plannedJob = await planAutonomousWorkerJob('gpt', {
+        gptId: 'arcanos-build',
+        body: {
+          prompt: 'Inspect current latency.'
+        }
+      });
+
+      expect(plannedJob.priority).toBe(0);
+      expect(plannedJob.maxRetries).toBe(1);
+    } finally {
+      if (originalMaxRetries === undefined) {
+        delete process.env.GPT_JOB_MAX_RETRIES;
+      } else {
+        process.env.GPT_JOB_MAX_RETRIES = originalMaxRetries;
+      }
+    }
+  });
+
   it('classifies transient and terminal failures separately', () => {
     expect(classifyWorkerExecutionError(new Error('OpenAI rate limit timeout')).retryable).toBe(true);
     expect(classifyWorkerExecutionError(new Error('OpenAI internal error')).retryable).toBe(true);

--- a/tests/worker-helper-route.test.ts
+++ b/tests/worker-helper-route.test.ts
@@ -504,7 +504,7 @@ describe('/worker-helper routes', () => {
       ok: true,
       status: 'pending',
       jobId: 'job-123',
-      poll: '/jobs/job-123',
+      poll: '/jobs/job-123/result',
       endpoint: 'worker-helper',
       cognitiveDomain: 'code',
       cognitiveDomainSource: 'detected'


### PR DESCRIPTION
## Summary

- Adds a schema-first scheduler contract for queue lanes, leases, retries, DAG timing, and scheduler adapters.
- Adds pure scheduler policy logic for priority lane classification, weighted fair scheduling, and retry-cap decisions.
- Adds a Postgres scheduler adapter backed by the existing `jobRepository` and a future Redis adapter stub.
- Wires worker claims through the Postgres scheduler adapter without replacing the current Postgres queue.
- Preserves the latency/priority GPT improvements, DAG slow-node observability, diagnostics, and focused test coverage from the local patch.

## Root Cause

GPT-triggered work could sit behind normal queued jobs and run near timeout boundaries, while queue scheduling policy lived inside repository code instead of a formal scheduler contract. Operators also lacked enough structured queue/DAG latency data to identify slow runs quickly.

## Validation

- `npm run type-check`
- `npm test -- --runTestsByPath tests/scheduler.test.ts tests/scheduler-postgres-adapter.test.ts tests/job-repository.claimNextPendingJob.test.ts tests/priority-gpt.test.ts tests/worker-autonomy-service.test.ts tests/gpt-async-idempotency.route.test.ts --coverage=false`
- `npm run lint --if-present` passed with existing warnings only
- Commit guard ran during commit and passed

## Notes

- No DB migration.
- No Redis runtime dependency.
- Existing Postgres queue remains the source of truth.
- `src/shared/text/promptIntentMode.ts` was left unstaged because it was unrelated local work.