### PR TITLE
[codex] fix GPT action sync routing

### DIFF
--- a/contracts/custom_gpt_route.openapi.v1.json
+++ b/contracts/custom_gpt_route.openapi.v1.json
@@ -3,20 +3,30 @@
   "info": {
     "title": "Arcanos GPT Route API",
     "version": "1.0.0",
-    "description": "Canonical public contract for GPT-routed module requests and allowlisted control-plane dispatch. GPT identity is path-bound at /gpt/{gptId}; generated tool clients may also echo the same gptId in the JSON body, and mismatched body/path IDs are rejected. POST /gpt/{gptId} accepts flexible request bodies with action as a string and payload as an open object so durable GPT actions, approved runtime inspection actions, and prompt-only fast-path generation can share one public endpoint. Simple prompt-generation requests that omit action can opt into inline fast-path execution with executionMode=fast. A bounded deterministic planner may normalize detail and section profiles for runtime inspection actions before execution, without inventing unsupported actions or bypassing response guards."
+    "description": "Canonical public contract for GPT-routed module requests and allowlisted control-plane dispatch. GPT identity is path-bound at /gpt/{gptId}; generated tool clients may also echo the same gptId in the JSON body, and mismatched body/path IDs are rejected. POST /gpt/{gptId} accepts flexible request bodies with action as a string and payload as an open object so durable GPT actions, approved runtime inspection actions, and prompt-only fast-path generation can share one public endpoint. For generated clients that place operation metadata outside the JSON body, the route also accepts action as a query parameter or operation-style body alias. Simple prompt-generation requests that omit action can opt into inline fast-path execution with executionMode=fast. A bounded deterministic planner may normalize detail and section profiles for runtime inspection actions before execution, without inventing unsupported actions or bypassing response guards."
   },
   "paths": {
     "/gpt/{gptId}": {
       "post": {
         "operationId": "invokeGptRoute",
         "summary": "Invoke a GPT-routed module request or universal control action",
-        "description": "POST /gpt/{gptId} is the universal public dispatcher. The path parameter is authoritative; a JSON body gptId is optional and must match the path when present. Use a prompt-only request with executionMode=fast for small prompt-generation work that should return inline. Use action=query to create one durable writing job, action=query_and_wait to create one durable writing job and wait briefly for fast completion, action=get_status to read status through the GPT compatibility bridge, action=get_result to read the final result through the GPT compatibility bridge, and approved control actions such as diagnostics, runtime.inspect, workers.status, queue.inspect, self_heal.status, and system_state for runtime inspection. For runtime.inspect and self_heal.status, payload.detail and payload.sections can request summary, standard, or full response profiles, and a deterministic bounded planner fills safe defaults when callers omit them. Unknown control-plane action names are rejected with a typed 400 error. Natural-language retrieval prompts, runtime inspection prompts without an explicit allowlisted action, DAG control prompts, and MCP control requests are still intentionally rejected on this route.",
+        "description": "POST /gpt/{gptId} is the universal public dispatcher. The path parameter is authoritative; a JSON body gptId is optional and must match the path when present. Use a prompt-only request with executionMode=fast for small prompt-generation work that should return inline. Use action=query to create one durable writing job, action=query_and_wait on core GPT IDs to execute synchronously through the lightweight direct action lane, action=get_status to read status through the GPT compatibility bridge, action=get_result to read the final result through the GPT compatibility bridge, and approved control actions such as diagnostics, runtime.inspect, workers.status, queue.inspect, self_heal.status, and system_state for runtime inspection. The action should be supplied in the JSON body when possible; generated-client compatibility also permits the same action in the query string or an operationId-style body alias. For runtime.inspect and self_heal.status, payload.detail and payload.sections can request summary, standard, or full response profiles, and a deterministic bounded planner fills safe defaults when callers omit them. Unknown control-plane action names are rejected with a typed 400 error. Natural-language retrieval prompts, runtime inspection prompts without an explicit allowlisted action, DAG control prompts, and MCP control requests are still intentionally rejected on this route.",
         "parameters": [
           {
             "name": "gptId",
             "in": "path",
             "required": true,
             "description": "GPT or module route identifier bound by the backend router.",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "name": "action",
+            "in": "query",
+            "required": false,
+            "description": "Generated-client compatibility hint for the same requested action normally supplied in the JSON body. Body action takes precedence.",
             "schema": {
               "type": "string",
               "minLength": 1
@@ -52,10 +62,10 @@
                   }
                 },
                 "queryAndWait": {
-                  "summary": "Canonical async bridge create-and-wait operation",
+                  "summary": "Canonical synchronous direct action operation",
                   "value": {
                     "action": "query_and_wait",
-                    "prompt": "Wait briefly for a fast completion.",
+                    "prompt": "Return the final result synchronously.",
                     "timeoutMs": 25000,
                     "pollIntervalMs": 500
                   }
@@ -139,7 +149,7 @@
         },
         "responses": {
           "200": {
-            "description": "Completed fast-path inline response, async bridge response, control-plane bridge response, or generic GPT response",
+            "description": "Completed fast-path inline response, direct query_and_wait response, async bridge response, control-plane bridge response, or generic GPT response",
             "content": {
               "application/json": {
                 "schema": {
@@ -335,6 +345,16 @@
             "type": "string",
             "minLength": 1,
             "description": "Requested action name. Canonical built-ins include query, query_and_wait, get_status, get_result, diagnostics, runtime.inspect, workers.status, queue.inspect, self_heal.status, and system_state. Module-specific action names are also allowed. Unsupported reserved control action names are rejected with HTTP 400."
+          },
+          "operationId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Generated-client compatibility alias for action. Operation-style names such as requestQueryAndWait are normalized to their canonical action when recognized."
+          },
+          "operation": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Generated-client compatibility alias for action."
           },
           "prompt": {
             "type": "string",
@@ -594,6 +614,9 @@
       "GptRouteSuccessResponse": {
         "oneOf": [
           {
+            "$ref": "#/components/schemas/GptDirectActionCompletedResponse"
+          },
+          {
             "$ref": "#/components/schemas/GptAsyncCompletedResponse"
           },
           {
@@ -606,6 +629,45 @@
             "$ref": "#/components/schemas/GptRouteGenericResponse"
           }
         ]
+      },
+      "GptDirectActionCompletedResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "ok",
+          "action",
+          "status",
+          "result"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "gptId": {
+            "type": "string"
+          },
+          "action": {
+            "const": "query_and_wait"
+          },
+          "status": {
+            "const": "completed"
+          },
+          "result": {},
+          "routeDecision": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "directAction": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "traceId": {
+            "type": "string"
+          },
+          "_route": {
+            "$ref": "#/components/schemas/GptRouteMeta"
+          }
+        }
       },
       "GptAsyncPendingResponse": {
         "type": "object",

--- a/docs/API.md
+++ b/docs/API.md
@@ -50,7 +50,7 @@ No API path changes are required for Railway. Ensure liveness (`/healthz`) and r
 `POST /gpt/:gptId` is the writing plane. It supports a typed async GPT bridge with idempotent retry handling for job-backed requests, but it must not be used for prompt-shaped control-plane retrieval.
 
 Writing vs control:
-- Writing plane: prompt generation, assistant responses, and explicit async write actions `query` and `query_and_wait`.
+- Writing plane: prompt generation, assistant responses, durable `query` jobs, non-core durable `query_and_wait` jobs, and core synchronous `query_and_wait` actions.
 - Direct control plane: `GET /jobs/:id`, `GET /jobs/:id/result`, `GET /workers/status`, `GET /worker-helper/health`, `GET /status`, `GET /status/safety/self-heal`, `POST /mcp`, and `/api/arcanos/dag/*`.
 - Router-handled compatibility control actions on `POST /gpt/:gptId`: `get_status`, `get_result`, `diagnostics`, and `system_state`. These are handled before write dispatch and never enqueue new GPT work.
 - Rejected on `POST /gpt/:gptId`: prompt-based job lookups, DAG execution/tracing prompts, runtime inspection prompts, and explicit MCP tool calls. The backend returns canonical control endpoints instead of routing them through generation.
@@ -67,11 +67,12 @@ Deduplication rules:
 - Transport-only retry hints such as `async`, `executionMode`, `responseMode`, `waitForResultMs`, and polling intervals do not create a new GPT job.
 - Reusing an explicit `Idempotency-Key` for a different semantic GPT request returns `409 IDEMPOTENCY_KEY_CONFLICT`.
 
-Canonical async bridge:
+Canonical GPT bridge:
 - `query`: `POST /gpt/:gptId` with `{ "action": "query", "prompt": "..." }` creates or reuses one durable GPT writing job and returns the canonical `jobId` without inline waiting.
-- `query_and_wait`: `POST /gpt/:gptId` with `{ "action": "query_and_wait", "prompt": "...", "timeoutMs": 25000, "pollIntervalMs": 500 }` creates or reuses one durable GPT writing job and waits briefly for fast completion.
+- `query_and_wait`: `POST /gpt/:gptId` with `{ "action": "query_and_wait", "prompt": "...", "timeoutMs": 25000 }` executes core GPT requests synchronously through the lightweight direct action lane and returns the final result inline. If direct execution fails or times out, the route returns a typed error instead of synthetic bounded fallback content. Non-core GPTs keep the durable job path.
 - `get_status`: `POST /gpt/:gptId` with `{ "action": "get_status", "payload": { "jobId": "..." } }` returns structured status from the control plane without creating work.
 - `get_result`: `POST /gpt/:gptId` with `{ "action": "get_result", "payload": { "jobId": "..." } }` returns structured job result state from the control plane without creating work.
+- Generated-client compatibility: body `action` is authoritative, but the router also accepts `?action=query_and_wait` and operation-style aliases such as `{ "operationId": "requestQueryAndWait" }` for clients that place GPT Action metadata outside the canonical body field.
 
 Legacy compatibility:
 - `POST /gpt/:gptId` with `{"prompt":"...","executionMode":"async","waitForResultMs":20000}` still supports one queue-backed request that either returns the final GPT result inline or times out safely with the canonical `jobId`.
@@ -80,8 +81,9 @@ Legacy compatibility:
 - Direct-return timeouts never enqueue a second job; they return the same canonical `jobId` and point callers to `GET /jobs/:id/result`.
 
 Job-backed `POST /gpt/:gptId` response shapes:
-- `202 Accepted` pending write: `{ ok:true, action:"query"|"query_and_wait", jobId, status:"queued"|"running"|"timeout", poll:"/jobs/:id/result", stream:"/jobs/:id/stream", timedOut?, jobStatus, lifecycleStatus, deduped?, idempotencyKey, idempotencySource, _route }`
-- `200 OK` completed write: `{ ok:true, action:"query_and_wait", jobId, status:"completed", result:{ text }, poll, stream, jobStatus, lifecycleStatus, deduped?, idempotencyKey, idempotencySource, _route }`
+- `202 Accepted` pending write: `{ ok:true, action:"query", jobId, status:"queued"|"running"|"timeout", poll:"/jobs/:id/result", stream:"/jobs/:id/stream", timedOut?, jobStatus, lifecycleStatus, deduped?, idempotencyKey, idempotencySource, _route }`
+- `200 OK` completed direct action: `{ ok:true, action:"query_and_wait", status:"completed", result:"...", directAction:{ inline:true, queueBypassed:true }, _route }`
+- `200 OK` completed async write for non-core durable jobs: `{ ok:true, action:"query_and_wait", jobId, status:"completed", result:{ text }, poll, stream, jobStatus, lifecycleStatus, deduped?, idempotencyKey, idempotencySource, _route }`
 - `200 OK` status retrieval: `{ ok:true, action:"get_status", jobId, status:"queued|running|completed|failed|cancelled|expired", ... }`
 - `200 OK` result retrieval: `{ ok:true, action:"get_result", jobId, status, output?, result?, error?, poll?, stream?, ... }`
 - Error shape: `{ ok:false, action, error:{ code, message } }`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,7 @@ Implementation rules:
 - `src/routes/gptRouter.ts` runs pre-dispatch classification through `src/routes/_core/gptPlaneClassification.ts`.
 - `src/routes/_core/gptDispatch.ts` is write-plane only and rejects leaked control requests with a fail-fast `write_guard`.
 - Control-plane compatibility actions such as `get_status`, `get_result`, `diagnostics`, and `system_state` are handled directly in the router and never enter the writing pipeline.
-- Canonical async write actions are `query` and `query_and_wait`. Canonical async read actions are `get_status` and `get_result`.
+- Canonical durable write actions are `query` and non-core `query_and_wait`. Core `query_and_wait` is synchronous direct action. Canonical async read actions are `get_status` and `get_result`.
 - Prompt-shaped control requests for job lookup, DAG execution/tracing, runtime inspection, or MCP tool calls are rejected with canonical control endpoints.
 
 ## Prerequisites
@@ -62,8 +62,8 @@ Long-running GPT requests are handled through the DB-backed `job_data` queue ins
 Execution model:
 1. `POST /gpt/:gptId` classifies the request as writing-plane or control-plane before dispatch.
 2. Control-plane reads (`get_status`, `get_result`, `diagnostics`, `system_state`) are served directly and never create GPT jobs.
-3. Writing-plane async requests (`query`, `query_and_wait`, or prompt-first async compatibility mode) persist a canonical GPT job row with hashed idempotency metadata.
-4. `query` returns the canonical `jobId` without inline waiting. `query_and_wait` waits briefly for inline completion and otherwise returns the same canonical `jobId`.
+3. Writing-plane durable requests (`query`, non-core `query_and_wait`, or prompt-first async compatibility mode) persist a canonical GPT job row with hashed idempotency metadata.
+4. `query` returns the canonical `jobId` without inline waiting. On core GPT IDs, `query_and_wait` uses the lightweight synchronous direct action lane and returns the final result inline.
 5. `src/workers/jobRunner.ts` claims `job_type='gpt'` rows and executes them in background mode.
 6. `GET /jobs/:id` and `GET /jobs/:id/stream` expose the canonical job lifecycle and terminal result.
 

--- a/docs/CUSTOM_GPTS.md
+++ b/docs/CUSTOM_GPTS.md
@@ -1,7 +1,7 @@
 # Custom GPTs and Backend Integration
 
 ## Overview
-Arcanos routes Custom GPT requests through the `/gpt/:gptId` gateway. This gateway is the writing plane: it resolves a GPT ID to a backend module, forwards generative work to the matched module, and returns an acknowledgement payload describing the matched module/action set. The routing table is built from module definitions (including their `gptIds`), with optional overrides via environment configuration. The canonical Custom GPT contract is path-based: call `/gpt/<gpt-id>` with either a prompt-first generative request or the typed async bridge actions `query`, `query_and_wait`, `get_status`, and `get_result`. Use direct control endpoints for jobs, DAG traces, runtime diagnostics, and MCP tools when those surfaces are available.【F:src/routes/gptRouter.ts†L16-L159】【F:src/config/gptRouterConfig.ts†L1-L92】【F:src/modules/moduleLoader.ts†L1-L64】
+Arcanos routes Custom GPT requests through the `/gpt/:gptId` gateway. This gateway is the writing plane: it resolves a GPT ID to a backend module, forwards generative work to the matched module, and returns an acknowledgement payload describing the matched module/action set. The routing table is built from module definitions (including their `gptIds`), with optional overrides via environment configuration. The canonical Custom GPT contract is path-based: call `/gpt/<gpt-id>` with either a prompt-first generative request or the typed GPT bridge actions `query`, `query_and_wait`, `get_status`, and `get_result`. Use direct control endpoints for jobs, DAG traces, runtime diagnostics, and MCP tools when those surfaces are available.【F:src/routes/gptRouter.ts†L16-L159】【F:src/config/gptRouterConfig.ts†L1-L92】【F:src/modules/moduleLoader.ts†L1-L64】
 
 ## Why We Use Custom GPTs
 Custom GPTs let Arcanos ship specialized assistants (Backstage Booker, Arcanos Gaming, Tutor) that:
@@ -61,7 +61,8 @@ Rules:
 - Use `executionMode: "fast"` for small prompt-generation requests that should return inline without queueing.
 - Use `executionMode: "async"` or `executionMode: "orchestrated"` when the caller wants durable/orchestrated behavior even for prompt-generation text.
 - Use `action: "query"` with a non-empty `prompt` when the caller wants a durable writing job immediately and will poll later.
-- Use `action: "query_and_wait"` with a non-empty `prompt` when the caller wants one durable writing job plus a bounded inline wait.
+- Use `action: "query_and_wait"` with a non-empty `prompt` when the caller wants the core GPT to complete synchronously through the lightweight direct action lane. The route returns a typed error if direct execution fails or times out; it does not synthesize bounded fallback content for latency guard events. Non-core GPT IDs keep the durable job plus bounded wait behavior.
+- Body `action` is canonical. The router also accepts `?action=query_and_wait` and operation-style aliases such as `operationId: "requestQueryAndWait"` for generated GPT Action clients that separate operation metadata from body arguments.
 - Use `action: "get_status"` or `action: "get_result"` with `payload.jobId` when you need to fetch canonical async GPT job state without creating new work.
 - Use direct control endpoints instead of `/gpt/:gptId` for runtime inspection, DAG tracing/execution, and MCP tool calls.
 - Retrieval by natural-language prompt is intentionally blocked. Do not ask the GPT route to “look up job 123” in `prompt`; use the structured `action + payload.jobId` contract.
@@ -101,7 +102,7 @@ Create a durable writing job:
 }
 ```
 
-Create a durable writing job and wait briefly:
+Execute a core GPT action synchronously:
 ```json
 {
   "action": "query_and_wait",
@@ -132,8 +133,8 @@ Fetch result without creating work:
 ```
 
 Canonical response guidance:
-- Pending write: `{ "ok": true, "action": "query"|"query_and_wait", "jobId": "job_123", "status": "pending" }`
-- Completed `query_and_wait`: `{ "ok": true, "action": "query_and_wait", "jobId": "job_123", "status": "completed", "result": { "text": "..." } }`
+- Pending write: `{ "ok": true, "action": "query", "jobId": "job_123", "status": "pending" }`
+- Completed `query_and_wait`: `{ "ok": true, "action": "query_and_wait", "status": "completed", "result": "..." }`
 - Status read: `{ "ok": true, "action": "get_status", "jobId": "job_123", "status": "queued|running|completed|failed|cancelled|expired" }`
 - Result read: `{ "ok": true, "action": "get_result", "jobId": "job_123", "status": "completed", "output": { "text": "..." } }`
 - Error: `{ "ok": false, "action": "...", "error": { "code": "...", "message": "..." } }`
@@ -276,6 +277,6 @@ success_response:
 - **Happy path:** Call `/gpt/<gpt-id>` with a valid `action` and `payload` and confirm `_gptAck` metadata returns for the matched module.【F:src/routes/gptRouter.ts†L96-L159】
 - **Edge case:** Use an unknown GPT ID and confirm a `404` with `Unknown GPTID` is returned.【F:src/routes/gptRouter.ts†L70-L104】
 - **Failure mode:** Call a valid GPT ID with an invalid action and confirm the module returns `Action not found` or `Module not found` as appropriate.【F:src/routes/modules.ts†L16-L56】
-- **Async bridge:** Confirm `query` creates one job, `query_and_wait` either completes inline or returns pending, and `get_status` / `get_result` never create work.
+- **Async bridge:** Confirm `query` creates one job, core `query_and_wait` completes through the direct action lane without bounded fallback text, non-core durable writes still use jobs, and `get_status` / `get_result` never create work.
 - **Fast path:** Confirm `executionMode: "fast"` for a prompt-generation request returns `200`, `routeDecision.path: "fast_path"`, `x-gpt-fast-path-queue-bypassed: true`, and `x-gpt-queue-bypassed: true`.
 - **Guardrail:** Confirm prompt-based job retrieval is rejected and callers are pointed at structured control actions or `/jobs/*`.

--- a/docs/GPT_ASYNC_DOCUMENTATION_WORKFLOW.md
+++ b/docs/GPT_ASYNC_DOCUMENTATION_WORKFLOW.md
@@ -1,9 +1,9 @@
 # ARCANOS GPT Async Documentation Workflow
 
 ## /gpt/:gptId API Behavior
-`POST /gpt/:gptId` is the writing plane. Use it to create GPT generation work with `query` or `query_and_wait`; do not use it to retrieve jobs, inspect queues, read DAG traces, or invoke MCP tools.
+`POST /gpt/:gptId` is the writing plane. Use it to create durable GPT generation work with `query` or non-core `query_and_wait`; core `query_and_wait` executes synchronously through the direct action lane. Do not use it to retrieve jobs, inspect queues, read DAG traces, or invoke MCP tools.
 
-`query_and_wait` may complete inside the direct execution window. If the job is still queued or running when that bounded window expires, the response returns job coordinates and the caller must poll the jobs API.
+Non-core `query_and_wait` may complete inside the direct execution window. If the job is still queued or running when that bounded window expires, the response returns job coordinates and the caller must poll the jobs API. Core `query_and_wait` returns the final inline result or a typed execution error; it does not synthesize bounded fallback content.
 
 Canonical async response shape:
 ```json

--- a/docs/GPT_FAST_PATH.md
+++ b/docs/GPT_FAST_PATH.md
@@ -4,9 +4,9 @@
 `POST /gpt/:gptId` now has two execution modes:
 
 - `fast_path`: inline prompt generation for small requests that look like prompt-generation work. It bypasses job creation, worker orchestration, DAG planning, memory overlays, research overlays, and audit overlays.
-- `orchestrated_path`: non-fast-path behavior. Execution planning may still return through bounded module dispatch, or it may use durable async jobs for explicit async requests, complex prompts, explicit actions, idempotent retries, and long-running work.
+- `orchestrated_path`: non-fast-path behavior. Execution planning may still return through bounded module dispatch, or it may use durable async jobs for `query`, non-core `query_and_wait`, explicit async requests, complex prompts, idempotent retries, and long-running work.
 
-The route keeps a single public endpoint so existing Custom GPT integrations do not need a new URL. The router branches internally before async job planning. Explicit async bridge actions (`query`, `query_and_wait`, `get_status`, `get_result`) always keep their current job-backed behavior; fast path is for prompt-generation requests that omit `action`.
+The route keeps a single public endpoint so existing Custom GPT integrations do not need a new URL. The router branches internally before async job planning. `query` keeps its job-backed behavior, `get_status` and `get_result` stay on the control plane, and core `query_and_wait` now uses the synchronous direct action lane by default. Fast path remains available for prompt-generation requests that omit `action`.
 
 Fast-path eligibility is implemented in `src/shared/gpt/gptFastPath.ts`. Inline execution is implemented in `src/services/gptFastPath.ts`.
 
@@ -19,7 +19,7 @@ A request is eligible when all of these are true:
 - General short-form generation that does not ask for a prompt, such as `Generate a launch email`, stays out of the fast path by design. Small unadorned core requests then use the bounded direct path unless explicit async mode, heavy-request thresholds, idempotency, or `GPT_ROUTE_ASYNC_CORE_DEFAULT=true` require a durable job.
 - If the caller explicitly sets fast mode, all other eligibility checks still apply.
 - There is no explicit idempotency key.
-- The action is omitted. Explicit async bridge actions stay orchestrated even if `executionMode` is `fast`.
+- The action is omitted for prompt-generation fast path. Explicit `query` and non-core `query_and_wait` stay orchestrated even if `executionMode` is `fast`; core `query_and_wait` uses the direct action lane.
 - The request does not carry heavy fields such as `tools`, `workflow`, `dag`, `files`, `images`, `research`, a non-object `payload`, or a non-empty object `payload`.
 - Prompt length, message count, and requested max words stay under configured limits.
 

--- a/packages/cli/__tests__/gpt-client.test.ts
+++ b/packages/cli/__tests__/gpt-client.test.ts
@@ -508,7 +508,7 @@ describe("GPT route OpenAPI contract and client", () => {
       spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.queryAndWait?.value
     ).toEqual({
       action: "query_and_wait",
-      prompt: "Wait briefly for a fast completion.",
+      prompt: "Return the final result synchronously.",
       timeoutMs: 25000,
       pollIntervalMs: 500
     });

--- a/src/routes/_core/gptDispatch.ts
+++ b/src/routes/_core/gptDispatch.ts
@@ -45,6 +45,10 @@ import {
   assertWritingPlaneClassification,
   classifyGptRequestPlane,
 } from "./gptPlaneClassification.js";
+import {
+  ARCANOS_SUPPRESS_TIMEOUT_FALLBACK_FLAG,
+  normalizeBooleanFlagValue
+} from "@shared/gpt/gptDirectAction.js";
 
 export type AskEnvelope =
   | { ok: true; result: unknown; _route: RouteMeta }
@@ -71,6 +75,7 @@ export type RouteGptRequestInput = {
   bypassIntentRouting?: boolean;
   runtimeExecutionMode?: 'request' | 'background';
   parentAbortSignal?: AbortSignal;
+  suppressTimeoutFallback?: boolean;
 };
 
 function extractPrompt(body: any): string | null {
@@ -124,6 +129,7 @@ const FORWARDED_TOP_LEVEL_PAYLOAD_KEYS = [
   'maxWords',
   'max_words',
   '__arcanosExecutionMode',
+  ARCANOS_SUPPRESS_TIMEOUT_FALLBACK_FLAG,
 ] as const;
 
 function mergeForwardedTopLevelPayloadFields(
@@ -197,6 +203,14 @@ function applyRuntimeExecutionModeOverride(
     ...payload,
     __arcanosExecutionMode: runtimeExecutionMode
   };
+}
+
+function readSuppressTimeoutFallbackFlag(payload: unknown): boolean {
+  if (!isRecord(payload)) {
+    return false;
+  }
+
+  return normalizeBooleanFlagValue(payload[ARCANOS_SUPPRESS_TIMEOUT_FALLBACK_FLAG]);
 }
 
 function actionRequiresPrompt(action: string): boolean {
@@ -828,7 +842,8 @@ export async function routeGptRequest(input: RouteGptRequestInput): Promise<AskE
     request,
     bypassIntentRouting,
     runtimeExecutionMode,
-    parentAbortSignal
+    parentAbortSignal,
+    suppressTimeoutFallback: suppressTimeoutFallbackInput
   } = input;
   const trimmedGptId = (gptId ?? "").trim();
   const requestEndpoint = request?.originalUrl ?? request?.url ?? request?.path;
@@ -836,6 +851,9 @@ export async function routeGptRequest(input: RouteGptRequestInput): Promise<AskE
     buildDispatchPayload(body),
     runtimeExecutionMode
   );
+  const suppressTimeoutFallback =
+    suppressTimeoutFallbackInput === true ||
+    readSuppressTimeoutFallbackFlag(preDispatchPayload);
   const diagnosticTextInput = extractPrompt(preDispatchPayload) ?? extractDiagnosticTextInput(body as Record<string, unknown> | undefined);
   const promptDebugRequestId = requestId ?? `gpt-${trimmedGptId || 'unknown'}`;
   const rawPrompt = extractPrompt(body) ?? diagnosticTextInput ?? '';
@@ -1625,71 +1643,72 @@ export async function routeGptRequest(input: RouteGptRequestInput): Promise<AskE
 
       if (
         isDispatchTimeout &&
-      activeEntry.module === 'ARCANOS:CORE' &&
-      action === 'query' &&
-      typeof prompt === 'string' &&
-      prompt.length > 0
-    ) {
-      const timeoutPhase = resolveArcanosCoreTimeoutPhase(err) ?? 'module-dispatch';
-      const timeoutFallback = buildArcanosCoreTimeoutFallbackEnvelope({
-        prompt,
-        gptId: trimmedGptId,
-        requestId,
-        route: activeEntry.route,
-        timeoutPhase,
-      });
-      recordDispatcherRoute({
-        gptId: trimmedGptId,
-        module: activeEntry.module,
-        route: activeEntry.route,
-        handler: 'module-dispatcher',
-        outcome: 'timeout',
-      });
-      recordDispatcherFallback({
-        gptId: trimmedGptId,
-        module: activeEntry.module,
-        reason: 'module_timeout_static_fallback',
-      });
-      logger?.warn?.('gpt.dispatch.timeout_fallback', {
-        requestId,
-        gptId: trimmedGptId,
-        module: activeEntry.module,
-        action,
-        route: activeEntry.route,
-        errorType: 'module_timeout_static_fallback',
-        error: errorMessage,
-        timeoutPhase,
-        timeoutMs,
-        timeoutSource,
-        durationMs: Date.now() - dispatchStartedAt,
-      });
-      recordPromptDebugTrace(promptDebugRequestId, 'response', {
-        traceId: request?.traceId ?? null,
-        endpoint: requestEndpoint ?? '/gpt/:gptId',
-        method: request?.method ?? null,
-        rawPrompt,
-        normalizedPrompt,
-        selectedRoute: activeEntry.route,
-        selectedModule: activeEntry.module,
-        responseReturned: timeoutFallback.result,
-        fallbackPathUsed: 'module-timeout-static-fallback',
-        fallbackReason: dispatchErrorMessage,
-      });
-      return {
-        ok: true,
-        result: timeoutFallback.result,
-        _route: {
-          ...baseRoute,
-          ...timeoutFallback._route,
+        !suppressTimeoutFallback &&
+        activeEntry.module === 'ARCANOS:CORE' &&
+        action === 'query' &&
+        typeof prompt === 'string' &&
+        prompt.length > 0
+      ) {
+        const timeoutPhase = resolveArcanosCoreTimeoutPhase(err) ?? 'module-dispatch';
+        const timeoutFallback = buildArcanosCoreTimeoutFallbackEnvelope({
+          prompt,
+          gptId: trimmedGptId,
+          requestId,
+          route: activeEntry.route,
+          timeoutPhase,
+        });
+        recordDispatcherRoute({
+          gptId: trimmedGptId,
+          module: activeEntry.module,
+          route: activeEntry.route,
+          handler: 'module-dispatcher',
+          outcome: 'timeout',
+        });
+        recordDispatcherFallback({
+          gptId: trimmedGptId,
+          module: activeEntry.module,
+          reason: 'module_timeout_static_fallback',
+        });
+        logger?.warn?.('gpt.dispatch.timeout_fallback', {
+          requestId,
+          gptId: trimmedGptId,
           module: activeEntry.module,
           action,
-          matchMethod,
           route: activeEntry.route,
-          availableActions,
-          moduleVersion: (moduleMetadata as any)?.version ?? null,
-        },
-      };
-    }
+          errorType: 'module_timeout_static_fallback',
+          error: errorMessage,
+          timeoutPhase,
+          timeoutMs,
+          timeoutSource,
+          durationMs: Date.now() - dispatchStartedAt,
+        });
+        recordPromptDebugTrace(promptDebugRequestId, 'response', {
+          traceId: request?.traceId ?? null,
+          endpoint: requestEndpoint ?? '/gpt/:gptId',
+          method: request?.method ?? null,
+          rawPrompt,
+          normalizedPrompt,
+          selectedRoute: activeEntry.route,
+          selectedModule: activeEntry.module,
+          responseReturned: timeoutFallback.result,
+          fallbackPathUsed: 'module-timeout-static-fallback',
+          fallbackReason: dispatchErrorMessage,
+        });
+        return {
+          ok: true,
+          result: timeoutFallback.result,
+          _route: {
+            ...baseRoute,
+            ...timeoutFallback._route,
+            module: activeEntry.module,
+            action,
+            matchMethod,
+            route: activeEntry.route,
+            availableActions,
+            moduleVersion: (moduleMetadata as any)?.version ?? null,
+          },
+        };
+      }
 
     recordDispatcherRoute({
       gptId: trimmedGptId,

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -30,6 +30,7 @@ import {
   runWithRequestAbortTimeout
 } from '@arcanos/runtime';
 import { hasDagOrchestrationIntentCue } from '@services/naturalLanguageMemory.js';
+import { shouldTreatPromptAsDagExecution } from '@shared/dag/dagExecutionRouting.js';
 import {
   recordDagTraceTimeout,
   recordGptFastPathLatency,
@@ -111,7 +112,8 @@ import {
   type GptFastPathDecision,
   type GptFastPathModeHint
 } from '@shared/gpt/gptFastPath.js';
-import { executeFastGptPrompt } from '@services/gptFastPath.js';
+import { ARCANOS_SUPPRESS_TIMEOUT_FALLBACK_FLAG } from '@shared/gpt/gptDirectAction.js';
+import { executeDirectGptAction, executeFastGptPrompt } from '@services/gptFastPath.js';
 import { executeRuntimeInspection } from '@services/runtimeInspectionRoutingService.js';
 import { getWorkerControlStatus } from '@services/workerControlService.js';
 import { buildSafetySelfHealSnapshot } from '@services/selfHealRuntimeInspectionService.js';
@@ -133,6 +135,7 @@ const DEFAULT_GPT_ASYNC_HEAVY_MAX_WORDS = 700;
 const DEFAULT_GPT_ASYNC_HEAVY_WAIT_FOR_RESULT_MS = 500;
 const DIRECT_RETURN_ROUTE_TIMEOUT_HEADROOM_MS = 750;
 const DEBUG_GPT_MAX_BYTES_HEADER = 'x-debug-max-bytes';
+const QUERY_AND_WAIT_DIRECT_ACTION_REASON = 'query_and_wait_direct_action';
 const DIRECT_RETURN_WAIT_KEYS = [
   'waitForResultMs',
   'wait_for_result_ms',
@@ -356,16 +359,77 @@ function extractDispatcherResultText(result: unknown): string {
   }
 }
 
-function readActionAlias(record: Record<string, unknown>): string | null {
-  const actionValue = record.action;
-  if (typeof actionValue === 'string' && actionValue.trim().length > 0) {
-    return actionValue.trim();
+function readFirstNonEmptyString(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
   }
 
-  const operationValue = record.operation;
-  return typeof operationValue === 'string' && operationValue.trim().length > 0
-    ? operationValue.trim()
-    : null;
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const normalizedEntry = readFirstNonEmptyString(entry);
+      if (normalizedEntry) {
+        return normalizedEntry;
+      }
+    }
+  }
+
+  return null;
+}
+
+function normalizeRequestedActionName(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const lowered = trimmed.toLowerCase();
+  const decamelized = trimmed.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
+  const compact = decamelized.replace(/[^a-z0-9]+/g, '');
+
+  if (compact === 'invokegptroute' || compact === 'gptroute' || compact === 'invokegpt') {
+    return null;
+  }
+
+  if (
+    compact === 'queryandwait' ||
+    compact === 'requestqueryandwait' ||
+    compact === 'gptqueryandwait'
+  ) {
+    return GPT_QUERY_AND_WAIT_ACTION;
+  }
+
+  if (compact === 'query') {
+    return GPT_QUERY_ACTION;
+  }
+
+  if (compact === 'getstatus') {
+    return GPT_GET_STATUS_ACTION;
+  }
+
+  if (compact === 'getresult') {
+    return GPT_GET_RESULT_ACTION;
+  }
+
+  if (compact === 'systemstate') {
+    return 'system_state';
+  }
+
+  return lowered;
+}
+
+function readActionAlias(record: Record<string, unknown>): string | null {
+  const actionValue =
+    readFirstNonEmptyString(record.action) ??
+    readFirstNonEmptyString(record.operation) ??
+    readFirstNonEmptyString(record.operationId) ??
+    readFirstNonEmptyString(record.operation_id) ??
+    readFirstNonEmptyString(record.toolAction) ??
+    readFirstNonEmptyString(record.tool_action) ??
+    readFirstNonEmptyString(record.gptAction) ??
+    readFirstNonEmptyString(record.gpt_action);
+
+  return actionValue ? normalizeRequestedActionName(actionValue) : null;
 }
 
 function resolveRequestedAction(body: unknown): string | null {
@@ -385,7 +449,19 @@ function resolveRequestedAction(body: unknown): string | null {
   }
 
   const payloadAction = readActionAlias(payload as Record<string, unknown>);
-  return payloadAction ? payloadAction.toLowerCase() : null;
+  return payloadAction;
+}
+
+function resolveRequestedActionFromRequest(req: express.Request): string | null {
+  return (
+    resolveRequestedAction(req.body) ??
+    readActionAlias(req.query as Record<string, unknown>) ??
+    normalizeRequestedActionName(
+      readFirstNonEmptyString(req.header('x-gpt-action')) ??
+      readFirstNonEmptyString(req.header('x-arcanos-action')) ??
+      ''
+    )
+  );
 }
 
 function readPayloadRecord(
@@ -439,6 +515,21 @@ function extractPromptText(body: unknown): string | null {
     extractPromptTextFromRecord(normalizedBody) ??
     extractPromptTextFromRecord(readPayloadRecord(normalizedBody))
   );
+}
+
+function extractPromptTextFromRequest(req: express.Request): string | null {
+  return (
+    extractPromptText(req.body) ??
+    extractPromptTextFromRecord(req.query as Record<string, unknown>)
+  );
+}
+
+function shouldUseDagExecutionTimeoutProfile(prompt: string | null): boolean {
+  if (!prompt || !hasDagOrchestrationIntentCue(prompt)) {
+    return false;
+  }
+
+  return shouldTreatPromptAsDagExecution(prompt);
 }
 
 function resolveDebugGptPublicResponseMaxBytes(req: express.Request): number | undefined {
@@ -1010,6 +1101,84 @@ function buildDirectReturnTimeoutResponse(params: {
   };
 }
 
+function shouldUseQueryAndWaitDirectActionLane(params: {
+  queryAndWaitRequested: boolean;
+  gptId: string;
+  promptText: string | null;
+}): boolean {
+  if (!params.queryAndWaitRequested || !params.promptText) {
+    return false;
+  }
+
+  return ARCANOS_CORE_GPT_IDS.has(params.gptId);
+}
+
+function resolveQueryAndWaitDirectActionTimeoutMs(params: {
+  requestedWaitForResultMs: number | undefined;
+  routeTimeoutMs: number;
+}): number {
+  const requestedWaitMs = params.requestedWaitForResultMs ?? resolveGptWaitTimeoutMs();
+  return Math.max(
+    1,
+    clampAsyncWaitForRouteTimeout(
+      resolveAsyncGptWaitForResultMs(requestedWaitMs),
+      params.routeTimeoutMs
+    )
+  );
+}
+
+function buildQueryAndWaitDirectRouteDecision(params: {
+  body: unknown;
+  promptText: string;
+  timeoutMs: number;
+  explicitMode: GptFastPathModeHint;
+}): GptFastPathDecision {
+  return {
+    path: 'fast_path',
+    eligible: true,
+    reason: QUERY_AND_WAIT_DIRECT_ACTION_REASON,
+    queueBypassed: true,
+    promptLength: params.promptText.length,
+    messageCount: extractMessageCount(params.body),
+    maxWords: extractMaxWords(params.body),
+    timeoutMs: params.timeoutMs,
+    action: GPT_QUERY_AND_WAIT_ACTION,
+    promptGenerationIntent: false,
+    explicitMode: params.explicitMode
+  };
+}
+
+function resolveDirectGptActionFailureStatus(error: unknown): number {
+  if (isAbortError(error)) {
+    return 504;
+  }
+
+  const message = resolveErrorMessage(error).toLowerCase();
+  if (message.includes('openai client unavailable') || message.includes('client unavailable')) {
+    return 503;
+  }
+
+  if (message.includes('returned empty output')) {
+    return 500;
+  }
+
+  const status = (error as { status?: unknown; statusCode?: unknown } | null)?.status;
+  const statusCode = typeof status === 'number'
+    ? status
+    : (error as { statusCode?: unknown } | null)?.statusCode;
+  if (typeof statusCode === 'number' && Number.isInteger(statusCode)) {
+    if (statusCode === 429) {
+      return 429;
+    }
+
+    if (statusCode >= 500 && statusCode <= 599) {
+      return 502;
+    }
+  }
+
+  return 502;
+}
+
 function resolveDefaultGptQueryAndWaitRouteTimeoutMs(): number {
   return resolveGptWaitTimeoutMs() + DIRECT_RETURN_ROUTE_TIMEOUT_HEADROOM_MS;
 }
@@ -1041,6 +1210,7 @@ function normalizeQueryAndWaitBody(
 
   const normalizedQueryBody = { ...normalizedBody };
   delete normalizedQueryBody.action;
+  normalizedQueryBody[ARCANOS_SUPPRESS_TIMEOUT_FALLBACK_FLAG] = true;
   if (readBooleanEnv('GPT_ROUTE_ASYNC_CORE_DEFAULT', false)) {
     normalizedQueryBody.executionMode = 'async';
   }
@@ -1734,13 +1904,15 @@ function applyGptQueueBypassedHeader(
 router.post("/:gptId", async (req, res, next) => {
   const routeGptId = req.params.gptId;
   const priorityGpt = isPriorityGpt(routeGptId);
-  const requestedAction = resolveRequestedAction(req.body);
+  const requestedAction = resolveRequestedActionFromRequest(req);
   const queryRequested = requestedAction === GPT_QUERY_ACTION;
   const queryAndWaitRequested = requestedAction === GPT_QUERY_AND_WAIT_ACTION;
   const bypassIntentRouting = queryRequested || queryAndWaitRequested;
   const asyncBridgeAction = resolveAsyncBridgeAction(queryAndWaitRequested);
-  const promptText = extractPromptText(req.body);
-  const routeTimeoutProfile = 'default';
+  const promptText = extractPromptTextFromRequest(req);
+  const routeTimeoutProfile = shouldUseDagExecutionTimeoutProfile(promptText)
+    ? 'dag_execution'
+    : 'default';
   const explicitAsyncWaitForResultMs = readRequestedAsyncGptWaitForResultMs(req, req.body);
   const explicitAsyncPollIntervalMs = readRequestedAsyncGptPollIntervalMs(req, req.body);
   const queryAndWaitRequestedTimeoutMs =
@@ -2397,6 +2569,163 @@ router.post("/:gptId", async (req, res, next) => {
             event: 'idempotency_key_present',
             source: 'explicit'
           });
+        }
+
+        if (
+          shouldUseQueryAndWaitDirectActionLane({
+            queryAndWaitRequested,
+            gptId: incomingGptId,
+            promptText
+          })
+        ) {
+          const directActionTimeoutMs = resolveQueryAndWaitDirectActionTimeoutMs({
+            requestedWaitForResultMs: explicitAsyncWaitForResultMs,
+            routeTimeoutMs
+          });
+          const directActionRouteDecision = buildQueryAndWaitDirectRouteDecision({
+            body: effectiveBody,
+            promptText: promptText!,
+            timeoutMs: directActionTimeoutMs,
+            explicitMode: resolveRequestedFastPathMode(req, effectiveBody)
+          });
+          applyGptRouteDecisionHeaders(res, directActionRouteDecision);
+          applyGptQueueBypassedHeader(res, true);
+          recordGptRouteDecision({
+            path: directActionRouteDecision.path,
+            reason: directActionRouteDecision.reason,
+            queueBypassed: true
+          });
+          requestLogger?.info?.('gpt.request.route_decision', {
+            endpoint: req.originalUrl,
+            gptId: incomingGptId,
+            action: GPT_QUERY_AND_WAIT_ACTION,
+            path: directActionRouteDecision.path,
+            reason: directActionRouteDecision.reason,
+            queueBypassed: true,
+            promptLength: directActionRouteDecision.promptLength,
+            messageCount: directActionRouteDecision.messageCount,
+            maxWords: directActionRouteDecision.maxWords,
+            timeoutMs: directActionRouteDecision.timeoutMs,
+            promptGenerationIntent: directActionRouteDecision.promptGenerationIntent,
+            explicitMode: directActionRouteDecision.explicitMode
+          });
+
+          const directActionStartedAt = Date.now();
+          try {
+            const directEnvelope = await executeDirectGptAction({
+              gptId: incomingGptId,
+              prompt: promptText!,
+              requestId,
+              action: GPT_QUERY_AND_WAIT_ACTION,
+              timeoutMs: directActionTimeoutMs,
+              parentSignal: clientAbortController.signal,
+              logger: requestLogger
+            });
+            const totalLatencyMs = Date.now() - directActionStartedAt;
+            recordGptFastPathLatency({
+              gptId: incomingGptId,
+              outcome: 'completed',
+              durationMs: totalLatencyMs
+            });
+            const routingInfo: GptRoutingInfo = {
+              gptId: directEnvelope._route.gptId,
+              moduleName: directEnvelope._route.module,
+              route: directEnvelope._route.route,
+              matchMethod: 'exact'
+            };
+            logGptConnection(routingInfo);
+            logGptAckSent(routingInfo, 1);
+            requestLogger?.info?.('integration.job.query_and_wait_completed', {
+              endpoint: req.originalUrl,
+              gptId: incomingGptId,
+              requestId,
+              waitForResultMs: directActionTimeoutMs,
+              directExecution: true,
+              latencyMs: totalLatencyMs
+            });
+            logGptDispatcherOutcome({
+              req,
+              traceId,
+              gptId: incomingGptId,
+              action: GPT_QUERY_AND_WAIT_ACTION,
+              status: 200
+            });
+            return sendGuardedGptJsonResponse(
+              req,
+              res,
+              {
+                ok: true,
+                gptId: incomingGptId,
+                action: GPT_QUERY_AND_WAIT_ACTION,
+                status: 'completed',
+                result: extractDispatcherResultText(directEnvelope.result),
+                routeDecision: directActionRouteDecision,
+                directAction: directEnvelope.directAction,
+                traceId,
+                _route: {
+                  ...directEnvelope._route,
+                  requestId,
+                  traceId
+                }
+              },
+              'gpt.response.query_and_wait_direct_completed',
+              200
+            );
+          } catch (error) {
+            const errorMessage = resolveErrorMessage(error);
+            const directActionFailureStatus = resolveDirectGptActionFailureStatus(error);
+            const timedOut = directActionFailureStatus === 504;
+            recordGptFastPathLatency({
+              gptId: incomingGptId,
+              outcome: 'error',
+              durationMs: Date.now() - directActionStartedAt
+            });
+            requestLogger?.warn?.(
+              timedOut
+                ? 'gpt.request.query_and_wait_direct_timeout'
+                : 'gpt.request.query_and_wait_direct_failed',
+              {
+                endpoint: req.originalUrl,
+                gptId: incomingGptId,
+                requestId,
+                timeoutMs: directActionTimeoutMs,
+                statusCode: directActionFailureStatus,
+                error: errorMessage
+              }
+            );
+            const errorPayload = buildGptDispatcherErrorPayload({
+              requestId,
+              traceId,
+              gptId: incomingGptId,
+              action: GPT_QUERY_AND_WAIT_ACTION,
+              code: timedOut ? 'GPT_QUERY_AND_WAIT_TIMEOUT' : 'GPT_QUERY_AND_WAIT_FAILED',
+              message: errorMessage,
+              route: 'query_and_wait_direct'
+            });
+            logGptDispatcherOutcome({
+              req,
+              traceId,
+              gptId: incomingGptId,
+              action: GPT_QUERY_AND_WAIT_ACTION,
+              status: directActionFailureStatus,
+              error: {
+                name: error instanceof Error ? error.name : 'Error',
+                message: errorMessage
+              }
+            });
+            return sendGuardedGptJsonResponse(
+              req,
+              res,
+              {
+                ...errorPayload,
+                routeDecision: directActionRouteDecision
+              },
+              timedOut
+                ? 'gpt.response.query_and_wait_direct_timeout'
+                : 'gpt.response.query_and_wait_direct_failed',
+              directActionFailureStatus
+            );
+          }
         }
 
         const fastPathDecision = classifyGptFastPathRequest({
@@ -3411,7 +3740,13 @@ router.post("/:gptId", async (req, res, next) => {
           202
         );
       }
-      if (routeTimedOut && responseOpen && promptText && ARCANOS_CORE_GPT_IDS.has(gptId)) {
+      if (
+        routeTimedOut &&
+        responseOpen &&
+        promptText &&
+        ARCANOS_CORE_GPT_IDS.has(gptId) &&
+        requestedAction !== GPT_QUERY_AND_WAIT_ACTION
+      ) {
         const timeoutPhase = resolveArcanosCoreTimeoutPhase(err) ?? 'gpt-route';
         const timeoutFallback = buildArcanosCoreTimeoutFallbackEnvelope({
           prompt: promptText,

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -295,6 +295,7 @@ function buildGptDispatcherErrorPayload(params: {
     gptId: params.gptId,
     action: params.action,
     route: GPT_DISPATCHER_ROUTE,
+    code: params.code,
     traceId: params.traceId,
     error: {
       code: params.code,
@@ -2047,6 +2048,15 @@ router.post("/:gptId", async (req, res, next) => {
         const routingValidation = await resolveGptRouting(incomingGptId, requestId);
         if (!routingValidation.ok) {
           const statusCode = routingValidation.error.code === 'UNKNOWN_GPT' ? 404 : 400;
+          const errorPayload = buildGptDispatcherErrorPayload({
+            requestId,
+            traceId,
+            gptId: incomingGptId,
+            action: requestedAction ?? GPT_QUERY_ACTION,
+            code: routingValidation.error.code,
+            message: routingValidation.error.message,
+            route: 'routing_validation'
+          });
           requestLogger?.warn?.('gpt.request.route_result', {
             endpoint: req.originalUrl,
             gptId: incomingGptId,
@@ -2065,7 +2075,7 @@ router.post("/:gptId", async (req, res, next) => {
           return sendGuardedGptJsonResponse(
             req,
             res,
-            routingValidation,
+            errorPayload,
             'gpt.response.route_error',
             statusCode
           );

--- a/src/services/arcanos-core.ts
+++ b/src/services/arcanos-core.ts
@@ -12,6 +12,10 @@ import { generateMockResponse } from '@services/openai.js';
 import { getOpenAIClientOrAdapter } from '@services/openai/clientBridge.js';
 import { getAiExecutionContext } from '@services/openai/aiExecutionContext.js';
 import { APPLICATION_CONSTANTS } from '@shared/constants.js';
+import {
+  ARCANOS_SUPPRESS_TIMEOUT_FALLBACK_FLAG,
+  normalizeBooleanFlagValue
+} from '@shared/gpt/gptDirectAction.js';
 import type { ModuleDef } from './moduleLoader.js';
 import { executeSystemStateRequest } from './systemState.js';
 import {
@@ -35,6 +39,7 @@ type ArcanosCoreQueryPayload = {
   max_words?: number;
   maxWords?: number;
   __arcanosExecutionMode?: string;
+  [ARCANOS_SUPPRESS_TIMEOUT_FALLBACK_FLAG]?: boolean | string | number;
 };
 
 type ArcanosCoreExecutionMode = 'request' | 'background';
@@ -74,6 +79,7 @@ export interface RunArcanosCoreQueryParams {
   overrideAuditSafe?: string;
   runOptions?: Omit<TrinityRunOptions, 'sourceEndpoint'>;
   executionModeOverride?: ArcanosCoreExecutionMode;
+  allowTimeoutFallback?: boolean;
 }
 
 export interface BuildArcanosCoreTimeoutFallbackParams {
@@ -646,6 +652,48 @@ export async function runArcanosCoreQuery(
     const durationMs = Date.now() - startedAt;
     if (shouldRecoverViaCoreDegradedPath(error, durationMs, pipelinePlan)) {
       const primaryTimeoutPhase = resolveCoreFallbackTimeoutPhase(error);
+      if (params.allowTimeoutFallback === false) {
+        logger.warn('[PIPELINE] timeout fallback suppressed', {
+          module: 'ARCANOS:CORE',
+          sourceEndpoint: params.sourceEndpoint,
+          executionMode: pipelinePlan.executionMode,
+          durationMs,
+          timeoutKind: 'pipeline_timeout',
+          timeoutPhase: primaryTimeoutPhase,
+          primaryTimeoutMs: pipelinePlan.primaryTimeoutMs,
+          totalTimeoutMs: pipelinePlan.totalTimeoutMs,
+          degradedTimeoutMs: pipelinePlan.degradedTimeoutMs,
+          error: errorMessage
+        });
+        emitCoreRuntimeTrace({
+          phase: 'fallback_suppressed',
+          startedAt,
+          requestId: trinityRequestId ?? params.requestId,
+          sourceEndpoint: params.sourceEndpoint,
+          executionMode: pipelinePlan.executionMode,
+          runtimeBudget,
+          timeoutMs: pipelinePlan.primaryTimeoutMs,
+          totalTimeoutMs: pipelinePlan.totalTimeoutMs,
+          degradedReason: ARCANOS_CORE_PIPELINE_TIMEOUT_REASON,
+          timeoutPhase: primaryTimeoutPhase,
+          level: 'warn',
+          extra: {
+            error: errorMessage
+          }
+        });
+        recordTraceEvent('core.pipeline.timeout_fallback_suppressed', {
+          sourceEndpoint: params.sourceEndpoint,
+          executionMode: pipelinePlan.executionMode,
+          durationMs,
+          timeoutKind: 'pipeline_timeout',
+          timeoutPhase: primaryTimeoutPhase,
+          primaryTimeoutMs: pipelinePlan.primaryTimeoutMs,
+          totalTimeoutMs: pipelinePlan.totalTimeoutMs,
+          degradedTimeoutMs: pipelinePlan.degradedTimeoutMs
+        });
+        throw error;
+      }
+
       emitCoreRuntimeTrace({
         phase: 'fallback_triggered',
         startedAt,
@@ -907,6 +955,9 @@ export const ArcanosCore: ModuleDef = {
           : normalizedPayload.__arcanosExecutionMode === 'request'
           ? 'request'
           : undefined;
+      const allowTimeoutFallback = !normalizeBooleanFlagValue(
+        normalizedPayload[ARCANOS_SUPPRESS_TIMEOUT_FALLBACK_FLAG]
+      );
       const { client } = getOpenAIClientOrAdapter();
       emitCoreRuntimeTrace({
         phase: 'gpt_config_loaded',
@@ -944,7 +995,8 @@ export const ArcanosCore: ModuleDef = {
           ...(answerMode ? { answerMode } : {}),
           ...(maxWords ? { maxWords } : {})
         },
-        executionModeOverride
+        executionModeOverride,
+        allowTimeoutFallback
       });
     },
     async system_state(payload: unknown) {

--- a/src/services/gptFastPath.ts
+++ b/src/services/gptFastPath.ts
@@ -45,12 +45,55 @@ export interface FastGptPromptEnvelope {
   };
 }
 
+export interface ExecuteDirectGptActionInput {
+  gptId: string;
+  prompt: string;
+  requestId?: string;
+  action: 'query_and_wait';
+  timeoutMs: number;
+  parentSignal?: AbortSignal;
+  logger?: {
+    info?: (message: string, meta?: Record<string, unknown>) => void;
+    warn?: (message: string, meta?: Record<string, unknown>) => void;
+    error?: (message: string, meta?: Record<string, unknown>) => void;
+  };
+}
+
+export interface DirectGptActionEnvelope {
+  ok: true;
+  result: Record<string, unknown>;
+  directAction: {
+    inline: true;
+    queueBypassed: true;
+    orchestrationBypassed: true;
+    action: 'query_and_wait';
+    timeoutMs: number;
+    modelLatencyMs: number;
+    totalLatencyMs: number;
+  };
+  _route: {
+    requestId?: string;
+    gptId: string;
+    module: 'GPT:DIRECT_ACTION';
+    action: 'query_and_wait';
+    route: 'direct_action';
+    timestamp: string;
+  };
+}
+
 const FAST_PATH_ROUTING_STAGE = 'GPT-FAST-PATH';
 const FAST_PATH_SYSTEM_INSTRUCTIONS = [
   'You are ARCANOS fast-path prompt generation.',
   'Generate the requested prompt directly and concisely.',
   'Do not describe internal routing, queues, tools, memory, audits, or orchestration.',
   'Return only the user-facing prompt or prompt text requested by the caller.'
+].join(' ');
+const DIRECT_ACTION_ROUTING_STAGE = 'GPT-DIRECT-ACTION';
+const DIRECT_ACTION_SYSTEM_INSTRUCTIONS = [
+  'You are ARCANOS direct GPT Action execution.',
+  'Answer the caller request directly and concretely.',
+  'Do not describe internal routing, queues, tools, memory, audits, or orchestration.',
+  'Return only the final user-facing result.'
 ].join(' ');
 
 function readUsageNumber(usage: unknown, key: string): number {
@@ -142,6 +185,73 @@ function buildFastPathResult(input: {
         'queue',
         'worker_orchestration',
         'dag_planning',
+        'memory_overlay',
+        'research_overlay',
+        'audit_overlay'
+      ]
+    }
+  };
+}
+
+function buildDirectActionResult(input: {
+  outputText: string;
+  model: string;
+  requestId?: string;
+  responseId?: string | null;
+  createdAtMs: number;
+  modelLatencyMs: number;
+  totalLatencyMs: number;
+  timeoutMs: number;
+  usage: unknown;
+}): Record<string, unknown> {
+  const usage = normalizeUsage(input.usage);
+  const requestId =
+    input.requestId?.trim() ||
+    input.responseId?.trim() ||
+    `gpt-direct-action-${input.createdAtMs}`;
+
+  return {
+    result: input.outputText,
+    module: 'direct_action',
+    meta: {
+      id: requestId,
+      created: input.createdAtMs,
+      tokens: usage
+    },
+    activeModel: input.model,
+    fallbackFlag: false,
+    routingStages: [DIRECT_ACTION_ROUTING_STAGE],
+    auditSafe: {
+      mode: false,
+      overrideUsed: false,
+      auditFlags: ['DIRECT_ACTION_MINIMAL_PIPELINE'],
+      processedSafely: true
+    },
+    memoryContext: {
+      entriesAccessed: 0,
+      contextSummary: 'Bypassed for GPT direct action.',
+      memoryEnhanced: false
+    },
+    taskLineage: {
+      requestId,
+      logged: false
+    },
+    directAction: {
+      inline: true,
+      queueBypassed: true,
+      orchestrationBypassed: true,
+      modelLatencyMs: input.modelLatencyMs,
+      totalLatencyMs: input.totalLatencyMs,
+      timeoutMs: input.timeoutMs,
+      bypassedSubsystems: [
+        'queue',
+        'worker_orchestration',
+        'dag_planning',
+        'trinity_intake',
+        'trinity_reasoning',
+        'trinity_clear_audit',
+        'trinity_reflection',
+        'trinity_final',
         'memory_overlay',
         'research_overlay',
         'audit_overlay'
@@ -264,6 +374,127 @@ export async function executeFastGptPrompt(
       gptId: input.gptId,
       requestId: input.requestId,
       durationMs: Date.now() - startedAtMs,
+      timeoutMs: input.timeoutMs,
+      error: resolveErrorMessage(error)
+    });
+    throw error;
+  }
+}
+
+/**
+ * Execute a GPT Action query_and_wait request through the minimal synchronous lane.
+ * This path intentionally returns provider failures and timeout failures as errors
+ * instead of routing through Trinity's degraded/static fallback machinery.
+ */
+export async function executeDirectGptAction(
+  input: ExecuteDirectGptActionInput
+): Promise<DirectGptActionEnvelope> {
+  const startedAtMs = Date.now();
+  const { client } = getOpenAIClientOrAdapter();
+
+  if (!client) {
+    input.logger?.warn?.('gpt.direct_action.client_unavailable', {
+      gptId: input.gptId,
+      requestId: input.requestId,
+      action: input.action,
+      reason: 'openai_client_unavailable'
+    });
+    throw new Error('OpenAI client unavailable for GPT direct action.');
+  }
+
+  const model = resolveGptFastPathModel();
+  const parentSignal = input.parentSignal ?? getRequestAbortSignal();
+  let modelLatencyMs = 0;
+
+  try {
+    const { response, outputText } = await runWithRequestAbortTimeout(
+      {
+        timeoutMs: input.timeoutMs,
+        requestId: input.requestId,
+        parentSignal,
+        abortMessage: `GPT direct action timeout after ${input.timeoutMs}ms`
+      },
+      async () => {
+        const modelStartedAtMs = Date.now();
+        const activeSignal = getRequestAbortSignal() ?? parentSignal;
+        const result = await callTextResponse(
+          client,
+          {
+            model,
+            instructions: DIRECT_ACTION_SYSTEM_INSTRUCTIONS,
+            input: input.prompt,
+            store: false
+          },
+          { signal: activeSignal }
+        );
+        modelLatencyMs = Date.now() - modelStartedAtMs;
+        return result;
+      }
+    );
+    const normalizedOutputText = outputText.trim();
+    if (!normalizedOutputText) {
+      throw new Error('GPT direct action returned empty output.');
+    }
+
+    const totalLatencyMs = Date.now() - startedAtMs;
+    recordAiOperation({
+      provider: 'openai',
+      operation: 'responses.create',
+      sourceType: 'gpt_direct_action',
+      sourceName: input.gptId,
+      model,
+      outcome: 'ok',
+      durationMs: modelLatencyMs,
+      promptTokens: normalizeUsage(response.usage).prompt_tokens,
+      completionTokens: normalizeUsage(response.usage).completion_tokens,
+      totalTokens: normalizeUsage(response.usage).total_tokens
+    });
+
+    return {
+      ok: true,
+      result: buildDirectActionResult({
+        outputText: normalizedOutputText,
+        model,
+        requestId: input.requestId,
+        responseId: typeof response.id === 'string' ? response.id : null,
+        createdAtMs: Date.now(),
+        modelLatencyMs,
+        totalLatencyMs,
+        timeoutMs: input.timeoutMs,
+        usage: response.usage
+      }),
+      directAction: {
+        inline: true,
+        queueBypassed: true,
+        orchestrationBypassed: true,
+        action: input.action,
+        timeoutMs: input.timeoutMs,
+        modelLatencyMs,
+        totalLatencyMs
+      },
+      _route: {
+        ...(input.requestId ? { requestId: input.requestId } : {}),
+        gptId: input.gptId,
+        module: 'GPT:DIRECT_ACTION',
+        action: input.action,
+        route: 'direct_action',
+        timestamp: new Date().toISOString()
+      }
+    };
+  } catch (error) {
+    recordAiOperation({
+      provider: 'openai',
+      operation: 'responses.create',
+      sourceType: 'gpt_direct_action',
+      sourceName: input.gptId,
+      model,
+      outcome: 'error',
+      durationMs: modelLatencyMs
+    });
+    input.logger?.error?.('gpt.direct_action.failed', {
+      gptId: input.gptId,
+      requestId: input.requestId,
+      action: input.action,
       timeoutMs: input.timeoutMs,
       error: resolveErrorMessage(error)
     });

--- a/src/shared/gpt/gptDirectAction.ts
+++ b/src/shared/gpt/gptDirectAction.ts
@@ -1,0 +1,23 @@
+export const ARCANOS_SUPPRESS_TIMEOUT_FALLBACK_FLAG =
+  '__arcanosSuppressTimeoutFallback' as const;
+
+export function normalizeBooleanFlagValue(value: unknown): boolean {
+  if (value === true) {
+    return true;
+  }
+
+  if (value === false || value === null || value === undefined) {
+    return false;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value !== 0;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
+  }
+
+  return false;
+}

--- a/tests/arcanos-core.timeout.test.ts
+++ b/tests/arcanos-core.timeout.test.ts
@@ -238,6 +238,38 @@ describe('runArcanosCoreQuery timeout clamp', () => {
     expect(recordTraceEventMock).toHaveBeenCalledWith('core.pipeline.degraded', expect.any(Object));
   });
 
+  it('rethrows pipeline timeouts when fallback recovery is disabled', async () => {
+    process.env.ARCANOS_CORE_PIPELINE_TIMEOUT_MS = '5000';
+    const timeoutError = new Error('ARCANOS:CORE pipeline timeout after 3000ms');
+    timeoutError.name = 'AbortError';
+
+    runWithRequestAbortTimeoutMock.mockRejectedValueOnce(timeoutError);
+
+    await expect(
+      runArcanosCoreQuery({
+        client: {} as never,
+        prompt: 'Return the direct GPT Action result.',
+        sourceEndpoint: 'gpt.arcanos-core.query',
+        allowTimeoutFallback: false
+      })
+    ).rejects.toThrow('ARCANOS:CORE pipeline timeout after 3000ms');
+
+    expect(runWithRequestAbortTimeoutMock).toHaveBeenCalledTimes(1);
+    expect(runTrinityWritingPipelineMock).not.toHaveBeenCalled();
+    expect(recordTraceEventMock).toHaveBeenCalledWith(
+      'core.pipeline.timeout_fallback_suppressed',
+      expect.any(Object)
+    );
+    expect(recordTraceEventMock).not.toHaveBeenCalledWith(
+      'core.pipeline.degraded',
+      expect.any(Object)
+    );
+    expect(recordTraceEventMock).not.toHaveBeenCalledWith(
+      'core.pipeline.static_fallback',
+      expect.any(Object)
+    );
+  });
+
   it('recovers when Trinity aborts near the shared pipeline deadline before the wrapper stamps its own timeout message', async () => {
     process.env.ARCANOS_CORE_PIPELINE_TIMEOUT_MS = '5000';
     const timeoutError = new Error('Request was aborted.');

--- a/tests/gpt-async-idempotency.route.test.ts
+++ b/tests/gpt-async-idempotency.route.test.ts
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals
 
 const mockRouteGptRequest = jest.fn();
 const mockResolveGptRouting = jest.fn();
+const executeFastGptPromptMock = jest.fn();
+const executeDirectGptActionMock = jest.fn();
 const findOrCreateGptJobMock = jest.fn();
 const getJobByIdMock = jest.fn();
 const planAutonomousWorkerJobMock = jest.fn();
@@ -18,6 +20,11 @@ class MockJobRepositoryUnavailableError extends Error {}
 jest.unstable_mockModule('../src/routes/_core/gptDispatch.js', () => ({
   resolveGptRouting: mockResolveGptRouting,
   routeGptRequest: mockRouteGptRequest,
+}));
+
+jest.unstable_mockModule('../src/services/gptFastPath.js', () => ({
+  executeFastGptPrompt: executeFastGptPromptMock,
+  executeDirectGptAction: executeDirectGptActionMock,
 }));
 
 jest.unstable_mockModule('../src/platform/logging/gptLogger.js', () => ({
@@ -116,6 +123,41 @@ function buildApp() {
   return app;
 }
 
+function buildDirectActionEnvelope(result = 'OK') {
+  return {
+    ok: true,
+    result: {
+      result,
+      module: 'direct_action',
+      activeModel: 'gpt-test',
+      routingStages: ['GPT-DIRECT-ACTION'],
+      directAction: {
+        inline: true,
+        queueBypassed: true,
+        orchestrationBypassed: true,
+        timeoutMs: 24_000,
+      },
+    },
+    directAction: {
+      inline: true,
+      queueBypassed: true,
+      orchestrationBypassed: true,
+      action: 'query_and_wait',
+      timeoutMs: 24_000,
+      modelLatencyMs: 1,
+      totalLatencyMs: 2,
+    },
+    _route: {
+      requestId: 'req-direct-action',
+      gptId: 'arcanos-core',
+      module: 'GPT:DIRECT_ACTION',
+      action: 'query_and_wait',
+      route: 'direct_action',
+      timestamp: '2026-04-24T00:00:00.000Z',
+    },
+  };
+}
+
 describe('async /gpt idempotency', () => {
   const originalAsyncIdempotencyEnv = captureEnv(ASYNC_IDEMPOTENCY_ENV_KEYS);
 
@@ -126,6 +168,7 @@ describe('async /gpt idempotency', () => {
     }
     process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT = 'true';
     process.env.PRIORITY_QUEUE_ENABLED = 'false';
+    executeDirectGptActionMock.mockResolvedValue(buildDirectActionEnvelope());
     mockResolveGptRouting.mockImplementation(async (gptId: string) => ({
       ok: true,
       plan: {
@@ -1103,35 +1146,9 @@ describe('async /gpt idempotency', () => {
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
-  it('keeps query_and_wait prompt execution isolated from GPT control truncation limits', async () => {
+  it('keeps core query_and_wait prompt execution on the direct action lane', async () => {
     process.env.GPT_PUBLIC_RESPONSE_MAX_BYTES = '5000';
-    findOrCreateGptJobMock.mockResolvedValue({
-      job: {
-        id: 'job-query-and-wait-ok',
-        status: 'completed'
-      },
-      created: true,
-      deduped: false,
-      dedupeReason: 'new_job'
-    });
-    waitForQueuedGptJobCompletionMock.mockResolvedValue({
-      state: 'completed',
-      job: {
-        id: 'job-query-and-wait-ok',
-        status: 'completed',
-        output: {
-          ok: true,
-          result: 'OK',
-          _route: {
-            gptId: 'arcanos-core',
-            module: 'ARCANOS:CORE',
-            route: 'core',
-            action: 'query',
-            timestamp: '2026-04-11T10:00:03.000Z'
-          }
-        }
-      }
-    });
+    executeDirectGptActionMock.mockResolvedValueOnce(buildDirectActionEnvelope('OK'));
 
     const response = await request(buildApp())
       .post('/gpt/arcanos-core')
@@ -1144,22 +1161,39 @@ describe('async /gpt idempotency', () => {
     expect(response.headers['x-response-truncated']).toBeUndefined();
     expect(response.body).toMatchObject({
       ok: true,
-      jobId: 'job-query-and-wait-ok',
+      gptId: 'arcanos-core',
+      action: 'query_and_wait',
       status: 'completed',
-      lifecycleStatus: 'completed',
-      result: 'OK'
-    });
-    expect(response.body.meta).toBeUndefined();
-    expect(findOrCreateGptJobMock.mock.calls[0]?.[0]).toMatchObject({
-      input: {
+      result: 'OK',
+      routeDecision: {
+        path: 'fast_path',
+        reason: 'query_and_wait_direct_action',
+        queueBypassed: true,
+      },
+      directAction: {
+        inline: true,
+        queueBypassed: true,
+        orchestrationBypassed: true,
+        action: 'query_and_wait',
+      },
+      _route: {
         gptId: 'arcanos-core',
-        body: {
-          prompt: 'Reply with OK',
-          executionMode: 'async'
-        },
-        routeHint: 'query'
+        module: 'GPT:DIRECT_ACTION',
+        action: 'query_and_wait',
+        route: 'direct_action',
       }
     });
+    expect(response.body.meta).toBeUndefined();
+    expect(executeDirectGptActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gptId: 'arcanos-core',
+        prompt: 'Reply with OK',
+        action: 'query_and_wait',
+        timeoutMs: 24_000,
+      })
+    );
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
@@ -1393,13 +1427,13 @@ describe('async /gpt idempotency', () => {
     expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
   });
 
-  it('fails query_and_wait clearly when durable async jobs are unavailable instead of falling back to sync query routing', async () => {
+  it('fails non-core query_and_wait clearly when durable async jobs are unavailable instead of falling back to sync query routing', async () => {
     findOrCreateGptJobMock.mockRejectedValue(
       new MockJobRepositoryUnavailableError('jobs backend unavailable')
     );
 
     const response = await request(buildApp())
-      .post('/gpt/arcanos-core')
+      .post('/gpt/arcanos-gaming')
       .send({
         action: 'query_and_wait',
         prompt: 'Generate a Seth Rollins promo prompt'

--- a/tests/gpt-fast-path.route.test.ts
+++ b/tests/gpt-fast-path.route.test.ts
@@ -411,6 +411,51 @@ describe('GPT fast-path route branching', () => {
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
+  it('returns a traced unknown-GPT error for query_and_wait without creating jobs', async () => {
+    mockResolveGptRouting.mockResolvedValueOnce({
+      ok: false,
+      error: {
+        code: 'UNKNOWN_GPT',
+        message: "gptId 'invalid-id' is not registered",
+      },
+      _route: {
+        gptId: 'invalid-id',
+        timestamp: '2026-04-24T00:00:00.000Z',
+      },
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/invalid-id')
+      .send({
+        action: 'query_and_wait',
+        prompt: 'Analyze this deployment timeout.',
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      ok: false,
+      gptId: 'invalid-id',
+      action: 'query_and_wait',
+      route: '/gpt/:gptId',
+      code: 'UNKNOWN_GPT',
+      traceId: expect.any(String),
+      error: {
+        code: 'UNKNOWN_GPT',
+        message: "gptId 'invalid-id' is not registered",
+      },
+      _route: {
+        gptId: 'invalid-id',
+        action: 'query_and_wait',
+        route: 'routing_validation',
+        traceId: expect.any(String),
+      },
+    });
+    expect(executeDirectGptActionMock).not.toHaveBeenCalled();
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
   it('returns a typed error instead of bounded fallback when direct query_and_wait times out', async () => {
     const timeoutError = new Error('GPT direct action timeout after 24000ms');
     timeoutError.name = 'AbortError';
@@ -426,6 +471,8 @@ describe('GPT fast-path route branching', () => {
     expect(response.status).toBe(504);
     expect(response.body).toMatchObject({
       ok: false,
+      code: 'GPT_QUERY_AND_WAIT_TIMEOUT',
+      traceId: expect.any(String),
       error: {
         code: 'GPT_QUERY_AND_WAIT_TIMEOUT',
         message: 'GPT direct action timeout after 24000ms',
@@ -459,6 +506,8 @@ describe('GPT fast-path route branching', () => {
     expect(response.status).toBe(503);
     expect(response.body).toMatchObject({
       ok: false,
+      code: 'GPT_QUERY_AND_WAIT_FAILED',
+      traceId: expect.any(String),
       error: {
         code: 'GPT_QUERY_AND_WAIT_FAILED',
         message: 'OpenAI client unavailable for GPT direct action.',
@@ -487,6 +536,8 @@ describe('GPT fast-path route branching', () => {
     expect(response.status).toBe(500);
     expect(response.body).toMatchObject({
       ok: false,
+      code: 'GPT_QUERY_AND_WAIT_FAILED',
+      traceId: expect.any(String),
       error: {
         code: 'GPT_QUERY_AND_WAIT_FAILED',
         message: 'GPT direct action returned empty output.',

--- a/tests/gpt-fast-path.route.test.ts
+++ b/tests/gpt-fast-path.route.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals
 const mockRouteGptRequest = jest.fn();
 const mockResolveGptRouting = jest.fn();
 const executeFastGptPromptMock = jest.fn();
+const executeDirectGptActionMock = jest.fn();
 const findOrCreateGptJobMock = jest.fn();
 const getJobByIdMock = jest.fn();
 const planAutonomousWorkerJobMock = jest.fn();
@@ -22,6 +23,7 @@ jest.unstable_mockModule('../src/routes/_core/gptDispatch.js', () => ({
 
 jest.unstable_mockModule('../src/services/gptFastPath.js', () => ({
   executeFastGptPrompt: executeFastGptPromptMock,
+  executeDirectGptAction: executeDirectGptActionMock,
 }));
 
 jest.unstable_mockModule('../src/platform/logging/gptLogger.js', () => ({
@@ -120,6 +122,41 @@ function buildFastPathEnvelope() {
   };
 }
 
+function buildDirectActionEnvelope() {
+  return {
+    ok: true,
+    result: {
+      result: 'Direct action response.',
+      module: 'direct_action',
+      activeModel: 'gpt-test',
+      routingStages: ['GPT-DIRECT-ACTION'],
+      directAction: {
+        inline: true,
+        queueBypassed: true,
+        orchestrationBypassed: true,
+        timeoutMs: 24_000,
+      },
+    },
+    directAction: {
+      inline: true,
+      queueBypassed: true,
+      orchestrationBypassed: true,
+      action: 'query_and_wait',
+      timeoutMs: 24_000,
+      modelLatencyMs: 10,
+      totalLatencyMs: 12,
+    },
+    _route: {
+      requestId: 'req-direct-action',
+      gptId: 'arcanos-core',
+      module: 'GPT:DIRECT_ACTION',
+      action: 'query_and_wait',
+      route: 'direct_action',
+      timestamp: '2026-04-21T12:01:00.000Z',
+    },
+  };
+}
+
 const GPT_ROUTE_TEST_ENV_KEYS = [
   'GPT_ASYNC_HEAVY_PROMPT_CHARS',
   'GPT_ASYNC_HEAVY_MESSAGE_COUNT',
@@ -181,6 +218,7 @@ describe('GPT fast-path route branching', () => {
       }
     }));
     executeFastGptPromptMock.mockResolvedValue(buildFastPathEnvelope());
+    executeDirectGptActionMock.mockResolvedValue(buildDirectActionEnvelope());
     planAutonomousWorkerJobMock.mockResolvedValue({
       status: 'pending',
       retryCount: 0,
@@ -257,6 +295,208 @@ describe('GPT fast-path route branching', () => {
     );
     expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
     expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('runs core query_and_wait through the direct action lane by default', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'query_and_wait',
+        prompt: 'Analyze this deployment timeout.',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['x-gpt-route-decision']).toBe('fast_path');
+    expect(response.headers['x-gpt-route-decision-reason']).toBe('query_and_wait_direct_action');
+    expect(response.headers['x-gpt-fast-path-queue-bypassed']).toBe('true');
+    expect(response.headers['x-gpt-queue-bypassed']).toBe('true');
+    expect(response.body).toMatchObject({
+      ok: true,
+      gptId: 'arcanos-core',
+      action: 'query_and_wait',
+      status: 'completed',
+      result: 'Direct action response.',
+      routeDecision: {
+        path: 'fast_path',
+        reason: 'query_and_wait_direct_action',
+        queueBypassed: true,
+        action: 'query_and_wait',
+      },
+      directAction: {
+        inline: true,
+        queueBypassed: true,
+        orchestrationBypassed: true,
+        action: 'query_and_wait',
+      },
+      _route: {
+        gptId: 'arcanos-core',
+        module: 'GPT:DIRECT_ACTION',
+        action: 'query_and_wait',
+        route: 'direct_action',
+      },
+    });
+    expect(executeDirectGptActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gptId: 'arcanos-core',
+        prompt: 'Analyze this deployment timeout.',
+        action: 'query_and_wait',
+        timeoutMs: 24_000,
+      })
+    );
+    expect(executeFastGptPromptMock).not.toHaveBeenCalled();
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(waitForQueuedGptJobCompletionMock).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('recognizes query_and_wait supplied as a request query parameter', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core?action=query_and_wait')
+      .send({
+        prompt: 'Analyze this deployment timeout.',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['x-gpt-route-decision']).toBe('fast_path');
+    expect(response.headers['x-gpt-route-decision-reason']).toBe('query_and_wait_direct_action');
+    expect(response.body).toMatchObject({
+      ok: true,
+      gptId: 'arcanos-core',
+      action: 'query_and_wait',
+      status: 'completed',
+      _route: {
+        module: 'GPT:DIRECT_ACTION',
+        action: 'query_and_wait',
+        route: 'direct_action',
+      },
+    });
+    expect(executeDirectGptActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gptId: 'arcanos-core',
+        prompt: 'Analyze this deployment timeout.',
+        action: 'query_and_wait',
+      })
+    );
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('recognizes operation-style query_and_wait action aliases', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        operationId: 'requestQueryAndWait',
+        prompt: 'Analyze this deployment timeout.',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['x-gpt-route-decision-reason']).toBe('query_and_wait_direct_action');
+    expect(response.body).toMatchObject({
+      ok: true,
+      action: 'query_and_wait',
+      _route: {
+        module: 'GPT:DIRECT_ACTION',
+        action: 'query_and_wait',
+        route: 'direct_action',
+      },
+    });
+    expect(executeDirectGptActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: 'Analyze this deployment timeout.',
+        action: 'query_and_wait',
+      })
+    );
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns a typed error instead of bounded fallback when direct query_and_wait times out', async () => {
+    const timeoutError = new Error('GPT direct action timeout after 24000ms');
+    timeoutError.name = 'AbortError';
+    executeDirectGptActionMock.mockRejectedValueOnce(timeoutError);
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'query_and_wait',
+        prompt: 'Analyze this deployment timeout.',
+      });
+
+    expect(response.status).toBe(504);
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'GPT_QUERY_AND_WAIT_TIMEOUT',
+        message: 'GPT direct action timeout after 24000ms',
+      },
+      routeDecision: {
+        reason: 'query_and_wait_direct_action',
+      },
+      _route: {
+        gptId: 'arcanos-core',
+        action: 'query_and_wait',
+        route: 'query_and_wait_direct',
+      },
+    });
+    expect(JSON.stringify(response.body)).not.toContain('bounded fallback response');
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns service unavailable when the direct action client is unavailable', async () => {
+    executeDirectGptActionMock.mockRejectedValueOnce(
+      new Error('OpenAI client unavailable for GPT direct action.')
+    );
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'query_and_wait',
+        prompt: 'Analyze this deployment timeout.',
+      });
+
+    expect(response.status).toBe(503);
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'GPT_QUERY_AND_WAIT_FAILED',
+        message: 'OpenAI client unavailable for GPT direct action.',
+      },
+      _route: {
+        action: 'query_and_wait',
+        route: 'query_and_wait_direct',
+      },
+    });
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns internal error when direct action execution produces no output', async () => {
+    executeDirectGptActionMock.mockRejectedValueOnce(
+      new Error('GPT direct action returned empty output.')
+    );
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'query_and_wait',
+        prompt: 'Analyze this deployment timeout.',
+      });
+
+    expect(response.status).toBe(500);
+    expect(response.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'GPT_QUERY_AND_WAIT_FAILED',
+        message: 'GPT direct action returned empty output.',
+      },
+      _route: {
+        action: 'query_and_wait',
+        route: 'query_and_wait_direct',
+      },
+    });
+    expect(findOrCreateGptJobMock).not.toHaveBeenCalled();
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 

--- a/tests/gpt-fast-path.service.test.ts
+++ b/tests/gpt-fast-path.service.test.ts
@@ -21,7 +21,7 @@ jest.unstable_mockModule('../src/platform/observability/appMetrics.js', () => ({
   recordAiOperation: recordAiOperationMock,
 }));
 
-const { executeFastGptPrompt } = await import('../src/services/gptFastPath.js');
+const { executeDirectGptAction, executeFastGptPrompt } = await import('../src/services/gptFastPath.js');
 
 function buildDecision(timeoutMs = 8_000) {
   return {
@@ -99,5 +99,58 @@ describe('executeFastGptPrompt', () => {
       expect.anything()
     );
     expect(result.result.activeModel).toBe('gpt-fast-override');
+  });
+
+  it('executes query_and_wait through the generic direct action instructions', async () => {
+    process.env.GPT_FAST_PATH_MODEL = 'gpt-direct-test';
+
+    const result = await executeDirectGptAction({
+      gptId: 'arcanos-core',
+      prompt: 'Summarize deployment health.',
+      action: 'query_and_wait',
+      timeoutMs: 24_000,
+      requestId: 'req-direct-action',
+    });
+
+    expect(callTextResponseMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        model: 'gpt-direct-test',
+        input: 'Summarize deployment health.',
+        store: false,
+        instructions: expect.stringContaining('direct GPT Action execution'),
+      }),
+      expect.anything()
+    );
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        result: 'Generated prompt text',
+        module: 'direct_action',
+        activeModel: 'gpt-direct-test',
+        fallbackFlag: false,
+        routingStages: ['GPT-DIRECT-ACTION'],
+      },
+      directAction: {
+        inline: true,
+        queueBypassed: true,
+        orchestrationBypassed: true,
+        action: 'query_and_wait',
+        timeoutMs: 24_000,
+      },
+      _route: {
+        gptId: 'arcanos-core',
+        module: 'GPT:DIRECT_ACTION',
+        action: 'query_and_wait',
+        route: 'direct_action',
+      },
+    });
+    expect(recordAiOperationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceType: 'gpt_direct_action',
+        model: 'gpt-direct-test',
+        outcome: 'ok',
+      })
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Route core `query_and_wait` GPT Action calls through a synchronous direct action lane instead of async job planning or full `ARCANOS:CORE` orchestration.
- Suppress bounded/static timeout fallback behavior for direct GPT Action execution and return typed timeout/failure errors instead.
- Recognize generated-client action shapes including `?action=query_and_wait` and `operationId: "requestQueryAndWait"` so live GPT Action metadata does not fall through as a default `query`.
- Update OpenAPI/docs and add focused route/service/core timeout regression coverage.

## Root Cause

The direct lane only triggered when the router saw a canonical body `action: "query_and_wait"`. Some live GPT Action calls can put operation metadata outside that body field, so the route normalized the request as a default `query` and dispatched to `ARCANOS:CORE`.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('contracts/custom_gpt_route.openapi.v1.json','utf8')); console.log('contract json ok')"`
- `npm run type-check`
- `npm test -- --runTestsByPath tests/gpt-fast-path.route.test.ts tests/gpt-fast-path.service.test.ts tests/arcanos-core.timeout.test.ts tests/gpt-async-idempotency.route.test.ts --coverage=false`
- `npm test -- --runTestsByPath tests/gpt-router-universal-dispatch.test.ts tests/introspection-openapi-contract.route.test.ts tests/runtime-diagnostics.route.test.ts --coverage=false`
- `git diff --check` clean except CRLF warnings
- Commit hook `guard:commit` and `sync:check` passed during commit