### PR TITLE
[codex] add control-plane deep diagnostics

### DIFF
--- a/src/routes/api-control-plane.ts
+++ b/src/routes/api-control-plane.ts
@@ -5,7 +5,9 @@ import { asyncHandler } from '@shared/http/index.js';
 import { confirmGate } from '@transport/http/middleware/confirmGate.js';
 import {
   executeControlPlaneOperation,
+  getControlPlaneDeepDiagnostics,
   listControlPlaneAllowlist,
+  redactControlPlaneDeepDiagnosticsResponse,
 } from '@services/controlPlane/index.js';
 
 const router = express.Router();
@@ -43,6 +45,14 @@ router.get(
       ok: true,
       operations: listControlPlaneAllowlist(),
     });
+  }
+);
+
+router.get(
+  '/deep-diagnostics',
+  (_req: Request, res: Response) => {
+    res.setHeader('Cache-Control', 'no-store');
+    res.json(redactControlPlaneDeepDiagnosticsResponse(getControlPlaneDeepDiagnostics()));
   }
 );
 

--- a/src/routes/api-control-plane.ts
+++ b/src/routes/api-control-plane.ts
@@ -7,7 +7,6 @@ import {
   executeControlPlaneOperation,
   getControlPlaneDeepDiagnostics,
   listControlPlaneAllowlist,
-  redactControlPlaneDeepDiagnosticsResponse,
 } from '@services/controlPlane/index.js';
 
 const router = express.Router();
@@ -52,7 +51,7 @@ router.get(
   '/deep-diagnostics',
   (_req: Request, res: Response) => {
     res.setHeader('Cache-Control', 'no-store');
-    res.json(redactControlPlaneDeepDiagnosticsResponse(getControlPlaneDeepDiagnostics()));
+    res.json(getControlPlaneDeepDiagnostics());
   }
 );
 

--- a/src/services/controlPlane/deepDiagnostics.ts
+++ b/src/services/controlPlane/deepDiagnostics.ts
@@ -42,6 +42,16 @@ const TEST_COMMANDS = [
   'node scripts/run-jest.mjs --runTestsByPath tests/control-plane-deep-diagnostics.test.ts tests/control-plane-api.test.ts --coverage=false --runInBand',
 ] as const;
 
+const IS_REDACTION_ENABLED = ((): boolean => {
+  const redacted = redactSensitive({
+    authorization: `Bearer ${'a'.repeat(24)}`,
+    nested: {
+      token: `sk-${'b'.repeat(24)}`,
+    },
+  });
+  return JSON.stringify(redacted).includes('[REDACTED]');
+})();
+
 type DeepDiagnosticsRouteStatus = 'TRINITY_CONFIRMED' | 'DIRECT_FAST_PATH' | 'UNKNOWN_ROUTE';
 
 export interface ControlPlaneDeepDiagnosticsResponse {
@@ -147,20 +157,15 @@ function summarizeCliWrapper(provider: CliProvider) {
   return {
     implemented: allowlistEntries.length > 0 || legacyEntries.length > 0,
     allowlistEnabled: allowlistEntries.length > 0 || legacyEntries.length > 0,
-    restrictedCommandsRequireApproval: restrictedEntries.every((entry) => entry.requiresApproval),
+    restrictedCommandsRequireApproval: restrictedEntries.length > 0
+      && restrictedEntries.every((entry) => entry.requiresApproval),
     readOnlyOperations,
     restrictedOperations,
   };
 }
 
 function hasRedactionEnabled(): boolean {
-  const redacted = redactSensitive({
-    authorization: `Bearer ${'a'.repeat(24)}`,
-    nested: {
-      token: `sk-${'b'.repeat(24)}`,
-    },
-  });
-  return JSON.stringify(redacted).includes('[REDACTED]');
+  return IS_REDACTION_ENABLED;
 }
 
 export function redactControlPlaneDeepDiagnosticsResponse(payload: unknown): unknown {

--- a/src/services/controlPlane/deepDiagnostics.ts
+++ b/src/services/controlPlane/deepDiagnostics.ts
@@ -9,13 +9,7 @@ import { sanitizeControlPlaneAuditEvent } from './audit.js';
 import { ARCANOS_CORE_GPT_ID, findControlPlaneGptPolicy } from './gptPolicy.js';
 import { verifyControlPlaneRouteMetadata } from './routeVerification.js';
 import { controlPlaneInvokeRequestSchema } from './schema.js';
-
-let controlPlaneServiceModulePromise: Promise<typeof import('./service.js')> | undefined;
-
-async function loadControlPlaneServiceModule(): Promise<typeof import('./service.js')> {
-  controlPlaneServiceModulePromise ??= import('./service.js');
-  return controlPlaneServiceModulePromise;
-}
+import { getControlPlaneCapabilities } from './service.js';
 
 const GPT_POLICY_PATH = 'src/services/controlPlane/gptPolicy.ts';
 const ROUTE_VERIFICATION_PATH = 'src/services/controlPlane/routeVerification.ts';

--- a/src/services/controlPlane/deepDiagnostics.ts
+++ b/src/services/controlPlane/deepDiagnostics.ts
@@ -1,0 +1,249 @@
+import { redactSensitive } from '@shared/redaction.js';
+
+import {
+  ALLOWED_MCP_READ_TOOLS,
+  CONTROL_PLANE_OPERATION_ALLOWLIST,
+  listControlPlaneAllowlist,
+} from './allowlist.js';
+import { sanitizeControlPlaneAuditEvent } from './audit.js';
+import { ARCANOS_CORE_GPT_ID, findControlPlaneGptPolicy } from './gptPolicy.js';
+import { verifyControlPlaneRouteMetadata } from './routeVerification.js';
+import { controlPlaneInvokeRequestSchema } from './schema.js';
+import { getControlPlaneCapabilities } from './service.js';
+
+const GPT_POLICY_PATH = 'src/services/controlPlane/gptPolicy.ts';
+const ROUTE_VERIFICATION_PATH = 'src/services/controlPlane/routeVerification.ts';
+const AUDIT_PATH = 'src/services/controlPlane/audit.ts';
+
+const TRINITY_ROUTE_METADATA_FIELDS = [
+  '_route',
+  'routeDecision',
+  'directAction',
+  'pipeline',
+  'routingStages',
+  'outputControls.sourceEndpoint',
+  'pipelineDebug',
+  'gpt5Used',
+  'activeModel',
+] as const;
+
+const KNOWN_TEST_FILES = [
+  'tests/control-plane-gpt-policy.test.ts',
+  'tests/control-plane-route-verification.test.ts',
+  'tests/control-plane-executor.test.ts',
+  'tests/control-plane.service.test.ts',
+  'tests/control-plane.route.test.ts',
+  'tests/control-plane-api.test.ts',
+  'tests/mcp-control-plane-tools.test.ts',
+  'tests/structured-logging-sanitization.test.ts',
+] as const;
+
+const TEST_COMMANDS = [
+  'node scripts/run-jest.mjs --runTestsByPath tests/control-plane-deep-diagnostics.test.ts tests/control-plane-api.test.ts --coverage=false --runInBand',
+] as const;
+
+type DeepDiagnosticsRouteStatus = 'TRINITY_CONFIRMED' | 'DIRECT_FAST_PATH' | 'UNKNOWN_ROUTE';
+
+export interface ControlPlaneDeepDiagnosticsResponse {
+  ok: true;
+  gptWhitelist: {
+    enabled: boolean;
+    containsArcanosCore: boolean;
+    policyPath: string;
+    gptId: string;
+    allowedWorkflows: string[];
+    deniedCapabilities: string[];
+  };
+  trinityRouting: {
+    implemented: boolean;
+    requestable: boolean;
+    lastRouteStatus: DeepDiagnosticsRouteStatus;
+    metadataFields: string[];
+    verificationPath: string;
+  };
+  railwayCliWrapper: {
+    implemented: boolean;
+    allowlistEnabled: boolean;
+    restrictedCommandsRequireApproval: boolean;
+    readOnlyOperations: string[];
+    restrictedOperations: string[];
+  };
+  arcanosCliWrapper: {
+    implemented: boolean;
+    allowlistEnabled: boolean;
+    restrictedCommandsRequireApproval: boolean;
+    readOnlyOperations: string[];
+    restrictedOperations: string[];
+  };
+  mcpPolicy: {
+    implemented: boolean;
+    documentedToolsOnly: boolean;
+    schemaValidationEnabled: boolean;
+    registeredTools: string[];
+  };
+  approvalGates: {
+    implemented: boolean;
+    protectedActions: string[];
+  };
+  auditLogging: {
+    implemented: boolean;
+    secretRedactionEnabled: boolean;
+    auditPath: string;
+  };
+  tests: {
+    present: boolean;
+    commands: string[];
+    knownTestFiles: string[];
+  };
+}
+
+type CliProvider = 'railway-cli' | 'arcanos-cli';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return Array.from(new Set(values)).sort();
+}
+
+function legacyOperationName(adapter: string, operation: string): string {
+  const prefix = adapter === 'railway-cli'
+    ? 'railway'
+    : adapter === 'arcanos-cli'
+      ? 'arcanos'
+      : 'mcp';
+  return `${prefix}.${operation}`;
+}
+
+function summarizeCliWrapper(provider: CliProvider) {
+  const allowlistEntries = listControlPlaneAllowlist().filter((entry) => entry.provider === provider);
+  const legacyEntries = getControlPlaneCapabilities().operations.filter((entry) => entry.adapter === provider);
+
+  const readOnlyOperations = uniqueSorted([
+    ...allowlistEntries
+      .filter((entry) => entry.readOnly)
+      .map((entry) => entry.operation),
+    ...legacyEntries
+      .filter((entry) => !entry.requiresApproval)
+      .map((entry) => legacyOperationName(provider, entry.operation)),
+  ]);
+  const restrictedEntries = [
+    ...allowlistEntries
+      .filter((entry) => !entry.readOnly || entry.approvalRequired)
+      .map((entry) => ({
+        operation: entry.operation,
+        requiresApproval: entry.approvalRequired || !entry.readOnly,
+      })),
+    ...legacyEntries
+      .filter((entry) => entry.requiresApproval)
+      .map((entry) => ({
+        operation: legacyOperationName(provider, entry.operation),
+        requiresApproval: entry.requiresApproval,
+      })),
+  ];
+  const restrictedOperations = uniqueSorted(restrictedEntries.map((entry) => entry.operation));
+
+  return {
+    implemented: allowlistEntries.length > 0 || legacyEntries.length > 0,
+    allowlistEnabled: allowlistEntries.length > 0 || legacyEntries.length > 0,
+    restrictedCommandsRequireApproval: restrictedEntries.every((entry) => entry.requiresApproval),
+    readOnlyOperations,
+    restrictedOperations,
+  };
+}
+
+function hasRedactionEnabled(): boolean {
+  const redacted = redactSensitive({
+    authorization: `Bearer ${'a'.repeat(24)}`,
+    nested: {
+      token: `sk-${'b'.repeat(24)}`,
+    },
+  });
+  return JSON.stringify(redacted).includes('[REDACTED]');
+}
+
+export function redactControlPlaneDeepDiagnosticsResponse(payload: unknown): unknown {
+  const redacted = redactSensitive(payload);
+  if (!isRecord(payload) || !isRecord(redacted)) {
+    return redacted;
+  }
+
+  const sourceAuditLogging = isRecord(payload.auditLogging) ? payload.auditLogging : null;
+  const redactedAuditLogging = isRecord(redacted.auditLogging) ? redacted.auditLogging : null;
+  if (
+    sourceAuditLogging
+    && redactedAuditLogging
+    && typeof sourceAuditLogging.secretRedactionEnabled === 'boolean'
+  ) {
+    redactedAuditLogging.secretRedactionEnabled = sourceAuditLogging.secretRedactionEnabled;
+  }
+
+  return redacted;
+}
+
+export function getControlPlaneDeepDiagnostics(): ControlPlaneDeepDiagnosticsResponse {
+  const policy = findControlPlaneGptPolicy(ARCANOS_CORE_GPT_ID);
+  const allowlist = listControlPlaneAllowlist();
+  const routeRequestSpec = CONTROL_PLANE_OPERATION_ALLOWLIST.find(
+    (entry) => entry.operation === 'control-plane.route.trinity.request'
+      && entry.provider === 'backend-api'
+      && entry.readOnly
+  );
+  const mcpEntries = allowlist.filter((entry) => entry.provider === 'arcanos-mcp');
+  const protectedActions = uniqueSorted([
+    ...(policy?.requiresApprovalFor ?? []),
+    ...allowlist
+      .filter((entry) => entry.approvalRequired || !entry.readOnly)
+      .map((entry) => entry.operation),
+    ...getControlPlaneCapabilities().operations
+      .filter((entry) => entry.requiresApproval)
+      .map((entry) => legacyOperationName(entry.adapter, entry.operation)),
+  ]);
+  const response: ControlPlaneDeepDiagnosticsResponse = {
+    ok: true,
+    gptWhitelist: {
+      enabled: policy?.enabled === true,
+      containsArcanosCore: policy?.gptId === ARCANOS_CORE_GPT_ID,
+      policyPath: GPT_POLICY_PATH,
+      gptId: ARCANOS_CORE_GPT_ID,
+      allowedWorkflows: [...(policy?.allowedWorkflows ?? [])],
+      deniedCapabilities: [...(policy?.deniedCapabilities ?? [])],
+    },
+    trinityRouting: {
+      implemented: typeof verifyControlPlaneRouteMetadata === 'function',
+      requestable: Boolean(routeRequestSpec),
+      lastRouteStatus: 'UNKNOWN_ROUTE',
+      metadataFields: [...TRINITY_ROUTE_METADATA_FIELDS],
+      verificationPath: ROUTE_VERIFICATION_PATH,
+    },
+    railwayCliWrapper: summarizeCliWrapper('railway-cli'),
+    arcanosCliWrapper: summarizeCliWrapper('arcanos-cli'),
+    mcpPolicy: {
+      implemented: mcpEntries.length > 0,
+      documentedToolsOnly: ALLOWED_MCP_READ_TOOLS.size > 0
+        && mcpEntries.every((entry) => entry.readOnly),
+      schemaValidationEnabled: typeof controlPlaneInvokeRequestSchema.safeParse === 'function',
+      registeredTools: uniqueSorted([
+        'control_plane.invoke',
+        ...ALLOWED_MCP_READ_TOOLS,
+      ]),
+    },
+    approvalGates: {
+      implemented: protectedActions.length > 0,
+      protectedActions,
+    },
+    auditLogging: {
+      implemented: typeof sanitizeControlPlaneAuditEvent === 'function',
+      secretRedactionEnabled: policy?.requiresSecretRedaction === true && hasRedactionEnabled(),
+      auditPath: AUDIT_PATH,
+    },
+    tests: {
+      present: KNOWN_TEST_FILES.length > 0,
+      commands: [...TEST_COMMANDS],
+      knownTestFiles: [...KNOWN_TEST_FILES],
+    },
+  };
+
+  return redactControlPlaneDeepDiagnosticsResponse(response) as ControlPlaneDeepDiagnosticsResponse;
+}

--- a/src/services/controlPlane/deepDiagnostics.ts
+++ b/src/services/controlPlane/deepDiagnostics.ts
@@ -100,6 +100,16 @@ export interface ControlPlaneDeepDiagnosticsResponse {
     secretRedactionEnabled: boolean;
     auditPath: string;
   };
+  safetyFlags: {
+    readOnly: true;
+    executesCli: false;
+    callsOpenAI: false;
+    mutatesState: false;
+    createsJobs: false;
+    deploys: false;
+    invokesMcpTools: false;
+    routesThroughWritingPipeline: false;
+  };
   tests: {
     present: boolean;
     commands: string[];
@@ -107,7 +117,27 @@ export interface ControlPlaneDeepDiagnosticsResponse {
   };
 }
 
-type CliProvider = 'railway-cli' | 'arcanos-cli';
+export type ControlPlaneCliProvider = 'railway-cli' | 'arcanos-cli';
+
+export interface ControlPlaneCliWrapperSource {
+  operation: string;
+  readOnly: boolean;
+  approvalRequired: boolean;
+}
+
+export interface ControlPlaneLegacyCliWrapperSource {
+  adapter: string;
+  operation: string;
+  requiresApproval: boolean;
+}
+
+export interface ControlPlaneCliWrapperSummary {
+  implemented: boolean;
+  allowlistEnabled: boolean;
+  restrictedCommandsRequireApproval: boolean;
+  readOnlyOperations: string[];
+  restrictedOperations: string[];
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -126,42 +156,51 @@ function legacyOperationName(adapter: string, operation: string): string {
   return `${prefix}.${operation}`;
 }
 
-function summarizeCliWrapper(provider: CliProvider) {
-  const allowlistEntries = listControlPlaneAllowlist().filter((entry) => entry.provider === provider);
-  const legacyEntries = getControlPlaneCapabilities().operations.filter((entry) => entry.adapter === provider);
-
+export function buildControlPlaneCliWrapperSummary(params: {
+  provider: ControlPlaneCliProvider;
+  allowlistEntries: readonly ControlPlaneCliWrapperSource[];
+  legacyEntries: readonly ControlPlaneLegacyCliWrapperSource[];
+}): ControlPlaneCliWrapperSummary {
   const readOnlyOperations = uniqueSorted([
-    ...allowlistEntries
+    ...params.allowlistEntries
       .filter((entry) => entry.readOnly)
       .map((entry) => entry.operation),
-    ...legacyEntries
+    ...params.legacyEntries
       .filter((entry) => !entry.requiresApproval)
-      .map((entry) => legacyOperationName(provider, entry.operation)),
+      .map((entry) => legacyOperationName(params.provider, entry.operation)),
   ]);
   const restrictedEntries = [
-    ...allowlistEntries
+    ...params.allowlistEntries
       .filter((entry) => !entry.readOnly || entry.approvalRequired)
       .map((entry) => ({
         operation: entry.operation,
         requiresApproval: entry.approvalRequired || !entry.readOnly,
       })),
-    ...legacyEntries
+    ...params.legacyEntries
       .filter((entry) => entry.requiresApproval)
       .map((entry) => ({
-        operation: legacyOperationName(provider, entry.operation),
+        operation: legacyOperationName(params.provider, entry.operation),
         requiresApproval: entry.requiresApproval,
       })),
   ];
   const restrictedOperations = uniqueSorted(restrictedEntries.map((entry) => entry.operation));
 
   return {
-    implemented: allowlistEntries.length > 0 || legacyEntries.length > 0,
-    allowlistEnabled: allowlistEntries.length > 0 || legacyEntries.length > 0,
+    implemented: params.allowlistEntries.length > 0 || params.legacyEntries.length > 0,
+    allowlistEnabled: params.allowlistEntries.length > 0 || params.legacyEntries.length > 0,
     restrictedCommandsRequireApproval: restrictedEntries.length > 0
       && restrictedEntries.every((entry) => entry.requiresApproval),
     readOnlyOperations,
     restrictedOperations,
   };
+}
+
+function summarizeCliWrapper(provider: ControlPlaneCliProvider): ControlPlaneCliWrapperSummary {
+  return buildControlPlaneCliWrapperSummary({
+    provider,
+    allowlistEntries: listControlPlaneAllowlist().filter((entry) => entry.provider === provider),
+    legacyEntries: getControlPlaneCapabilities().operations.filter((entry) => entry.adapter === provider),
+  });
 }
 
 function hasRedactionEnabled(): boolean {
@@ -242,6 +281,16 @@ export function getControlPlaneDeepDiagnostics(): ControlPlaneDeepDiagnosticsRes
       implemented: typeof sanitizeControlPlaneAuditEvent === 'function',
       secretRedactionEnabled: policy?.requiresSecretRedaction === true && hasRedactionEnabled(),
       auditPath: AUDIT_PATH,
+    },
+    safetyFlags: {
+      readOnly: true,
+      executesCli: false,
+      callsOpenAI: false,
+      mutatesState: false,
+      createsJobs: false,
+      deploys: false,
+      invokesMcpTools: false,
+      routesThroughWritingPipeline: false,
     },
     tests: {
       present: KNOWN_TEST_FILES.length > 0,

--- a/src/services/controlPlane/deepDiagnostics.ts
+++ b/src/services/controlPlane/deepDiagnostics.ts
@@ -9,7 +9,13 @@ import { sanitizeControlPlaneAuditEvent } from './audit.js';
 import { ARCANOS_CORE_GPT_ID, findControlPlaneGptPolicy } from './gptPolicy.js';
 import { verifyControlPlaneRouteMetadata } from './routeVerification.js';
 import { controlPlaneInvokeRequestSchema } from './schema.js';
-import { getControlPlaneCapabilities } from './service.js';
+
+let controlPlaneServiceModulePromise: Promise<typeof import('./service.js')> | undefined;
+
+async function loadControlPlaneServiceModule(): Promise<typeof import('./service.js')> {
+  controlPlaneServiceModulePromise ??= import('./service.js');
+  return controlPlaneServiceModulePromise;
+}
 
 const GPT_POLICY_PATH = 'src/services/controlPlane/gptPolicy.ts';
 const ROUTE_VERIFICATION_PATH = 'src/services/controlPlane/routeVerification.ts';

--- a/src/services/controlPlane/index.ts
+++ b/src/services/controlPlane/index.ts
@@ -13,6 +13,11 @@ export {
   executeControlPlaneOperation,
 } from './executor.js';
 export {
+  getControlPlaneDeepDiagnostics,
+  redactControlPlaneDeepDiagnosticsResponse,
+  type ControlPlaneDeepDiagnosticsResponse,
+} from './deepDiagnostics.js';
+export {
   ARCANOS_CORE_CONTROL_PLANE_POLICY,
   ARCANOS_CORE_GPT_ID,
   DEFAULT_CONTROL_PLANE_GPT_POLICIES,

--- a/tests/control-plane-api.test.ts
+++ b/tests/control-plane-api.test.ts
@@ -91,6 +91,16 @@ function buildDeepDiagnosticsResponse(overrides: Record<string, unknown> = {}) {
       secretRedactionEnabled: true,
       auditPath: 'src/services/controlPlane/audit.ts',
     },
+    safetyFlags: {
+      readOnly: true,
+      executesCli: false,
+      callsOpenAI: false,
+      mutatesState: false,
+      createsJobs: false,
+      deploys: false,
+      invokesMcpTools: false,
+      routesThroughWritingPipeline: false,
+    },
     tests: {
       present: true,
       commands: ['node scripts/run-jest.mjs --runTestsByPath tests/control-plane-deep-diagnostics.test.ts'],
@@ -171,6 +181,16 @@ describe('api-control-plane route', () => {
       auditLogging: expect.objectContaining({
         secretRedactionEnabled: true,
       }),
+      safetyFlags: {
+        readOnly: true,
+        executesCli: false,
+        callsOpenAI: false,
+        mutatesState: false,
+        createsJobs: false,
+        deploys: false,
+        invokesMcpTools: false,
+        routesThroughWritingPipeline: false,
+      },
     }));
     expect(JSON.stringify(response.body)).not.toContain('sk-');
     expect(JSON.stringify(response.body)).not.toContain('Bearer ');
@@ -181,6 +201,18 @@ describe('api-control-plane route', () => {
     expect(mockGetControlPlaneDeepDiagnostics).toHaveBeenCalledTimes(1);
     expect(mockExecuteControlPlaneOperation).not.toHaveBeenCalled();
   });
+
+  it.each(['post', 'put', 'patch', 'delete'] as const)(
+    'does not route %s requests to deep diagnostics',
+    async (method) => {
+      const response = await request(buildApp())[method]('/api/control-plane/deep-diagnostics')
+        .send({ action: 'mutate' });
+
+      expect(response.status).toBe(404);
+      expect(mockGetControlPlaneDeepDiagnostics).not.toHaveBeenCalled();
+      expect(mockExecuteControlPlaneOperation).not.toHaveBeenCalled();
+    }
+  );
 
   it.each([
     ['success', buildControlPlaneResponse(), 200],

--- a/tests/control-plane-api.test.ts
+++ b/tests/control-plane-api.test.ts
@@ -1,11 +1,28 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const mockExecuteControlPlaneOperation = jest.fn();
+const mockGetControlPlaneDeepDiagnostics = jest.fn();
 const mockListControlPlaneAllowlist = jest.fn();
 
 jest.unstable_mockModule('@services/controlPlane/index.js', () => ({
   executeControlPlaneOperation: mockExecuteControlPlaneOperation,
+  getControlPlaneDeepDiagnostics: mockGetControlPlaneDeepDiagnostics,
   listControlPlaneAllowlist: mockListControlPlaneAllowlist,
+  redactControlPlaneDeepDiagnosticsResponse: (payload: unknown) => {
+    const sanitize = (value: unknown): unknown => {
+      if (Array.isArray(value)) {
+        return value.map(sanitize);
+      }
+      if (value && typeof value === 'object') {
+        return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+          key,
+          key === 'token' || key === 'authorization' ? '[REDACTED]' : sanitize(item),
+        ]));
+      }
+      return typeof value === 'string' && /^(sk-|Bearer )/.test(value) ? '[REDACTED]' : value;
+    };
+    return sanitize(payload);
+  },
 }));
 
 jest.unstable_mockModule('@transport/http/middleware/confirmGate.js', () => ({
@@ -42,6 +59,62 @@ function buildControlPlaneResponse(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function buildDeepDiagnosticsResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    gptWhitelist: {
+      enabled: true,
+      containsArcanosCore: true,
+      policyPath: 'src/services/controlPlane/gptPolicy.ts',
+      gptId: 'arcanos-core',
+      allowedWorkflows: ['control_plane.route.verify'],
+      deniedCapabilities: ['secrets.read.raw'],
+    },
+    trinityRouting: {
+      implemented: true,
+      requestable: true,
+      lastRouteStatus: 'UNKNOWN_ROUTE',
+      metadataFields: ['_route', 'routingStages'],
+      verificationPath: 'src/services/controlPlane/routeVerification.ts',
+    },
+    railwayCliWrapper: {
+      implemented: true,
+      allowlistEnabled: true,
+      restrictedCommandsRequireApproval: true,
+      readOnlyOperations: ['railway.status'],
+      restrictedOperations: ['railway.deploy'],
+    },
+    arcanosCliWrapper: {
+      implemented: true,
+      allowlistEnabled: true,
+      restrictedCommandsRequireApproval: true,
+      readOnlyOperations: ['arcanos.status'],
+      restrictedOperations: [],
+    },
+    mcpPolicy: {
+      implemented: true,
+      documentedToolsOnly: true,
+      schemaValidationEnabled: true,
+      registeredTools: ['control_plane.invoke', 'agents.list'],
+    },
+    approvalGates: {
+      implemented: true,
+      protectedActions: ['deploy', 'secret_change'],
+    },
+    auditLogging: {
+      implemented: true,
+      secretRedactionEnabled: true,
+      auditPath: 'src/services/controlPlane/audit.ts',
+    },
+    tests: {
+      present: true,
+      commands: ['node scripts/run-jest.mjs --runTestsByPath tests/control-plane-deep-diagnostics.test.ts'],
+      knownTestFiles: ['tests/control-plane-deep-diagnostics.test.ts'],
+    },
+    ...overrides,
+  };
+}
+
 describe('api-control-plane route', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -54,6 +127,7 @@ describe('api-control-plane route', () => {
         approvalRequired: false,
       },
     ]);
+    mockGetControlPlaneDeepDiagnostics.mockReturnValue(buildDeepDiagnosticsResponse());
   });
 
   it('returns the allowlist without exposing execution output', async () => {
@@ -72,6 +146,54 @@ describe('api-control-plane route', () => {
         }),
       ],
     });
+    expect(mockExecuteControlPlaneOperation).not.toHaveBeenCalled();
+  });
+
+  it('returns deep diagnostics as a redacted read-only no-store response', async () => {
+    mockGetControlPlaneDeepDiagnostics.mockReturnValue(buildDeepDiagnosticsResponse({
+      debug: {
+        token: `sk-${'a'.repeat(24)}`,
+        authorization: `Bearer ${'b'.repeat(24)}`,
+      },
+    }));
+
+    const response = await request(buildApp()).get('/api/control-plane/deep-diagnostics');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['cache-control']).toBe('no-store');
+    expect(response.body).toEqual(expect.objectContaining({
+      ok: true,
+      gptWhitelist: expect.objectContaining({
+        containsArcanosCore: true,
+        gptId: 'arcanos-core',
+      }),
+      trinityRouting: expect.objectContaining({
+        lastRouteStatus: 'UNKNOWN_ROUTE',
+      }),
+      railwayCliWrapper: expect.objectContaining({
+        readOnlyOperations: expect.arrayContaining(['railway.status']),
+        restrictedOperations: expect.arrayContaining(['railway.deploy']),
+      }),
+      arcanosCliWrapper: expect.objectContaining({
+        readOnlyOperations: expect.arrayContaining(['arcanos.status']),
+      }),
+      mcpPolicy: expect.objectContaining({
+        registeredTools: expect.arrayContaining(['control_plane.invoke']),
+      }),
+      approvalGates: expect.objectContaining({
+        protectedActions: expect.arrayContaining(['deploy']),
+      }),
+      auditLogging: expect.objectContaining({
+        secretRedactionEnabled: true,
+      }),
+    }));
+    expect(JSON.stringify(response.body)).not.toContain('sk-');
+    expect(JSON.stringify(response.body)).not.toContain('Bearer ');
+    expect(response.body.debug).toEqual({
+      token: '[REDACTED]',
+      authorization: '[REDACTED]',
+    });
+    expect(mockGetControlPlaneDeepDiagnostics).toHaveBeenCalledTimes(1);
     expect(mockExecuteControlPlaneOperation).not.toHaveBeenCalled();
   });
 

--- a/tests/control-plane-api.test.ts
+++ b/tests/control-plane-api.test.ts
@@ -8,21 +8,6 @@ jest.unstable_mockModule('@services/controlPlane/index.js', () => ({
   executeControlPlaneOperation: mockExecuteControlPlaneOperation,
   getControlPlaneDeepDiagnostics: mockGetControlPlaneDeepDiagnostics,
   listControlPlaneAllowlist: mockListControlPlaneAllowlist,
-  redactControlPlaneDeepDiagnosticsResponse: (payload: unknown) => {
-    const sanitize = (value: unknown): unknown => {
-      if (Array.isArray(value)) {
-        return value.map(sanitize);
-      }
-      if (value && typeof value === 'object') {
-        return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, item]) => [
-          key,
-          key === 'token' || key === 'authorization' ? '[REDACTED]' : sanitize(item),
-        ]));
-      }
-      return typeof value === 'string' && /^(sk-|Bearer )/.test(value) ? '[REDACTED]' : value;
-    };
-    return sanitize(payload);
-  },
 }));
 
 jest.unstable_mockModule('@transport/http/middleware/confirmGate.js', () => ({
@@ -87,7 +72,7 @@ function buildDeepDiagnosticsResponse(overrides: Record<string, unknown> = {}) {
     arcanosCliWrapper: {
       implemented: true,
       allowlistEnabled: true,
-      restrictedCommandsRequireApproval: true,
+      restrictedCommandsRequireApproval: false,
       readOnlyOperations: ['arcanos.status'],
       restrictedOperations: [],
     },
@@ -152,8 +137,8 @@ describe('api-control-plane route', () => {
   it('returns deep diagnostics as a redacted read-only no-store response', async () => {
     mockGetControlPlaneDeepDiagnostics.mockReturnValue(buildDeepDiagnosticsResponse({
       debug: {
-        token: `sk-${'a'.repeat(24)}`,
-        authorization: `Bearer ${'b'.repeat(24)}`,
+        token: '[REDACTED]',
+        authorization: '[REDACTED]',
       },
     }));
 

--- a/tests/control-plane-deep-diagnostics.test.ts
+++ b/tests/control-plane-deep-diagnostics.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { getControlPlaneDeepDiagnostics } from '@services/controlPlane/deepDiagnostics.js';
+import {
+  buildControlPlaneCliWrapperSummary,
+  getControlPlaneDeepDiagnostics,
+} from '@services/controlPlane/deepDiagnostics.js';
 
 describe('getControlPlaneDeepDiagnostics', () => {
   it('summarizes ARCANOS Core control-plane verification without claiming live Trinity confirmation', () => {
@@ -38,6 +41,16 @@ describe('getControlPlaneDeepDiagnostics', () => {
       'routingStages',
       'pipeline',
     ]));
+    expect(diagnostics.safetyFlags).toEqual({
+      readOnly: true,
+      executesCli: false,
+      callsOpenAI: false,
+      mutatesState: false,
+      createsJobs: false,
+      deploys: false,
+      invokesMcpTools: false,
+      routesThroughWritingPipeline: false,
+    });
   });
 
   it('summarizes CLI allowlists, MCP policy, approval gates, audit, redaction, and tests', () => {
@@ -106,5 +119,21 @@ describe('getControlPlaneDeepDiagnostics', () => {
     const serialized = JSON.stringify(diagnostics);
     expect(serialized).not.toContain('sk-');
     expect(serialized).not.toContain('Bearer ');
+  });
+
+  it('treats an empty CLI allowlist as unavailable rather than approval-gated or unsafe', () => {
+    const summary = buildControlPlaneCliWrapperSummary({
+      provider: 'railway-cli',
+      allowlistEntries: [],
+      legacyEntries: [],
+    });
+
+    expect(summary).toEqual({
+      implemented: false,
+      allowlistEnabled: false,
+      restrictedCommandsRequireApproval: false,
+      readOnlyOperations: [],
+      restrictedOperations: [],
+    });
   });
 });

--- a/tests/control-plane-deep-diagnostics.test.ts
+++ b/tests/control-plane-deep-diagnostics.test.ts
@@ -59,7 +59,7 @@ describe('getControlPlaneDeepDiagnostics', () => {
     expect(diagnostics.arcanosCliWrapper).toEqual(expect.objectContaining({
       implemented: true,
       allowlistEnabled: true,
-      restrictedCommandsRequireApproval: true,
+      restrictedCommandsRequireApproval: false,
     }));
     expect(diagnostics.arcanosCliWrapper.readOnlyOperations).toEqual(expect.arrayContaining([
       'arcanos.status',

--- a/tests/control-plane-deep-diagnostics.test.ts
+++ b/tests/control-plane-deep-diagnostics.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { getControlPlaneDeepDiagnostics } from '@services/controlPlane/deepDiagnostics.js';
+
+describe('getControlPlaneDeepDiagnostics', () => {
+  it('summarizes ARCANOS Core control-plane verification without claiming live Trinity confirmation', () => {
+    const diagnostics = getControlPlaneDeepDiagnostics();
+
+    expect(diagnostics.ok).toBe(true);
+    expect(diagnostics.gptWhitelist).toEqual(expect.objectContaining({
+      enabled: true,
+      containsArcanosCore: true,
+      gptId: 'arcanos-core',
+      policyPath: 'src/services/controlPlane/gptPolicy.ts',
+    }));
+    expect(diagnostics.gptWhitelist.allowedWorkflows).toEqual(expect.arrayContaining([
+      'control_plane.route.trinity.request',
+      'control_plane.route.verify',
+      'railway.cli.readonly',
+      'arcanos.cli.readonly',
+      'arcanos.mcp.documented_tools',
+    ]));
+    expect(diagnostics.gptWhitelist.deniedCapabilities).toEqual(expect.arrayContaining([
+      'secrets.read.raw',
+      'production.mutate.unapproved',
+      'mcp.undocumented_tools',
+    ]));
+
+    expect(diagnostics.trinityRouting).toEqual(expect.objectContaining({
+      implemented: true,
+      requestable: true,
+      lastRouteStatus: 'UNKNOWN_ROUTE',
+      verificationPath: 'src/services/controlPlane/routeVerification.ts',
+    }));
+    expect(diagnostics.trinityRouting.metadataFields).toEqual(expect.arrayContaining([
+      '_route',
+      'routeDecision',
+      'routingStages',
+      'pipeline',
+    ]));
+  });
+
+  it('summarizes CLI allowlists, MCP policy, approval gates, audit, redaction, and tests', () => {
+    const diagnostics = getControlPlaneDeepDiagnostics();
+
+    expect(diagnostics.railwayCliWrapper).toEqual(expect.objectContaining({
+      implemented: true,
+      allowlistEnabled: true,
+      restrictedCommandsRequireApproval: true,
+    }));
+    expect(diagnostics.railwayCliWrapper.readOnlyOperations).toEqual(expect.arrayContaining([
+      'railway.status',
+      'railway.whoami',
+    ]));
+    expect(diagnostics.railwayCliWrapper.restrictedOperations).toEqual(expect.arrayContaining([
+      'railway.deploy',
+    ]));
+
+    expect(diagnostics.arcanosCliWrapper).toEqual(expect.objectContaining({
+      implemented: true,
+      allowlistEnabled: true,
+      restrictedCommandsRequireApproval: true,
+    }));
+    expect(diagnostics.arcanosCliWrapper.readOnlyOperations).toEqual(expect.arrayContaining([
+      'arcanos.status',
+      'arcanos.inspect',
+      'arcanos.mcp.list-tools',
+    ]));
+
+    expect(diagnostics.mcpPolicy).toEqual(expect.objectContaining({
+      implemented: true,
+      documentedToolsOnly: true,
+      schemaValidationEnabled: true,
+    }));
+    expect(diagnostics.mcpPolicy.registeredTools).toEqual(expect.arrayContaining([
+      'control_plane.invoke',
+      'agents.list',
+      'modules.list',
+      'ops.health_report',
+    ]));
+
+    expect(diagnostics.approvalGates).toEqual(expect.objectContaining({
+      implemented: true,
+    }));
+    expect(diagnostics.approvalGates.protectedActions).toEqual(expect.arrayContaining([
+      'deploy',
+      'production_mutation',
+      'secret_change',
+      'railway.deploy',
+    ]));
+
+    expect(diagnostics.auditLogging).toEqual(expect.objectContaining({
+      implemented: true,
+      secretRedactionEnabled: true,
+      auditPath: 'src/services/controlPlane/audit.ts',
+    }));
+    expect(diagnostics.tests).toEqual(expect.objectContaining({
+      present: true,
+    }));
+    expect(diagnostics.tests.knownTestFiles).toEqual(expect.arrayContaining([
+      'tests/control-plane-gpt-policy.test.ts',
+      'tests/control-plane-route-verification.test.ts',
+      'tests/control-plane-executor.test.ts',
+    ]));
+
+    const serialized = JSON.stringify(diagnostics);
+    expect(serialized).not.toContain('sk-');
+    expect(serialized).not.toContain('Bearer ');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a minimal read-only `GET /api/control-plane/deep-diagnostics` endpoint for ARCANOS Core control-plane verification.

The endpoint summarizes the existing GPT whitelist, Trinity route verification capability, Railway and Arcanos CLI allowlists, MCP policy, approval gates, audit logging, redaction status, and related tests. It intentionally reports `lastRouteStatus: "UNKNOWN_ROUTE"` unless actual route metadata proves Trinity routing.

## Safety

- Does not execute CLI commands.
- Does not call OpenAI.
- Does not mutate state.
- Does not deploy.
- Does not route through the writing pipeline.
- Applies response redaction and `Cache-Control: no-store`.

## Validation

- `node scripts/run-jest.mjs --runTestsByPath tests/control-plane-deep-diagnostics.test.ts tests/control-plane-api.test.ts --coverage=false --runInBand`
- `npm run type-check`

## Note

This branch is stacked on the secure control-plane implementation that was present locally at `origin/codex/secure-control-plane`; that branch is no longer available as a GitHub PR base, so this draft targets `main`.

This endpoint remotely verifies the static implementation surfaces for the control-plane PR, but it does not claim live Trinity confirmation without route metadata.