### PR TITLE
[codex] fix worker DB snapshot slowness

### DIFF
--- a/src/core/db/query.ts
+++ b/src/core/db/query.ts
@@ -61,17 +61,25 @@ function classifySqlOperation(text: string): string {
   return 'other';
 }
 
-function normalizeTraceValue(value: string | undefined): string | undefined {
-  const normalized = value?.trim();
+function normalizeTraceValue(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
   return normalized ? normalized.slice(0, 120) : undefined;
 }
 
 function normalizeQueryTraceContext(
   traceContext: DbQueryTraceContext | undefined
 ): Record<string, string> {
-  const queryName = normalizeTraceValue(traceContext?.queryName);
-  const source = normalizeTraceValue(traceContext?.source);
-  const workerId = normalizeTraceValue(traceContext?.workerId);
+  if (!traceContext) {
+    return {};
+  }
+
+  const queryName = normalizeTraceValue(traceContext.queryName);
+  const source = normalizeTraceValue(traceContext.source);
+  const workerId = normalizeTraceValue(traceContext.workerId);
   return {
     ...(queryName ? { queryName } : {}),
     ...(source ? { source } : {}),

--- a/src/core/db/query.ts
+++ b/src/core/db/query.ts
@@ -16,6 +16,12 @@ const DEFAULT_SLOW_QUERY_LOG_MIN_MS = 250;
 const SLOW_QUERY_LOG_MIN_MS = Math.max(50, getEnvNumber('DB_QUERY_LOG_MIN_MS', DEFAULT_SLOW_QUERY_LOG_MIN_MS));
 const SHOULD_LOG_EVERY_QUERY = getConfiguredLogLevel() === LogLevel.DEBUG;
 
+export interface DbQueryTraceContext {
+  queryName?: string;
+  source?: string;
+  workerId?: string;
+}
+
 /**
  * Creates a cache key for database queries
  */
@@ -55,12 +61,37 @@ function classifySqlOperation(text: string): string {
   return 'other';
 }
 
+function normalizeTraceValue(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized ? normalized.slice(0, 120) : undefined;
+}
+
+function normalizeQueryTraceContext(
+  traceContext: DbQueryTraceContext | undefined
+): Record<string, string> {
+  const queryName = normalizeTraceValue(traceContext?.queryName);
+  const source = normalizeTraceValue(traceContext?.source);
+  const workerId = normalizeTraceValue(traceContext?.workerId);
+  return {
+    ...(queryName ? { queryName } : {}),
+    ...(source ? { source } : {}),
+    ...(workerId ? { workerId } : {})
+  };
+}
+
 /**
  * Enhanced query helper with caching and optimization
  */
-export async function query(text: string, params: unknown[] = [], attempt = 1, useCache = false): Promise<QueryResult> {
+export async function query(
+  text: string,
+  params: unknown[] = [],
+  attempt = 1,
+  useCache = false,
+  traceContext?: DbQueryTraceContext
+): Promise<QueryResult> {
   const operation = classifySqlOperation(text);
   const queryHash = createQueryHash(text);
+  const normalizedTraceContext = normalizeQueryTraceContext(traceContext);
   if (!isDatabaseConnected()) {
     throw new Error('Database not configured or not connected');
   }
@@ -77,6 +108,7 @@ export async function query(text: string, params: unknown[] = [], attempt = 1, u
     if (cachedResult) {
       if (SHOULD_LOG_EVERY_QUERY) {
         dbLogger.debug('db.query.cache_hit', {
+          ...normalizedTraceContext,
           operation,
           queryHash,
         });
@@ -126,6 +158,7 @@ export async function query(text: string, params: unknown[] = [], attempt = 1, u
       totalMs >= SLOW_QUERY_LOG_MIN_MS
     ) {
       dbLogger.warn('db.query.slow', {
+        ...normalizedTraceContext,
         operation,
         queryHash,
         durationMs: executionMs,
@@ -136,6 +169,7 @@ export async function query(text: string, params: unknown[] = [], attempt = 1, u
       });
     } else if (SHOULD_LOG_EVERY_QUERY) {
       dbLogger.debug('db.query.executed', {
+        ...normalizedTraceContext,
         operation,
         queryHash,
         durationMs: executionMs,
@@ -162,6 +196,7 @@ export async function query(text: string, params: unknown[] = [], attempt = 1, u
     return result;
   } catch (error) {
     dbLogger.error('db.query.error', {
+      ...normalizedTraceContext,
       operation,
       queryHash,
       attempt,
@@ -177,13 +212,14 @@ export async function query(text: string, params: unknown[] = [], attempt = 1, u
 
     if (attempt < 3) {
       dbLogger.warn('db.query.retry', {
+        ...normalizedTraceContext,
         operation,
         queryHash,
         attempt,
       }, {
         nextAttempt: attempt + 1,
       });
-      return query(text, params, attempt + 1, useCache);
+      return query(text, params, attempt + 1, useCache, traceContext);
     }
 
     throw error;

--- a/src/core/db/repositories/workerRuntimeRepository.ts
+++ b/src/core/db/repositories/workerRuntimeRepository.ts
@@ -183,7 +183,14 @@ export async function upsertWorkerRuntimeSnapshot(
         record.lastInspectorRunAt,
         record.updatedAt,
         serializedSnapshot
-      ]
+      ],
+      1,
+      false,
+      {
+        queryName: 'worker_runtime_snapshot_upsert',
+        workerId: record.workerId,
+        source
+      }
     );
   } catch (error) {
     outcome = 'error';
@@ -237,7 +244,14 @@ export async function recordWorkerLiveness(record: WorkerLivenessRecord): Promis
         record.workerId,
         record.lastSeenAt,
         record.healthStatus
-      ]
+      ],
+      1,
+      false,
+      {
+        queryName: 'worker_liveness_upsert',
+        workerId: record.workerId,
+        source: 'worker-liveness'
+      }
     );
   } catch (error) {
     outcome = 'error';
@@ -372,10 +386,27 @@ export async function upsertWorkerRuntimeState(
            last_inspector_run_at = EXCLUDED.last_inspector_run_at,
            updated_at = EXCLUDED.updated_at,
            snapshot = EXCLUDED.snapshot`,
-        params
+        params,
+        1,
+        false,
+        {
+          queryName: 'worker_runtime_state_with_legacy_upsert',
+          workerId: record.workerId,
+          source
+        }
       );
     } else {
-      await query(stateUpsertSql, params);
+      await query(
+        stateUpsertSql,
+        params,
+        1,
+        false,
+        {
+          queryName: 'worker_runtime_state_upsert',
+          workerId: record.workerId,
+          source
+        }
+      );
     }
   } catch (error) {
     outcome = 'error';
@@ -451,7 +482,14 @@ export async function appendWorkerRuntimeHistory(
         record.currentJobId,
         record.updatedAt,
         serializedSnapshot
-      ]
+      ],
+      1,
+      false,
+      {
+        queryName: 'worker_runtime_history_insert',
+        workerId: record.workerId,
+        source
+      }
     );
   } catch (error) {
     outcome = 'error';
@@ -497,7 +535,12 @@ export async function listWorkerLiveness(): Promise<WorkerLivenessSnapshotRecord
          health_status
        FROM worker_liveness
        ORDER BY last_seen_at DESC`,
-      []
+      [],
+      1,
+      false,
+      {
+        queryName: 'worker_liveness_list'
+      }
     );
 
     return result.rows.map((row) => ({
@@ -549,7 +592,12 @@ export async function listWorkerRuntimeStateSnapshots(): Promise<WorkerRuntimeSn
          snapshot
        FROM worker_runtime_state
        ORDER BY changed_at DESC`,
-      []
+      [],
+      1,
+      false,
+      {
+        queryName: 'worker_runtime_state_list'
+      }
     );
 
     return result.rows
@@ -603,7 +651,13 @@ export async function getWorkerRuntimeSnapshotById(
      FROM worker_runtime_snapshots
      WHERE worker_id = $1
      LIMIT 1`,
-    [workerId]
+    [workerId],
+    1,
+    false,
+    {
+      queryName: 'worker_runtime_snapshot_get',
+      workerId
+    }
   );
 
   const row = result.rows[0] as Record<string, unknown> | undefined;
@@ -642,7 +696,12 @@ export async function listWorkerRuntimeSnapshots(): Promise<WorkerRuntimeSnapsho
        snapshot
      FROM worker_runtime_snapshots
      ORDER BY updated_at DESC`,
-    []
+    [],
+    1,
+    false,
+    {
+      queryName: 'worker_runtime_snapshot_list'
+    }
   );
 
   return result.rows

--- a/src/services/workerRuntimeSnapshotPipeline.ts
+++ b/src/services/workerRuntimeSnapshotPipeline.ts
@@ -57,7 +57,7 @@ const defaultDependencies: WorkerRuntimeSnapshotPipelineDependencies = {
 };
 
 export function isWorkerSnapshotPipelineV2Enabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  return readBooleanEnv(env.WORKER_SNAPSHOT_PIPELINE_V2, false);
+  return readBooleanEnv(env.WORKER_SNAPSHOT_PIPELINE_V2, true);
 }
 
 export function isWorkerSnapshotLegacyPreservationEnabled(env: NodeJS.ProcessEnv = process.env): boolean {

--- a/tests/db-query.test.ts
+++ b/tests/db-query.test.ts
@@ -107,4 +107,48 @@ describe('db query helper', () => {
     expect(dbLoggerWarnMock.mock.calls[0]?.[1]).not.toHaveProperty('params');
     expect(releaseMock).toHaveBeenCalledTimes(1);
   });
+
+  it('ignores non-string trace context values without throwing', async () => {
+    const releaseMock = jest.fn();
+    const clientQueryMock = jest.fn().mockResolvedValue({
+      rows: [{ ok: true }],
+      rowCount: 1
+    });
+    getPoolMock.mockReturnValue({
+      connect: jest.fn().mockResolvedValue({
+        query: clientQueryMock,
+        release: releaseMock
+      })
+    });
+    const timestamps = [2_000, 2_000, 2_000, 2_060];
+    const dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => timestamps.shift() ?? 2_060);
+    const unsafeTraceContext = {
+      queryName: 42,
+      source: { nested: true },
+      workerId: null
+    } as unknown as Parameters<typeof query>[4];
+
+    try {
+      await expect(query(
+        'SELECT 1',
+        [],
+        1,
+        false,
+        unsafeTraceContext
+      )).resolves.toMatchObject({ rowCount: 1 });
+    } finally {
+      dateNowSpy.mockRestore();
+    }
+
+    const slowLogContext = dbLoggerWarnMock.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(slowLogContext).not.toHaveProperty('queryName');
+    expect(slowLogContext).not.toHaveProperty('source');
+    expect(slowLogContext).not.toHaveProperty('workerId');
+    expect(slowLogContext).toEqual(expect.objectContaining({
+      operation: 'select',
+      durationMs: 60,
+      rowCount: 1
+    }));
+    expect(releaseMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/db-query.test.ts
+++ b/tests/db-query.test.ts
@@ -72,7 +72,17 @@ describe('db query helper', () => {
     const dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => timestamps.shift() ?? 1_145);
 
     try {
-      await query('SELECT * FROM worker_runtime_snapshots WHERE worker_id = $1', ['worker-1']);
+      await query(
+        'SELECT * FROM worker_runtime_snapshots WHERE worker_id = $1',
+        ['worker-1'],
+        1,
+        false,
+        {
+          queryName: 'worker_runtime_snapshot_get',
+          workerId: 'worker-1',
+          source: 'worker-status'
+        }
+      );
     } finally {
       dateNowSpy.mockRestore();
     }
@@ -86,11 +96,15 @@ describe('db query helper', () => {
         executionMs: 85,
         poolWaitMs: 60,
         totalMs: 145,
-        rowCount: 1
+        rowCount: 1,
+        queryName: 'worker_runtime_snapshot_get',
+        workerId: 'worker-1',
+        source: 'worker-status'
       })
     );
     expect(dbLoggerWarnMock.mock.calls[0]?.[1]).not.toHaveProperty('text');
     expect(dbLoggerWarnMock.mock.calls[0]?.[1]).not.toHaveProperty('sql');
+    expect(dbLoggerWarnMock.mock.calls[0]?.[1]).not.toHaveProperty('params');
     expect(releaseMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/worker-autonomy-service.test.ts
+++ b/tests/worker-autonomy-service.test.ts
@@ -123,7 +123,7 @@ describe('workerAutonomyService', () => {
     recordWorkerLivenessMock.mockResolvedValue(undefined);
     upsertWorkerRuntimeStateMock.mockResolvedValue(undefined);
     appendWorkerRuntimeHistoryMock.mockResolvedValue(undefined);
-    delete process.env.WORKER_SNAPSHOT_PIPELINE_V2;
+    process.env.WORKER_SNAPSHOT_PIPELINE_V2 = 'false';
     delete process.env.WORKER_SNAPSHOT_PRESERVE_LEGACY_TABLE;
   });
 
@@ -1322,6 +1322,42 @@ describe('workerAutonomyService', () => {
         error: 'database write timeout'
       })
     );
+  });
+
+  it('routes worker heartbeat through V2 liveness by default when the env flag is unset', async () => {
+    delete process.env.WORKER_SNAPSHOT_PIPELINE_V2;
+
+    const service = new WorkerAutonomyService({
+      workerId: 'async-queue-slot-1',
+      workerType: 'async_queue',
+      heartbeatIntervalMs: 30_000,
+      leaseMs: 30_000,
+      inspectorIntervalMs: 30_000,
+      staleAfterMs: 90_000,
+      watchdogIdleMs: 120_000,
+      defaultMaxRetries: 2,
+      retryBackoffBaseMs: 2_000,
+      retryBackoffMaxMs: 60_000,
+      maxJobsPerHour: 120,
+      maxAiCallsPerHour: 120,
+      maxRssMb: 2_048,
+      queueDepthDeferralThreshold: 25,
+      queueDepthDeferralMs: 5_000,
+      failureWebhookUrl: null,
+      failureWebhookThreshold: 3,
+      failureWebhookCooldownMs: 300_000
+    });
+
+    await service.recordWorkerHeartbeat({ source: 'worker-heartbeat' });
+
+    expect(recordWorkerLivenessMock).toHaveBeenCalledWith({
+      workerId: 'async-queue-slot-1',
+      healthStatus: 'healthy',
+      lastSeenAt: expect.any(String)
+    });
+    expect(upsertWorkerRuntimeSnapshotMock).not.toHaveBeenCalled();
+
+    await service.flushSnapshotPipeline('test-cleanup');
   });
 
   it('routes worker heartbeat through V2 liveness without forcing rich snapshot persistence', async () => {

--- a/tests/worker-runtime-repository.test.ts
+++ b/tests/worker-runtime-repository.test.ts
@@ -74,7 +74,13 @@ describe('workerRuntimeRepository', () => {
         'async-queue-1',
         '2026-04-23T01:00:30.000Z',
         'healthy'
-      ]
+      ],
+      1,
+      false,
+      expect.objectContaining({
+        queryName: 'worker_liveness_upsert',
+        workerId: 'async-queue-1'
+      })
     );
   });
 
@@ -114,7 +120,14 @@ describe('workerRuntimeRepository', () => {
     expect(queryMock).toHaveBeenCalledTimes(1);
     expect(queryMock).toHaveBeenCalledWith(
       expect.stringContaining('WITH state_upsert AS'),
-      expect.any(Array)
+      expect.any(Array),
+      1,
+      false,
+      expect.objectContaining({
+        queryName: 'worker_runtime_state_with_legacy_upsert',
+        workerId: 'async-queue-1',
+        source: 'worker-idle'
+      })
     );
     expect(queryMock.mock.calls[0][0]).toContain('worker_runtime_state');
     expect(queryMock.mock.calls[0][0]).toContain('worker_runtime_snapshots');

--- a/tests/worker-runtime-snapshot-pipeline.test.ts
+++ b/tests/worker-runtime-snapshot-pipeline.test.ts
@@ -35,6 +35,7 @@ jest.unstable_mockModule('@platform/observability/appMetrics.js', () => ({
 const {
   WorkerRuntimeSnapshotPipeline,
   buildWorkerRuntimeSnapshotStateHash,
+  isWorkerSnapshotPipelineV2Enabled,
   normalizeWorkerRuntimeSnapshotForHash
 } = await import('../src/services/workerRuntimeSnapshotPipeline.js');
 
@@ -84,6 +85,13 @@ describe('WorkerRuntimeSnapshotPipeline', () => {
     repositoryRecordLivenessMock.mockResolvedValue(undefined);
     repositoryUpsertStateMock.mockResolvedValue(undefined);
     repositoryAppendHistoryMock.mockResolvedValue(undefined);
+  });
+
+  it('defaults the V2 pipeline on unless explicitly disabled', () => {
+    expect(isWorkerSnapshotPipelineV2Enabled({} as NodeJS.ProcessEnv)).toBe(true);
+    expect(isWorkerSnapshotPipelineV2Enabled({
+      WORKER_SNAPSHOT_PIPELINE_V2: 'false'
+    } as NodeJS.ProcessEnv)).toBe(false);
   });
 
   it('records heartbeat liveness without forcing rich snapshot persistence', async () => {


### PR DESCRIPTION
## Summary

Fixes the slow Railway worker DB path by defaulting the existing V2 worker snapshot pipeline on and adding safe query labels for worker-runtime DB operations.

## Root Cause

Production worker logs showed repeated `worker.runtime_snapshot.upsert.slow` events tied to `db.query.slow` for the legacy rich snapshot upsert. With `JOB_WORKER_CONCURRENCY=8` and `WORKER_SNAPSHOT_PIPELINE_V2` unset, each slot wrote full JSON snapshots on heartbeat/idle/inspector cycles, causing DB contention and timeout spikes.

## Changes

- Default `WORKER_SNAPSHOT_PIPELINE_V2` to enabled unless explicitly set false.
- Keep heartbeats on cheap liveness writes while rich state persists only on meaningful state changes through the existing V2 pipeline.
- Add safe `queryName`, `source`, and `workerId` labels to DB query slow/error/retry logs without logging SQL text or params.
- Label worker runtime repository queries for future production diagnosis.
- Update focused tests for default V2 behavior and trace-label safety.

## Validation

- `node scripts/run-jest.mjs --testPathPatterns=tests/db-query.test.ts tests/worker-runtime-repository.test.ts tests/worker-runtime-snapshot-pipeline.test.ts tests/worker-autonomy-service.test.ts --runInBand --coverage=false`
- `npm run type-check`
- `npm run build`
- `npm run validate:railway`
- `npx eslint src/core/db/query.ts src/core/db/repositories/workerRuntimeRepository.ts src/services/workerRuntimeSnapshotPipeline.ts tests/db-query.test.ts tests/worker-runtime-repository.test.ts tests/worker-runtime-snapshot-pipeline.test.ts tests/worker-autonomy-service.test.ts`

Production smoke was run before deploy and still showed the current deployed worker emitting DB timeout errors, which this PR targets.

## Rollback

Set `WORKER_SNAPSHOT_PIPELINE_V2=false` on the `ARCANOS Worker` Railway service and restart/redeploy the worker, or revert this commit. No schema rollback is required.