### PR TITLE
[codex] connect DAG and Trinity dispatcher diagnostics

### DIFF
--- a/contracts/custom_gpt_route.openapi.v1.json
+++ b/contracts/custom_gpt_route.openapi.v1.json
@@ -10,7 +10,7 @@
       "post": {
         "operationId": "invokeGptRoute",
         "summary": "Invoke a GPT-routed module request or universal control action",
-        "description": "POST /gpt/{gptId} is the universal public dispatcher. The path parameter is authoritative; a JSON body gptId is optional and must match the path when present. Use a prompt-only request with executionMode=fast for small prompt-generation work that should return inline. Use action=query to create one durable writing job, action=query_and_wait on core GPT IDs to execute synchronously through the lightweight direct action lane, action=get_status to read status through the GPT compatibility bridge, action=get_result to read the final result through the GPT compatibility bridge, and approved control actions such as diagnostics, runtime.inspect, workers.status, queue.inspect, self_heal.status, and system_state for runtime inspection. The action should be supplied in the JSON body when possible; generated-client compatibility also permits the same action in the query string or an operationId-style body alias. For runtime.inspect and self_heal.status, payload.detail and payload.sections can request summary, standard, or full response profiles, and a deterministic bounded planner fills safe defaults when callers omit them. Unknown control-plane action names are rejected with a typed 400 error. Natural-language retrieval prompts, runtime inspection prompts without an explicit allowlisted action, DAG control prompts, and MCP control requests are still intentionally rejected on this route.",
+        "description": "POST /gpt/{gptId} is the universal public dispatcher. The path parameter is authoritative; a JSON body gptId is optional and must match the path when present. Use a prompt-only request with executionMode=fast for small prompt-generation work that should return inline. Use action=query to create one durable writing job through the Trinity writing pipeline, action=query_and_wait on core GPT IDs to execute synchronously through the lightweight direct action lane, action=get_status to read status through the GPT compatibility bridge, action=get_result to read the final result through the GPT compatibility bridge, and approved control actions such as diagnostics, runtime.inspect, workers.status, queue.inspect, self_heal.status, and system_state for runtime inspection. The diagnostics action returns deterministic dispatcher metadata, including canonical DAG, Trinity, worker, and MCP bindings. The action should be supplied in the JSON body when possible; generated-client compatibility also permits the same action in the query string or an operationId-style body alias. For runtime.inspect and self_heal.status, payload.detail and payload.sections can request summary, standard, or full response profiles, and a deterministic bounded planner fills safe defaults when callers omit them. Unknown control-plane action names are rejected with a typed 400 error. Natural-language retrieval prompts, runtime inspection prompts without an explicit allowlisted action, DAG control prompts, and MCP control requests are still intentionally rejected on this route.",
         "parameters": [
           {
             "name": "gptId",
@@ -126,6 +126,12 @@
                     }
                   }
                 },
+                "diagnostics": {
+                  "summary": "Return deterministic dispatcher bindings for GPT, DAG, Trinity, workers, and MCP",
+                  "value": {
+                    "action": "diagnostics"
+                  }
+                },
                 "workersStatus": {
                   "summary": "Inspect worker runtime and queue state through the universal dispatcher",
                   "value": {
@@ -228,6 +234,23 @@
                         "workerHealth": "/worker-helper/health",
                         "selfHeal": "/status/safety/self-heal",
                         "mcp": "/mcp"
+                      }
+                    }
+                  },
+                  "dagControlPrompt": {
+                    "summary": "Natural-language DAG diagnostic prompts are rejected with DAG endpoint guidance",
+                    "value": {
+                      "ok": false,
+                      "action": "dag.run.create",
+                      "error": {
+                        "code": "DAG_CONTROL_REQUIRES_DIRECT_ENDPOINT",
+                        "message": "DAG execution must use /api/arcanos/dag/*, POST /mcp, or POST /dispatch with target='dag'."
+                      },
+                      "canonical": {
+                        "mcp": "/mcp",
+                        "dispatch": "/dispatch",
+                        "dagRuns": "/api/arcanos/dag/runs/{runId}",
+                        "dagTrace": "/api/arcanos/dag/runs/{runId}/trace"
                       }
                     }
                   },
@@ -626,9 +649,163 @@
             "$ref": "#/components/schemas/GptJobResultResponse"
           },
           {
+            "$ref": "#/components/schemas/GptDispatcherDiagnosticsResponse"
+          },
+          {
             "$ref": "#/components/schemas/GptRouteGenericResponse"
           }
         ]
+      },
+      "GptDispatcherDiagnosticsResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "ok",
+          "gptId",
+          "route",
+          "actions",
+          "controlActions",
+          "canonicalEndpoints",
+          "policy",
+          "subsystems",
+          "env",
+          "traceId",
+          "_route"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "gptId": {
+            "type": "string"
+          },
+          "route": {
+            "const": "/gpt/:gptId"
+          },
+          "actions": {
+            "type": "array",
+            "items": {
+              "enum": [
+                "query",
+                "query_and_wait",
+                "diagnostics",
+                "get_status",
+                "get_result"
+              ]
+            }
+          },
+          "controlActions": {
+            "type": "array",
+            "items": {
+              "enum": [
+                "diagnostics",
+                "system_state",
+                "runtime.inspect",
+                "workers.status",
+                "queue.inspect",
+                "self_heal.status"
+              ]
+            }
+          },
+          "canonicalEndpoints": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "properties": {
+              "status": {
+                "const": "/status"
+              },
+              "workers": {
+                "const": "/workers/status"
+              },
+              "workerHealth": {
+                "const": "/worker-helper/health"
+              },
+              "selfHeal": {
+                "const": "/status/safety/self-heal"
+              },
+              "trinityStatus": {
+                "const": "/trinity/status"
+              },
+              "mcp": {
+                "const": "/mcp"
+              },
+              "dagCapabilities": {
+                "const": "/api/arcanos/capabilities"
+              },
+              "dagRuns": {
+                "const": "/api/arcanos/dag/runs"
+              },
+              "dagRunStatus": {
+                "const": "/api/arcanos/dag/runs/{runId}"
+              },
+              "dagTrace": {
+                "const": "/api/arcanos/dag/runs/{runId}/trace"
+              },
+              "dispatchDag": {
+                "const": "/dispatch"
+              }
+            }
+          },
+          "policy": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "writingPlane": {
+                "const": "/gpt/:gptId"
+              },
+              "controlPlane": {
+                "const": "direct-endpoints"
+              },
+              "trinityWritingAction": {
+                "const": "query"
+              },
+              "trinityDirectActionBypass": {
+                "const": "query_and_wait"
+              },
+              "systemOperationsThroughWritingPipeline": {
+                "const": false
+              }
+            }
+          },
+          "subsystems": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "trinity": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "dag": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "workers": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "controlPlane": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "mcp": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          },
+          "env": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "traceId": {
+            "type": "string"
+          },
+          "_route": {
+            "$ref": "#/components/schemas/GptRouteMeta"
+          }
+        }
       },
       "GptDirectActionCompletedResponse": {
         "type": "object",

--- a/contracts/custom_gpt_route.openapi.v1.json
+++ b/contracts/custom_gpt_route.openapi.v1.json
@@ -249,7 +249,9 @@
                       "canonical": {
                         "mcp": "/mcp",
                         "dispatch": "/dispatch",
-                        "dagRuns": "/api/arcanos/dag/runs/{runId}",
+                        "dagCapabilities": "/api/arcanos/capabilities",
+                        "dagRuns": "/api/arcanos/dag/runs",
+                        "dagRunStatus": "/api/arcanos/dag/runs/{runId}",
                         "dagTrace": "/api/arcanos/dag/runs/{runId}/trace"
                       }
                     }

--- a/src/platform/runtime/writingPlaneContract.ts
+++ b/src/platform/runtime/writingPlaneContract.ts
@@ -179,7 +179,9 @@ function buildDagControlCanonical() {
   return {
     mcp: '/mcp',
     dispatch: '/dispatch',
-    dagRuns: '/api/arcanos/dag/runs/{runId}',
+    dagCapabilities: '/api/arcanos/capabilities',
+    dagRuns: '/api/arcanos/dag/runs',
+    dagRunStatus: '/api/arcanos/dag/runs/{runId}',
     dagTrace: '/api/arcanos/dag/runs/{runId}/trace',
   };
 }

--- a/src/platform/runtime/writingPlaneContract.ts
+++ b/src/platform/runtime/writingPlaneContract.ts
@@ -1,4 +1,5 @@
 import { classifyRuntimeInspectionPrompt } from '@services/runtimeInspectionRoutingService.js';
+import { shouldTreatPromptAsDagExecution } from '@shared/dag/dagExecutionRouting.js';
 import { normalizeGptRequestBody } from '@shared/gpt/gptIdempotency.js';
 import {
   GPT_DIRECT_CONTROL_ACTIONS,
@@ -77,6 +78,11 @@ export type WritingPlaneInputClassification =
       canonical: Record<string, string | null>;
       jobLookup?: NaturalLanguageJobLookupIntent;
     };
+
+type ControlWritingPlaneInputClassification = Extract<
+  WritingPlaneInputClassification,
+  { plane: 'control' }
+>;
 
 type McpControlAction = 'mcp.invoke' | 'mcp.list_tools';
 
@@ -166,6 +172,31 @@ function isExplicitWritingPlaneControlAction(
 function buildUnsupportedControlActionCanonical() {
   return {
     supportedActions: GPT_DIRECT_CONTROL_ACTIONS.join(', '),
+  };
+}
+
+function buildDagControlCanonical() {
+  return {
+    mcp: '/mcp',
+    dispatch: '/dispatch',
+    dagRuns: '/api/arcanos/dag/runs/{runId}',
+    dagTrace: '/api/arcanos/dag/runs/{runId}/trace',
+  };
+}
+
+function buildDagControlClassification(params: {
+  action: string;
+  reason: string;
+}): ControlWritingPlaneInputClassification {
+  return {
+    plane: 'control',
+    kind: 'dag_control',
+    action: params.action,
+    reason: params.reason,
+    errorCode: 'DAG_CONTROL_REQUIRES_DIRECT_ENDPOINT',
+    message:
+      "DAG execution must use /api/arcanos/dag/*, POST /mcp, or POST /dispatch with target='dag'.",
+    canonical: buildDagControlCanonical(),
   };
 }
 
@@ -386,21 +417,21 @@ export function classifyWritingPlaneInput(input: {
   const explicitDagAction =
     normalizeDagControlAction(normalizedAction) ?? detectEmbeddedDagAction(input.body);
   if (explicitDagAction || normalizedExecutionMode === 'dag' || normalizedTarget === 'dag') {
-    return {
-      plane: 'control',
-      kind: 'dag_control',
+    return buildDagControlClassification({
       action: explicitDagAction ?? normalizedAction ?? 'dag.run.create',
       reason: 'explicit_dag_control_action',
-      errorCode: 'DAG_CONTROL_REQUIRES_DIRECT_ENDPOINT',
-      message:
-        "DAG execution must use /api/arcanos/dag/*, POST /mcp, or POST /dispatch with target='dag'.",
-      canonical: {
-        mcp: '/mcp',
-        dispatch: '/dispatch',
-        dagRuns: '/api/arcanos/dag/runs/{runId}',
-        dagTrace: '/api/arcanos/dag/runs/{runId}/trace',
-      },
-    };
+    });
+  }
+
+  if (
+    isQueryLikeAction(normalizedAction) &&
+    input.promptText &&
+    shouldTreatPromptAsDagExecution(input.promptText, { requireDagTokenForArtifact: true })
+  ) {
+    return buildDagControlClassification({
+      action: 'dag.run.create',
+      reason: 'prompt_dag_control_requires_direct_endpoint',
+    });
   }
 
   if (isQueryLikeAction(normalizedAction)) {

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -91,6 +91,7 @@ import {
   parseGptJobResultRequest
 } from '@shared/gpt/gptJobResult.js';
 import {
+  GPT_DIRECT_CONTROL_ACTIONS,
   type GptDirectControlAction,
   normalizeGptDirectControlAction,
 } from '@shared/gpt/gptControlActions.js';
@@ -129,6 +130,26 @@ const GPT_DISPATCHER_ACTIONS = [
   GPT_GET_STATUS_ACTION,
   GPT_GET_RESULT_ACTION
 ] as const;
+const GPT_DISPATCHER_CANONICAL_ENDPOINTS = {
+  status: '/status',
+  workers: '/workers/status',
+  workerHealth: '/worker-helper/health',
+  selfHeal: '/status/safety/self-heal',
+  trinityStatus: '/trinity/status',
+  mcp: '/mcp',
+  dagCapabilities: '/api/arcanos/capabilities',
+  dagRuns: '/api/arcanos/dag/runs',
+  dagRunStatus: '/api/arcanos/dag/runs/{runId}',
+  dagTrace: '/api/arcanos/dag/runs/{runId}/trace',
+  dispatchDag: '/dispatch'
+} as const;
+const GPT_DISPATCHER_POLICY = {
+  writingPlane: GPT_DISPATCHER_ROUTE,
+  controlPlane: 'direct-endpoints',
+  trinityWritingAction: GPT_QUERY_ACTION,
+  trinityDirectActionBypass: GPT_QUERY_AND_WAIT_ACTION,
+  systemOperationsThroughWritingPipeline: false
+} as const;
 const DEFAULT_GPT_ASYNC_HEAVY_PROMPT_CHARS = 1_200;
 const DEFAULT_GPT_ASYNC_HEAVY_MESSAGE_COUNT = 8;
 const DEFAULT_GPT_ASYNC_HEAVY_MAX_WORDS = 700;
@@ -312,6 +333,44 @@ function buildGptDispatcherErrorPayload(params: {
   };
 }
 
+function buildDispatcherSubsystemBindings() {
+  return {
+    trinity: {
+      statusEndpoint: GPT_DISPATCHER_CANONICAL_ENDPOINTS.trinityStatus,
+      writingEndpoint: GPT_DISPATCHER_ROUTE,
+      writingAction: GPT_QUERY_ACTION,
+      sourceEndpoint: 'gpt.arcanos-core.query',
+      pipeline: 'runTrinityWritingPipeline',
+      directActionBypass: GPT_QUERY_AND_WAIT_ACTION
+    },
+    dag: {
+      routePolicy: 'direct_endpoint_required',
+      controlGuard: 'DAG_CONTROL_REQUIRES_DIRECT_ENDPOINT',
+      dispatchEndpoint: GPT_DISPATCHER_CANONICAL_ENDPOINTS.dispatchDag,
+      dispatchTarget: 'dag',
+      capabilitiesEndpoint: GPT_DISPATCHER_CANONICAL_ENDPOINTS.dagCapabilities,
+      runsEndpoint: GPT_DISPATCHER_CANONICAL_ENDPOINTS.dagRuns,
+      runStatusEndpoint: GPT_DISPATCHER_CANONICAL_ENDPOINTS.dagRunStatus,
+      traceEndpoint: GPT_DISPATCHER_CANONICAL_ENDPOINTS.dagTrace,
+      mcpEndpoint: GPT_DISPATCHER_CANONICAL_ENDPOINTS.mcp
+    },
+    workers: {
+      statusEndpoint: GPT_DISPATCHER_CANONICAL_ENDPOINTS.workers,
+      helperHealthEndpoint: GPT_DISPATCHER_CANONICAL_ENDPOINTS.workerHealth,
+      controlActions: ['workers.status', 'queue.inspect']
+    },
+    controlPlane: {
+      statusEndpoint: GPT_DISPATCHER_CANONICAL_ENDPOINTS.status,
+      selfHealEndpoint: GPT_DISPATCHER_CANONICAL_ENDPOINTS.selfHeal,
+      controlActions: ['runtime.inspect', 'self_heal.status', 'system_state', 'diagnostics']
+    },
+    mcp: {
+      endpoint: GPT_DISPATCHER_CANONICAL_ENDPOINTS.mcp,
+      auth: 'bearer'
+    }
+  };
+}
+
 function buildGptDispatcherDiagnosticsPayload(params: {
   requestId: string | undefined;
   traceId: string;
@@ -322,6 +381,10 @@ function buildGptDispatcherDiagnosticsPayload(params: {
     gptId: params.gptId,
     route: GPT_DISPATCHER_ROUTE,
     actions: [...GPT_DISPATCHER_ACTIONS],
+    controlActions: [...GPT_DIRECT_CONTROL_ACTIONS],
+    canonicalEndpoints: { ...GPT_DISPATCHER_CANONICAL_ENDPOINTS },
+    policy: GPT_DISPATCHER_POLICY,
+    subsystems: buildDispatcherSubsystemBindings(),
     env: buildDispatcherEnvStatus(),
     traceId: params.traceId,
     _route: buildDispatcherRouteMeta({

--- a/tests/gpt-router-auth-logging.test.ts
+++ b/tests/gpt-router-auth-logging.test.ts
@@ -727,6 +727,45 @@ describe('gpt router auth logging', () => {
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
+  it('rejects natural-language DAG diagnostic prompts with DAG endpoint guidance', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(requestContext);
+    app.use('/gpt', gptRouter);
+
+    const response = await request(app)
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'query_and_wait',
+        prompt: 'Run live DAG diagnostics and inspect the Trinity worker pipeline status.',
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual(expect.objectContaining({
+      ok: false,
+      gptId: 'arcanos-core',
+      action: 'dag.run.create',
+      route: '/gpt/:gptId',
+      traceId: expect.any(String),
+      error: {
+        code: 'DAG_CONTROL_REQUIRES_DIRECT_ENDPOINT',
+        message: "DAG execution must use /api/arcanos/dag/*, POST /mcp, or POST /dispatch with target='dag'.",
+      },
+      canonical: {
+        mcp: '/mcp',
+        dispatch: '/dispatch',
+        dagRuns: '/api/arcanos/dag/runs/{runId}',
+        dagTrace: '/api/arcanos/dag/runs/{runId}/trace',
+      },
+      _route: expect.objectContaining({
+        gptId: 'arcanos-core',
+        route: 'control_guard',
+        action: 'dag.run.create',
+      }),
+    }));
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
   it('rejects explicit MCP control actions and points callers to /mcp', async () => {
     const app = express();
     app.use(express.json());

--- a/tests/gpt-router-auth-logging.test.ts
+++ b/tests/gpt-router-auth-logging.test.ts
@@ -715,7 +715,9 @@ describe('gpt router auth logging', () => {
       canonical: {
         mcp: '/mcp',
         dispatch: '/dispatch',
-        dagRuns: '/api/arcanos/dag/runs/{runId}',
+        dagCapabilities: '/api/arcanos/capabilities',
+        dagRuns: '/api/arcanos/dag/runs',
+        dagRunStatus: '/api/arcanos/dag/runs/{runId}',
         dagTrace: '/api/arcanos/dag/runs/{runId}/trace',
       },
       _route: expect.objectContaining({
@@ -754,7 +756,9 @@ describe('gpt router auth logging', () => {
       canonical: {
         mcp: '/mcp',
         dispatch: '/dispatch',
-        dagRuns: '/api/arcanos/dag/runs/{runId}',
+        dagCapabilities: '/api/arcanos/capabilities',
+        dagRuns: '/api/arcanos/dag/runs',
+        dagRunStatus: '/api/arcanos/dag/runs/{runId}',
         dagTrace: '/api/arcanos/dag/runs/{runId}/trace',
       },
       _route: expect.objectContaining({

--- a/tests/runtime-diagnostics.route.test.ts
+++ b/tests/runtime-diagnostics.route.test.ts
@@ -86,6 +86,62 @@ describe('runtime diagnostics routes', () => {
         'get_status',
         'get_result'
       ]),
+      controlActions: expect.arrayContaining([
+        'diagnostics',
+        'runtime.inspect',
+        'workers.status',
+        'queue.inspect',
+        'self_heal.status'
+      ]),
+      canonicalEndpoints: expect.objectContaining({
+        status: '/status',
+        workers: '/workers/status',
+        workerHealth: '/worker-helper/health',
+        selfHeal: '/status/safety/self-heal',
+        trinityStatus: '/trinity/status',
+        mcp: '/mcp',
+        dagCapabilities: '/api/arcanos/capabilities',
+        dagRuns: '/api/arcanos/dag/runs',
+        dagRunStatus: '/api/arcanos/dag/runs/{runId}',
+        dagTrace: '/api/arcanos/dag/runs/{runId}/trace',
+        dispatchDag: '/dispatch'
+      }),
+      policy: expect.objectContaining({
+        writingPlane: '/gpt/:gptId',
+        controlPlane: 'direct-endpoints',
+        trinityWritingAction: 'query',
+        trinityDirectActionBypass: 'query_and_wait',
+        systemOperationsThroughWritingPipeline: false
+      }),
+      subsystems: expect.objectContaining({
+        trinity: expect.objectContaining({
+          statusEndpoint: '/trinity/status',
+          writingEndpoint: '/gpt/:gptId',
+          writingAction: 'query',
+          sourceEndpoint: 'gpt.arcanos-core.query',
+          pipeline: 'runTrinityWritingPipeline',
+          directActionBypass: 'query_and_wait'
+        }),
+        dag: expect.objectContaining({
+          routePolicy: 'direct_endpoint_required',
+          controlGuard: 'DAG_CONTROL_REQUIRES_DIRECT_ENDPOINT',
+          dispatchEndpoint: '/dispatch',
+          dispatchTarget: 'dag',
+          capabilitiesEndpoint: '/api/arcanos/capabilities',
+          runsEndpoint: '/api/arcanos/dag/runs',
+          runStatusEndpoint: '/api/arcanos/dag/runs/{runId}',
+          traceEndpoint: '/api/arcanos/dag/runs/{runId}/trace',
+          mcpEndpoint: '/mcp'
+        }),
+        workers: expect.objectContaining({
+          statusEndpoint: '/workers/status',
+          helperHealthEndpoint: '/worker-helper/health'
+        }),
+        mcp: expect.objectContaining({
+          endpoint: '/mcp',
+          auth: 'bearer'
+        })
+      }),
       env: expect.objectContaining({
         hasOpenAIKey: false,
         hasArcanosModel: expect.any(Boolean),

--- a/tests/trinity-writing-pipeline.test.ts
+++ b/tests/trinity-writing-pipeline.test.ts
@@ -360,4 +360,40 @@ describe('runTrinityWritingPipeline', () => {
       })
     );
   });
+
+  it('rejects natural-language DAG diagnostic prompts before the Trinity engine executes', async () => {
+    await expect(
+      runTrinityWritingPipeline({
+        input: {
+          prompt: 'Run live DAG diagnostics and inspect the Trinity worker pipeline status.',
+          sourceEndpoint: 'write',
+          body: {
+            action: 'query_and_wait',
+            prompt: 'Run live DAG diagnostics and inspect the Trinity worker pipeline status.'
+          }
+        },
+        context: {
+          client: {} as never,
+          requestId: 'req-dag-prompt-leak-1'
+        }
+      })
+    ).rejects.toMatchObject({
+      name: 'TrinityControlLeakError',
+      classification: expect.objectContaining({
+        kind: 'dag_control',
+        action: 'dag.run.create'
+      })
+    });
+
+    expect(runThroughBrainMock).not.toHaveBeenCalled();
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      'trinity.control_leak_detected',
+      expect.objectContaining({
+        requestId: 'req-dag-prompt-leak-1',
+        sourceEndpoint: 'write',
+        classification: 'dag_control',
+        action: 'dag.run.create'
+      })
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Adds deterministic dispatcher diagnostics metadata for DAG, Trinity, workers, control-plane, and MCP bindings.
- Classifies natural-language DAG execution/diagnostic prompts as DAG control-plane traffic with DAG-specific endpoint guidance.
- Updates the GPT route OpenAPI contract and focused tests for dispatcher diagnostics and Trinity control-plane leak protection.

## Root Cause

The core `/gpt/{gptId}` dispatcher was healthy, but DAG/Trinity diagnostic prompts were routed through generic runtime-inspection classification. That produced `CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT` and left the dispatcher diagnostics response without enough subsystem binding metadata to verify the DAG/Trinity connection.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('contracts/custom_gpt_route.openapi.v1.json','utf8')); console.log('openapi json ok')"`
- `node scripts/run-jest.mjs --runTestsByPath tests/runtime-diagnostics.route.test.ts tests/gpt-router-auth-logging.test.ts tests/trinity-writing-pipeline.test.ts tests/gpt-router-universal-dispatch.test.ts tests/dispatcher-priority.route.test.ts --coverage=false`
- `npm run type-check`

Note: `npm test -- --runTestsByPath ...` also had all selected tests pass, but exited non-zero because the repo enforces full coverage thresholds even on focused path runs.