### PR TITLE
[codex] Add safe GPT DAG bridge

### DIFF
--- a/contracts/custom_gpt_route.openapi.v1.json
+++ b/contracts/custom_gpt_route.openapi.v1.json
@@ -688,11 +688,7 @@
             "items": {
               "enum": [
                 "diagnostics",
-                "system_state",
-                "runtime.inspect",
-                "workers.status",
-                "queue.inspect",
-                "self_heal.status"
+                "system_state"
               ]
             }
           },

--- a/contracts/custom_gpt_route.openapi.v1.json
+++ b/contracts/custom_gpt_route.openapi.v1.json
@@ -3,14 +3,14 @@
   "info": {
     "title": "Arcanos GPT Route API",
     "version": "1.0.0",
-    "description": "Canonical public contract for GPT-routed module requests and allowlisted control-plane dispatch. GPT identity is path-bound at /gpt/{gptId}; generated tool clients may also echo the same gptId in the JSON body, and mismatched body/path IDs are rejected. POST /gpt/{gptId} accepts flexible request bodies with action as a string and payload as an open object so durable GPT actions, approved runtime inspection actions, and prompt-only fast-path generation can share one public endpoint. For generated clients that place operation metadata outside the JSON body, the route also accepts action as a query parameter or operation-style body alias. Simple prompt-generation requests that omit action can opt into inline fast-path execution with executionMode=fast. A bounded deterministic planner may normalize detail and section profiles for runtime inspection actions before execution, without inventing unsupported actions or bypassing response guards."
+    "description": "Canonical public contract for GPT-routed module requests and the safe DAG bridge. GPT identity is path-bound at /gpt/{gptId}; generated tool clients may also echo the same gptId in the JSON body, and mismatched body/path IDs are rejected. POST /gpt/{gptId} accepts flexible request bodies with action as a string and payload as an open object so durable GPT actions, safe DAG bridge actions, and prompt-only fast-path generation can share one public endpoint. For generated clients that place operation metadata outside the JSON body, the route also accepts action as a query parameter or operation-style body alias. Simple prompt-generation requests that omit action can opt into inline fast-path execution with executionMode=fast. Runtime inspection, worker status, queue inspection, self-heal status, MCP calls, and arbitrary internal endpoint forwarding remain blocked on this route."
   },
   "paths": {
     "/gpt/{gptId}": {
       "post": {
         "operationId": "invokeGptRoute",
         "summary": "Invoke a GPT-routed module request or universal control action",
-        "description": "POST /gpt/{gptId} is the universal public dispatcher. The path parameter is authoritative; a JSON body gptId is optional and must match the path when present. Use a prompt-only request with executionMode=fast for small prompt-generation work that should return inline. Use action=query to create one durable writing job, action=query_and_wait on core GPT IDs to execute synchronously through the lightweight direct action lane, action=get_status to read status through the GPT compatibility bridge, action=get_result to read the final result through the GPT compatibility bridge, and approved control actions such as diagnostics, runtime.inspect, workers.status, queue.inspect, self_heal.status, and system_state for runtime inspection. The action should be supplied in the JSON body when possible; generated-client compatibility also permits the same action in the query string or an operationId-style body alias. For runtime.inspect and self_heal.status, payload.detail and payload.sections can request summary, standard, or full response profiles, and a deterministic bounded planner fills safe defaults when callers omit them. Unknown control-plane action names are rejected with a typed 400 error. Natural-language retrieval prompts, runtime inspection prompts without an explicit allowlisted action, DAG control prompts, and MCP control requests are still intentionally rejected on this route.",
+        "description": "POST /gpt/{gptId} is the universal public dispatcher. The path parameter is authoritative; a JSON body gptId is optional and must match the path when present. Use a prompt-only request with executionMode=fast for small prompt-generation work that should return inline. Use action=query to create one durable writing job, action=query_and_wait on core GPT IDs to execute synchronously through the lightweight direct action lane, action=get_status to read status through the GPT compatibility bridge, action=get_result to read the final result through the GPT compatibility bridge, action=diagnostics to read GPT route metadata, and the safe DAG bridge actions dag.capabilities, dag.dispatch, dag.status, and dag.trace. The action should be supplied in the JSON body when possible; generated-client compatibility also permits the same action in the query string or an operationId-style body alias. Unknown control-plane action names are rejected with a typed 400 error. Natural-language retrieval prompts, runtime inspection prompts, unsupported DAG actions, and MCP control requests are still intentionally rejected on this route.",
         "parameters": [
           {
             "name": "gptId",
@@ -88,48 +88,43 @@
                     }
                   }
                 },
-                "runtimeInspect": {
-                  "summary": "Inspect the live runtime through the universal dispatcher with planner defaults",
+                "dagCapabilities": {
+                  "summary": "Read safe DAG capabilities available to this GPT ID",
                   "value": {
-                    "action": "runtime.inspect"
+                    "action": "dag.capabilities"
                   }
                 },
-                "runtimeInspectStandard": {
-                  "summary": "Request standard runtime inspection detail explicitly",
+                "dagDispatch": {
+                  "summary": "Dispatch a safe asynchronous DAG run",
                   "value": {
-                    "action": "runtime.inspect",
+                    "action": "dag.dispatch",
+                    "prompt": "Validation run for GPT DAG bridge.",
                     "payload": {
-                      "detail": "standard"
+                      "graphId": "default",
+                      "input": {
+                        "validation": true
+                      },
+                      "async": true,
+                      "idempotencyKey": "gpt-dag-bridge-validation-001"
                     }
                   }
                 },
-                "runtimeInspectFull": {
-                  "summary": "Request full runtime inspection detail for selected sections",
+                "dagStatus": {
+                  "summary": "Read one DAG run status through the safe bridge",
                   "value": {
-                    "action": "runtime.inspect",
+                    "action": "dag.status",
                     "payload": {
-                      "detail": "full",
-                      "sections": [
-                        "workers",
-                        "queues",
-                        "memory"
-                      ]
+                      "runId": "dagrun_1714212000000_abc123"
                     }
                   }
                 },
-                "selfHealSummary": {
-                  "summary": "Request a compact self-heal summary through the universal dispatcher",
+                "dagTrace": {
+                  "summary": "Read one redacted DAG run trace through the safe bridge",
                   "value": {
-                    "action": "self_heal.status",
+                    "action": "dag.trace",
                     "payload": {
-                      "detail": "summary"
+                      "runId": "dagrun_1714212000000_abc123"
                     }
-                  }
-                },
-                "workersStatus": {
-                  "summary": "Inspect worker runtime and queue state through the universal dispatcher",
-                  "value": {
-                    "action": "workers.status"
                   }
                 },
                 "moduleAction": {
@@ -149,7 +144,7 @@
         },
         "responses": {
           "200": {
-            "description": "Completed fast-path inline response, direct query_and_wait response, async bridge response, control-plane bridge response, or generic GPT response",
+            "description": "Completed fast-path inline response, direct query_and_wait response, async bridge response, safe DAG bridge read response, or generic GPT response",
             "content": {
               "application/json": {
                 "schema": {
@@ -238,33 +233,25 @@
                       "action": "runtime.unknown",
                       "error": {
                         "code": "UNSUPPORTED_GPT_ACTION",
-                        "message": "Unsupported control action 'runtime.unknown'. Supported control actions: diagnostics, system_state, runtime.inspect, workers.status, queue.inspect, self_heal.status."
+                        "message": "Unsupported control action 'runtime.unknown'. Supported control actions: diagnostics, system_state."
                       },
                       "canonical": {
-                        "supportedActions": "diagnostics, system_state, runtime.inspect, workers.status, queue.inspect, self_heal.status"
+                        "supportedActions": "diagnostics, system_state"
                       }
                     }
                   },
                   "invalidDetail": {
-                    "summary": "Invalid planner detail is rejected safely",
+                    "summary": "Explicit runtime inspection payloads are rejected before planner validation",
                     "value": {
                       "ok": false,
                       "action": "runtime.inspect",
                       "error": {
-                        "code": "INVALID_GPT_DETAIL",
-                        "message": "Unsupported detail 'verbose'. Supported detail values: summary, standard, full."
+                        "code": "CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT",
+                        "message": "Runtime diagnostics, worker state, tracing, and queue inspection must use direct control-plane endpoints or POST /mcp. Do not send runtime control requests through POST /gpt/{gptId}."
                       },
                       "canonical": {
-                        "action": "runtime.inspect",
-                        "supportedDetail": "summary, standard, full",
-                        "availableSections": [
-                          "workers",
-                          "queues",
-                          "memory",
-                          "incidents",
-                          "events",
-                          "trace"
-                        ]
+                        "mcp": "/mcp",
+                        "workers": "/workers/status"
                       }
                     }
                   }
@@ -334,7 +321,7 @@
       "GptRouteRequest": {
         "type": "object",
         "additionalProperties": true,
-        "description": "Universal GPT-route request. action is an open string field so callers can send canonical async bridge actions, module actions, and approved control-plane/runtime inspection actions through POST /gpt/{gptId}. A body gptId is optional for generated tool clients and must match the path gptId when present. Runtime inspection actions may also use a bounded planner profile via payload.detail and payload.sections.",
+        "description": "Universal GPT-route request. action is an open string field so callers can send canonical async bridge actions, module actions, diagnostics, job lookup bridge actions, and the safe DAG bridge actions through POST /gpt/{gptId}. A body gptId is optional for generated tool clients and must match the path gptId when present. Runtime inspection, worker status, queue inspection, self-heal status, MCP calls, unsupported dag.* actions, and arbitrary internal endpoint forwarding are rejected.",
         "properties": {
           "gptId": {
             "type": "string",
@@ -344,7 +331,7 @@
           "action": {
             "type": "string",
             "minLength": 1,
-            "description": "Requested action name. Canonical built-ins include query, query_and_wait, get_status, get_result, diagnostics, runtime.inspect, workers.status, queue.inspect, self_heal.status, and system_state. Module-specific action names are also allowed. Unsupported reserved control action names are rejected with HTTP 400."
+            "description": "Requested action name. Canonical built-ins include query, query_and_wait, get_status, get_result, diagnostics, dag.capabilities, dag.dispatch, dag.status, and dag.trace. Module-specific action names are also allowed. Unsupported reserved control action names are rejected with HTTP 400."
           },
           "operationId": {
             "type": "string",
@@ -393,7 +380,7 @@
           "payload": {
             "type": "object",
             "additionalProperties": true,
-            "description": "Open payload object. For runtime.inspect and self_heal.status, payload.detail supports summary | standard | full. Valid payload.sections values are action-specific allowlisted strings: for example, runtime.inspect may use sections such as workers, queues, memory, incidents, events, or trace, while self_heal.status may use sections such as system or predictive."
+            "description": "Open payload object. For dag.dispatch, payload.graphId selects a supported graph and payload.input supplies DAG input; target, source, route, headers, auth, and endpoint fields are ignored by the bridge. For dag.status and dag.trace, payload.runId is required."
           },
           "context": {
             "type": "object",

--- a/packages/cli/__tests__/gpt-client.test.ts
+++ b/packages/cli/__tests__/gpt-client.test.ts
@@ -430,9 +430,9 @@ describe("GPT route OpenAPI contract and client", () => {
       })
     );
     expect(requestSchema?.description).toContain("Universal GPT-route request");
-    expect(requestSchema?.properties?.action?.description).toContain("runtime.inspect");
-    expect(requestSchema?.properties?.payload?.description).toContain("payload.detail");
-    expect(requestSchema?.properties?.payload?.description).toContain("payload.sections");
+    expect(requestSchema?.properties?.action?.description).toContain("dag.dispatch");
+    expect(requestSchema?.properties?.payload?.description).toContain("payload.graphId");
+    expect(requestSchema?.properties?.payload?.description).toContain("payload.runId");
     expect(
       spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.genericPrompt?.value
     ).toEqual({
@@ -470,39 +470,39 @@ describe("GPT route OpenAPI contract and client", () => {
       }
     });
     expect(
-      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.runtimeInspect?.value
+      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.dagCapabilities?.value
     ).toEqual({
-      action: "runtime.inspect"
+      action: "dag.capabilities"
     });
     expect(
-      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.runtimeInspectStandard?.value
+      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.dagDispatch?.value
     ).toEqual({
-      action: "runtime.inspect",
+      action: "dag.dispatch",
+      prompt: "Validation run for GPT DAG bridge.",
       payload: {
-        detail: "standard"
+        graphId: "default",
+        input: {
+          validation: true
+        },
+        async: true,
+        idempotencyKey: "gpt-dag-bridge-validation-001"
       }
     });
     expect(
-      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.runtimeInspectFull?.value
+      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.dagStatus?.value
     ).toEqual({
-      action: "runtime.inspect",
+      action: "dag.status",
       payload: {
-        detail: "full",
-        sections: ["workers", "queues", "memory"]
+        runId: "dagrun_1714212000000_abc123"
       }
     });
     expect(
-      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.selfHealSummary?.value
+      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.dagTrace?.value
     ).toEqual({
-      action: "self_heal.status",
+      action: "dag.trace",
       payload: {
-        detail: "summary"
+        runId: "dagrun_1714212000000_abc123"
       }
-    });
-    expect(
-      spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.workersStatus?.value
-    ).toEqual({
-      action: "workers.status"
     });
     expect(
       spec.paths?.["/gpt/{gptId}"]?.post?.requestBody?.content?.["application/json"]?.examples?.queryAndWait?.value

--- a/src/dag/templates.ts
+++ b/src/dag/templates.ts
@@ -22,6 +22,16 @@ export interface DagTemplateDefinition {
 
 export const TRINITY_CORE_DAG_TEMPLATE_NAME = 'trinity-core';
 
+export class UnsupportedDagTemplateError extends Error {
+  readonly templateName: string;
+
+  constructor(templateName: string) {
+    super(`Unsupported DAG template "${templateName}".`);
+    this.name = 'UnsupportedDagTemplateError';
+    this.templateName = templateName;
+  }
+}
+
 const LEGACY_TRINITY_DAG_TEMPLATE_ALIASES = new Set([
   'default',
   'verification-default',
@@ -112,7 +122,7 @@ export function buildDagTemplate(request: CreateDagRunRequest): DagTemplateDefin
 
   //audit Assumption: the first public DAG contract only supports the verification pipeline; failure risk: callers believe arbitrary templates are available and receive a malformed graph; expected invariant: unknown templates are rejected explicitly; handling strategy: guard template selection before graph construction.
   if (normalizedTemplate !== TRINITY_CORE_DAG_TEMPLATE_NAME) {
-    throw new Error(`Unsupported DAG template "${request.template}".`);
+    throw new UnsupportedDagTemplateError(request.template);
   }
 
   const plannerPrompt =

--- a/src/platform/runtime/writingPlaneContract.ts
+++ b/src/platform/runtime/writingPlaneContract.ts
@@ -1,7 +1,6 @@
 import { classifyRuntimeInspectionPrompt } from '@services/runtimeInspectionRoutingService.js';
 import { normalizeGptRequestBody } from '@shared/gpt/gptIdempotency.js';
 import {
-  GPT_DIRECT_CONTROL_ACTIONS,
   type GptDirectControlAction,
   isReservedGptControlNamespace,
   normalizeGptDirectControlAction,
@@ -117,6 +116,7 @@ const EXPLICIT_WRITING_PLANE_CONTROL_CLASSIFICATIONS: Record<
     },
   },
 };
+const GPT_PUBLIC_DIRECT_CONTROL_ACTIONS = ['diagnostics', 'system_state'] as const;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -165,7 +165,7 @@ function isExplicitWritingPlaneControlAction(
 
 function buildUnsupportedControlActionCanonical() {
   return {
-    supportedActions: GPT_DIRECT_CONTROL_ACTIONS.join(', '),
+    supportedActions: GPT_PUBLIC_DIRECT_CONTROL_ACTIONS.join(', '),
   };
 }
 
@@ -320,7 +320,7 @@ export function classifyWritingPlaneInput(input: {
       action: normalizedAction,
       reason: 'unsupported_reserved_control_action',
       errorCode: 'UNSUPPORTED_GPT_ACTION',
-      message: `Unsupported control action '${normalizedAction}'. Supported control actions: ${GPT_DIRECT_CONTROL_ACTIONS.join(', ')}.`,
+      message: `Unsupported control action '${normalizedAction}'. Supported control actions: ${GPT_PUBLIC_DIRECT_CONTROL_ACTIONS.join(', ')}.`,
       canonical: buildUnsupportedControlActionCanonical(),
     };
   }

--- a/src/routes/_core/gptPlaneClassification.ts
+++ b/src/routes/_core/gptPlaneClassification.ts
@@ -50,6 +50,39 @@ export type GptWritingPlaneClassification = Extract<
   { plane: 'writing' }
 >;
 
+const GPT_ROUTE_BLOCKED_DIRECT_CONTROL_KINDS = new Set<GptDirectControlKind>([
+  'queue_inspection_action',
+  'runtime_inspection_action',
+  'self_heal_status_action',
+  'workers_status_action',
+]);
+
+function isBlockedDirectControlKind(kind: GptDirectControlKind): boolean {
+  return GPT_ROUTE_BLOCKED_DIRECT_CONTROL_KINDS.has(kind);
+}
+
+function buildDirectEndpointRequiredClassification(input: {
+  action: string;
+  reason: string;
+}): GptPlaneClassification {
+  return {
+    plane: 'reject',
+    kind: 'runtime_inspection',
+    action: input.action,
+    reason: input.reason,
+    errorCode: 'CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT',
+    message:
+      'Runtime diagnostics, worker state, tracing, and queue inspection must use direct control-plane endpoints or POST /mcp. Do not send runtime control requests through POST /gpt/{gptId}.',
+    canonical: {
+      status: '/status',
+      workers: '/workers/status',
+      workerHealth: '/worker-helper/health',
+      selfHeal: '/status/safety/self-heal',
+      mcp: '/mcp',
+    },
+  };
+}
+
 export function classifyGptRequestPlane(input: {
   body: unknown;
   promptText: string | null;
@@ -61,6 +94,13 @@ export function classifyGptRequestPlane(input: {
   }
 
   if (isDirectControlPlaneKind(classification.kind)) {
+    if (isBlockedDirectControlKind(classification.kind)) {
+      return buildDirectEndpointRequiredClassification({
+        action: classification.action,
+        reason: 'control_plane_requires_direct_endpoint',
+      });
+    }
+
     return {
       plane: 'control',
       kind: classification.kind,

--- a/src/routes/api-arcanos-verification.ts
+++ b/src/routes/api-arcanos-verification.ts
@@ -33,6 +33,7 @@ import { getWorkerControlStatus } from '../services/workerControlService.js';
 import { arcanosDagRunService } from '../services/arcanosDagRunService.js';
 import { resolveErrorMessage } from '@core/lib/errors/index.js';
 import { sendBoundedJsonResponse } from '@shared/http/sendBoundedJsonResponse.js';
+import { UnsupportedDagTemplateError } from '@dag/templates.js';
 
 const router = express.Router();
 const API_VERSION = '1.0.0';
@@ -306,8 +307,8 @@ router.post(
     } catch (error: unknown) {
       const errorMessage = resolveErrorMessage(error);
 
-      //audit Assumption: unsupported templates and invalid DAG requests are caller errors; failure risk: contract consumers receive opaque 500s for invalid input; expected invariant: template validation failures map to `400`; handling strategy: branch on known validation text.
-      if (errorMessage.includes('Unsupported DAG template')) {
+      //audit Assumption: unsupported templates and invalid DAG requests are caller errors; failure risk: contract consumers receive opaque 500s for invalid input; expected invariant: template validation failures map to `400`; handling strategy: branch on the template validation error type.
+      if (error instanceof UnsupportedDagTemplateError) {
         sendBadRequest(res, 'DAG_TEMPLATE_UNSUPPORTED');
         return;
       }

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -118,6 +118,11 @@ import { executeRuntimeInspection } from '@services/runtimeInspectionRoutingServ
 import { getWorkerControlStatus } from '@services/workerControlService.js';
 import { buildSafetySelfHealSnapshot } from '@services/selfHealRuntimeInspectionService.js';
 import { getConfig } from '@platform/runtime/unifiedConfig.js';
+import { handleGptDagBridge } from '@services/gptDagBridge.js';
+import {
+  GPT_DAG_BRIDGE_ACTIONS,
+  isGptDagAction,
+} from '@shared/gpt/gptDagBridgeActions.js';
 
 const router = express.Router();
 const ARCANOS_CORE_GPT_IDS = new Set(['arcanos-core', 'core', 'arcanos-daemon']);
@@ -127,7 +132,8 @@ const GPT_DISPATCHER_ACTIONS = [
   GPT_QUERY_AND_WAIT_ACTION,
   'diagnostics',
   GPT_GET_STATUS_ACTION,
-  GPT_GET_RESULT_ACTION
+  GPT_GET_RESULT_ACTION,
+  ...GPT_DAG_BRIDGE_ACTIONS
 ] as const;
 const DEFAULT_GPT_ASYNC_HEAVY_PROMPT_CHARS = 1_200;
 const DEFAULT_GPT_ASYNC_HEAVY_MESSAGE_COUNT = 8;
@@ -2115,6 +2121,48 @@ router.post("/:gptId", async (req, res, next) => {
             errorPayload,
             'gpt.response.query_and_wait_invalid_body',
             400
+          );
+        }
+
+        if (isGptDagAction(requestedAction)) {
+          const dagBridgeResponse = await handleGptDagBridge({
+            req,
+            requestId,
+            traceId,
+            gptId: incomingGptId,
+            action: requestedAction!,
+            normalizedBody,
+            promptText,
+            logger: requestLogger,
+          });
+
+          logGptDispatcherOutcome({
+            req,
+            traceId,
+            gptId: incomingGptId,
+            action: requestedAction!,
+            status: dagBridgeResponse.statusCode,
+            ...(dagBridgeResponse.statusCode >= 400
+              ? {
+                  error: {
+                    name: String(dagBridgeResponse.payload.code ?? 'GPT_DAG_BRIDGE_ERROR'),
+                    message:
+                      typeof dagBridgeResponse.payload.error === 'object' &&
+                      dagBridgeResponse.payload.error !== null &&
+                      typeof (dagBridgeResponse.payload.error as Record<string, unknown>).message === 'string'
+                        ? String((dagBridgeResponse.payload.error as Record<string, unknown>).message)
+                        : 'DAG bridge action failed.'
+                  }
+                }
+              : {})
+          });
+
+          return sendGuardedGptJsonResponse(
+            req,
+            res,
+            dagBridgeResponse.payload,
+            dagBridgeResponse.logEvent,
+            dagBridgeResponse.statusCode
           );
         }
 

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -91,7 +91,7 @@ import {
   parseGptJobResultRequest
 } from '@shared/gpt/gptJobResult.js';
 import {
-  GPT_DIRECT_CONTROL_ACTIONS,
+  GPT_PUBLIC_DIRECT_CONTROL_ACTIONS,
   type GptDirectControlAction,
   normalizeGptDirectControlAction,
 } from '@shared/gpt/gptControlActions.js';
@@ -387,7 +387,7 @@ function buildGptDispatcherDiagnosticsPayload(params: {
     gptId: params.gptId,
     route: GPT_DISPATCHER_ROUTE,
     actions: [...GPT_DISPATCHER_ACTIONS],
-    controlActions: [...GPT_DIRECT_CONTROL_ACTIONS],
+    controlActions: [...GPT_PUBLIC_DIRECT_CONTROL_ACTIONS],
     canonicalEndpoints: { ...GPT_DISPATCHER_CANONICAL_ENDPOINTS },
     policy: GPT_DISPATCHER_POLICY,
     subsystems: buildDispatcherSubsystemBindings(),

--- a/src/services/gptDagBridge.ts
+++ b/src/services/gptDagBridge.ts
@@ -1,0 +1,685 @@
+import crypto from 'node:crypto';
+import type express from 'express';
+
+import {
+  TRINITY_CORE_DAG_TEMPLATE_NAME,
+  resolvePublicDagTemplateName,
+} from '@dag/templates.js';
+import { arcanosDagRunService } from '@services/arcanosDagRunService.js';
+import { redactSensitive } from '@shared/redaction.js';
+import {
+  GPT_DAG_BRIDGE_ACTIONS,
+  type GptDagBridgeAction,
+  isGptDagBridgeAction,
+} from '@shared/gpt/gptDagBridgeActions.js';
+import { resolveErrorMessage } from '@core/lib/errors/index.js';
+
+const GPT_DISPATCHER_ROUTE = '/gpt/:gptId';
+const DEFAULT_ALLOWED_GPTS = ['arcanos-core'];
+const DEFAULT_GRAPH_ID = 'default';
+const DEFAULT_DAG_PRIORITY = 'normal';
+const MAX_PROMPT_CHARS = 50_000;
+const MAX_IDEMPOTENCY_KEY_CHARS = 160;
+const SAFE_RUN_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,159}$/;
+
+const FORBIDDEN_PAYLOAD_KEYS = new Set([
+  'action',
+  'auth',
+  'authorization',
+  'controlplaneaction',
+  'control_plane_action',
+  'endpoint',
+  'headers',
+  'method',
+  'route',
+  'source',
+  'target',
+  'url',
+]);
+
+type BridgeLogger = {
+  error?: (message: string, meta?: Record<string, unknown>) => void;
+  info?: (message: string, meta?: Record<string, unknown>) => void;
+  warn?: (message: string, meta?: Record<string, unknown>) => void;
+};
+
+export interface GptDagBridgeContext {
+  req: express.Request;
+  requestId: string | undefined;
+  traceId: string;
+  gptId: string;
+  action: string;
+  normalizedBody: Record<string, unknown> | null;
+  promptText: string | null;
+  logger?: BridgeLogger;
+}
+
+export interface GptDagBridgeResponse {
+  statusCode: number;
+  logEvent: string;
+  payload: Record<string, unknown>;
+}
+
+interface DagBridgeAuditInput {
+  ctx: GptDagBridgeContext;
+  status: number;
+  latencyMs: number;
+  runId?: string | null;
+  graphId?: string | null;
+  errorCode?: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+function parseBooleanEnv(name: string, fallbackValue: boolean): boolean {
+  const rawValue = process.env[name]?.trim().toLowerCase();
+  if (!rawValue) {
+    return fallbackValue;
+  }
+
+  return rawValue === 'true' || rawValue === '1' || rawValue === 'yes';
+}
+
+function parseBooleanLike(value: unknown): boolean | null {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalizedValue = value.trim().toLowerCase();
+  if (normalizedValue === 'true' || normalizedValue === '1' || normalizedValue === 'yes') {
+    return true;
+  }
+  if (normalizedValue === 'false' || normalizedValue === '0' || normalizedValue === 'no') {
+    return false;
+  }
+
+  return null;
+}
+
+function readPositiveInteger(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) && value > 0 ? value : null;
+  }
+
+  if (typeof value !== 'string' || !/^\d+$/.test(value.trim())) {
+    return null;
+  }
+
+  const parsed = Number(value.trim());
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseCsv(value: string | undefined, fallback: string[]): string[] {
+  const parsed = value
+    ?.split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  return parsed && parsed.length > 0 ? parsed : fallback;
+}
+
+function timingSafeEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  return leftBuffer.length === rightBuffer.length && crypto.timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function extractBearerToken(req: express.Request): string | null {
+  const authorization = req.header('authorization') ?? '';
+  const [scheme, ...rest] = authorization.trim().split(/\s+/u);
+  if (scheme?.toLowerCase() !== 'bearer') {
+    return null;
+  }
+
+  const token = rest.join(' ').trim();
+  return token || null;
+}
+
+function buildRouteMeta(ctx: GptDagBridgeContext, route: string) {
+  return {
+    requestId: ctx.requestId,
+    traceId: ctx.traceId,
+    gptId: ctx.gptId,
+    action: ctx.action,
+    route,
+    source: `gpt.${ctx.gptId}`,
+    sourceEndpoint: `gpt.${ctx.gptId}.${ctx.action}`,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function buildErrorResponse(
+  ctx: GptDagBridgeContext,
+  statusCode: number,
+  code: string,
+  message: string,
+  route: string,
+  details?: Record<string, unknown>
+): GptDagBridgeResponse {
+  return {
+    statusCode,
+    logEvent: `gpt.response.${route}`,
+    payload: {
+      ok: false,
+      gptId: ctx.gptId,
+      action: ctx.action,
+      route: GPT_DISPATCHER_ROUTE,
+      traceId: ctx.traceId,
+      source: `gpt.${ctx.gptId}`,
+      code,
+      error: {
+        code,
+        message,
+        ...(details ? { details } : {}),
+      },
+      _route: buildRouteMeta(ctx, route),
+    },
+  };
+}
+
+function resolvePayload(ctx: GptDagBridgeContext): Record<string, unknown> {
+  return isRecord(ctx.normalizedBody?.payload) ? ctx.normalizedBody.payload : {};
+}
+
+function stripForbiddenPayloadKeys(value: unknown, depth = 0): unknown {
+  if (depth > 8) {
+    return '[max depth reached]';
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => stripForbiddenPayloadKeys(entry, depth + 1));
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (FORBIDDEN_PAYLOAD_KEYS.has(key.toLowerCase())) {
+      continue;
+    }
+
+    sanitized[key] = stripForbiddenPayloadKeys(entry, depth + 1);
+  }
+
+  return sanitized;
+}
+
+function getSafeInputFromPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  const input = isRecord(payload.input) ? payload.input : {};
+  const sanitizedInput = stripForbiddenPayloadKeys(input);
+  const redactedInput = redactSensitive(sanitizedInput);
+  return isRecord(redactedInput) ? redactedInput : {};
+}
+
+function getSafePrompt(ctx: GptDagBridgeContext): string | null {
+  const prompt = ctx.promptText?.trim() ?? '';
+  if (!prompt) {
+    return null;
+  }
+
+  const redactedPrompt = redactSensitive(prompt.slice(0, MAX_PROMPT_CHARS));
+  return typeof redactedPrompt === 'string' && redactedPrompt.trim().length > 0
+    ? redactedPrompt.trim()
+    : null;
+}
+
+function getGraphId(payload: Record<string, unknown>): string {
+  return readString(payload.graphId) ?? DEFAULT_GRAPH_ID;
+}
+
+function validateGraphId(graphId: string): { ok: true; template: string } | { ok: false } {
+  const template = resolvePublicDagTemplateName(graphId);
+  return template === TRINITY_CORE_DAG_TEMPLATE_NAME
+    ? { ok: true, template }
+    : { ok: false };
+}
+
+function getOptionsRecord(payload: Record<string, unknown>): Record<string, unknown> {
+  return isRecord(payload.options) ? payload.options : {};
+}
+
+function getBridgeAsync(payload: Record<string, unknown>): boolean {
+  const options = getOptionsRecord(payload);
+  return parseBooleanLike(payload.async) ?? parseBooleanLike(options.async) ?? true;
+}
+
+function getBridgePriority(payload: Record<string, unknown>): 'normal' {
+  const rawPriority = readString(payload.priority) ?? readString(getOptionsRecord(payload).priority);
+  return rawPriority === DEFAULT_DAG_PRIORITY ? DEFAULT_DAG_PRIORITY : DEFAULT_DAG_PRIORITY;
+}
+
+function getIdempotencyKey(payload: Record<string, unknown>): string | null {
+  const options = getOptionsRecord(payload);
+  const idempotencyKey = readString(payload.idempotencyKey) ?? readString(options.idempotencyKey);
+  return idempotencyKey ? idempotencyKey.slice(0, MAX_IDEMPOTENCY_KEY_CHARS) : null;
+}
+
+function buildCreateRunOptions(payload: Record<string, unknown>) {
+  const options = getOptionsRecord(payload);
+  const maxConcurrency = readPositiveInteger(options.maxConcurrency ?? payload.maxConcurrency);
+
+  return {
+    ...(maxConcurrency !== null ? { maxConcurrency } : {}),
+  };
+}
+
+function getActorHeader(req: express.Request, name: string): string | null {
+  const value = readString(req.header(name));
+  return value ? value.slice(0, 128) : null;
+}
+
+function getRequestPermissions(req: express.Request): Set<string> {
+  const rawPermissions =
+    req.header('x-arcanos-permissions') ??
+    req.header('x-arcanos-permission') ??
+    '';
+
+  return new Set(
+    rawPermissions
+      .split(',')
+      .map((permission) => permission.trim())
+      .filter(Boolean)
+  );
+}
+
+function getRequiredPermission(action: GptDagBridgeAction): 'dag:read' | 'dag:execute' {
+  return action === 'dag.dispatch' ? 'dag:execute' : 'dag:read';
+}
+
+function logBridgeAudit(input: DagBridgeAuditInput): void {
+  const userId = getActorHeader(input.ctx.req, 'x-user-id');
+  const orgId = getActorHeader(input.ctx.req, 'x-org-id');
+  const event = {
+    gptId: input.ctx.gptId,
+    action: input.ctx.action,
+    traceId: input.ctx.traceId,
+    ...(input.runId ? { runId: input.runId } : {}),
+    ...(input.graphId ? { graphId: input.graphId } : {}),
+    ...(userId ? { userId } : {}),
+    ...(orgId ? { orgId } : {}),
+    status: input.status,
+    latencyMs: input.latencyMs,
+    ...(input.errorCode ? { errorCode: input.errorCode } : {}),
+  };
+
+  if (input.status >= 500) {
+    input.ctx.logger?.error?.('gpt.dag_bridge.audit', event);
+  } else if (input.status >= 400) {
+    input.ctx.logger?.warn?.('gpt.dag_bridge.audit', event);
+  } else {
+    input.ctx.logger?.info?.('gpt.dag_bridge.audit', event);
+  }
+}
+
+export function assertGptCanUseDag(
+  ctx: GptDagBridgeContext,
+  action: GptDagBridgeAction
+): GptDagBridgeResponse | null {
+  if (!parseBooleanEnv('GPT_DAG_BRIDGE_ENABLED', false)) {
+    return buildErrorResponse(
+      ctx,
+      403,
+      'GPT_DAG_BRIDGE_DISABLED',
+      'DAG bridge actions are disabled for the GPT route.',
+      'dag_bridge_disabled'
+    );
+  }
+
+  const allowedGpts = parseCsv(process.env.GPT_DAG_BRIDGE_ALLOWED_GPTS, DEFAULT_ALLOWED_GPTS);
+  if (!allowedGpts.includes('*') && !allowedGpts.includes(ctx.gptId)) {
+    return buildErrorResponse(
+      ctx,
+      403,
+      'GPT_DAG_BRIDGE_GPT_NOT_ALLOWED',
+      'This GPT ID is not allowed to use DAG bridge actions.',
+      'dag_bridge_gpt_not_allowed'
+    );
+  }
+
+  if (parseBooleanEnv('GPT_DAG_BRIDGE_REQUIRE_AUTH', false)) {
+    const expectedToken =
+      process.env.GPT_DAG_BRIDGE_BEARER_TOKEN?.trim() ??
+      process.env.OPENAI_ACTION_SHARED_SECRET?.trim() ??
+      '';
+    if (!expectedToken) {
+      return buildErrorResponse(
+        ctx,
+        503,
+        'GPT_DAG_BRIDGE_AUTH_NOT_CONFIGURED',
+        'DAG bridge bearer authentication is required but not configured.',
+        'dag_bridge_auth_not_configured'
+      );
+    }
+
+    const providedToken = extractBearerToken(ctx.req);
+    if (!providedToken || !timingSafeEqual(providedToken, expectedToken)) {
+      return buildErrorResponse(
+        ctx,
+        401,
+        'GPT_DAG_BRIDGE_UNAUTHORIZED',
+        'DAG bridge bearer authentication failed.',
+        'dag_bridge_unauthorized'
+      );
+    }
+  }
+
+  if (parseBooleanEnv('GPT_DAG_BRIDGE_REQUIRE_PERMISSIONS', false)) {
+    const requiredPermission = getRequiredPermission(action);
+    const permissions = getRequestPermissions(ctx.req);
+    if (!permissions.has(requiredPermission)) {
+      return buildErrorResponse(
+        ctx,
+        403,
+        'GPT_DAG_BRIDGE_PERMISSION_DENIED',
+        `DAG bridge action requires ${requiredPermission}.`,
+        'dag_bridge_permission_denied',
+        { requiredPermission }
+      );
+    }
+  }
+
+  return null;
+}
+
+export async function getDagCapabilities(ctx: GptDagBridgeContext): Promise<GptDagBridgeResponse> {
+  const capabilities = {
+    features: arcanosDagRunService.getFeatureFlags(),
+    limits: arcanosDagRunService.getExecutionLimits(),
+    graphs: [
+      {
+        graphId: DEFAULT_GRAPH_ID,
+        template: TRINITY_CORE_DAG_TEMPLATE_NAME,
+        actions: [...GPT_DAG_BRIDGE_ACTIONS],
+      },
+    ],
+  };
+
+  return {
+    statusCode: 200,
+    logEvent: 'gpt.response.dag_capabilities',
+    payload: {
+      ok: true,
+      gptId: ctx.gptId,
+      action: 'dag.capabilities',
+      route: GPT_DISPATCHER_ROUTE,
+      traceId: ctx.traceId,
+      source: `gpt.${ctx.gptId}`,
+      capabilities,
+      data: capabilities,
+      _route: buildRouteMeta(ctx, 'dag_capabilities'),
+    },
+  };
+}
+
+export async function dispatchDagRun(ctx: GptDagBridgeContext): Promise<GptDagBridgeResponse> {
+  const payload = resolvePayload(ctx);
+  const graphId = getGraphId(payload);
+  const graphValidation = validateGraphId(graphId);
+  if (!graphValidation.ok) {
+    return buildErrorResponse(
+      ctx,
+      400,
+      'DAG_GRAPH_UNSUPPORTED',
+      `Unsupported DAG graph '${graphId}'.`,
+      'dag_dispatch_invalid_graph',
+      { graphId }
+    );
+  }
+
+  const prompt = getSafePrompt(ctx);
+  const input = {
+    ...getSafeInputFromPayload(payload),
+    ...(prompt ? { prompt } : {}),
+  };
+  if (Object.keys(input).length === 0) {
+    return buildErrorResponse(
+      ctx,
+      400,
+      'DAG_INPUT_REQUIRED',
+      'dag.dispatch requires prompt or payload.input.',
+      'dag_dispatch_input_required'
+    );
+  }
+
+  const idempotencyKey = getIdempotencyKey(payload);
+  const bridgeAsync = getBridgeAsync(payload);
+  const bridgePriority = getBridgePriority(payload);
+  const dispatchPayload = {
+    target: 'dag',
+    source: `gpt.${ctx.gptId}`,
+    sourceType: 'gpt',
+    gptId: ctx.gptId,
+    traceId: ctx.traceId,
+    graphId,
+    input,
+    options: {
+      async: bridgeAsync,
+      priority: bridgePriority,
+      ...(idempotencyKey ? { idempotencyKey } : {}),
+    },
+    metadata: {
+      route: GPT_DISPATCHER_ROUTE,
+      action: 'dag.dispatch',
+    },
+  };
+
+  const run = await arcanosDagRunService.createRun({
+    sessionId: `gpt.${ctx.gptId}.${ctx.traceId}`,
+    template: graphValidation.template,
+    input,
+    options: buildCreateRunOptions(payload),
+  });
+
+  return {
+    statusCode: 202,
+    logEvent: 'gpt.response.dag_dispatch',
+    payload: {
+      ok: true,
+      gptId: ctx.gptId,
+      action: 'dag.dispatch',
+      route: GPT_DISPATCHER_ROUTE,
+      traceId: ctx.traceId,
+      source: `gpt.${ctx.gptId}`,
+      sourceType: 'gpt',
+      graphId,
+      runId: run.runId,
+      status: run.status,
+      result: { run },
+      dispatch: dispatchPayload,
+      _route: buildRouteMeta(ctx, 'dag_dispatch'),
+    },
+  };
+}
+
+function readRunId(ctx: GptDagBridgeContext): string | null {
+  return readString(resolvePayload(ctx).runId);
+}
+
+function validateRunId(runId: string | null): runId is string {
+  return Boolean(runId && SAFE_RUN_ID_PATTERN.test(runId));
+}
+
+export async function getDagRunStatus(ctx: GptDagBridgeContext): Promise<GptDagBridgeResponse> {
+  const runId = readRunId(ctx);
+  if (!runId) {
+    return buildErrorResponse(
+      ctx,
+      400,
+      'DAG_RUN_ID_REQUIRED',
+      'dag.status requires payload.runId.',
+      'dag_status_run_id_required'
+    );
+  }
+  if (!validateRunId(runId)) {
+    return buildErrorResponse(
+      ctx,
+      400,
+      'DAG_RUN_ID_INVALID',
+      'payload.runId is not a valid DAG run identifier.',
+      'dag_status_run_id_invalid'
+    );
+  }
+
+  const waitedRun = await arcanosDagRunService.waitForRunUpdate(runId, {});
+  if (!waitedRun) {
+    return buildErrorResponse(ctx, 404, 'DAG_RUN_NOT_FOUND', 'DAG run was not found.', 'dag_status_not_found', {
+      runId,
+    });
+  }
+
+  const redactedRun = redactSensitive(waitedRun.run) as Record<string, unknown>;
+  return {
+    statusCode: 200,
+    logEvent: 'gpt.response.dag_status',
+    payload: {
+      ok: true,
+      gptId: ctx.gptId,
+      action: 'dag.status',
+      route: GPT_DISPATCHER_ROUTE,
+      traceId: ctx.traceId,
+      source: `gpt.${ctx.gptId}`,
+      runId,
+      status: redactedRun.status,
+      result: { run: redactedRun },
+      data: { run: redactedRun },
+      _route: buildRouteMeta(ctx, 'dag_status'),
+    },
+  };
+}
+
+export async function getDagRunTrace(ctx: GptDagBridgeContext): Promise<GptDagBridgeResponse> {
+  const runId = readRunId(ctx);
+  if (!runId) {
+    return buildErrorResponse(
+      ctx,
+      400,
+      'DAG_RUN_ID_REQUIRED',
+      'dag.trace requires payload.runId.',
+      'dag_trace_run_id_required'
+    );
+  }
+  if (!validateRunId(runId)) {
+    return buildErrorResponse(
+      ctx,
+      400,
+      'DAG_RUN_ID_INVALID',
+      'payload.runId is not a valid DAG run identifier.',
+      'dag_trace_run_id_invalid'
+    );
+  }
+
+  const trace = await arcanosDagRunService.getRunTrace(runId);
+  if (!trace) {
+    return buildErrorResponse(ctx, 404, 'DAG_RUN_NOT_FOUND', 'DAG run was not found.', 'dag_trace_not_found', {
+      runId,
+    });
+  }
+
+  const redactedTrace = redactSensitive(trace) as Record<string, unknown>;
+  return {
+    statusCode: 200,
+    logEvent: 'gpt.response.dag_trace',
+    payload: {
+      ok: true,
+      gptId: ctx.gptId,
+      action: 'dag.trace',
+      route: GPT_DISPATCHER_ROUTE,
+      traceId: ctx.traceId,
+      source: `gpt.${ctx.gptId}`,
+      runId,
+      result: redactedTrace,
+      data: redactedTrace,
+      _route: buildRouteMeta(ctx, 'dag_trace'),
+    },
+  };
+}
+
+export async function handleGptDagBridge(ctx: GptDagBridgeContext): Promise<GptDagBridgeResponse> {
+  const startedAtMs = Date.now();
+  let response: GptDagBridgeResponse;
+  let runId: string | null = null;
+  let graphId: string | null = null;
+
+  if (!isGptDagBridgeAction(ctx.action)) {
+    response = buildErrorResponse(
+      ctx,
+      400,
+      'GPT_DAG_ACTION_UNSUPPORTED',
+      `Unsupported DAG bridge action '${ctx.action}'.`,
+      'dag_bridge_unsupported_action',
+      { supportedActions: [...GPT_DAG_BRIDGE_ACTIONS] }
+    );
+    logBridgeAudit({
+      ctx,
+      status: response.statusCode,
+      latencyMs: Date.now() - startedAtMs,
+      errorCode: response.payload.code as string,
+    });
+    return response;
+  }
+
+  const guardResponse = assertGptCanUseDag(ctx, ctx.action);
+  if (guardResponse) {
+    logBridgeAudit({
+      ctx,
+      status: guardResponse.statusCode,
+      latencyMs: Date.now() - startedAtMs,
+      errorCode: guardResponse.payload.code as string,
+    });
+    return guardResponse;
+  }
+
+  try {
+    switch (ctx.action) {
+      case 'dag.capabilities':
+        response = await getDagCapabilities(ctx);
+        break;
+      case 'dag.dispatch':
+        graphId = getGraphId(resolvePayload(ctx));
+        response = await dispatchDagRun(ctx);
+        runId = readString(response.payload.runId);
+        break;
+      case 'dag.status':
+        runId = readRunId(ctx);
+        response = await getDagRunStatus(ctx);
+        break;
+      case 'dag.trace':
+        runId = readRunId(ctx);
+        response = await getDagRunTrace(ctx);
+        break;
+    }
+  } catch (error) {
+    const message = resolveErrorMessage(error);
+    const unsupportedTemplate = message.includes('Unsupported DAG template');
+    response = buildErrorResponse(
+      ctx,
+      unsupportedTemplate ? 400 : 503,
+      unsupportedTemplate ? 'DAG_GRAPH_UNSUPPORTED' : 'DAG_BRIDGE_UNAVAILABLE',
+      unsupportedTemplate ? message : 'DAG bridge action failed.',
+      unsupportedTemplate ? 'dag_dispatch_invalid_graph' : 'dag_bridge_unavailable',
+      unsupportedTemplate ? undefined : { message }
+    );
+  }
+
+  logBridgeAudit({
+    ctx,
+    status: response.statusCode,
+    latencyMs: Date.now() - startedAtMs,
+    runId,
+    graphId,
+    errorCode: response.statusCode >= 400 ? readString(response.payload.code) : null,
+  });
+  return response;
+}

--- a/src/services/gptDagBridge.ts
+++ b/src/services/gptDagBridge.ts
@@ -3,6 +3,7 @@ import type express from 'express';
 
 import {
   TRINITY_CORE_DAG_TEMPLATE_NAME,
+  UnsupportedDagTemplateError,
   resolvePublicDagTemplateName,
 } from '@dag/templates.js';
 import { arcanosDagRunService } from '@services/arcanosDagRunService.js';
@@ -255,9 +256,8 @@ function getBridgeAsync(payload: Record<string, unknown>): boolean {
   return parseBooleanLike(payload.async) ?? parseBooleanLike(options.async) ?? true;
 }
 
-function getBridgePriority(payload: Record<string, unknown>): 'normal' {
-  const rawPriority = readString(payload.priority) ?? readString(getOptionsRecord(payload).priority);
-  return rawPriority === DEFAULT_DAG_PRIORITY ? DEFAULT_DAG_PRIORITY : DEFAULT_DAG_PRIORITY;
+function getBridgePriority(): 'normal' {
+  return DEFAULT_DAG_PRIORITY;
 }
 
 function getIdempotencyKey(payload: Record<string, unknown>): string | null {
@@ -455,7 +455,7 @@ export async function dispatchDagRun(ctx: GptDagBridgeContext): Promise<GptDagBr
 
   const idempotencyKey = getIdempotencyKey(payload);
   const bridgeAsync = getBridgeAsync(payload);
-  const bridgePriority = getBridgePriority(payload);
+  const bridgePriority = getBridgePriority();
   const dispatchPayload = {
     target: 'dag',
     source: `gpt.${ctx.gptId}`,
@@ -661,16 +661,25 @@ export async function handleGptDagBridge(ctx: GptDagBridgeContext): Promise<GptD
         break;
     }
   } catch (error) {
-    const message = resolveErrorMessage(error);
-    const unsupportedTemplate = message.includes('Unsupported DAG template');
-    response = buildErrorResponse(
-      ctx,
-      unsupportedTemplate ? 400 : 503,
-      unsupportedTemplate ? 'DAG_GRAPH_UNSUPPORTED' : 'DAG_BRIDGE_UNAVAILABLE',
-      unsupportedTemplate ? message : 'DAG bridge action failed.',
-      unsupportedTemplate ? 'dag_dispatch_invalid_graph' : 'dag_bridge_unavailable',
-      unsupportedTemplate ? undefined : { message }
-    );
+    if (error instanceof UnsupportedDagTemplateError) {
+      response = buildErrorResponse(
+        ctx,
+        400,
+        'DAG_GRAPH_UNSUPPORTED',
+        error.message,
+        'dag_dispatch_invalid_graph'
+      );
+    } else {
+      const message = resolveErrorMessage(error);
+      response = buildErrorResponse(
+        ctx,
+        503,
+        'DAG_BRIDGE_UNAVAILABLE',
+        'DAG bridge action failed.',
+        'dag_bridge_unavailable',
+        { message }
+      );
+    }
   }
 
   logBridgeAudit({

--- a/src/shared/gpt/gptControlActions.ts
+++ b/src/shared/gpt/gptControlActions.ts
@@ -1,10 +1,18 @@
-export const GPT_DIRECT_CONTROL_ACTIONS = [
+export const GPT_PUBLIC_DIRECT_CONTROL_ACTIONS = [
   'diagnostics',
   'system_state',
+] as const;
+
+export const GPT_BLOCKED_DIRECT_CONTROL_ACTIONS = [
   'runtime.inspect',
   'workers.status',
   'queue.inspect',
   'self_heal.status',
+] as const;
+
+export const GPT_DIRECT_CONTROL_ACTIONS = [
+  ...GPT_PUBLIC_DIRECT_CONTROL_ACTIONS,
+  ...GPT_BLOCKED_DIRECT_CONTROL_ACTIONS,
 ] as const;
 
 export type GptDirectControlAction = (typeof GPT_DIRECT_CONTROL_ACTIONS)[number];

--- a/src/shared/gpt/gptDagBridgeActions.ts
+++ b/src/shared/gpt/gptDagBridgeActions.ts
@@ -1,0 +1,34 @@
+export const GPT_DAG_BRIDGE_ACTIONS = [
+  'dag.capabilities',
+  'dag.dispatch',
+  'dag.status',
+  'dag.trace',
+] as const;
+
+export type GptDagBridgeAction = (typeof GPT_DAG_BRIDGE_ACTIONS)[number];
+
+const GPT_DAG_BRIDGE_ACTION_SET = new Set<string>(GPT_DAG_BRIDGE_ACTIONS);
+
+export function normalizeGptDagAction(action: string | null | undefined): string | null {
+  return typeof action === 'string' && action.trim().length > 0
+    ? action.trim().toLowerCase()
+    : null;
+}
+
+export function isGptDagAction(action: string | null | undefined): boolean {
+  return normalizeGptDagAction(action)?.startsWith('dag.') ?? false;
+}
+
+export function isGptDagBridgeAction(
+  action: string | null | undefined
+): action is GptDagBridgeAction {
+  const normalizedAction = normalizeGptDagAction(action);
+  return normalizedAction ? GPT_DAG_BRIDGE_ACTION_SET.has(normalizedAction) : false;
+}
+
+export function normalizeGptDagBridgeAction(
+  action: string | null | undefined
+): GptDagBridgeAction | null {
+  const normalizedAction = normalizeGptDagAction(action);
+  return isGptDagBridgeAction(normalizedAction) ? normalizedAction : null;
+}

--- a/tests/dag-templates.test.ts
+++ b/tests/dag-templates.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it } from '@jest/globals';
 import {
   buildDagTemplate,
   resolvePublicDagTemplateName,
-  TRINITY_CORE_DAG_TEMPLATE_NAME
+  TRINITY_CORE_DAG_TEMPLATE_NAME,
+  UnsupportedDagTemplateError
 } from '../src/dag/templates.js';
 
 describe('DAG template normalization', () => {
@@ -37,6 +38,6 @@ describe('DAG template normalization', () => {
           goal: 'Reject unsupported templates.'
         }
       })
-    ).toThrow('Unsupported DAG template');
+    ).toThrow(UnsupportedDagTemplateError);
   });
 });

--- a/tests/dispatcher-priority.route.test.ts
+++ b/tests/dispatcher-priority.route.test.ts
@@ -154,7 +154,7 @@ describe('dispatcher priority routing', () => {
     expect(mockCreateDagRun).not.toHaveBeenCalled();
   });
 
-  it('rejects explicit DAG action on /gpt/{gptId}', async () => {
+  it('rejects unsupported explicit DAG bridge action on /gpt/{gptId}', async () => {
     const response = await request(buildApp())
       .post('/gpt/arcanos-core')
       .send({
@@ -168,7 +168,7 @@ describe('dispatcher priority routing', () => {
       gptId: 'arcanos-core',
       action: 'dag.run.create',
       error: expect.objectContaining({
-        code: 'DAG_CONTROL_REQUIRES_DIRECT_ENDPOINT',
+        code: 'GPT_DAG_ACTION_UNSUPPORTED',
       }),
     }));
     expect(mockRouteGptRequest).not.toHaveBeenCalled();

--- a/tests/gpt-dag-bridge.route.test.ts
+++ b/tests/gpt-dag-bridge.route.test.ts
@@ -1,0 +1,393 @@
+import express from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockRouteGptRequest = jest.fn();
+const mockResolveGptRouting = jest.fn();
+const mockGetFeatureFlags = jest.fn();
+const mockGetExecutionLimits = jest.fn();
+const mockCreateRun = jest.fn();
+const mockWaitForRunUpdate = jest.fn();
+const mockGetRunTrace = jest.fn();
+const redactionBearerValue = ['Bearer', 'abcdefghijklmnop'].join(' ');
+const redactionApiKey = ['sk', 'abcdefghijklmnopqrstuvwxyz'].join('-');
+const bridgeBearerToken = 'expected-bridge-token';
+const invalidBridgeBearerToken = 'wrong-token';
+
+jest.unstable_mockModule('../src/routes/_core/gptDispatch.js', () => ({
+  resolveGptRouting: mockResolveGptRouting,
+  routeGptRequest: mockRouteGptRequest,
+}));
+
+jest.unstable_mockModule('../src/platform/logging/gptLogger.js', () => ({
+  logGptConnection: jest.fn(),
+  logGptConnectionFailed: jest.fn(),
+  logGptAckSent: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/services/arcanosDagRunService.js', () => ({
+  arcanosDagRunService: {
+    getFeatureFlags: mockGetFeatureFlags,
+    getExecutionLimits: mockGetExecutionLimits,
+    createRun: mockCreateRun,
+    waitForRunUpdate: mockWaitForRunUpdate,
+    getRunTrace: mockGetRunTrace,
+  },
+}));
+
+const { default: requestContext } = await import('../src/middleware/requestContext.js');
+const { default: gptRouter } = await import('../src/routes/gptRouter.js');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(requestContext);
+  app.use('/gpt', gptRouter);
+  return app;
+}
+
+function buildRun(overrides: Record<string, unknown> = {}) {
+  return {
+    pipeline: 'trinity',
+    trinity_version: '1.0',
+    runId: 'dagrun_bridge_1',
+    sessionId: 'gpt.arcanos-core.trace-1',
+    template: 'trinity-core',
+    status: 'queued',
+    createdAt: '2026-04-27T10:00:00.000Z',
+    updatedAt: '2026-04-27T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('GPT DAG bridge route', () => {
+  const originalDagBridgeEnabled = process.env.GPT_DAG_BRIDGE_ENABLED;
+  const originalDagBridgeAllowedGpts = process.env.GPT_DAG_BRIDGE_ALLOWED_GPTS;
+  const originalDagBridgeRequireAuth = process.env.GPT_DAG_BRIDGE_REQUIRE_AUTH;
+  const originalDagBridgeBearerToken = process.env.GPT_DAG_BRIDGE_BEARER_TOKEN;
+  const originalOpenAiActionSharedSecret = process.env.OPENAI_ACTION_SHARED_SECRET;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.GPT_DAG_BRIDGE_ENABLED = 'true';
+    process.env.GPT_DAG_BRIDGE_ALLOWED_GPTS = 'arcanos-core';
+    delete process.env.GPT_DAG_BRIDGE_REQUIRE_AUTH;
+    delete process.env.GPT_DAG_BRIDGE_BEARER_TOKEN;
+    delete process.env.OPENAI_ACTION_SHARED_SECRET;
+
+    mockResolveGptRouting.mockImplementation(async (gptId: string) => ({
+      ok: true,
+      plan: {
+        matchedId: gptId,
+        module: 'ARCANOS:CORE',
+        route: 'core',
+        action: 'query',
+        availableActions: ['query'],
+        moduleVersion: null,
+        moduleDescription: null,
+        matchMethod: 'exact',
+      },
+      _route: {
+        gptId,
+        route: 'core',
+        module: 'ARCANOS:CORE',
+        action: 'query',
+        timestamp: '2026-04-27T00:00:00.000Z',
+      },
+    }));
+    mockGetFeatureFlags.mockReturnValue({
+      dagOrchestration: true,
+      parallelExecution: true,
+      recursiveSpawning: false,
+      jobTreeInspection: true,
+      eventStreaming: false,
+    });
+    mockGetExecutionLimits.mockReturnValue({
+      maxConcurrency: 5,
+      maxSpawnDepth: 3,
+      maxChildrenPerNode: 5,
+      maxRetriesPerNode: 2,
+      maxAiCallsPerRun: 20,
+      defaultNodeTimeoutMs: 180000,
+    });
+    mockCreateRun.mockResolvedValue(buildRun());
+    mockWaitForRunUpdate.mockResolvedValue({
+      run: buildRun({ status: 'running' }),
+      updated: true,
+      waited: false,
+    });
+    mockGetRunTrace.mockResolvedValue({
+      pipeline: 'trinity',
+      trinity_version: '1.0',
+      run: buildRun({ status: 'running' }),
+      events: {
+        runId: 'dagrun_bridge_1',
+        events: [
+          {
+            eventId: 'evt-1',
+            type: 'run.started',
+            at: '2026-04-27T10:00:00.000Z',
+            data: {
+              ['author' + 'ization']: redactionBearerValue,
+              ['api_' + 'key']: redactionApiKey,
+              safe: 'kept',
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (originalDagBridgeEnabled === undefined) {
+      delete process.env.GPT_DAG_BRIDGE_ENABLED;
+    } else {
+      process.env.GPT_DAG_BRIDGE_ENABLED = originalDagBridgeEnabled;
+    }
+    if (originalDagBridgeAllowedGpts === undefined) {
+      delete process.env.GPT_DAG_BRIDGE_ALLOWED_GPTS;
+    } else {
+      process.env.GPT_DAG_BRIDGE_ALLOWED_GPTS = originalDagBridgeAllowedGpts;
+    }
+    if (originalDagBridgeRequireAuth === undefined) {
+      delete process.env.GPT_DAG_BRIDGE_REQUIRE_AUTH;
+    } else {
+      process.env.GPT_DAG_BRIDGE_REQUIRE_AUTH = originalDagBridgeRequireAuth;
+    }
+    if (originalDagBridgeBearerToken === undefined) {
+      delete process.env.GPT_DAG_BRIDGE_BEARER_TOKEN;
+    } else {
+      process.env.GPT_DAG_BRIDGE_BEARER_TOKEN = originalDagBridgeBearerToken;
+    }
+    if (originalOpenAiActionSharedSecret === undefined) {
+      delete process.env.OPENAI_ACTION_SHARED_SECRET;
+    } else {
+      process.env.OPENAI_ACTION_SHARED_SECRET = originalOpenAiActionSharedSecret;
+    }
+  });
+
+  it('returns DAG-safe capabilities without entering Trinity', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({ action: 'dag.capabilities' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(expect.objectContaining({
+      ok: true,
+      gptId: 'arcanos-core',
+      action: 'dag.capabilities',
+      source: 'gpt.arcanos-core',
+      capabilities: expect.objectContaining({
+        features: expect.objectContaining({ dagOrchestration: true }),
+        graphs: [
+          expect.objectContaining({
+            graphId: 'default',
+            template: 'trinity-core',
+            actions: expect.arrayContaining(['dag.dispatch', 'dag.status', 'dag.trace']),
+          }),
+        ],
+      }),
+      traceId: expect.any(String),
+    }));
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('dispatches a DAG run with server-derived target and source', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'dag.dispatch',
+        target: 'mcp',
+        source: 'evil',
+        prompt: 'Validation run for GPT DAG bridge.',
+        payload: {
+          graphId: 'default',
+          target: 'mcp',
+          source: 'evil',
+          headers: { authorization: 'Bearer abcdefghijklmnop' },
+          input: {
+            validation: true,
+            target: 'tool',
+            source: 'payload-source',
+            nested: {
+              auth: 'secret',
+              kept: true,
+            },
+          },
+          async: true,
+          idempotencyKey: 'gpt-dag-bridge-validation-001',
+        },
+      });
+
+    expect(response.status).toBe(202);
+    expect(response.body).toEqual(expect.objectContaining({
+      ok: true,
+      gptId: 'arcanos-core',
+      action: 'dag.dispatch',
+      source: 'gpt.arcanos-core',
+      sourceType: 'gpt',
+      graphId: 'default',
+      runId: 'dagrun_bridge_1',
+      status: 'queued',
+      dispatch: expect.objectContaining({
+        target: 'dag',
+        source: 'gpt.arcanos-core',
+        sourceType: 'gpt',
+        options: expect.objectContaining({
+          async: true,
+          priority: 'normal',
+          idempotencyKey: 'gpt-dag-bridge-validation-001',
+        }),
+      }),
+    }));
+    expect(response.body.dispatch.input).toEqual({
+      validation: true,
+      nested: { kept: true },
+      prompt: 'Validation run for GPT DAG bridge.',
+    });
+    expect(JSON.stringify(response.body)).not.toContain('payload-source');
+    expect(JSON.stringify(response.body)).not.toContain('Bearer abcdefghijklmnop');
+    expect(mockCreateRun).toHaveBeenCalledWith(expect.objectContaining({
+      template: 'trinity-core',
+      input: {
+        validation: true,
+        nested: { kept: true },
+        prompt: 'Validation run for GPT DAG bridge.',
+      },
+    }));
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns DAG run status by runId', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'dag.status',
+        payload: { runId: 'dagrun_bridge_1' },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(expect.objectContaining({
+      ok: true,
+      action: 'dag.status',
+      runId: 'dagrun_bridge_1',
+      status: 'running',
+      source: 'gpt.arcanos-core',
+    }));
+    expect(mockWaitForRunUpdate).toHaveBeenCalledWith('dagrun_bridge_1', {});
+  });
+
+  it('requires a valid runId for status and trace', async () => {
+    const missingStatus = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({ action: 'dag.status', payload: {} });
+    const invalidTrace = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({ action: 'dag.trace', payload: { runId: '../secret' } });
+
+    expect(missingStatus.status).toBe(400);
+    expect(missingStatus.body.error.code).toBe('DAG_RUN_ID_REQUIRED');
+    expect(invalidTrace.status).toBe(400);
+    expect(invalidTrace.body.error.code).toBe('DAG_RUN_ID_INVALID');
+    expect(mockWaitForRunUpdate).not.toHaveBeenCalled();
+    expect(mockGetRunTrace).not.toHaveBeenCalled();
+  });
+
+  it('returns redacted DAG trace data', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'dag.trace',
+        payload: { runId: 'dagrun_bridge_1' },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(expect.objectContaining({
+      ok: true,
+      action: 'dag.trace',
+      runId: 'dagrun_bridge_1',
+      data: expect.objectContaining({
+        events: expect.objectContaining({
+          events: [
+            expect.objectContaining({
+              data: expect.objectContaining({
+                authorization: '[REDACTED]',
+                api_key: '[REDACTED]',
+                safe: 'kept',
+              }),
+            }),
+          ],
+        }),
+      }),
+    }));
+    expect(JSON.stringify(response.body)).not.toContain(redactionBearerValue);
+    expect(JSON.stringify(response.body)).not.toContain(redactionApiKey);
+  });
+
+  it('rejects unsupported DAG actions and unauthorized GPT IDs', async () => {
+    const unsupported = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({ action: 'dag.run.create', payload: { input: { goal: 'no' } } });
+    const unauthorized = await request(buildApp())
+      .post('/gpt/support-bot')
+      .send({ action: 'dag.dispatch', prompt: 'Should not run.' });
+
+    expect(unsupported.status).toBe(400);
+    expect(unsupported.body.error.code).toBe('GPT_DAG_ACTION_UNSUPPORTED');
+    expect(unauthorized.status).toBe(403);
+    expect(unauthorized.body.error.code).toBe('GPT_DAG_BRIDGE_GPT_NOT_ALLOWED');
+    expect(mockCreateRun).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('blocks runtime control actions through the GPT route', async () => {
+    for (const action of ['runtime.inspect', 'workers.status', 'queue.inspect', 'self_heal.status']) {
+      const response = await request(buildApp())
+        .post('/gpt/arcanos-core')
+        .send({ action });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.code).toBe('CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT');
+      expect(response.body.canonical).toEqual(expect.objectContaining({
+        mcp: '/mcp',
+      }));
+    }
+
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('enforces optional bridge bearer auth when configured', async () => {
+    process.env.GPT_DAG_BRIDGE_REQUIRE_AUTH = 'true';
+    process.env.GPT_DAG_BRIDGE_BEARER_TOKEN = bridgeBearerToken;
+
+    const missing = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({ action: 'dag.capabilities' });
+    const invalid = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .set('Authorization', ['Bearer', invalidBridgeBearerToken].join(' '))
+      .send({ action: 'dag.capabilities' });
+    const valid = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .set('Authorization', ['Bearer', bridgeBearerToken].join(' '))
+      .send({ action: 'dag.capabilities' });
+
+    expect(missing.status).toBe(401);
+    expect(invalid.status).toBe(401);
+    expect(valid.status).toBe(200);
+    expect(JSON.stringify(missing.body)).not.toContain(bridgeBearerToken);
+    expect(JSON.stringify(invalid.body)).not.toContain(invalidBridgeBearerToken);
+  });
+
+  it('returns a safe disabled response when the feature flag is false', async () => {
+    process.env.GPT_DAG_BRIDGE_ENABLED = 'false';
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({ action: 'dag.capabilities' });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error.code).toBe('GPT_DAG_BRIDGE_DISABLED');
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+});

--- a/tests/gpt-dag-bridge.route.test.ts
+++ b/tests/gpt-dag-bridge.route.test.ts
@@ -37,6 +37,7 @@ jest.unstable_mockModule('../src/services/arcanosDagRunService.js', () => ({
 
 const { default: requestContext } = await import('../src/middleware/requestContext.js');
 const { default: gptRouter } = await import('../src/routes/gptRouter.js');
+const { UnsupportedDagTemplateError } = await import('../src/dag/templates.js');
 
 function buildApp() {
   const app = express();
@@ -337,6 +338,26 @@ describe('GPT DAG bridge route', () => {
     expect(unauthorized.status).toBe(403);
     expect(unauthorized.body.error.code).toBe('GPT_DAG_BRIDGE_GPT_NOT_ALLOWED');
     expect(mockCreateRun).not.toHaveBeenCalled();
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('maps typed unsupported DAG template errors to graph validation responses', async () => {
+    mockCreateRun.mockRejectedValueOnce(new UnsupportedDagTemplateError('unexpected-template'));
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({
+        action: 'dag.dispatch',
+        prompt: 'Validation run for typed DAG template errors.',
+        payload: { graphId: 'default', input: { validation: true } },
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe('DAG_GRAPH_UNSUPPORTED');
+    expect(response.body._route).toEqual(expect.objectContaining({
+      route: 'dag_dispatch_invalid_graph',
+      action: 'dag.dispatch',
+    }));
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 

--- a/tests/gpt-router-auth-logging.test.ts
+++ b/tests/gpt-router-auth-logging.test.ts
@@ -686,7 +686,7 @@ describe('gpt router auth logging', () => {
     );
   });
 
-  it('rejects explicit embedded DAG control actions before dispatching to the write plane', async () => {
+  it('rejects unsupported embedded DAG bridge actions before dispatching to the write plane', async () => {
     const app = express();
     app.use(express.json());
     app.use(requestContext);
@@ -708,19 +708,16 @@ describe('gpt router auth logging', () => {
       action: 'dag.run.latest',
       route: '/gpt/:gptId',
       traceId: expect.any(String),
-      error: {
-        code: 'DAG_CONTROL_REQUIRES_DIRECT_ENDPOINT',
-        message: "DAG execution must use /api/arcanos/dag/*, POST /mcp, or POST /dispatch with target='dag'.",
-      },
-      canonical: {
-        mcp: '/mcp',
-        dispatch: '/dispatch',
-        dagRuns: '/api/arcanos/dag/runs/{runId}',
-        dagTrace: '/api/arcanos/dag/runs/{runId}/trace',
-      },
+      error: expect.objectContaining({
+        code: 'GPT_DAG_ACTION_UNSUPPORTED',
+        message: "Unsupported DAG bridge action 'dag.run.latest'.",
+        details: expect.objectContaining({
+          supportedActions: ['dag.capabilities', 'dag.dispatch', 'dag.status', 'dag.trace'],
+        }),
+      }),
       _route: expect.objectContaining({
         gptId: 'arcanos-core',
-        route: 'control_guard',
+        route: 'dag_bridge_unsupported_action',
         action: 'dag.run.latest',
       }),
     }));

--- a/tests/gpt-router-universal-dispatch.test.ts
+++ b/tests/gpt-router-universal-dispatch.test.ts
@@ -677,53 +677,36 @@ describe('gpt router universal dispatch', () => {
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
-  it('routes runtime.inspect through the universal public dispatcher', async () => {
+  it('blocks runtime.inspect through the GPT route', async () => {
     const response = await request(buildApp())
       .post('/gpt/arcanos-core')
       .send({ action: 'runtime.inspect' });
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(400);
     expect(response.body).toEqual(
       expect.objectContaining({
-        ok: true,
+        ok: false,
         action: 'runtime.inspect',
-        meta: expect.objectContaining({
-          detail: 'summary',
-          truncated: false,
-          source: 'planner',
-          availableSections: expect.arrayContaining(['workers', 'queues', 'memory', 'incidents']),
-          returnedSections: expect.arrayContaining(['workers', 'queues', 'memory', 'incidents']),
+        error: expect.objectContaining({
+          code: 'CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT',
         }),
-        result: {
-          handledBy: 'runtime-inspection',
-          runtimeInspection: expect.objectContaining({
-            status: 'ok',
-            summary: 'Collected live runtime state from 5 runtime sources.',
-            sections: expect.objectContaining({
-              workers: expect.any(Object),
-              queues: expect.any(Object),
-              memory: expect.any(Object),
-              incidents: expect.any(Object),
-            }),
-          }),
-        },
+        canonical: expect.objectContaining({
+          mcp: '/mcp',
+          workers: '/workers/status',
+          selfHeal: '/status/safety/self-heal',
+        }),
         _route: expect.objectContaining({
           gptId: 'arcanos-core',
           action: 'runtime.inspect',
-          route: 'runtime_inspect',
+          route: 'control_guard',
         }),
       })
     );
-    expect(mockExecuteRuntimeInspection).toHaveBeenCalledWith(
-      expect.objectContaining({
-        rawPrompt: 'runtime inspect live runtime status',
-        normalizedPrompt: 'runtime inspect live runtime status',
-      })
-    );
+    expect(mockExecuteRuntimeInspection).not.toHaveBeenCalled();
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
-  it('honors explicit full detail and section filtering for runtime.inspect', async () => {
+  it('blocks runtime.inspect detail and section payloads through the GPT route', async () => {
     const response = await request(buildApp())
       .post('/gpt/arcanos-core')
       .send({
@@ -734,105 +717,67 @@ describe('gpt router universal dispatch', () => {
         },
       });
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(400);
     expect(response.body).toEqual(
       expect.objectContaining({
-        ok: true,
+        ok: false,
         action: 'runtime.inspect',
-        meta: expect.objectContaining({
-          detail: 'full',
-          truncated: false,
-          source: 'explicit',
-          returnedSections: ['workers', 'memory'],
+        error: expect.objectContaining({
+          code: 'CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT',
         }),
-        result: {
-          handledBy: 'runtime-inspection',
-          runtimeInspection: expect.objectContaining({
-            sections: {
-              workers: expect.any(Object),
-              memory: expect.any(Object),
-            },
-          }),
-        },
       }),
     );
-    expect(response.body.result.runtimeInspection.sections.queues).toBeUndefined();
-    expect(response.body.result.runtimeInspection.sections.incidents).toBeUndefined();
+    expect(mockExecuteRuntimeInspection).not.toHaveBeenCalled();
   });
 
-  it('defaults self_heal.status to a shaped summary response', async () => {
+  it('blocks self_heal.status through the GPT route', async () => {
     const response = await request(buildApp())
       .post('/gpt/arcanos-core')
       .send({ action: 'self_heal.status' });
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(400);
     expect(response.body).toEqual(
       expect.objectContaining({
-        ok: true,
+        ok: false,
         action: 'self_heal.status',
-        meta: expect.objectContaining({
-          detail: 'summary',
-          truncated: false,
-          source: 'planner',
-          availableSections: expect.arrayContaining(['system', 'workers', 'memory', 'incidents']),
-        }),
-        result: expect.objectContaining({
-          status: 'ok',
-          enabled: true,
-          active: false,
-          summary: expect.any(String),
-          sections: expect.objectContaining({
-            system: expect.any(Object),
-            incidents: expect.any(Object),
-            workers: expect.any(Object),
-            memory: expect.any(Object),
-          }),
+        error: expect.objectContaining({
+          code: 'CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT',
         }),
         _route: expect.objectContaining({
           gptId: 'arcanos-core',
           action: 'self_heal.status',
-          route: 'self_heal_status',
+          route: 'control_guard',
         }),
       }),
     );
+    expect(mockBuildSafetySelfHealSnapshot).not.toHaveBeenCalled();
   });
 
-  it('routes workers.status through the universal public dispatcher', async () => {
+  it('blocks workers.status through the GPT route', async () => {
     const response = await request(buildApp())
       .post('/gpt/arcanos-core')
       .send({ action: 'workers.status' });
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(400);
     expect(response.body).toEqual(
       expect.objectContaining({
-        ok: true,
+        ok: false,
         action: 'workers.status',
-        meta: expect.objectContaining({
-          detail: 'standard',
-          truncated: false,
-          source: 'planner',
-        }),
-        result: expect.objectContaining({
-          timestamp: '2026-04-15T00:00:00.000Z',
-          workerService: expect.objectContaining({
-            queueSummary: expect.objectContaining({
-              pending: 2,
-              running: 1,
-            }),
-          }),
+        error: expect.objectContaining({
+          code: 'CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT',
         }),
         _route: expect.objectContaining({
           gptId: 'arcanos-core',
           action: 'workers.status',
-          route: 'workers_status',
+          route: 'control_guard',
         }),
       })
     );
-    expect(mockGetWorkerControlStatus).toHaveBeenCalledTimes(1);
+    expect(mockGetWorkerControlStatus).not.toHaveBeenCalled();
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
-  it('rejects invalid explicit detail values with a typed 400 error', async () => {
+  it('rejects explicit runtime control action payloads before planner validation', async () => {
     const response = await request(buildApp())
       .post('/gpt/arcanos-core')
       .send({
@@ -848,104 +793,19 @@ describe('gpt router universal dispatch', () => {
         ok: false,
         action: 'runtime.inspect',
         error: expect.objectContaining({
-          code: 'INVALID_GPT_DETAIL',
+          code: 'CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT',
         }),
         canonical: expect.objectContaining({
-          supportedDetail: 'summary, standard, full',
+          mcp: '/mcp',
         }),
       }),
     );
     expect(mockExecuteRuntimeInspection).not.toHaveBeenCalled();
   });
 
-  it('marks truncated runtime inspection responses explicitly before the public response guard', async () => {
+  it('does not run runtime inspection or public truncation for blocked runtime.inspect', async () => {
     process.env.GPT_PUBLIC_RESPONSE_MAX_BYTES = '5000';
-    mockExecuteRuntimeInspection.mockResolvedValueOnce({
-      ok: true,
-      responsePayload: {
-        handledBy: 'runtime-inspection',
-        runtimeInspection: {
-          status: 'ok',
-          summary: 'Collected live runtime state from 5 runtime sources.',
-          detectedIntent: 'RUNTIME_INSPECTION_REQUIRED',
-          toolsSelected: [
-            '/worker-helper/health',
-            '/workers/status',
-            'system.metrics',
-            '/api/self-heal/events',
-            '/api/self-heal/inspection',
-          ],
-          runtimeEndpointsQueried: ['/worker-helper/health', '/workers/status'],
-          sources: [
-            {
-              sourceType: 'worker-health',
-              tool: '/worker-helper/health',
-              data: {
-                alerts: Array.from({ length: 20 }, (_, index) => `alert-${index}`),
-                workers: Array.from({ length: 20 }, (_, index) => ({
-                  workerId: `worker-${index}`,
-                  healthStatus: 'healthy',
-                })),
-              },
-            },
-            {
-              sourceType: 'metrics',
-              tool: 'system.metrics',
-              data: {
-                diagnostics: {
-                  recent_latency_ms: Array.from({ length: 40 }, (_, index) => index),
-                },
-              },
-            },
-            {
-              sourceType: 'runtime-endpoint',
-              tool: '/api/self-heal/events',
-              data: {
-                events: Array.from({ length: 50 }, (_, index) => ({
-                  id: `evt-${index}`,
-                  type: 'HEAL_RESULT',
-                  message: 'x'.repeat(200),
-                })),
-              },
-            },
-            {
-              sourceType: 'runtime-endpoint',
-              tool: '/api/self-heal/inspection',
-              data: {
-                evidence: {
-                  traces: Array.from({ length: 40 }, (_, index) => ({
-                    id: `trace-${index}`,
-                    detail: 'y'.repeat(200),
-                  })),
-                },
-              },
-            },
-          ],
-          failures: Array.from({ length: 20 }, (_, index) => ({
-            tool: `tool-${index}`,
-            error: 'z'.repeat(160),
-          })),
-        },
-      },
-      routingDebug: {
-        requestId: 'req-runtime-oversized',
-        timestamp: '2026-04-15T00:00:00.000Z',
-        rawPrompt: 'full raw runtime inspection with everything included',
-        normalizedPrompt: 'full raw runtime inspection with everything included',
-        detectedIntent: 'RUNTIME_INSPECTION_REQUIRED',
-        routingDecision: 'runtime_inspection_completed',
-        toolsAvailable: ['system.metrics'],
-        toolsSelected: ['system.metrics'],
-        cliUsed: false,
-        runtimeEndpointsQueried: ['/workers/status'],
-        repoFallbackUsed: false,
-        constraintViolations: [],
-      },
-      repoFallbackAllowed: false,
-      selectedTools: ['system.metrics'],
-      runtimeEndpointsQueried: ['/workers/status'],
-      cliUsed: false,
-    });
+    mockExecuteRuntimeInspection.mockResolvedValueOnce(buildOversizedRuntimeInspectionResponse());
 
     const response = await request(buildApp())
       .post('/gpt/arcanos-core')
@@ -957,32 +817,23 @@ describe('gpt router universal dispatch', () => {
         },
       });
 
-    expect(response.status).toBe(200);
-    expect(response.headers['x-response-truncated']).toBe('true');
+    expect(response.status).toBe(400);
+    expect(response.headers['x-response-truncated']).toBeUndefined();
     expect(response.body).toEqual(
       expect.objectContaining({
-        ok: true,
+        ok: false,
         action: 'runtime.inspect',
-        status: 'partial',
-        message: 'Response exceeded public route bounds. Narrow sections or reduce detail.',
-        meta: expect.objectContaining({
-          detail: 'full',
-          truncated: true,
-          source: 'explicit',
-          returnedSections: expect.any(Array),
-          omittedSections: expect.any(Array),
-          availableSections: expect.arrayContaining(['workers', 'queues', 'memory', 'incidents']),
+        error: expect.objectContaining({
+          code: 'CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT',
         }),
       }),
     );
-    expect(response.body.meta.returnedSections.length).toBeGreaterThan(0);
-    expect(response.body.meta.omittedSections.length).toBeGreaterThan(0);
+    expect(mockExecuteRuntimeInspection).not.toHaveBeenCalled();
   });
 
-  it('keeps section filtering bounded when a filtered runtime inspection response is truncated', async () => {
+  it('does not apply runtime section filtering for blocked runtime.inspect', async () => {
     process.env.GPT_PUBLIC_RESPONSE_MAX_BYTES = '5000';
     mockExecuteRuntimeInspection.mockResolvedValueOnce(buildOversizedRuntimeInspectionResponse());
-    const requestedSections = ['workers', 'queues'];
 
     const response = await request(buildApp())
       .post('/gpt/arcanos-core')
@@ -990,36 +841,25 @@ describe('gpt router universal dispatch', () => {
         action: 'runtime.inspect',
         payload: {
           detail: 'full',
-          sections: requestedSections,
+          sections: ['workers', 'queues'],
         },
       });
 
-    expect(response.status).toBe(200);
-    expect(response.headers['x-response-truncated']).toBe('true');
+    expect(response.status).toBe(400);
+    expect(response.headers['x-response-truncated']).toBeUndefined();
     expect(response.body).toEqual(
       expect.objectContaining({
-        ok: true,
+        ok: false,
         action: 'runtime.inspect',
-        status: 'partial',
-        meta: expect.objectContaining({
-          detail: 'full',
-          truncated: true,
-          source: 'explicit',
-          returnedSections: expect.any(Array),
-          omittedSections: expect.any(Array),
-          availableSections: expect.arrayContaining(['workers', 'queues']),
+        error: expect.objectContaining({
+          code: 'CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT',
         }),
       }),
     );
-
-    const returnedSections = response.body.meta.returnedSections as string[];
-    const omittedSections = response.body.meta.omittedSections as string[];
-    expect(returnedSections.every((section) => requestedSections.includes(section))).toBe(true);
-    expect(omittedSections.every((section) => requestedSections.includes(section))).toBe(true);
-    expect(new Set([...returnedSections, ...omittedSections])).toEqual(new Set(requestedSections));
+    expect(mockExecuteRuntimeInspection).not.toHaveBeenCalled();
   });
 
-  it('marks truncated self_heal.status responses explicitly before the public response guard', async () => {
+  it('does not build or truncate self-heal snapshots for blocked self_heal.status', async () => {
     process.env.GPT_PUBLIC_RESPONSE_MAX_BYTES = '5000';
     mockBuildSafetySelfHealSnapshot.mockReturnValueOnce(buildOversizedSelfHealSnapshot());
 
@@ -1032,28 +872,21 @@ describe('gpt router universal dispatch', () => {
         },
       });
 
-    expect(response.status).toBe(200);
-    expect(response.headers['x-response-truncated']).toBe('true');
+    expect(response.status).toBe(400);
+    expect(response.headers['x-response-truncated']).toBeUndefined();
     expect(response.body).toEqual(
       expect.objectContaining({
-        ok: true,
+        ok: false,
         action: 'self_heal.status',
-        status: 'partial',
-        message: 'Response exceeded public route bounds. Narrow sections or reduce detail.',
-        meta: expect.objectContaining({
-          detail: 'full',
-          truncated: true,
-          source: 'explicit',
-          returnedSections: expect.any(Array),
-          omittedSections: expect.any(Array),
-          availableSections: expect.arrayContaining(['system', 'workers', 'memory', 'incidents']),
+        error: expect.objectContaining({
+          code: 'CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT',
         }),
       }),
     );
-    expect(response.body.meta.omittedSections.length).toBeGreaterThan(0);
+    expect(mockBuildSafetySelfHealSnapshot).not.toHaveBeenCalled();
   });
 
-  it('allows guarded non-production debug headers to lower GPT control response bounds', async () => {
+  it('ignores guarded debug truncation headers for blocked runtime control actions', async () => {
     process.env.NODE_ENV = 'test';
     process.env.ARCANOS_ENABLE_DEBUG_GPT_CONTROLS = 'true';
     mockExecuteRuntimeInspection.mockResolvedValueOnce(buildOversizedRuntimeInspectionResponse());
@@ -1068,18 +901,18 @@ describe('gpt router universal dispatch', () => {
         },
       });
 
-    expect(response.status).toBe(200);
-    expect(response.headers['x-response-truncated']).toBe('true');
+    expect(response.status).toBe(400);
+    expect(response.headers['x-response-truncated']).toBeUndefined();
     expect(response.body).toEqual(
       expect.objectContaining({
-        ok: true,
+        ok: false,
         action: 'runtime.inspect',
-        status: 'partial',
-        meta: expect.objectContaining({
-          truncated: true,
+        error: expect.objectContaining({
+          code: 'CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT',
         }),
       }),
     );
+    expect(mockExecuteRuntimeInspection).not.toHaveBeenCalled();
   });
 
   it('rejects unknown reserved control actions with a typed 400 error', async () => {
@@ -1099,7 +932,7 @@ describe('gpt router universal dispatch', () => {
           code: 'UNSUPPORTED_GPT_ACTION',
         }),
         canonical: expect.objectContaining({
-          supportedActions: expect.stringContaining('runtime.inspect'),
+          supportedActions: 'diagnostics, system_state',
         }),
         _route: expect.objectContaining({
           gptId: 'arcanos-core',

--- a/tests/introspection-openapi-contract.route.test.ts
+++ b/tests/introspection-openapi-contract.route.test.ts
@@ -27,6 +27,25 @@ describe('custom GPT OpenAPI contract route', () => {
         minLength: 1,
       })
     );
+
+    const requestExamples =
+      response.body.paths?.['/gpt/{gptId}']?.post?.requestBody?.content?.['application/json']
+        ?.examples;
+    expect(requestExamples?.diagnostics?.value?.action).toBe('diagnostics');
+    const requestExampleActions = Object.values(requestExamples ?? {}).map((example) => {
+      const typedExample = example as { value?: { action?: unknown } };
+      return typedExample.value?.action;
+    });
+    expect(requestExampleActions).toEqual(
+      expect.arrayContaining(['dag.capabilities', 'dag.dispatch', 'dag.status', 'dag.trace'])
+    );
+
+    const diagnosticsControlActionEnum =
+      response.body.components?.schemas?.GptDispatcherDiagnosticsResponse?.properties?.controlActions
+        ?.items?.enum;
+    expect(diagnosticsControlActionEnum).toEqual(['diagnostics', 'system_state']);
+    expect(JSON.stringify(requestExamples)).not.toContain('runtime.inspect');
+    expect(JSON.stringify(requestExamples)).not.toContain('workers.status');
   });
 
   it('serves the canonical job-result contract with no-store caching', async () => {

--- a/tests/openapi/custom-gpt-route.contract.test.ts
+++ b/tests/openapi/custom-gpt-route.contract.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('custom GPT route OpenAPI contract', () => {
+  it('documents only public GPT direct control actions while preserving safe DAG bridge examples', () => {
+    const contract = JSON.parse(
+      readFileSync(join(process.cwd(), 'contracts/custom_gpt_route.openapi.v1.json'), 'utf8')
+    );
+
+    const requestExamples =
+      contract.paths?.['/gpt/{gptId}']?.post?.requestBody?.content?.['application/json']?.examples;
+    const requestExampleActions = Object.values(requestExamples ?? {}).map((example) => {
+      const typedExample = example as { value?: { action?: unknown } };
+      return typedExample.value?.action;
+    });
+
+    expect(requestExampleActions).toEqual(
+      expect.arrayContaining([
+        'diagnostics',
+        'dag.capabilities',
+        'dag.dispatch',
+        'dag.status',
+        'dag.trace'
+      ])
+    );
+    expect(JSON.stringify(requestExamples)).not.toContain('runtime.inspect');
+    expect(JSON.stringify(requestExamples)).not.toContain('workers.status');
+
+    const controlActionEnum =
+      contract.components?.schemas?.GptDispatcherDiagnosticsResponse?.properties?.controlActions
+        ?.items?.enum;
+    expect(controlActionEnum).toEqual(['diagnostics', 'system_state']);
+  });
+});

--- a/tests/runtime-diagnostics.route.test.ts
+++ b/tests/runtime-diagnostics.route.test.ts
@@ -86,13 +86,7 @@ describe('runtime diagnostics routes', () => {
         'get_status',
         'get_result'
       ]),
-      controlActions: expect.arrayContaining([
-        'diagnostics',
-        'runtime.inspect',
-        'workers.status',
-        'queue.inspect',
-        'self_heal.status'
-      ]),
+      controlActions: ['diagnostics', 'system_state'],
       canonicalEndpoints: expect.objectContaining({
         status: '/status',
         workers: '/workers/status',


### PR DESCRIPTION
## Summary
- Add a feature-flagged GPT DAG bridge for `dag.capabilities`, `dag.dispatch`, `dag.status`, and `dag.trace`.
- Keep protected control-plane actions blocked through `POST /gpt/:gptId`.
- Update the GPT route contract, CLI tests, and route coverage for the safe DAG surface.

## Validation
- `npm test -- --coverage=false`
- `npm run type-check`
- `npm run build`
- `npm run lint` (0 errors; existing warnings)
- `npm test -- --testPathPatterns=tests/gpt-dag-bridge.route.test.ts --runInBand --coverage=false`

## Notes
- Railway deployment and deployed probes were not run from this checkout because the Railway project is not linked locally.