### PR TITLE
[codex] add root deep diagnostics bridge

### DIFF
--- a/contracts/custom_gpt_route.openapi.v1.json
+++ b/contracts/custom_gpt_route.openapi.v1.json
@@ -3,14 +3,14 @@
   "info": {
     "title": "Arcanos GPT Route API",
     "version": "1.0.0",
-    "description": "Canonical public contract for GPT-routed module requests and the safe DAG bridge. GPT identity is path-bound at /gpt/{gptId}; generated tool clients may also echo the same gptId in the JSON body, and mismatched body/path IDs are rejected. POST /gpt/{gptId} accepts flexible request bodies with action as a string and payload as an open object so durable GPT actions, safe DAG bridge actions, and prompt-only fast-path generation can share one public endpoint. For generated clients that place operation metadata outside the JSON body, the route also accepts action as a query parameter or operation-style body alias. Simple prompt-generation requests that omit action can opt into inline fast-path execution with executionMode=fast. Runtime inspection, worker status, queue inspection, self-heal status, MCP calls, and arbitrary internal endpoint forwarding remain blocked on this route."
+    "description": "Canonical public contract for GPT-routed module requests and the safe DAG bridge. GPT identity is path-bound at /gpt/{gptId}; generated tool clients may also echo the same gptId in the JSON body, and mismatched body/path IDs are rejected. POST /gpt/{gptId} accepts flexible request bodies with action as a string and payload as an open object so durable GPT actions, safe DAG bridge actions, and prompt-only fast-path generation can share one public endpoint. For generated clients that place operation metadata outside the JSON body, the route also accepts action as a query parameter or operation-style body alias. Simple prompt-generation requests that omit action can opt into inline fast-path execution with executionMode=fast. Runtime inspection, worker status, queue inspection, self-heal status, MCP calls, and arbitrary internal endpoint forwarding remain blocked on this route. Private root.deep_diagnostics is root-only, bearer-protected, environment-gated, and limited to a hardcoded diagnostics report."
   },
   "paths": {
     "/gpt/{gptId}": {
       "post": {
         "operationId": "invokeGptRoute",
         "summary": "Invoke a GPT-routed module request or universal control action",
-        "description": "POST /gpt/{gptId} is the universal public dispatcher. The path parameter is authoritative; a JSON body gptId is optional and must match the path when present. Use a prompt-only request with executionMode=fast for small prompt-generation work that should return inline. Use action=query to create one durable writing job through the Trinity writing pipeline, action=query_and_wait on core GPT IDs to execute synchronously through the lightweight direct action lane, action=get_status to read status through the GPT compatibility bridge, action=get_result to read the final result through the GPT compatibility bridge, action=diagnostics to read deterministic GPT route metadata, and the safe DAG bridge actions dag.capabilities, dag.dispatch, dag.status, and dag.trace. The action should be supplied in the JSON body when possible; generated-client compatibility also permits the same action in the query string or an operationId-style body alias. Unknown control-plane action names are rejected with a typed 400 error. Natural-language retrieval prompts, runtime inspection prompts, unsupported DAG actions, MCP control requests, and runtime.inspect/workers.status/queue.inspect/self_heal.status control actions are still intentionally rejected on this route.",
+        "description": "POST /gpt/{gptId} is the universal public dispatcher. The path parameter is authoritative; a JSON body gptId is optional and must match the path when present. Use a prompt-only request with executionMode=fast for small prompt-generation work that should return inline. Use action=query to create one durable writing job through the Trinity writing pipeline, action=query_and_wait on core GPT IDs to execute synchronously through the lightweight direct action lane, action=get_status to read status through the GPT compatibility bridge, action=get_result to read the final result through the GPT compatibility bridge, action=diagnostics to read deterministic GPT route metadata, and the safe DAG bridge actions dag.capabilities, dag.dispatch, dag.status, and dag.trace. The action should be supplied in the JSON body when possible; generated-client compatibility also permits the same action in the query string or an operationId-style body alias. Unknown control-plane action names are rejected with a typed 400 error. Natural-language retrieval prompts, runtime inspection prompts, unsupported DAG actions, MCP control requests, and runtime.inspect/workers.status/queue.inspect/self_heal.status control actions are still intentionally rejected on this route. The private action root.deep_diagnostics is a root-only diagnostics bridge for allowlisted GPT IDs and requires ENABLE_ROOT_DEEP_DIAGNOSTICS=true plus an exact Bearer token match against ARCANOS_ADMIN_TOKEN.",
         "parameters": [
           {
             "name": "gptId",
@@ -143,6 +143,12 @@
                       "venue": "Daily's Place"
                     }
                   }
+                },
+                "rootDeepDiagnostics": {
+                  "summary": "Root-only deep diagnostics bridge for an allowlisted core GPT",
+                  "value": {
+                    "action": "root.deep_diagnostics"
+                  }
                 }
               }
             }
@@ -150,7 +156,7 @@
         },
         "responses": {
           "200": {
-            "description": "Completed fast-path inline response, direct query_and_wait response, async bridge response, safe DAG bridge read response, or generic GPT response",
+            "description": "Completed fast-path inline response, direct query_and_wait response, async bridge response, safe DAG bridge read response, or generic GPT response Root deep diagnostics responses are returned only for authorized private root.deep_diagnostics calls.",
             "content": {
               "application/json": {
                 "schema": {
@@ -284,6 +290,25 @@
               }
             }
           },
+          "403": {
+            "description": "Root diagnostics denied because the action is disabled, the GPT is not allowlisted, or the Bearer token is missing or invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootDiagnosticsForbiddenResponse"
+                },
+                "examples": {
+                  "rootDiagnosticsForbidden": {
+                    "summary": "Root diagnostics authorization failed",
+                    "value": {
+                      "ok": false,
+                      "error": "ROOT_DIAGNOSTICS_FORBIDDEN"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "404": {
             "description": "Unknown GPT route or missing async job status lookup",
             "content": {
@@ -346,7 +371,7 @@
       "GptRouteRequest": {
         "type": "object",
         "additionalProperties": true,
-        "description": "Universal GPT-route request. action is an open string field so callers can send canonical async bridge actions, module actions, diagnostics, job lookup bridge actions, and the safe DAG bridge actions through POST /gpt/{gptId}. A body gptId is optional for generated tool clients and must match the path gptId when present. Runtime inspection, worker status, queue inspection, self-heal status, MCP calls, unsupported dag.* actions, and arbitrary internal endpoint forwarding are rejected.",
+        "description": "Universal GPT-route request. action is an open string field so callers can send canonical async bridge actions, module actions, diagnostics, job lookup bridge actions, and the safe DAG bridge actions through POST /gpt/{gptId}. A body gptId is optional for generated tool clients and must match the path gptId when present. Runtime inspection, worker status, queue inspection, self-heal status, MCP calls, unsupported dag.* actions, and arbitrary internal endpoint forwarding are rejected. root.deep_diagnostics is private, root-only, and authorized exclusively with the configured Bearer token.",
         "properties": {
           "gptId": {
             "type": "string",
@@ -356,7 +381,7 @@
           "action": {
             "type": "string",
             "minLength": 1,
-            "description": "Requested action name. Canonical built-ins include query, query_and_wait, get_status, get_result, diagnostics, dag.capabilities, dag.dispatch, dag.status, and dag.trace. Module-specific action names are also allowed. Unsupported reserved control action names are rejected with HTTP 400."
+            "description": "Requested action name. Canonical built-ins include query, query_and_wait, get_status, get_result, diagnostics, dag.capabilities, dag.dispatch, dag.status, and dag.trace. Module-specific action names are also allowed. Unsupported reserved control action names are rejected with HTTP 400. Private root.deep_diagnostics is available only to the configured root diagnostics allowlist."
           },
           "operationId": {
             "type": "string",
@@ -639,6 +664,9 @@
           },
           {
             "$ref": "#/components/schemas/GptDispatcherDiagnosticsResponse"
+          },
+          {
+            "$ref": "#/components/schemas/RootDeepDiagnosticsResponse"
           },
           {
             "$ref": "#/components/schemas/GptRouteGenericResponse"
@@ -1164,6 +1192,81 @@
           "timeoutMs": {
             "type": "integer",
             "minimum": 0
+          }
+        }
+      },
+      "RootDiagnosticsSubCheck": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "ok",
+          "name"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "data": {},
+          "error": {
+            "type": "string"
+          }
+        }
+      },
+      "RootDeepDiagnosticsResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "gptId",
+          "action",
+          "traceId",
+          "timestamp",
+          "report"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "gptId": {
+            "type": "string"
+          },
+          "action": {
+            "type": "string",
+            "const": "root.deep_diagnostics"
+          },
+          "traceId": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "report": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RootDiagnosticsSubCheck"
+            }
+          }
+        }
+      },
+      "RootDiagnosticsForbiddenResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "ok",
+          "error"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "const": false
+          },
+          "error": {
+            "type": "string",
+            "const": "ROOT_DIAGNOSTICS_FORBIDDEN"
           }
         }
       }

--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -118,6 +118,23 @@ describe("Arcanos CLI", () => {
       pollIntervalMs: 500
     });
 
+    expect(
+      parseCliInvocation([
+        "diagnostics",
+        "--gpt",
+        "arcanos-core",
+        "--root",
+        "--json",
+      ])
+    ).toMatchObject({
+      kind: "diagnostics",
+      gptId: "arcanos-core",
+      root: true,
+      options: {
+        json: true,
+      },
+    });
+
     expect(parseCliInvocation(["job-status", "job-123", "--json"])).toMatchObject({
       kind: "job-status",
       jobId: "job-123",
@@ -254,6 +271,79 @@ describe("Arcanos CLI", () => {
         body: expect.stringContaining("\"prompt\":\"ship it\"")
       })
     );
+  });
+
+  it("sends root diagnostics with an env-sourced redacted Bearer token", async () => {
+    const originalAdminToken = process.env.ARCANOS_ADMIN_TOKEN;
+    const cliToken = "cli-unit-test-admin-token";
+    process.env.ARCANOS_ADMIN_TOKEN = cliToken;
+    const fetchMock = jest.spyOn(globalThis, "fetch").mockResolvedValue(
+      createJsonResponse({
+        ok: true,
+        gptId: "arcanos-core",
+        action: "root.deep_diagnostics",
+        traceId: "trace-cli-root",
+        timestamp: "2026-04-27T00:00:00.000Z",
+        report: []
+      })
+    );
+    const stdout = createWritableCapture();
+    const stderr = createWritableCapture();
+
+    try {
+      const exitCode = await runCli(
+        [
+          "diagnostics",
+          "--gpt",
+          "arcanos-core",
+          "--root",
+          "--json",
+          "--base-url",
+          "http://127.0.0.1:3000"
+        ],
+        stdout.stream,
+        stderr.stream
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stderr.read()).toBe("");
+      const output = stdout.read();
+      expect(output).not.toContain(cliToken);
+      expect(JSON.parse(output)).toMatchObject({
+        ok: true,
+        data: {
+          command: "gpt.root_deep_diagnostics",
+          request: {
+            action: "root.deep_diagnostics",
+            authorization: "Bearer [REDACTED]",
+            gptId: "arcanos-core"
+          },
+          response: {
+            ok: true,
+            data: {
+              action: "root.deep_diagnostics",
+              traceId: "trace-cli-root"
+            }
+          }
+        }
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        new URL("/gpt/arcanos-core", "http://127.0.0.1:3000/"),
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            authorization: `Bearer ${cliToken}`
+          }),
+          body: JSON.stringify({ action: "root.deep_diagnostics" })
+        })
+      );
+    } finally {
+      if (originalAdminToken === undefined) {
+        delete process.env.ARCANOS_ADMIN_TOKEN;
+      } else {
+        process.env.ARCANOS_ADMIN_TOKEN = originalAdminToken;
+      }
+    }
   });
 
   it("sends generate requests through the GPT fast path and prints route diagnostics", async () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,4 +1,5 @@
 import { runAskCommand } from "./commands/ask.js";
+import { runDiagnosticsCommand } from "./commands/diagnostics.js";
 import { runDoctorCommand } from "./commands/doctor.js";
 import { runExecCommand } from "./commands/exec.js";
 import { runGenerateCommand } from "./commands/generate.js";
@@ -73,6 +74,8 @@ async function runCommand(invocation: Exclude<ReturnType<typeof parseCliInvocati
       return runQueryCommand(invocation);
     case "query-and-wait":
       return runQueryAndWaitCommand(invocation);
+    case "diagnostics":
+      return runDiagnosticsCommand(invocation);
     case "generate-and-wait":
       return runGenerateAndWaitCommand(invocation);
     case "job-status":

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -116,10 +116,12 @@ export {
   getJobStatus,
   invokeGptRoute,
   queryAndWaitGptRoute,
+  requestGptDiagnostics,
   type FetchGptJobResultOptions,
   type FetchGptJobStatusOptions,
   type GeneratePromptAndWaitOptions,
   type GptRouteRequestBody,
+  type InvokeGptDiagnosticsOptions,
   type InvokeGptJobLookupActionOptions,
   type InvokeGptRouteOptions,
   type QueryAndWaitGptRouteOptions

--- a/packages/cli/src/client/backend.ts
+++ b/packages/cli/src/client/backend.ts
@@ -96,6 +96,14 @@ export interface InvokeGptJobLookupActionOptions {
   fetchFn?: typeof fetch;
 }
 
+export interface InvokeGptDiagnosticsOptions {
+  baseUrl: string;
+  gptId: string;
+  root?: boolean;
+  headers?: Record<string, string>;
+  fetchFn?: typeof fetch;
+}
+
 export interface FetchGptJobResultOptions {
   baseUrl: string;
   jobId: string;
@@ -531,6 +539,30 @@ export async function requestQueryAndWait(
   options: QueryAndWaitGptRouteOptions
 ): Promise<Record<string, unknown>> {
   return queryAndWaitGptRoute(options);
+}
+
+export async function requestGptDiagnostics(
+  options: InvokeGptDiagnosticsOptions
+): Promise<Record<string, unknown>> {
+  const headers = {
+    ...(options.headers ?? {}),
+  };
+
+  if (options.root) {
+    const adminToken = process.env.ARCANOS_ADMIN_TOKEN;
+    if (typeof adminToken !== "string" || adminToken.length === 0) {
+      throw new Error("ARCANOS_ADMIN_TOKEN is required for root diagnostics.");
+    }
+    headers.authorization = `Bearer ${adminToken}`;
+  }
+
+  return invokeGptRoute({
+    baseUrl: options.baseUrl,
+    gptId: options.gptId,
+    action: options.root ? "root.deep_diagnostics" : "diagnostics",
+    headers,
+    fetchFn: options.fetchFn
+  });
 }
 
 export async function requestGptJobStatus(

--- a/packages/cli/src/commands/diagnostics.ts
+++ b/packages/cli/src/commands/diagnostics.ts
@@ -1,0 +1,47 @@
+import { requestGptDiagnostics } from "../client/backend.js";
+import { serializeDeterministicJson } from "../client/protocol.js";
+import type { CliCommandResult, DiagnosticsCommandInvocation } from "./types.js";
+
+export async function runDiagnosticsCommand(
+  invocation: DiagnosticsCommandInvocation
+): Promise<CliCommandResult<Record<string, unknown>>> {
+  const payload = await requestGptDiagnostics({
+    baseUrl: invocation.options.baseUrl,
+    gptId: invocation.gptId,
+    root: invocation.root
+  });
+
+  return {
+    command: invocation.root ? "gpt.root_deep_diagnostics" : "gpt.diagnostics",
+    request: {
+      command: invocation.root ? "gpt.root_deep_diagnostics" : "gpt.diagnostics",
+      baseUrl: invocation.options.baseUrl,
+      gptId: invocation.gptId,
+      action: invocation.root ? "root.deep_diagnostics" : "diagnostics",
+      ...(invocation.root ? { authorization: "Bearer [REDACTED]" } : {})
+    },
+    response: {
+      ok: true,
+      data: payload,
+      meta: {
+        executedBy: "http-backend-cli"
+      }
+    },
+    humanOutput: extractDiagnosticsHumanOutput(payload, invocation.root)
+  };
+}
+
+function extractDiagnosticsHumanOutput(payload: Record<string, unknown>, root: boolean): string {
+  const traceId = typeof payload.traceId === "string" ? payload.traceId : "unknown";
+  const ok = payload.ok !== false ? "ok" : "degraded";
+  const report = Array.isArray(payload.report) ? payload.report : [];
+  const failedChecks = report.filter((entry) => {
+    return Boolean(entry) && typeof entry === "object" && (entry as Record<string, unknown>).ok === false;
+  }).length;
+
+  if (root) {
+    return `Root diagnostics: ${ok} | checks=${report.length} | failed=${failedChecks} | traceId=${traceId}`;
+  }
+
+  return serializeDeterministicJson(payload);
+}

--- a/packages/cli/src/commands/parse.ts
+++ b/packages/cli/src/commands/parse.ts
@@ -48,6 +48,12 @@ export function parseCliInvocation(argv: string[]): CliInvocation {
         ...parseGenerateAndWaitArgs("query-and-wait", rest),
         options
       };
+    case "diagnostics":
+      return {
+        kind: "diagnostics",
+        ...parseDiagnosticsArgs(rest),
+        options
+      };
     case "generate-and-wait":
       return {
         kind: "generate-and-wait",
@@ -137,6 +143,7 @@ export function renderUsage(): string {
     "  arcanos generate --gpt <gpt-id> --prompt \"...\" [--mode fast|orchestrated] [--json]",
     "  arcanos query --gpt <gpt-id> --prompt \"...\" [--json]",
     "  arcanos query-and-wait --gpt <gpt-id> --prompt \"...\" [--timeout-ms <ms>] [--poll-interval-ms <ms>] [--json]",
+    "  arcanos diagnostics --gpt <gpt-id> [--root] [--json]",
     "  arcanos generate-and-wait --gpt <gpt-id> --prompt \"...\" [--timeout-ms <ms>] [--poll-interval-ms <ms>] [--json]",
     "  arcanos job-status <job-id> [--json]",
     "  arcanos job-result <job-id> [--json]",
@@ -270,6 +277,50 @@ function requireSingleArgument(command: string, args: string[]): string {
   }
 
   return args[0].trim();
+}
+
+function parseDiagnosticsArgs(args: string[]): {
+  gptId: string;
+  root: boolean;
+} {
+  let gptId: string | undefined;
+  let root = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const currentArgument = args[index];
+    if (!currentArgument.startsWith("--")) {
+      throw new Error('`diagnostics` only accepts --gpt and --root.');
+    }
+
+    if (currentArgument === "--root") {
+      root = true;
+      continue;
+    }
+
+    const nextValue = args[index + 1];
+    if (!nextValue || nextValue.startsWith("--")) {
+      throw new Error(`Flag "${currentArgument}" requires a value.`);
+    }
+
+    switch (currentArgument) {
+      case "--gpt":
+        gptId = nextValue.trim();
+        break;
+      default:
+        throw new Error(`Unknown flag "${currentArgument}" for \`diagnostics\`.`);
+    }
+
+    index += 1;
+  }
+
+  if (!gptId) {
+    throw new Error('`diagnostics` requires --gpt <gpt-id>.');
+  }
+
+  return {
+    gptId,
+    root
+  };
 }
 
 function parseQueryArgs(args: string[]): {

--- a/packages/cli/src/commands/types.ts
+++ b/packages/cli/src/commands/types.ts
@@ -52,6 +52,13 @@ export interface QueryAndWaitCommandInvocation {
   options: CliGlobalOptions;
 }
 
+export interface DiagnosticsCommandInvocation {
+  kind: "diagnostics";
+  gptId: string;
+  root: boolean;
+  options: CliGlobalOptions;
+}
+
 export interface JobStatusCommandInvocation {
   kind: "job-status";
   jobId: string;
@@ -119,6 +126,7 @@ export type CliInvocation =
   | GenerateAndWaitCommandInvocation
   | QueryCommandInvocation
   | QueryAndWaitCommandInvocation
+  | DiagnosticsCommandInvocation
   | JobStatusCommandInvocation
   | JobResultCommandInvocation
   | PlanCommandInvocation

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -124,6 +124,14 @@ import {
   GPT_DAG_BRIDGE_ACTIONS,
   isGptDagAction,
 } from '@shared/gpt/gptDagBridgeActions.js';
+import {
+  ROOT_DEEP_DIAGNOSTICS_ACTION,
+  ROOT_DIAGNOSTICS_FORBIDDEN,
+  authorizeRootDeepDiagnosticsRequest,
+  buildRootDeepDiagnosticsReport,
+  isRootDeepDiagnosticsAction,
+  logRootDeepDiagnosticsAttempt,
+} from '@services/rootDeepDiagnosticsBridge.js';
 
 const router = express.Router();
 const ARCANOS_CORE_GPT_IDS = new Set(['arcanos-core', 'core', 'arcanos-daemon']);
@@ -2113,6 +2121,65 @@ router.post("/:gptId", async (req, res, next) => {
           gptId: incomingGptId,
           ...buildGptRequestAuthState(req),
         });
+
+        if (isRootDeepDiagnosticsAction(requestedAction)) {
+          const rootDiagnosticsAuth = authorizeRootDeepDiagnosticsRequest(req, incomingGptId);
+          if (!rootDiagnosticsAuth.allowed) {
+            logRootDeepDiagnosticsAttempt({
+              req,
+              timestamp: new Date().toISOString(),
+              traceId,
+              gptId: incomingGptId,
+              action: ROOT_DEEP_DIAGNOSTICS_ACTION,
+              allowed: false,
+              denialReason: rootDiagnosticsAuth.reason,
+            });
+            logGptDispatcherOutcome({
+              req,
+              traceId,
+              gptId: incomingGptId,
+              action: ROOT_DEEP_DIAGNOSTICS_ACTION,
+              status: 403,
+              error: {
+                name: ROOT_DIAGNOSTICS_FORBIDDEN,
+                message: ROOT_DIAGNOSTICS_FORBIDDEN,
+              },
+            });
+            return res.status(403).json({
+              ok: false,
+              error: ROOT_DIAGNOSTICS_FORBIDDEN,
+            });
+          }
+
+          const diagnosticsPayload = await buildRootDeepDiagnosticsReport({
+            req,
+            gptId: incomingGptId,
+            traceId,
+          });
+          logRootDeepDiagnosticsAttempt({
+            req,
+            timestamp: diagnosticsPayload.timestamp,
+            traceId,
+            gptId: incomingGptId,
+            action: ROOT_DEEP_DIAGNOSTICS_ACTION,
+            allowed: true,
+            report: diagnosticsPayload.report,
+          });
+          logGptDispatcherOutcome({
+            req,
+            traceId,
+            gptId: incomingGptId,
+            action: ROOT_DEEP_DIAGNOSTICS_ACTION,
+            status: 200,
+          });
+          return sendGuardedGptJsonResponse(
+            req,
+            res,
+            diagnosticsPayload,
+            'gpt.response.root_deep_diagnostics',
+            200
+          );
+        }
 
         const routingValidation = await resolveGptRouting(incomingGptId, requestId);
         if (!routingValidation.ok) {

--- a/src/services/rootDeepDiagnosticsBridge.ts
+++ b/src/services/rootDeepDiagnosticsBridge.ts
@@ -1,0 +1,211 @@
+import crypto from 'node:crypto';
+import type { Request } from 'express';
+
+import { resolveErrorMessage } from '@core/lib/errors/index.js';
+import { auditLogger } from '@platform/logging/auditLogger.js';
+import { getRequestActorKey } from '@platform/runtime/security.js';
+import { runtimeDiagnosticsService } from '@services/runtimeDiagnosticsService.js';
+import { getTrinityStatus } from '@services/trinityStatusService.js';
+import {
+  getWorkerControlHealth,
+  getWorkerControlStatus,
+} from '@services/workerControlService.js';
+import { buildSafetySelfHealSnapshot } from '@services/selfHealRuntimeInspectionService.js';
+import { arcanosDagRunService } from '@services/arcanosDagRunService.js';
+
+export const ROOT_DEEP_DIAGNOSTICS_ACTION = 'root.deep_diagnostics';
+export const ROOT_DIAGNOSTICS_FORBIDDEN = 'ROOT_DIAGNOSTICS_FORBIDDEN';
+
+type RootDiagnosticsDenialReason =
+  | 'disabled'
+  | 'gpt_not_allowlisted'
+  | 'admin_token_missing'
+  | 'authorization_missing'
+  | 'authorization_mismatch';
+
+type RootDiagnosticsAuthResult =
+  | { allowed: true }
+  | {
+      allowed: false;
+      reason: RootDiagnosticsDenialReason;
+    };
+
+export interface RootDiagnosticsSubCheck {
+  ok: boolean;
+  name: string;
+  data: unknown | null;
+  error: string | null;
+}
+
+export interface RootDiagnosticsReportPayload {
+  ok: boolean;
+  gptId: string;
+  action: typeof ROOT_DEEP_DIAGNOSTICS_ACTION;
+  traceId: string;
+  timestamp: string;
+  report: RootDiagnosticsSubCheck[];
+}
+
+interface RootDiagnosticsAuditInput {
+  req: Request;
+  timestamp: string;
+  traceId: string;
+  gptId: string;
+  action: string;
+  allowed: boolean;
+  denialReason?: RootDiagnosticsDenialReason;
+  report?: RootDiagnosticsSubCheck[];
+}
+
+function parseRootDiagnosticGpts(): Set<string> {
+  return new Set(
+    (process.env.ARCANOS_ROOT_DIAGNOSTIC_GPTS ?? '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0)
+  );
+}
+
+function constantTimeEquals(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function resolveRequesterIdentity(req: Request): Record<string, unknown> {
+  if (req.authUser) {
+    return {
+      source: req.authUser.source,
+      id: req.authUser.id,
+      email: req.authUser.email,
+      role: req.authUser.role,
+    };
+  }
+
+  return {
+    source: 'request-actor-key',
+    actorKey: getRequestActorKey(req),
+  };
+}
+
+export function isRootDeepDiagnosticsAction(action: string | null | undefined): boolean {
+  return action === ROOT_DEEP_DIAGNOSTICS_ACTION;
+}
+
+export function authorizeRootDeepDiagnosticsRequest(req: Request, gptId: string): RootDiagnosticsAuthResult {
+  if (process.env.ENABLE_ROOT_DEEP_DIAGNOSTICS !== 'true') {
+    return { allowed: false, reason: 'disabled' };
+  }
+
+  if (!parseRootDiagnosticGpts().has(gptId)) {
+    return { allowed: false, reason: 'gpt_not_allowlisted' };
+  }
+
+  const adminToken = process.env.ARCANOS_ADMIN_TOKEN;
+  if (typeof adminToken !== 'string' || adminToken.length === 0) {
+    return { allowed: false, reason: 'admin_token_missing' };
+  }
+
+  const authorizationHeader = req.header('authorization');
+  if (typeof authorizationHeader !== 'string' || authorizationHeader.length === 0) {
+    return { allowed: false, reason: 'authorization_missing' };
+  }
+
+  const expectedAuthorizationHeader = `Bearer ${adminToken}`;
+  if (!constantTimeEquals(authorizationHeader, expectedAuthorizationHeader)) {
+    return { allowed: false, reason: 'authorization_mismatch' };
+  }
+
+  return { allowed: true };
+}
+
+async function runCheck(
+  name: string,
+  operation: () => Promise<unknown> | unknown
+): Promise<RootDiagnosticsSubCheck> {
+  try {
+    return {
+      ok: true,
+      name,
+      data: await operation(),
+      error: null,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      name,
+      data: null,
+      error: resolveErrorMessage(error),
+    };
+  }
+}
+
+export async function buildRootDeepDiagnosticsReport(params: {
+  req: Request;
+  gptId: string;
+  traceId: string;
+}): Promise<RootDiagnosticsReportPayload> {
+  const report = await Promise.all([
+    runCheck('/status', () => runtimeDiagnosticsService.getHealthSnapshot()),
+    runCheck('/workers/status', () => getWorkerControlStatus()),
+    runCheck('/worker-helper/health', () => getWorkerControlHealth()),
+    runCheck('/trinity/status', () => getTrinityStatus()),
+    runCheck('/status/safety/self-heal', () => buildSafetySelfHealSnapshot()),
+    runCheck('/api/arcanos/capabilities', () => ({
+      features: arcanosDagRunService.getFeatureFlags(),
+      limits: arcanosDagRunService.getExecutionLimits(),
+    })),
+    runCheck('diagnostics.summary', () => runtimeDiagnosticsService.getDiagnosticsSnapshot(params.req.app)),
+  ]);
+
+  return {
+    ok: report.every((check) => check.ok),
+    gptId: params.gptId,
+    action: ROOT_DEEP_DIAGNOSTICS_ACTION,
+    traceId: params.traceId,
+    timestamp: new Date().toISOString(),
+    report,
+  };
+}
+
+export function logRootDeepDiagnosticsAttempt(input: RootDiagnosticsAuditInput): void {
+  const failedChecks = input.report?.filter((check) => !check.ok).map((check) => check.name) ?? [];
+  const auditEntry = {
+    event: 'gpt.root_deep_diagnostics.audit',
+    timestamp: input.timestamp,
+    traceId: input.traceId,
+    requester: resolveRequesterIdentity(input.req),
+    gptId: input.gptId,
+    action: input.action,
+    allowed: input.allowed,
+    denied: !input.allowed,
+    denialReason: input.denialReason ?? null,
+    diagnosticsResultSummary: input.report
+      ? {
+          totalChecks: input.report.length,
+          failedChecks: failedChecks.length,
+          failedCheckNames: failedChecks,
+          ok: failedChecks.length === 0,
+        }
+      : null,
+  };
+
+  auditLogger.log(auditEntry);
+
+  const requestLogger = input.req.logger;
+  if (!requestLogger) {
+    return;
+  }
+
+  if (input.allowed) {
+    requestLogger.info('gpt.root_deep_diagnostics.audit', auditEntry);
+    return;
+  }
+
+  requestLogger.warn('gpt.root_deep_diagnostics.audit', auditEntry);
+}

--- a/src/services/rootDeepDiagnosticsBridge.ts
+++ b/src/services/rootDeepDiagnosticsBridge.ts
@@ -16,6 +16,14 @@ import { arcanosDagRunService } from '@services/arcanosDagRunService.js';
 export const ROOT_DEEP_DIAGNOSTICS_ACTION = 'root.deep_diagnostics';
 export const ROOT_DIAGNOSTICS_FORBIDDEN = 'ROOT_DIAGNOSTICS_FORBIDDEN';
 
+const ROOT_DIAGNOSTICS_MAX_OBJECT_KEYS = 32;
+const ROOT_DIAGNOSTICS_MAX_ARRAY_ITEMS = 8;
+const ROOT_DIAGNOSTICS_MAX_DEPTH = 5;
+const ROOT_DIAGNOSTICS_MAX_STRING_LENGTH = 1024;
+const ROOT_DIAGNOSTICS_REDACTED = '[REDACTED]';
+const ROOT_DIAGNOSTICS_SENSITIVE_KEY_PATTERN =
+  /(authorization|bearer|token|secret|password|api[_-]?key|credential)/i;
+
 type RootDiagnosticsDenialReason =
   | 'disabled'
   | 'gpt_not_allowlisted'
@@ -73,6 +81,64 @@ type RootDiagnosticsRequest = Request & {
   logger?: RootDiagnosticsRequestLogger;
   authUser?: RootDiagnosticsAuthUser;
 };
+
+function truncateRootDiagnosticsString(value: string): string {
+  if (value.length <= ROOT_DIAGNOSTICS_MAX_STRING_LENGTH) {
+    return value;
+  }
+
+  return `${value.slice(0, ROOT_DIAGNOSTICS_MAX_STRING_LENGTH)}...[truncated]`;
+}
+
+function normalizeRootDiagnosticsData(value: unknown, depth = 0, keyHint = ''): unknown | null {
+  if (ROOT_DIAGNOSTICS_SENSITIVE_KEY_PATTERN.test(keyHint)) {
+    return ROOT_DIAGNOSTICS_REDACTED;
+  }
+
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    return truncateRootDiagnosticsString(value);
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value !== 'object') {
+    return String(value);
+  }
+
+  if (depth >= ROOT_DIAGNOSTICS_MAX_DEPTH) {
+    return Array.isArray(value)
+      ? { total: value.length, truncated: value.length > 0 }
+      : { keys: Object.keys(value as Record<string, unknown>).slice(0, ROOT_DIAGNOSTICS_MAX_OBJECT_KEYS), truncated: true };
+  }
+
+  if (Array.isArray(value)) {
+    return {
+      total: value.length,
+      items: value
+        .slice(0, ROOT_DIAGNOSTICS_MAX_ARRAY_ITEMS)
+        .map((entry) => normalizeRootDiagnosticsData(entry, depth + 1, keyHint)),
+      truncated: value.length > ROOT_DIAGNOSTICS_MAX_ARRAY_ITEMS,
+    };
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>);
+  const output: Record<string, unknown> = {};
+  for (const [entryKey, entryValue] of entries.slice(0, ROOT_DIAGNOSTICS_MAX_OBJECT_KEYS)) {
+    output[entryKey] = normalizeRootDiagnosticsData(entryValue, depth + 1, entryKey);
+  }
+
+  if (entries.length > ROOT_DIAGNOSTICS_MAX_OBJECT_KEYS) {
+    output.truncatedKeys = entries.length - ROOT_DIAGNOSTICS_MAX_OBJECT_KEYS;
+  }
+
+  return output;
+}
 
 function parseRootDiagnosticGpts(): Set<string> {
   return new Set(
@@ -151,7 +217,7 @@ async function runCheck(
     return {
       ok: true,
       name,
-      data: (await operation()) ?? null,
+      data: normalizeRootDiagnosticsData(await operation()),
       error: null,
     };
   } catch (error) {

--- a/src/services/rootDeepDiagnosticsBridge.ts
+++ b/src/services/rootDeepDiagnosticsBridge.ts
@@ -16,10 +16,10 @@ import { arcanosDagRunService } from '@services/arcanosDagRunService.js';
 export const ROOT_DEEP_DIAGNOSTICS_ACTION = 'root.deep_diagnostics';
 export const ROOT_DIAGNOSTICS_FORBIDDEN = 'ROOT_DIAGNOSTICS_FORBIDDEN';
 
-const ROOT_DIAGNOSTICS_MAX_OBJECT_KEYS = 32;
-const ROOT_DIAGNOSTICS_MAX_ARRAY_ITEMS = 8;
-const ROOT_DIAGNOSTICS_MAX_DEPTH = 5;
-const ROOT_DIAGNOSTICS_MAX_STRING_LENGTH = 1024;
+const ROOT_DIAGNOSTICS_MAX_OBJECT_KEYS = 12;
+const ROOT_DIAGNOSTICS_MAX_ARRAY_ITEMS = 3;
+const ROOT_DIAGNOSTICS_MAX_DEPTH = 4;
+const ROOT_DIAGNOSTICS_MAX_STRING_LENGTH = 240;
 const ROOT_DIAGNOSTICS_REDACTED = '[REDACTED]';
 const ROOT_DIAGNOSTICS_SENSITIVE_KEY_PATTERN =
   /(authorization|bearer|token|secret|password|api[_-]?key|credential)/i;

--- a/src/services/rootDeepDiagnosticsBridge.ts
+++ b/src/services/rootDeepDiagnosticsBridge.ts
@@ -57,6 +57,23 @@ interface RootDiagnosticsAuditInput {
   report?: RootDiagnosticsSubCheck[];
 }
 
+interface RootDiagnosticsRequestLogger {
+  info: (event: string, data: Record<string, unknown>) => void;
+  warn: (event: string, data: Record<string, unknown>) => void;
+}
+
+interface RootDiagnosticsAuthUser {
+  source?: unknown;
+  id?: unknown;
+  email?: unknown;
+  role?: unknown;
+}
+
+type RootDiagnosticsRequest = Request & {
+  logger?: RootDiagnosticsRequestLogger;
+  authUser?: RootDiagnosticsAuthUser;
+};
+
 function parseRootDiagnosticGpts(): Set<string> {
   return new Set(
     (process.env.ARCANOS_ROOT_DIAGNOSTIC_GPTS ?? '')
@@ -78,12 +95,14 @@ function constantTimeEquals(left: string, right: string): boolean {
 }
 
 function resolveRequesterIdentity(req: Request): Record<string, unknown> {
-  if (req.authUser) {
+  const authUser = (req as RootDiagnosticsRequest).authUser;
+
+  if (authUser) {
     return {
-      source: req.authUser.source,
-      id: req.authUser.id,
-      email: req.authUser.email,
-      role: req.authUser.role,
+      source: authUser.source,
+      id: authUser.id,
+      email: authUser.email,
+      role: authUser.role,
     };
   }
 
@@ -132,7 +151,7 @@ async function runCheck(
     return {
       ok: true,
       name,
-      data: await operation(),
+      data: (await operation()) ?? null,
       error: null,
     };
   } catch (error) {
@@ -197,7 +216,7 @@ export function logRootDeepDiagnosticsAttempt(input: RootDiagnosticsAuditInput):
 
   auditLogger.log(auditEntry);
 
-  const requestLogger = input.req.logger;
+  const requestLogger = (input.req as RootDiagnosticsRequest).logger;
   if (!requestLogger) {
     return;
   }

--- a/tests/dispatcher-priority.route.test.ts
+++ b/tests/dispatcher-priority.route.test.ts
@@ -42,6 +42,7 @@ jest.unstable_mockModule('../src/services/runtimeInspectionRoutingService.js', (
 }));
 
 jest.unstable_mockModule('../src/services/workerControlService.js', () => ({
+  getWorkerControlHealth: jest.fn(),
   getWorkerControlStatus: jest.fn(),
 }));
 

--- a/tests/gpt-root-deep-diagnostics.route.test.ts
+++ b/tests/gpt-root-deep-diagnostics.route.test.ts
@@ -1,0 +1,337 @@
+import express from 'express';
+import request from 'supertest';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockRouteGptRequest = jest.fn();
+const mockResolveGptRouting = jest.fn();
+const mockAuditLog = jest.fn();
+const mockGetHealthSnapshot = jest.fn();
+const mockGetDiagnosticsSnapshot = jest.fn();
+const mockGetWorkerControlStatus = jest.fn();
+const mockGetWorkerControlHealth = jest.fn();
+const mockGetTrinityStatus = jest.fn();
+const mockBuildSafetySelfHealSnapshot = jest.fn();
+const mockGetFeatureFlags = jest.fn();
+const mockGetExecutionLimits = jest.fn();
+
+const TEST_ADMIN_TOKEN = 'unit-test-admin-token';
+
+jest.unstable_mockModule('../src/routes/_core/gptDispatch.js', () => ({
+  resolveGptRouting: mockResolveGptRouting,
+  routeGptRequest: mockRouteGptRequest,
+}));
+
+jest.unstable_mockModule('../src/platform/logging/gptLogger.js', () => ({
+  logGptConnection: jest.fn(),
+  logGptConnectionFailed: jest.fn(),
+  logGptAckSent: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/platform/logging/auditLogger.js', () => ({
+  auditLogger: {
+    log: mockAuditLog,
+  },
+}));
+
+jest.unstable_mockModule('../src/services/runtimeDiagnosticsService.js', () => ({
+  runtimeDiagnosticsService: {
+    getHealthSnapshot: mockGetHealthSnapshot,
+    getDiagnosticsSnapshot: mockGetDiagnosticsSnapshot,
+    recordRequestCompletion: jest.fn(),
+  },
+}));
+
+jest.unstable_mockModule('../src/services/workerControlService.js', () => ({
+  getWorkerControlStatus: mockGetWorkerControlStatus,
+  getWorkerControlHealth: mockGetWorkerControlHealth,
+}));
+
+jest.unstable_mockModule('../src/services/runtimeInspectionRoutingService.js', () => ({
+  executeRuntimeInspection: jest.fn(),
+  classifyRuntimeInspectionPrompt: jest.fn(() => ({
+    detectedIntent: 'STANDARD',
+    matchedKeywords: [],
+    repoInspectionDisabled: false,
+    onlyReturnRuntimeValues: false,
+  })),
+}));
+
+jest.unstable_mockModule('../src/services/trinityStatusService.js', () => ({
+  getTrinityStatus: mockGetTrinityStatus,
+}));
+
+jest.unstable_mockModule('../src/services/selfHealRuntimeInspectionService.js', () => ({
+  buildSafetySelfHealSnapshot: mockBuildSafetySelfHealSnapshot,
+}));
+
+jest.unstable_mockModule('../src/services/arcanosDagRunService.js', () => ({
+  arcanosDagRunService: {
+    getFeatureFlags: mockGetFeatureFlags,
+    getExecutionLimits: mockGetExecutionLimits,
+  },
+}));
+
+const { default: requestContext } = await import('../src/middleware/requestContext.js');
+const { default: gptRouter } = await import('../src/routes/gptRouter.js');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(requestContext);
+  app.use('/gpt', gptRouter);
+  return app;
+}
+
+function collectConsoleOutput(calls: unknown[][]): string {
+  return calls.map((call) => call.map((entry) => String(entry)).join(' ')).join('\n');
+}
+
+describe('root.deep_diagnostics GPT bridge', () => {
+  let consoleLogSpy: ReturnType<typeof jest.spyOn>;
+  const originalEnv = {
+    ARCANOS_ADMIN_TOKEN: process.env.ARCANOS_ADMIN_TOKEN,
+    ARCANOS_ROOT_DIAGNOSTIC_GPTS: process.env.ARCANOS_ROOT_DIAGNOSTIC_GPTS,
+    ENABLE_ROOT_DEEP_DIAGNOSTICS: process.env.ENABLE_ROOT_DEEP_DIAGNOSTICS,
+    GPT_ROUTE_ASYNC_CORE_DEFAULT: process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT,
+  };
+
+  beforeEach(() => {
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    jest.clearAllMocks();
+    process.env.ARCANOS_ADMIN_TOKEN = TEST_ADMIN_TOKEN;
+    process.env.ARCANOS_ROOT_DIAGNOSTIC_GPTS = 'arcanos-core';
+    process.env.ENABLE_ROOT_DEEP_DIAGNOSTICS = 'true';
+    process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT = 'false';
+
+    mockResolveGptRouting.mockResolvedValue({
+      ok: true,
+      plan: {
+        matchedId: 'arcanos-core',
+        module: 'ARCANOS:CORE',
+        route: 'core',
+        action: 'query',
+        availableActions: ['query'],
+        moduleVersion: null,
+        moduleDescription: null,
+        matchMethod: 'exact',
+      },
+      _route: {
+        gptId: 'arcanos-core',
+        route: 'core',
+        module: 'ARCANOS:CORE',
+        action: 'query',
+        timestamp: '2026-04-27T00:00:00.000Z',
+      },
+    });
+    mockRouteGptRequest.mockResolvedValue({
+      ok: true,
+      result: { handledBy: 'module-dispatch' },
+      _route: {
+        gptId: 'arcanos-core',
+        module: 'ARCANOS:CORE',
+        route: 'core',
+        availableActions: ['query'],
+      },
+    });
+    mockGetHealthSnapshot.mockReturnValue({ status: 'ok', timestamp: '2026-04-27T00:00:00.000Z' });
+    mockGetWorkerControlStatus.mockResolvedValue({ workerService: { health: { overallStatus: 'healthy' } } });
+    mockGetWorkerControlHealth.mockResolvedValue({ overallStatus: 'healthy' });
+    mockGetTrinityStatus.mockResolvedValue({ pipeline: 'trinity', status: 'healthy' });
+    mockBuildSafetySelfHealSnapshot.mockReturnValue({ enabled: true, active: false });
+    mockGetFeatureFlags.mockReturnValue({ dag: true });
+    mockGetExecutionLimits.mockReturnValue({ maxConcurrency: 1 });
+    mockGetDiagnosticsSnapshot.mockResolvedValue({ requests_total: 1, errors_total: 0 });
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    consoleLogSpy.mockRestore();
+  });
+
+  it('denies missing Authorization with the exact forbidden payload', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({ action: 'root.deep_diagnostics' });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      ok: false,
+      error: 'ROOT_DIAGNOSTICS_FORBIDDEN',
+    });
+    expect(mockAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+      allowed: false,
+      denialReason: 'authorization_missing',
+      gptId: 'arcanos-core',
+      action: 'root.deep_diagnostics',
+    }));
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('denies the wrong Bearer token without logging the token value', async () => {
+    const wrongToken = 'wrong-unit-test-token';
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .set('Authorization', `Bearer ${wrongToken}`)
+      .send({ action: 'root.deep_diagnostics' });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      ok: false,
+      error: 'ROOT_DIAGNOSTICS_FORBIDDEN',
+    });
+    expect(mockAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+      allowed: false,
+      denialReason: 'authorization_mismatch',
+    }));
+    expect(collectConsoleOutput(consoleLogSpy.mock.calls)).not.toContain(wrongToken);
+    expect(JSON.stringify(mockAuditLog.mock.calls)).not.toContain(wrongToken);
+  });
+
+  it('denies when ARCANOS_ADMIN_TOKEN is empty', async () => {
+    process.env.ARCANOS_ADMIN_TOKEN = '';
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .set('Authorization', `Bearer ${TEST_ADMIN_TOKEN}`)
+      .send({ action: 'root.deep_diagnostics' });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      ok: false,
+      error: 'ROOT_DIAGNOSTICS_FORBIDDEN',
+    });
+    expect(mockAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+      allowed: false,
+      denialReason: 'admin_token_missing',
+    }));
+  });
+
+  it('denies when ENABLE_ROOT_DEEP_DIAGNOSTICS is disabled', async () => {
+    process.env.ENABLE_ROOT_DEEP_DIAGNOSTICS = 'false';
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .set('Authorization', `Bearer ${TEST_ADMIN_TOKEN}`)
+      .send({ action: 'root.deep_diagnostics' });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      ok: false,
+      error: 'ROOT_DIAGNOSTICS_FORBIDDEN',
+    });
+    expect(mockAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+      allowed: false,
+      denialReason: 'disabled',
+    }));
+  });
+
+  it('denies non-allowlisted GPT IDs', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-daemon')
+      .set('Authorization', `Bearer ${TEST_ADMIN_TOKEN}`)
+      .send({ action: 'root.deep_diagnostics' });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      ok: false,
+      error: 'ROOT_DIAGNOSTICS_FORBIDDEN',
+    });
+    expect(mockAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+      allowed: false,
+      denialReason: 'gpt_not_allowlisted',
+      gptId: 'arcanos-daemon',
+    }));
+  });
+
+  it('lets wrong actions follow normal GPT route behavior', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .set('Authorization', `Bearer ${TEST_ADMIN_TOKEN}`)
+      .send({
+        action: 'root.not_deep_diagnostics',
+        prompt: 'Use the normal route.',
+      });
+
+    expect(response.status).toBe(200);
+    expect(mockRouteGptRequest).toHaveBeenCalledTimes(1);
+    expect(mockAuditLog).not.toHaveBeenCalledWith(expect.objectContaining({
+      action: 'root.deep_diagnostics',
+    }));
+    expect(mockGetWorkerControlHealth).not.toHaveBeenCalled();
+  });
+
+  it('returns a root diagnostics report for the allowlisted GPT and correct token', async () => {
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .set('Authorization', `Bearer ${TEST_ADMIN_TOKEN}`)
+      .send({ action: 'root.deep_diagnostics' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(expect.objectContaining({
+      ok: true,
+      gptId: 'arcanos-core',
+      action: 'root.deep_diagnostics',
+      traceId: expect.any(String),
+      timestamp: expect.any(String),
+      report: expect.arrayContaining([
+        expect.objectContaining({ ok: true, name: '/status', error: null }),
+        expect.objectContaining({ ok: true, name: '/workers/status', error: null }),
+        expect.objectContaining({ ok: true, name: '/worker-helper/health', error: null }),
+        expect.objectContaining({ ok: true, name: '/trinity/status', error: null }),
+        expect.objectContaining({ ok: true, name: '/status/safety/self-heal', error: null }),
+        expect.objectContaining({ ok: true, name: '/api/arcanos/capabilities', error: null }),
+        expect.objectContaining({ ok: true, name: 'diagnostics.summary', error: null }),
+      ]),
+    }));
+    expect(response.body.report).toHaveLength(7);
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+    expect(mockAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+      allowed: true,
+      diagnosticsResultSummary: expect.objectContaining({
+        totalChecks: 7,
+        failedChecks: 0,
+        ok: true,
+      }),
+    }));
+    expect(collectConsoleOutput(consoleLogSpy.mock.calls)).not.toContain(TEST_ADMIN_TOKEN);
+    expect(JSON.stringify(mockAuditLog.mock.calls)).not.toContain(TEST_ADMIN_TOKEN);
+  });
+
+  it('keeps the report alive when a sub-check fails', async () => {
+    mockGetWorkerControlHealth.mockRejectedValueOnce(new Error('worker health unavailable'));
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .set('Authorization', `Bearer ${TEST_ADMIN_TOKEN}`)
+      .send({ action: 'root.deep_diagnostics' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(expect.objectContaining({
+      ok: false,
+      report: expect.arrayContaining([
+        expect.objectContaining({
+          ok: false,
+          name: '/worker-helper/health',
+          data: null,
+          error: 'worker health unavailable',
+        }),
+      ]),
+    }));
+    expect(mockAuditLog).toHaveBeenCalledWith(expect.objectContaining({
+      allowed: true,
+      diagnosticsResultSummary: expect.objectContaining({
+        totalChecks: 7,
+        failedChecks: 1,
+        failedCheckNames: ['/worker-helper/health'],
+        ok: false,
+      }),
+    }));
+  });
+});

--- a/tests/gpt-root-deep-diagnostics.route.test.ts
+++ b/tests/gpt-root-deep-diagnostics.route.test.ts
@@ -369,7 +369,7 @@ describe('root.deep_diagnostics GPT bridge', () => {
         }),
       }),
     }));
-    expect(workerStatus.data.recentFailedJobs.items).toHaveLength(8);
+    expect(workerStatus.data.recentFailedJobs.items).toHaveLength(3);
     expect(JSON.stringify(response.body)).not.toContain('unit-test-secret-value');
   });
 });

--- a/tests/gpt-root-deep-diagnostics.route.test.ts
+++ b/tests/gpt-root-deep-diagnostics.route.test.ts
@@ -334,4 +334,42 @@ describe('root.deep_diagnostics GPT bridge', () => {
       }),
     }));
   });
+
+  it('bounds large sub-check data so the report contract is preserved', async () => {
+    mockGetWorkerControlStatus.mockResolvedValueOnce({
+      recentFailedJobs: Array.from({ length: 64 }, (_, index) => ({
+        id: `failed-${index}`,
+        apiKey: 'unit-test-secret-value',
+        error_message: 'worker failure detail '.repeat(300),
+      })),
+    });
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .set('Authorization', `Bearer ${TEST_ADMIN_TOKEN}`)
+      .send({ action: 'root.deep_diagnostics' });
+
+    const workerStatus = response.body.report.find(
+      (check: Record<string, unknown>) => check.name === '/workers/status'
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(expect.objectContaining({
+      ok: true,
+      report: expect.any(Array),
+    }));
+    expect(response.body).not.toHaveProperty('truncated');
+    expect(workerStatus).toEqual(expect.objectContaining({
+      ok: true,
+      data: expect.objectContaining({
+        recentFailedJobs: expect.objectContaining({
+          total: 64,
+          truncated: true,
+          items: expect.any(Array),
+        }),
+      }),
+    }));
+    expect(workerStatus.data.recentFailedJobs.items).toHaveLength(8);
+    expect(JSON.stringify(response.body)).not.toContain('unit-test-secret-value');
+  });
 });

--- a/tests/gpt-router-universal-dispatch.test.ts
+++ b/tests/gpt-router-universal-dispatch.test.ts
@@ -7,6 +7,7 @@ const mockResolveGptRouting = jest.fn();
 const mockExecuteSystemStateRequest = jest.fn();
 const mockExecuteRuntimeInspection = jest.fn();
 const mockGetWorkerControlStatus = jest.fn();
+const mockGetWorkerControlHealth = jest.fn();
 const mockBuildSafetySelfHealSnapshot = jest.fn();
 const mockGetDiagnosticsSnapshot = jest.fn();
 
@@ -46,6 +47,7 @@ jest.unstable_mockModule('../src/services/runtimeInspectionRoutingService.js', (
 
 jest.unstable_mockModule('../src/services/workerControlService.js', () => ({
   getWorkerControlStatus: mockGetWorkerControlStatus,
+  getWorkerControlHealth: mockGetWorkerControlHealth,
 }));
 
 jest.unstable_mockModule('../src/services/selfHealRuntimeInspectionService.js', () => ({


### PR DESCRIPTION
## Summary
- Add a narrow `root.deep_diagnostics` bridge for `POST /gpt/:gptId`, guarded by `ENABLE_ROOT_DEEP_DIAGNOSTICS`, `ARCANOS_ROOT_DIAGNOSTIC_GPTS`, and `ARCANOS_ADMIN_TOKEN` bearer auth.
- Hardcode the allowed diagnostics checks and keep existing control-plane routing guards intact.
- Add audit logging for allowed and denied attempts without logging bearer tokens.
- Add Arcanos CLI support via `arcanos diagnostics --gpt <id> [--root]` with redacted request metadata.
- Update the custom GPT OpenAPI contract and tests.

## Validation
- `npm run type-check`
- `npm test` passed before rebase.
- Post-rebase targeted tests passed:
  - `npm test -- --runTestsByPath tests/gpt-root-deep-diagnostics.route.test.ts tests/dispatcher-priority.route.test.ts tests/gpt-router-universal-dispatch.test.ts packages/cli/__tests__/cli.test.ts --coverage=false`
  - `npm test -- --runTestsByPath packages/cli/__tests__/transport-matrix.test.ts --coverage=false`
- Post-rebase full `npm test` had one transient timeout in `packages/cli/__tests__/transport-matrix.test.ts`; direct rerun passed.
- Source/staged token scans for `ARCANOS_ADMIN_TOKEN=[REDACTED]` and `Bearer [REDACTED]` patterns.
- Railway production deploy for service `ARCANOS V2`: `f0bca96c-f0a1-49c9-8f7d-169b06958016` (`SUCCESS`).
- Runtime verification:
  - CLI status/workers/self-heal checks succeeded
  - Missing auth and wrong bearer diagnostics attempts returned `ROOT_DIAGNOSTICS_FORBIDDEN`
  - Authorized root diagnostics succeeded with trace `trace_1777321707902_qhvlxb`
  - Normal query succeeded with trace `trace_1777321708651_xcljlr`
  - Existing control-plane guard returned `CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT` with trace `trace_1777321719571_0o08mg`

## Railway Variables
- `ARCANOS_ADMIN_TOKEN=[REDACTED]`
- `ARCANOS_ROOT_DIAGNOSTIC_GPTS=arcanos-core`
- `ENABLE_ROOT_DEEP_DIAGNOSTICS=true`
