### PR TITLE
[codex] Route generation through Trinity facade

### DIFF
--- a/config/coverageScope.js
+++ b/config/coverageScope.js
@@ -36,7 +36,6 @@ export const codecovCoverageScopeFiles = [
   'src/modules/arcanos-gaming.ts',
   'src/platform/logging/structuredLogging.ts',
   'src/platform/resilience/runtimeErrors.ts',
-  'src/platform/runtime/arcanosPipelinePrompts.ts',
   'src/platform/runtime/auditSafe.ts',
   'src/platform/runtime/daemonRegistry.ts',
   'src/platform/runtime/dispatchMessages.ts',

--- a/docs/TRINITY_PIPELINE.md
+++ b/docs/TRINITY_PIPELINE.md
@@ -6,7 +6,8 @@ The Trinity pipeline is the main AI writing path in this codebase. It accepts pr
 Current entrypoints:
 - Protected GPT Action gateway: `POST /gpt-access/jobs/create` in `src/routes/gpt-access.ts`
 - Canonical writing plane: `POST /gpt/:gptId` in `src/routes/gptRouter.ts`
-- Shared writing facade: `src/core/logic/trinityWritingPipeline.ts` (`runTrinityWritingPipeline`)
+- Canonical generation facade: `src/core/logic/trinityGenerationFacade.ts` (`runTrinityGenerationFacade`)
+- Backward-compatible writing facade: `src/core/logic/trinityWritingPipeline.ts` (`runTrinityWritingPipeline`)
 - Low-level engine: `src/core/logic/trinity.ts` (`runThroughBrain`)
 
 Use `/gpt-access/*` for protected backend calls from Custom GPTs and operator integrations. Do not route job result lookup, worker status, queue inspection, MCP diagnostics, or runtime inspection through `/gpt/:gptId`.
@@ -44,6 +45,7 @@ Protected async Trinity execution follows this path:
    - It classifies input with `classifyWritingPlaneInput(...)`.
    - Non-writing/control requests throw `TrinityControlLeakError` before the low-level engine runs.
    - Valid writing requests are logged with `sourceEndpoint` and passed to `runThroughBrain(...)`.
+   - Successful writing results are stamped with `meta.pipeline: "trinity"`, `meta.bypass: false`, `meta.sourceEndpoint`, and `meta.classification: "writing"`.
 
 7. `runThroughBrain(...)` runs the Trinity stages.
    - Pre-flight: request ID, tier detection, audit-safe config, memory context, guardrails, and runtime budget.
@@ -182,6 +184,46 @@ Treat completed output as degraded when any of these are present:
 - `activeModel` contains `static-timeout-fallback`
 - `auditSafe.auditFlags` contains `CORE_PIPELINE_TIMEOUT_FALLBACK`
 
+Successful writing/generation output must include this invariant in `meta`:
+
+```json
+{
+  "pipeline": "trinity",
+  "bypass": false,
+  "sourceEndpoint": "<caller>",
+  "classification": "writing"
+}
+```
+
+The invariant is applied by `applyTrinityGenerationInvariant(...)` in `src/core/logic/trinityGenerationFacade.ts`. Callers should preserve it when adapting older response envelopes.
+
+## Writing and Control Boundaries
+Writing/generation requests must enter the generation facade. Current writing-plane callers include:
+- `/gpt-access/jobs/create` queued GPT execution via `src/workers/jobRunner.ts`
+- `/gpt/:gptId` module dispatch, fast path, and direct `query_and_wait`
+- `/ask` normal generation and system-review generation paths
+- `/arcanos-pipeline`
+- `/api/openai/prompt`
+- Research/web search/RAG synthesis, secure reasoning, tutor/gaming/booker generation, CEF AI prompt execution, image prompt enhancement, reusable-code generation, AFOL, GPT sync, and simulation completion
+
+These control-plane routes must not enter Trinity:
+- `/mcp`
+- `/status`
+- `/healthz`
+- `/workers/status`
+- `/worker-helper/health`
+- `/gpt-access/status`
+- `/gpt-access/jobs/result`
+- `/trinity/status`
+
+`/ask` tool runtimes, daemon tools, DAG tooling, worker status tools, HRC scoring, memory validation, audit-safe mode interpretation, auto-heal planning, daily summaries, self-improve patch proposal generation, idle/provider probes, vision, embeddings, and adapter wrappers are intentionally outside the writing facade because they are control/evaluation/infrastructure paths or non-text-generation SDK boundaries. They must not be exposed as arbitrary user writing routes, and they must not call back through `/gpt/:gptId`.
+
+Raw SDK calls are allowed only at these boundaries:
+- OpenAI adapter and shared OpenAI service helpers (`src/core/adapters/openai.adapter.ts`, `src/services/openai/*`, `src/services/openaiClient.ts`)
+- Embeddings, vision, and image generation SDK surfaces where the operation is not text writing
+- Control/evaluation utilities listed above
+- Standalone `workers/` package OpenAI handler and SDK wrapper, which are separate worker-package infrastructure; backend GPT jobs use `src/workers/jobRunner.ts` and the Trinity worker path
+
 ## Related Routes
 - `POST /gpt-access/jobs/create`: protected async Trinity/GPT job creation.
 - `POST /gpt-access/jobs/result`: protected job result lookup.
@@ -193,5 +235,5 @@ Treat completed output as degraded when any of these are present:
 
 ## Legacy Notes
 - `GET|POST /brain` is a legacy ask-compatible route and returns `410 Gone` unless `ASK_ROUTE_MODE=compat`.
-- `POST /arcanos-pipeline` is a separate legacy multi-step route and is not the same as `runThroughBrain`.
+- `POST /arcanos-pipeline` is a legacy compatibility route, but its text generation now enters the Trinity generation facade.
 - System operations must not be sent through the writing pipeline.

--- a/docs/TRINITY_PIPELINE.md
+++ b/docs/TRINITY_PIPELINE.md
@@ -216,11 +216,12 @@ These control-plane routes must not enter Trinity:
 - `/gpt-access/jobs/result`
 - `/trinity/status`
 
-`/ask` tool runtimes, daemon tools, DAG tooling, worker status tools, HRC scoring, memory validation, audit-safe mode interpretation, auto-heal planning, daily summaries, self-improve patch proposal generation, idle/provider probes, vision, embeddings, and adapter wrappers are intentionally outside the writing facade because they are control/evaluation/infrastructure paths or non-text-generation SDK boundaries. They must not be exposed as arbitrary user writing routes, and they must not call back through `/gpt/:gptId`.
+`/ask` tool runtimes, daemon tools, DAG tooling, worker status tools, HRC scoring, memory validation, audit-safe mode interpretation, auto-heal planning, daily summaries, self-improve patch proposal generation, idle/provider probes, vision, embeddings, simulation streaming compatibility, and adapter wrappers are intentionally outside the writing facade because they are control/evaluation/infrastructure paths, non-text-generation SDK boundaries, or stream transports Trinity does not yet expose. They must not be exposed as arbitrary user writing routes, and they must not call back through `/gpt/:gptId`.
 
 Raw SDK calls are allowed only at these boundaries:
 - OpenAI adapter and shared OpenAI service helpers (`src/core/adapters/openai.adapter.ts`, `src/services/openai/*`, `src/services/openaiClient.ts`)
 - Embeddings, vision, and image generation SDK surfaces where the operation is not text writing
+- Simulation streaming requests while Trinity exposes only completed `TrinityResult` generation
 - Control/evaluation utilities listed above
 - Standalone `workers/` package OpenAI handler and SDK wrapper, which are separate worker-package infrastructure; backend GPT jobs use `src/workers/jobRunner.ts` and the Trinity worker path
 

--- a/scripts/check-routing-boundaries.js
+++ b/scripts/check-routing-boundaries.js
@@ -22,6 +22,7 @@ const BOUNDARY_GROUPS = [
     filePatterns: [
       /^src\/services\/runtimeInspectionRoutingService\.ts$/i,
       /^src\/services\/systemState\.ts$/i,
+      /^src\/services\/controlPlane\/.*\.(?:ts|js)$/i,
       /^src\/routes\/ask\/dagTools\.ts$/i,
       /^src\/mcp\/server\/jobTools\.ts$/i,
     ],
@@ -31,7 +32,7 @@ const BOUNDARY_GROUPS = [
         reason: 'control-plane modules must not import the writing dispatcher',
       },
       {
-        pattern: /\bfrom ['"][^'"]*(?:@core\/logic\/trinityWritingPipeline|\/core\/logic\/trinityWritingPipeline)(?:\.js)?['"]|\brequire\(['"][^'"]*(?:@core\/logic\/trinityWritingPipeline|\/core\/logic\/trinityWritingPipeline)(?:\.js)?['"]\)/,
+        pattern: /\bfrom ['"][^'"]*(?:@core\/logic\/trinityWritingPipeline|\/core\/logic\/trinityWritingPipeline|@core\/logic\/trinityGenerationFacade|\/core\/logic\/trinityGenerationFacade)(?:\.js)?['"]|\brequire\(['"][^'"]*(?:@core\/logic\/trinityWritingPipeline|\/core\/logic\/trinityWritingPipeline|@core\/logic\/trinityGenerationFacade|\/core\/logic\/trinityGenerationFacade)(?:\.js)?['"]\)/,
         reason: 'control-plane modules must not invoke the Trinity writing facade',
       },
     ],

--- a/scripts/check-routing-boundaries.js
+++ b/scripts/check-routing-boundaries.js
@@ -52,6 +52,7 @@ const BOUNDARY_GROUPS = [
 
 const DIRECT_TRINITY_IMPORT_ALLOWED_FILES = new Set([
   'src/core/logic/trinity.ts',
+  'src/core/logic/trinityGenerationFacade.ts',
   'src/core/logic/trinityWritingPipeline.ts',
 ]);
 

--- a/src/core/afol/routes.ts
+++ b/src/core/afol/routes.ts
@@ -41,6 +41,23 @@ function getMessageContent(message: unknown): string | undefined {
   return typeof record.content === 'string' ? record.content : undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readTrinityCacheStatus(result: { meta?: unknown }): boolean {
+  if (!isRecord(result.meta)) {
+    return false;
+  }
+
+  if (result.meta.cached === true || result.meta.cacheHit === true) {
+    return true;
+  }
+
+  const cache = result.meta.cache;
+  return isRecord(cache) && cache.hit === true;
+}
+
 async function executeModelRoute(
   route: RouteSelection,
   intent: string | undefined,
@@ -87,11 +104,12 @@ async function executeModelRoute(
         }
       }
     });
+    const cached = readTrinityCacheStatus(result);
 
     recordTraceEvent('afol.route.success', {
       route: route.name,
       model: result.activeModel,
-      cached: false
+      cached
     });
 
     return {
@@ -99,7 +117,7 @@ async function executeModelRoute(
       input: prompt,
       output: result.result,
       model: result.activeModel,
-      cached: false,
+      cached,
       metadata: {
         routeReason: route.reason,
         intent

--- a/src/core/afol/routes.ts
+++ b/src/core/afol/routes.ts
@@ -1,8 +1,11 @@
-import { callOpenAI, getDefaultModel, getFallbackModel, generateMockResponse } from "@services/openai.js";
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import { getDefaultModel, getFallbackModel, generateMockResponse } from "@services/openai.js";
+import { getOpenAIClientOrAdapter } from '@services/openai/clientBridge.js';
 import { recordTraceEvent } from "@platform/logging/telemetry.js";
 import { DecideInput, RouteExecutionResult, RouteSelection } from './types.js';
 import { getEnvNumber } from "@platform/runtime/env.js";
 import { resolveErrorMessage } from "@core/lib/errors/index.js";
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
 
 // Use config layer for env access (adapter boundary pattern)
 const PRIMARY_TOKEN_LIMIT = getEnvNumber('AFOL_PRIMARY_TOKEN_LIMIT', 1024);
@@ -53,26 +56,50 @@ async function executeModelRoute(
   });
 
   try {
-    const result = await callOpenAI(model, prompt, tokenLimit, true, {
-      metadata: {
-        route: route.name,
-        reason: route.reason,
-        intent
+    const { client } = getOpenAIClientOrAdapter();
+    if (!client) {
+      throw new Error('OpenAI client unavailable for AFOL Trinity route.');
+    }
+
+    const result = await runTrinityWritingPipeline({
+      input: {
+        prompt,
+        moduleId: 'AFOL',
+        sourceEndpoint: `afol.${route.name}`,
+        requestedAction: 'query',
+        body: {
+          prompt,
+          model,
+          tokenLimit,
+          route: route.name,
+          reason: route.reason,
+          intent
+        },
+        tokenLimit,
+        executionMode: 'request'
+      },
+      context: {
+        client,
+        runtimeBudget: createRuntimeBudget(),
+        runOptions: {
+          answerMode: 'direct',
+          strictUserVisibleOutput: true
+        }
       }
     });
 
     recordTraceEvent('afol.route.success', {
       route: route.name,
-      model: result.model,
-      cached: result.cached
+      model: result.activeModel,
+      cached: false
     });
 
     return {
       route: route.name,
       input: prompt,
-      output: result.output,
-      model: result.model,
-      cached: result.cached,
+      output: result.result,
+      model: result.activeModel,
+      cached: false,
       metadata: {
         routeReason: route.reason,
         intent

--- a/src/core/logic/trinityGenerationFacade.ts
+++ b/src/core/logic/trinityGenerationFacade.ts
@@ -1,0 +1,250 @@
+import type OpenAI from 'openai';
+
+import { resolveErrorMessage } from '@core/lib/errors/index.js';
+import { logger } from '@platform/logging/structuredLogging.js';
+import { createRuntimeBudget, type RuntimeBudget } from '@platform/resilience/runtimeBudget.js';
+import {
+  classifyWritingPlaneInput,
+  type WritingPlaneInputClassification,
+} from '@platform/runtime/writingPlaneContract.js';
+import { generateRequestId } from '@shared/idGenerator.js';
+
+import { runThroughBrain, type TrinityResult, type TrinityRunOptions } from './trinity.js';
+import { readIntentMode, resolveIntentMode } from './trinityHonesty.js';
+
+export interface TrinityGenerationInput {
+  prompt: string;
+  gptId?: string;
+  moduleId?: string;
+  sessionId?: string;
+  overrideAuditSafe?: string;
+  sourceEndpoint: string;
+  requestedAction?: string | null;
+  body?: unknown;
+  tokenLimit?: number;
+  outputLimit?: number;
+  maxOutputTokens?: number;
+  executionMode?: string;
+  background?: Record<string, unknown>;
+}
+
+export interface TrinityGenerationContext {
+  client: OpenAI;
+  requestId?: string;
+  runtimeBudget?: RuntimeBudget;
+  runOptions?: Omit<TrinityRunOptions, 'sourceEndpoint'>;
+}
+
+export interface TrinityGenerationFacadeRequest {
+  input: TrinityGenerationInput;
+  context: TrinityGenerationContext;
+}
+
+type TrinityControlLeakClassification = Extract<
+  WritingPlaneInputClassification,
+  { plane: 'control' }
+>;
+
+export class TrinityControlLeakError extends Error {
+  code = 'TRINITY_CONTROL_LEAK';
+  classification: TrinityControlLeakClassification;
+  requestId: string;
+  sourceEndpoint: string;
+
+  constructor(params: {
+    classification: TrinityControlLeakClassification;
+    requestId: string;
+    sourceEndpoint: string;
+  }) {
+    super(params.classification.message);
+    this.name = 'TrinityControlLeakError';
+    this.classification = params.classification;
+    this.requestId = params.requestId;
+    this.sourceEndpoint = params.sourceEndpoint;
+  }
+}
+
+function resolveRequestId(params: TrinityGenerationFacadeRequest): string {
+  return (
+    params.context.requestId?.trim() ||
+    generateRequestId('trinity')
+  );
+}
+
+function readActionAlias(record: Record<string, unknown>): string | null {
+  const directAction = record.action;
+  if (typeof directAction === 'string' && directAction.trim().length > 0) {
+    return directAction.trim();
+  }
+
+  const operation = record.operation;
+  return typeof operation === 'string' && operation.trim().length > 0
+    ? operation.trim()
+    : null;
+}
+
+function readRequestedAction(body: unknown): string | null {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return null;
+  }
+
+  const bodyRecord = body as Record<string, unknown>;
+  const directAction = readActionAlias(bodyRecord);
+  if (directAction) {
+    return directAction;
+  }
+
+  const payload = bodyRecord.payload;
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null;
+  }
+
+  return readActionAlias(payload as Record<string, unknown>);
+}
+
+function normalizePositiveInteger(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.trunc(value)
+    : undefined;
+}
+
+export function classifyTrinityGenerationInput(
+  params: TrinityGenerationFacadeRequest
+): WritingPlaneInputClassification {
+  return classifyWritingPlaneInput({
+    body: params.input.body,
+    promptText: params.input.prompt,
+    requestedAction: params.input.requestedAction ?? readRequestedAction(params.input.body),
+  });
+}
+
+export function applyTrinityGenerationInvariant(
+  result: TrinityResult,
+  params: {
+    sourceEndpoint: string;
+    gptId?: string;
+    moduleId?: string;
+    requestedAction?: string | null;
+    tokenLimit?: number;
+    outputLimit?: number;
+    maxOutputTokens?: number;
+    executionMode?: string;
+    background?: Record<string, unknown>;
+  }
+): TrinityResult {
+  const tokenLimit = normalizePositiveInteger(params.tokenLimit);
+  const outputLimit =
+    normalizePositiveInteger(params.outputLimit) ??
+    normalizePositiveInteger(params.maxOutputTokens);
+
+  result.meta = {
+    ...result.meta,
+    pipeline: 'trinity',
+    bypass: false,
+    sourceEndpoint: params.sourceEndpoint,
+    classification: 'writing',
+    ...(params.gptId ? { gptId: params.gptId } : {}),
+    ...(params.moduleId ? { moduleId: params.moduleId } : {}),
+    ...(params.requestedAction !== undefined ? { requestedAction: params.requestedAction } : {}),
+    ...(params.executionMode ? { executionMode: params.executionMode } : {}),
+    ...(tokenLimit !== undefined ? { tokenLimit } : {}),
+    ...(outputLimit !== undefined ? { outputLimit } : {}),
+    ...(params.background ? { background: params.background } : {}),
+  };
+
+  return result;
+}
+
+/**
+ * Canonical writing/generation facade for Trinity.
+ * Inputs/outputs: normalized generation input plus execution context -> structured TrinityResult.
+ * Edge cases: control-plane leakage is rejected inside the Trinity boundary before the low-level engine executes.
+ */
+export async function runTrinityGenerationFacade(
+  params: TrinityGenerationFacadeRequest
+): Promise<TrinityResult> {
+  const requestId = resolveRequestId(params);
+  const sourceEndpoint = params.input.sourceEndpoint.trim();
+  const requestedAction = params.input.requestedAction ?? readRequestedAction(params.input.body);
+  const classification = classifyTrinityGenerationInput(params);
+
+  if (classification.plane !== 'writing') {
+    logger.error('trinity.control_leak_detected', {
+      module: 'trinity',
+      requestId,
+      sourceEndpoint,
+      plane: classification.plane,
+      classification: classification.kind,
+      action: classification.action,
+      reason: classification.reason,
+      errorCode: classification.errorCode,
+      canonical: classification.canonical,
+    });
+    throw new TrinityControlLeakError({
+      classification,
+      requestId,
+      sourceEndpoint,
+    });
+  }
+
+  const prompt = params.input.prompt.trim();
+  const runtimeBudget = params.context.runtimeBudget ?? createRuntimeBudget();
+  const startedAt = Date.now();
+  const intentMode = resolveIntentMode(prompt, params.context.runOptions ?? {});
+
+  logger.info('trinity.entry', {
+    module: 'trinity',
+    requestId,
+    sourceEndpoint,
+    action: classification.action ?? 'query',
+    intentMode,
+    promptLength: prompt.length,
+  });
+
+  try {
+    const result = await runThroughBrain(
+      params.context.client,
+      prompt,
+      params.input.sessionId,
+      params.input.overrideAuditSafe,
+      {
+        ...(params.context.runOptions ?? {}),
+        sourceEndpoint,
+      },
+      runtimeBudget
+    );
+
+    const output = applyTrinityGenerationInvariant(result, {
+      sourceEndpoint,
+      gptId: params.input.gptId,
+      moduleId: params.input.moduleId,
+      requestedAction,
+      tokenLimit: params.input.tokenLimit,
+      outputLimit: params.input.outputLimit,
+      maxOutputTokens: params.input.maxOutputTokens,
+      executionMode: params.input.executionMode,
+      background: params.input.background,
+    });
+
+    logger.info('trinity.exit', {
+      module: 'trinity',
+      requestId,
+      sourceEndpoint,
+      durationMs: Date.now() - startedAt,
+      activeModel: output.activeModel,
+      fallbackFlag: output.fallbackFlag,
+      intentMode: output.outputControls ? readIntentMode(output.outputControls) : intentMode,
+    });
+
+    return output;
+  } catch (error) {
+    logger.error('trinity.error', {
+      module: 'trinity',
+      requestId,
+      sourceEndpoint,
+      durationMs: Date.now() - startedAt,
+      error: resolveErrorMessage(error),
+    });
+    throw error;
+  }
+}

--- a/src/core/logic/trinityGenerationFacade.ts
+++ b/src/core/logic/trinityGenerationFacade.ts
@@ -12,8 +12,11 @@ import { generateRequestId } from '@shared/idGenerator.js';
 import { runThroughBrain, type TrinityResult, type TrinityRunOptions } from './trinity.js';
 import { readIntentMode, resolveIntentMode } from './trinityHonesty.js';
 
+export type TrinityGenerationMessage = OpenAI.Chat.Completions.ChatCompletionMessageParam;
+
 export interface TrinityGenerationInput {
-  prompt: string;
+  prompt?: string;
+  messages?: TrinityGenerationMessage[];
   gptId?: string;
   moduleId?: string;
   sessionId?: string;
@@ -103,17 +106,90 @@ function readRequestedAction(body: unknown): string | null {
 }
 
 function normalizePositiveInteger(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) && value > 0
-    ? Math.trunc(value)
-    : undefined;
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+
+  const truncated = Math.trunc(value);
+  return truncated > 0 ? truncated : 1;
+}
+
+function serializeMessageContentPart(part: unknown): string {
+  if (typeof part === 'string') {
+    return part;
+  }
+
+  if (!part || typeof part !== 'object') {
+    return '';
+  }
+
+  const partRecord = part as Record<string, unknown>;
+  if (typeof partRecord.text === 'string') {
+    return partRecord.text;
+  }
+
+  try {
+    return JSON.stringify(partRecord);
+  } catch {
+    return String(part);
+  }
+}
+
+function serializeMessageContent(content: unknown): string {
+  if (typeof content === 'string') {
+    return content.trim();
+  }
+
+  if (Array.isArray(content)) {
+    return content
+      .map(serializeMessageContentPart)
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  return '';
+}
+
+export function buildPromptFromTrinityMessages(
+  messages: readonly TrinityGenerationMessage[] | undefined
+): string {
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return '';
+  }
+
+  return messages
+    .map((message) => {
+      const role = typeof message.role === 'string' ? message.role : 'message';
+      const name =
+        'name' in message && typeof message.name === 'string' && message.name.trim().length > 0
+          ? `:${message.name.trim()}`
+          : '';
+      const content = serializeMessageContent(message.content).trim();
+      return content ? `[${role}${name}]\n${content}` : '';
+    })
+    .filter(Boolean)
+    .join('\n\n')
+    .trim();
+}
+
+export function resolveTrinityGenerationPrompt(input: TrinityGenerationInput): string {
+  const explicitPrompt = typeof input.prompt === 'string' ? input.prompt.trim() : '';
+  if (explicitPrompt) {
+    return explicitPrompt;
+  }
+
+  return buildPromptFromTrinityMessages(input.messages);
 }
 
 export function classifyTrinityGenerationInput(
   params: TrinityGenerationFacadeRequest
 ): WritingPlaneInputClassification {
+  const prompt = resolveTrinityGenerationPrompt(params.input);
+
   return classifyWritingPlaneInput({
     body: params.input.body,
-    promptText: params.input.prompt,
+    promptText: prompt || null,
     requestedAction: params.input.requestedAction ?? readRequestedAction(params.input.body),
   });
 }
@@ -137,22 +213,23 @@ export function applyTrinityGenerationInvariant(
     normalizePositiveInteger(params.outputLimit) ??
     normalizePositiveInteger(params.maxOutputTokens);
 
-  result.meta = {
-    ...result.meta,
-    pipeline: 'trinity',
-    bypass: false,
-    sourceEndpoint: params.sourceEndpoint,
-    classification: 'writing',
-    ...(params.gptId ? { gptId: params.gptId } : {}),
-    ...(params.moduleId ? { moduleId: params.moduleId } : {}),
-    ...(params.requestedAction !== undefined ? { requestedAction: params.requestedAction } : {}),
-    ...(params.executionMode ? { executionMode: params.executionMode } : {}),
-    ...(tokenLimit !== undefined ? { tokenLimit } : {}),
-    ...(outputLimit !== undefined ? { outputLimit } : {}),
-    ...(params.background ? { background: params.background } : {}),
+  return {
+    ...result,
+    meta: {
+      ...result.meta,
+      pipeline: 'trinity',
+      bypass: false,
+      sourceEndpoint: params.sourceEndpoint,
+      classification: 'writing',
+      ...(params.gptId ? { gptId: params.gptId } : {}),
+      ...(params.moduleId ? { moduleId: params.moduleId } : {}),
+      ...(params.requestedAction !== undefined ? { requestedAction: params.requestedAction } : {}),
+      ...(params.executionMode ? { executionMode: params.executionMode } : {}),
+      ...(tokenLimit !== undefined ? { tokenLimit } : {}),
+      ...(outputLimit !== undefined ? { outputLimit } : {}),
+      ...(params.background ? { background: { ...params.background } } : {}),
+    },
   };
-
-  return result;
 }
 
 /**
@@ -187,7 +264,11 @@ export async function runTrinityGenerationFacade(
     });
   }
 
-  const prompt = params.input.prompt.trim();
+  const prompt = resolveTrinityGenerationPrompt(params.input);
+  if (!prompt) {
+    throw new Error('Trinity generation requires a non-empty prompt or messages array.');
+  }
+
   const runtimeBudget = params.context.runtimeBudget ?? createRuntimeBudget();
   const startedAt = Date.now();
   const intentMode = resolveIntentMode(prompt, params.context.runOptions ?? {});

--- a/src/core/logic/trinityGenerationFacade.ts
+++ b/src/core/logic/trinityGenerationFacade.ts
@@ -111,7 +111,7 @@ function normalizePositiveInteger(value: unknown): number | undefined {
   }
 
   const truncated = Math.trunc(value);
-  return truncated > 0 ? truncated : 1;
+  return Math.max(1, truncated);
 }
 
 function serializeMessageContentPart(part: unknown): string {

--- a/src/core/logic/trinityTypes.ts
+++ b/src/core/logic/trinityTypes.ts
@@ -89,6 +89,17 @@ export interface TrinityResult {
     tokens?: TrinityMetaTokens | undefined;
     id: string;
     created: number;
+    pipeline?: 'trinity';
+    bypass?: false;
+    sourceEndpoint?: string;
+    classification?: 'writing';
+    gptId?: string;
+    moduleId?: string;
+    requestedAction?: string | null;
+    executionMode?: string;
+    tokenLimit?: number;
+    outputLimit?: number;
+    background?: Record<string, unknown>;
   };
   activeModel: string;
   fallbackFlag: boolean;

--- a/src/core/logic/trinityWritingPipeline.ts
+++ b/src/core/logic/trinityWritingPipeline.ts
@@ -1,185 +1,36 @@
-import type OpenAI from 'openai';
-
-import { resolveErrorMessage } from '@core/lib/errors/index.js';
-import { logger } from '@platform/logging/structuredLogging.js';
-import { createRuntimeBudget, type RuntimeBudget } from '@platform/resilience/runtimeBudget.js';
+import type {
+  TrinityGenerationContext,
+  TrinityGenerationFacadeRequest,
+  TrinityGenerationInput
+} from './trinityGenerationFacade.js';
 import {
-  classifyWritingPlaneInput,
-  type WritingPlaneInputClassification,
-} from '@platform/runtime/writingPlaneContract.js';
-import { generateRequestId } from '@shared/idGenerator.js';
+  runTrinityGenerationFacade,
+  TrinityControlLeakError,
+  applyTrinityGenerationInvariant,
+  classifyTrinityGenerationInput
+} from './trinityGenerationFacade.js';
+import type { TrinityResult } from './trinity.js';
 
-import { runThroughBrain, type TrinityResult, type TrinityRunOptions } from './trinity.js';
-import { readIntentMode, resolveIntentMode } from './trinityHonesty.js';
+export interface TrinityWritingInput extends TrinityGenerationInput {}
 
-export interface TrinityWritingInput {
-  prompt: string;
-  sessionId?: string;
-  overrideAuditSafe?: string;
-  sourceEndpoint: string;
-  requestedAction?: string | null;
-  body?: unknown;
-}
+export interface TrinityWritingContext extends TrinityGenerationContext {}
 
-export interface TrinityWritingContext {
-  client: OpenAI;
-  requestId?: string;
-  runtimeBudget?: RuntimeBudget;
-  runOptions?: Omit<TrinityRunOptions, 'sourceEndpoint'>;
-}
+export interface TrinityWritingPipelineRequest extends TrinityGenerationFacadeRequest {}
 
-export interface TrinityWritingPipelineRequest {
-  input: TrinityWritingInput;
-  context: TrinityWritingContext;
-}
-
-type TrinityControlLeakClassification = Extract<
-  WritingPlaneInputClassification,
-  { plane: 'control' }
->;
-
-export class TrinityControlLeakError extends Error {
-  code = 'TRINITY_CONTROL_LEAK';
-  classification: TrinityControlLeakClassification;
-  requestId: string;
-  sourceEndpoint: string;
-
-  constructor(params: {
-    classification: TrinityControlLeakClassification;
-    requestId: string;
-    sourceEndpoint: string;
-  }) {
-    super(params.classification.message);
-    this.name = 'TrinityControlLeakError';
-    this.classification = params.classification;
-    this.requestId = params.requestId;
-    this.sourceEndpoint = params.sourceEndpoint;
-  }
-}
-
-function resolveRequestId(params: TrinityWritingPipelineRequest): string {
-  return (
-    params.context.requestId?.trim() ||
-    generateRequestId('trinity')
-  );
-}
-
-function readActionAlias(record: Record<string, unknown>): string | null {
-  const directAction = record.action;
-  if (typeof directAction === 'string' && directAction.trim().length > 0) {
-    return directAction.trim();
-  }
-
-  const operation = record.operation;
-  return typeof operation === 'string' && operation.trim().length > 0
-    ? operation.trim()
-    : null;
-}
-
-function readRequestedAction(body: unknown): string | null {
-  if (!body || typeof body !== 'object' || Array.isArray(body)) {
-    return null;
-  }
-
-  const bodyRecord = body as Record<string, unknown>;
-  const directAction = readActionAlias(bodyRecord);
-  if (directAction) {
-    return directAction;
-  }
-
-  const payload = bodyRecord.payload;
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-    return null;
-  }
-
-  return readActionAlias(payload as Record<string, unknown>);
-}
-
-function classifyTrinityInput(params: TrinityWritingPipelineRequest): WritingPlaneInputClassification {
-  return classifyWritingPlaneInput({
-    body: params.input.body,
-    promptText: params.input.prompt,
-    requestedAction: params.input.requestedAction ?? readRequestedAction(params.input.body),
-  });
-}
+export {
+  TrinityControlLeakError,
+  applyTrinityGenerationInvariant,
+  classifyTrinityGenerationInput,
+  runTrinityGenerationFacade
+};
 
 /**
- * Execute the Trinity pipeline from the writing plane only.
+ * Backward-compatible alias for the canonical Trinity generation facade.
  * Inputs/outputs: normalized writing input plus execution context -> structured TrinityResult.
- * Edge cases: control-plane leakage is rejected before the low-level Trinity engine executes.
+ * Edge cases: control-plane leakage is rejected by `runTrinityGenerationFacade` before the low-level engine executes.
  */
 export async function runTrinityWritingPipeline(
   params: TrinityWritingPipelineRequest
 ): Promise<TrinityResult> {
-  const requestId = resolveRequestId(params);
-  const sourceEndpoint = params.input.sourceEndpoint.trim();
-  const classification = classifyTrinityInput(params);
-
-  if (classification.plane !== 'writing') {
-    logger.error('trinity.control_leak_detected', {
-      module: 'trinity',
-      requestId,
-      sourceEndpoint,
-      plane: classification.plane,
-      classification: classification.kind,
-      action: classification.action,
-      reason: classification.reason,
-      errorCode: classification.errorCode,
-      canonical: classification.canonical,
-    });
-    throw new TrinityControlLeakError({
-      classification,
-      requestId,
-      sourceEndpoint,
-    });
-  }
-
-  const prompt = params.input.prompt.trim();
-  const runtimeBudget = params.context.runtimeBudget ?? createRuntimeBudget();
-  const startedAt = Date.now();
-  const intentMode = resolveIntentMode(prompt, params.context.runOptions ?? {});
-
-  logger.info('trinity.entry', {
-    module: 'trinity',
-    requestId,
-    sourceEndpoint,
-    action: classification.action ?? 'query',
-    intentMode,
-    promptLength: prompt.length,
-  });
-
-  try {
-    const result = await runThroughBrain(
-      params.context.client,
-      prompt,
-      params.input.sessionId,
-      params.input.overrideAuditSafe,
-      {
-        ...(params.context.runOptions ?? {}),
-        sourceEndpoint,
-      },
-      runtimeBudget
-    );
-
-    logger.info('trinity.exit', {
-      module: 'trinity',
-      requestId,
-      sourceEndpoint,
-      durationMs: Date.now() - startedAt,
-      activeModel: result.activeModel,
-      fallbackFlag: result.fallbackFlag,
-      intentMode: result.outputControls ? readIntentMode(result.outputControls) : intentMode,
-    });
-
-    return result;
-  } catch (error) {
-    logger.error('trinity.error', {
-      module: 'trinity',
-      requestId,
-      sourceEndpoint,
-      durationMs: Date.now() - startedAt,
-      error: resolveErrorMessage(error),
-    });
-    throw error;
-  }
+  return runTrinityGenerationFacade(params);
 }

--- a/src/core/logic/trinityWritingPipeline.ts
+++ b/src/core/logic/trinityWritingPipeline.ts
@@ -7,7 +7,9 @@ import {
   runTrinityGenerationFacade,
   TrinityControlLeakError,
   applyTrinityGenerationInvariant,
-  classifyTrinityGenerationInput
+  buildPromptFromTrinityMessages,
+  classifyTrinityGenerationInput,
+  resolveTrinityGenerationPrompt
 } from './trinityGenerationFacade.js';
 import type { TrinityResult } from './trinity.js';
 
@@ -20,7 +22,9 @@ export interface TrinityWritingPipelineRequest extends TrinityGenerationFacadeRe
 export {
   TrinityControlLeakError,
   applyTrinityGenerationInvariant,
+  buildPromptFromTrinityMessages,
   classifyTrinityGenerationInput,
+  resolveTrinityGenerationPrompt,
   runTrinityGenerationFacade
 };
 

--- a/src/core/logic/tutor-logic.ts
+++ b/src/core/logic/tutor-logic.ts
@@ -1,8 +1,5 @@
-import {
-  getDefaultModel,
-  getGPT5Model,
-  generateMockResponse
-} from "@services/openai.js";
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import { generateMockResponse } from "@services/openai.js";
 import { searchScholarly } from "@services/scholarlyFetcher.js";
 import {
   DEFAULT_AUDIT_SYSTEM_PROMPT,
@@ -17,6 +14,7 @@ import { getOpenAIClientOrAdapter } from "@services/openai/clientBridge.js";
 import { getEnv, getEnvNumber } from "@platform/runtime/env.js";
 import { resolveErrorMessage } from "@core/lib/errors/index.js";
 import { tryExtractExactLiteralPromptShortcut } from "@services/exactLiteralPromptShortcut.js";
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
 
 const DEFAULT_TOKEN_LIMIT = getEnvNumber('TUTOR_DEFAULT_TOKEN_LIMIT', 200);
 
@@ -128,12 +126,12 @@ async function runTutorPipeline(
     temperature?: number;
   } = {}
 ): Promise<TutorPipelineOutput> {
-  const { adapter } = getOpenAIClientOrAdapter();
+  const { client } = getOpenAIClientOrAdapter();
   // Use config layer for env access (adapter boundary pattern)
   const testMode = getEnv('OPENAI_API_KEY') === 'test_key_for_mocking';
 
   //audit Assumption: missing adapter or test mode uses mock pipeline
-  if (!adapter || testMode) {
+  if (!client || testMode) {
     const mock = generateMockResponse(prompt, 'query');
     return {
       tutor_response: mock.result || '',
@@ -151,63 +149,52 @@ async function runTutorPipeline(
   }
 
   try {
-    const intakeModel = getDefaultModel();
-    const reasoningModel = getGPT5Model();
-    const auditModel = getDefaultModel();
-    //audit Assumption: token limit is required; Handling: default if absent
     const tokenLimit = options.tokenLimit ?? DEFAULT_TOKEN_LIMIT;
+    const tutorPrompt = [
+      options.intakePrompt || DEFAULT_INTAKE_SYSTEM_PROMPT,
+      options.reasoningPrompt || DEFAULT_REASONING_SYSTEM_PROMPT,
+      options.auditPrompt || DEFAULT_AUDIT_SYSTEM_PROMPT,
+      '',
+      prompt
+    ].join('\n\n');
 
-    const intakeResponse = await adapter.responses.create({
-      model: intakeModel,
-      messages: [
-        { role: 'system', content: options.intakePrompt || DEFAULT_INTAKE_SYSTEM_PROMPT },
-        { role: 'user', content: prompt }
-      ],
-      max_tokens: tokenLimit
-    });
-
-    const refinedPrompt = intakeResponse.choices[0]?.message?.content?.trim() || prompt;
-
-    const reasoningResponse = await adapter.responses.create({
-      model: reasoningModel,
-      messages: [
-        {
-          role: 'system',
-          content: options.reasoningPrompt || DEFAULT_REASONING_SYSTEM_PROMPT
+    const trinityResult = await runTrinityWritingPipeline({
+      input: {
+        prompt: tutorPrompt,
+        moduleId: 'ARCANOS:TUTOR',
+        sourceEndpoint: 'tutor.pipeline',
+        requestedAction: 'query',
+        body: {
+          prompt,
+          tokenLimit,
+          temperature: options.temperature ?? 0.3
         },
-        { role: 'user', content: refinedPrompt }
-      ],
-      temperature: options.temperature ?? 0.3,
-      max_tokens: tokenLimit
+        tokenLimit,
+        executionMode: 'request'
+      },
+      context: {
+        client,
+        runtimeBudget: createRuntimeBudget(),
+        runOptions: {
+          answerMode: 'direct',
+          strictUserVisibleOutput: true
+        }
+      }
     });
 
-    const reasoningOutput = reasoningResponse.choices[0]?.message?.content?.trim() || '';
-
-    const auditResponse = await adapter.responses.create({
-      model: auditModel,
-      messages: [
-        {
-          role: 'system',
-          content: options.auditPrompt || DEFAULT_AUDIT_SYSTEM_PROMPT
-        },
-        { role: 'user', content: reasoningOutput }
-      ],
-      max_tokens: tokenLimit
-    });
-
-    const finalized = auditResponse.choices[0]?.message?.content?.trim() || reasoningOutput;
+    const finalized = trinityResult.result.trim();
 
     return {
       tutor_response: finalized,
       pipeline_trace: {
-        intake: refinedPrompt,
-        reasoning: reasoningOutput,
+        intake: prompt,
+        reasoning: finalized,
         finalized
       },
       model: {
-        intake: intakeModel,
-        reasoning: reasoningModel,
-        audit: auditModel
+        intake: trinityResult.activeModel,
+        reasoning: trinityResult.activeModel,
+        audit: trinityResult.activeModel
       }
     };
   } catch (error: unknown) {

--- a/src/routes/_core/gptDispatch.ts
+++ b/src/routes/_core/gptDispatch.ts
@@ -82,6 +82,34 @@ export type RouteGptRequestInput = {
   suppressTimeoutFallback?: boolean;
 };
 
+function extractMessageContentText(content: unknown): string | null {
+  if (typeof content === "string" && content.trim().length > 0) {
+    return content.trim();
+  }
+
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  const parts = content
+    .map((part) => {
+      if (typeof part === "string") {
+        return part;
+      }
+
+      if (part && typeof part === "object" && !Array.isArray(part)) {
+        const record = part as Record<string, unknown>;
+        return typeof record.text === "string" ? record.text : "";
+      }
+
+      return "";
+    })
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  return parts.length > 0 ? parts.join("\n") : null;
+}
+
 function extractPrompt(body: any): string | null {
   const direct =
     body?.message ||
@@ -95,7 +123,8 @@ function extractPrompt(body: any): string | null {
 
   if (Array.isArray(body?.messages)) {
     const lastUser = [...body.messages].reverse().find((m: any) => m?.role === "user");
-    if (typeof lastUser?.content === "string" && lastUser.content.trim().length > 0) return lastUser.content.trim();
+    const messageText = extractMessageContentText(lastUser?.content);
+    if (messageText) return messageText;
   }
 
   return null;

--- a/src/routes/_core/gptDispatch.ts
+++ b/src/routes/_core/gptDispatch.ts
@@ -26,6 +26,7 @@ import {
 import { extractDiagnosticTextInput, isDiagnosticRequest } from "@shared/http/diagnosticRequest.js";
 import { isRecord } from "@shared/typeGuards.js";
 import { resolveErrorMessage } from "@core/lib/errors/index.js";
+import { TrinityControlLeakError } from "@core/logic/trinityWritingPipeline.js";
 import type { Request } from "express";
 import {
   getRequestAbortContext,
@@ -46,7 +47,6 @@ import {
   type PromptDebugTracePatch,
 } from "@services/promptDebugTraceService.js";
 import {
-  assertWritingPlaneClassification,
   classifyGptRequestPlane,
 } from "./gptPlaneClassification.js";
 import {
@@ -516,6 +516,9 @@ const DEFAULT_BACKGROUND_MODULE_DISPATCH_TIMEOUT_MS = 180000;
 const SUPPRESS_PROMPT_DEBUG_TRACE_FLAG = '__arcanosSuppressPromptDebugTrace';
 const REDACTED_GPT_ACCESS_PROMPT = '[REDACTED_GPT_ACCESS_PROMPT]';
 const REDACTED_GPT_ACCESS_PAYLOAD = '[REDACTED_GPT_ACCESS_PAYLOAD]';
+const INTERNAL_GPT_ID_FIELD = '__arcanosGptId';
+const INTERNAL_SOURCE_ENDPOINT_FIELD = '__arcanosSourceEndpoint';
+const INTERNAL_REQUESTED_ACTION_FIELD = '__arcanosRequestedAction';
 
 function readPromptDebugSuppressionFlag(value: unknown): boolean {
   if (!isRecord(value)) {
@@ -528,6 +531,48 @@ function readPromptDebugSuppressionFlag(value: unknown): boolean {
 
 function shouldSuppressPromptDebugTrace(body: unknown, preDispatchPayload: unknown): boolean {
   return readPromptDebugSuppressionFlag(body) || readPromptDebugSuppressionFlag(preDispatchPayload);
+}
+
+function readInternalStringField(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const candidate = value[key];
+  return typeof candidate === 'string' && candidate.trim().length > 0
+    ? candidate.trim()
+    : undefined;
+}
+
+function resolveDispatchSourceEndpoint(body: unknown, requestEndpoint: string | undefined): string {
+  return (
+    readInternalStringField(body, INTERNAL_SOURCE_ENDPOINT_FIELD) ??
+    (typeof requestEndpoint === 'string' && requestEndpoint.trim().length > 0
+      ? requestEndpoint.trim()
+      : '/gpt/:gptId')
+  );
+}
+
+function enrichWritingDispatchPayload(
+  payload: unknown,
+  params: {
+    gptId: string;
+    sourceEndpoint: string;
+    requestedAction?: string | null;
+  }
+): unknown {
+  if (!isRecord(payload)) {
+    return payload;
+  }
+
+  return {
+    ...payload,
+    [INTERNAL_GPT_ID_FIELD]: params.gptId,
+    [INTERNAL_SOURCE_ENDPOINT_FIELD]: params.sourceEndpoint,
+    ...(params.requestedAction
+      ? { [INTERNAL_REQUESTED_ACTION_FIELD]: params.requestedAction }
+      : {})
+  };
 }
 
 function sanitizePromptDebugExecutorPayload(value: unknown): unknown {
@@ -999,28 +1044,7 @@ export async function routeGptRequest(input: RouteGptRequestInput): Promise<AskE
     requestedAction: rawRequestedAction ?? null,
   });
   if (writePlaneClassification.plane !== "writing") {
-    const controlError =
-      writePlaneClassification.plane === "reject"
-        ? {
-            code: writePlaneClassification.errorCode,
-            message: writePlaneClassification.message,
-            details: {
-              canonical: writePlaneClassification.canonical,
-              reason: writePlaneClassification.reason,
-              kind: writePlaneClassification.kind,
-            },
-          }
-        : {
-            code: "WRITING_PLANE_ONLY",
-            message:
-              "Control-plane requests must be handled by direct control handlers before entering the writing dispatcher.",
-            details: {
-              reason: writePlaneClassification.reason,
-              kind: writePlaneClassification.kind,
-            },
-          };
-
-    logger?.warn?.("gpt.dispatch.write_guard_rejected", {
+    logger?.warn?.("gpt.dispatch.write_guard.deferred_to_trinity", {
       requestId,
       gptId: trimmedGptId,
       endpoint: requestEndpoint,
@@ -1029,62 +1053,7 @@ export async function routeGptRequest(input: RouteGptRequestInput): Promise<AskE
       kind: writePlaneClassification.kind,
       reason: writePlaneClassification.reason,
     });
-    if (writePlaneClassification.kind === "mcp_control") {
-      logger?.error?.("gpt.dispatch.write_guard.mcp_violation", {
-        requestId,
-        gptId: trimmedGptId,
-        endpoint: requestEndpoint,
-        action: writePlaneClassification.action,
-        plane: writePlaneClassification.plane,
-        kind: writePlaneClassification.kind,
-        reason: writePlaneClassification.reason,
-      });
-    }
-    if (writePlaneClassification.kind === "dag_control") {
-      logger?.error?.("gpt.dispatch.write_guard.dag_violation", {
-        requestId,
-        gptId: trimmedGptId,
-        endpoint: requestEndpoint,
-        action: writePlaneClassification.action,
-        plane: writePlaneClassification.plane,
-        kind: writePlaneClassification.kind,
-        reason: writePlaneClassification.reason,
-      });
-    }
-    recordDispatcherMisroute({
-      gptId: trimmedGptId,
-      module: "write-guard",
-      reason: writePlaneClassification.reason,
-    });
-    recordDispatcherRoute({
-      gptId: trimmedGptId,
-      module: "write-guard",
-      route: "write_guard",
-      handler: "write-guard",
-      outcome: "rejected",
-    });
-    recordDispatchPromptDebugTrace(promptDebugRequestId, "fallback", {
-      traceId: request?.traceId ?? null,
-      endpoint: requestEndpoint ?? "/gpt/:gptId",
-      method: request?.method ?? null,
-      rawPrompt,
-      normalizedPrompt,
-      selectedRoute: "write_guard",
-      selectedModule: "write-guard",
-      fallbackPathUsed: "write-guard",
-      fallbackReason: controlError.message,
-    }, suppressPromptDebugTrace);
-    return {
-      ok: false,
-      error: controlError,
-      _route: {
-        ...baseRoute,
-        action: writePlaneClassification.action,
-        route: "write_guard",
-      },
-    };
   }
-  assertWritingPlaneClassification(writePlaneClassification);
 
   logger?.info?.("gpt.write.entry", {
     requestId,
@@ -1146,13 +1115,21 @@ export async function routeGptRequest(input: RouteGptRequestInput): Promise<AskE
     forcedDirectRoute: forceDirectModuleRouting,
     bypassIntentRouting: bypassIntentRouting === true,
   });
-  const payload = preDispatchPayload;
+  const dispatchSourceEndpoint = resolveDispatchSourceEndpoint(body, requestEndpoint);
+  const payload = enrichWritingDispatchPayload(preDispatchPayload, {
+    gptId: trimmedGptId,
+    sourceEndpoint: dispatchSourceEndpoint,
+    requestedAction: rawRequestedAction ?? writePlaneClassification.action
+  });
   const prompt = extractPrompt(payload);
   const requestedMode = extractMode(body, payload);
   let activeEntry = entry;
   let moduleMetadata = getModuleMetadata(activeEntry.module);
   let availableActions = moduleMetadata?.actions ?? [];
   let requestedAction = resolveRequestedActionAlias(rawRequestedAction, availableActions);
+  if (writePlaneClassification.plane !== 'writing' && activeEntry.module === 'ARCANOS:CORE') {
+    requestedAction = 'query';
+  }
 
   //audit Assumption: gameplay generation must be explicit and never inferred from a GPT binding alone; failure risk: minimal or context-free prompts fall into the gaming simulation pipeline; expected invariant: ARCANOS:GAMING executes only when callers send `mode:"gameplay"`; handling strategy: fail closed before memory, repo inspection, HRC, and module dispatch.
   if (activeEntry.module === "ARCANOS:GAMING" && requestedMode !== "gameplay") {
@@ -1688,6 +1665,53 @@ export async function routeGptRequest(input: RouteGptRequestInput): Promise<AskE
         timeoutSource,
         durationMs: Date.now() - dispatchStartedAt,
       });
+      }
+
+      if (err instanceof TrinityControlLeakError) {
+        recordDispatcherMisroute({
+          gptId: trimmedGptId,
+          module: activeEntry.module,
+          reason: err.classification.reason,
+        });
+        recordDispatcherRoute({
+          gptId: trimmedGptId,
+          module: activeEntry.module,
+          route: activeEntry.route,
+          handler: 'trinity-control-guard',
+          outcome: 'rejected',
+        });
+        recordDispatchPromptDebugTrace(promptDebugRequestId, 'fallback', {
+          traceId: request?.traceId ?? null,
+          endpoint: requestEndpoint ?? '/gpt/:gptId',
+          method: request?.method ?? null,
+          rawPrompt,
+          normalizedPrompt,
+          selectedRoute: activeEntry.route,
+          selectedModule: activeEntry.module,
+          fallbackPathUsed: 'trinity-control-guard',
+          fallbackReason: err.message,
+        }, suppressPromptDebugTrace);
+        return {
+          ok: false,
+          error: {
+            code: err.classification.errorCode,
+            message: err.message,
+            details: {
+              canonical: err.classification.canonical,
+              reason: err.classification.reason,
+              kind: err.classification.kind,
+            },
+          },
+          _route: {
+            ...baseRoute,
+            module: activeEntry.module,
+            action,
+            matchMethod,
+            route: 'trinity_control_guard',
+            availableActions,
+            moduleVersion: (moduleMetadata as any)?.version ?? null,
+          },
+        };
       }
 
       if (isDispatchCancellation) {

--- a/src/routes/_core/gptDispatch.ts
+++ b/src/routes/_core/gptDispatch.ts
@@ -53,6 +53,7 @@ import {
   ARCANOS_SUPPRESS_TIMEOUT_FALLBACK_FLAG,
   normalizeBooleanFlagValue
 } from "@shared/gpt/gptDirectAction.js";
+import { extractLastUserMessageText } from "@shared/gpt/messageContentText.js";
 
 export type AskEnvelope =
   | { ok: true; result: unknown; _route: RouteMeta }
@@ -82,34 +83,6 @@ export type RouteGptRequestInput = {
   suppressTimeoutFallback?: boolean;
 };
 
-function extractMessageContentText(content: unknown): string | null {
-  if (typeof content === "string" && content.trim().length > 0) {
-    return content.trim();
-  }
-
-  if (!Array.isArray(content)) {
-    return null;
-  }
-
-  const parts = content
-    .map((part) => {
-      if (typeof part === "string") {
-        return part;
-      }
-
-      if (part && typeof part === "object" && !Array.isArray(part)) {
-        const record = part as Record<string, unknown>;
-        return typeof record.text === "string" ? record.text : "";
-      }
-
-      return "";
-    })
-    .map((part) => part.trim())
-    .filter(Boolean);
-
-  return parts.length > 0 ? parts.join("\n") : null;
-}
-
 function extractPrompt(body: any): string | null {
   const direct =
     body?.message ||
@@ -121,11 +94,8 @@ function extractPrompt(body: any): string | null {
 
   if (typeof direct === "string" && direct.trim().length > 0) return direct.trim();
 
-  if (Array.isArray(body?.messages)) {
-    const lastUser = [...body.messages].reverse().find((m: any) => m?.role === "user");
-    const messageText = extractMessageContentText(lastUser?.content);
-    if (messageText) return messageText;
-  }
+  const messageText = extractLastUserMessageText(body?.messages);
+  if (messageText) return messageText;
 
   return null;
 }

--- a/src/routes/api-reusable-code.ts
+++ b/src/routes/api-reusable-code.ts
@@ -76,7 +76,8 @@ router.post(
     res.json({
       success: true,
       model: result.model,
-      snippets: result.snippets
+      snippets: result.snippets,
+      meta: result.meta
     });
   })
 );

--- a/src/routes/api-reusable-code.ts
+++ b/src/routes/api-reusable-code.ts
@@ -56,9 +56,9 @@ router.post(
   '/api/reusables',
   createValidationMiddleware(reusableCodeRequestSchema),
   asyncHandler(async (req: Request, res: Response) => {
-    const { adapter } = getOpenAIClientOrAdapter();
-    if (!adapter) {
-      sendCodegenServiceUnavailable(res, 'adapter');
+    const { client } = getOpenAIClientOrAdapter();
+    if (!client) {
+      sendCodegenServiceUnavailable(res, 'client');
       return;
     }
 
@@ -67,7 +67,7 @@ router.post(
     const includeDocs = requestBody.includeDocs ?? true;
     const language = requestBody.language ?? 'typescript';
 
-    const result = await generateReusableCodeSnippets(adapter, {
+    const result = await generateReusableCodeSnippets(client, {
       target: target as ReusableCodeTarget,
       includeDocs,
       language

--- a/src/routes/ask/index.ts
+++ b/src/routes/ask/index.ts
@@ -57,7 +57,6 @@ import { detectCognitiveDomain } from '@dispatcher/detectCognitiveDomain.js';
 import { gptFallbackClassifier } from '@dispatcher/gptDomainClassifier.js';
 import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
 import { buildPromptShortcutTelemetry } from '@routes/_core/promptShortcutResponse.js';
-import { shouldStoreOpenAIResponses } from '@config/openaiStore.js';
 import { planAutonomousWorkerJob } from '@services/workerAutonomyService.js';
 import {
   waitForQueuedAskJobCompletion,
@@ -631,7 +630,7 @@ export const handleAIRequest = async (
     const validation = validateAIRequest(req as Request, res as Response, endpointName);
     if (!validation) return; // validateAIRequest has already sent a response
 
-    const { adapter } = validation;
+    const { client: openai } = validation;
     let reviewInput = validation.input;
 
     // Sanitize user input to reduce prompt-injection surface
@@ -644,30 +643,42 @@ export const handleAIRequest = async (
     };
 
     try {
-      const modelResponse = await adapter.responses.create({
-        model: getGPT5Model(),
-        store: shouldStoreOpenAIResponses(),
-        input: [
-          { role: 'developer', content: SYSTEM_REVIEW_PROMPT },
-          {
-            role: 'user',
-            content: [
-              'Subject: intent_system',
-              '',
-              'Input:',
-              '',
-              String.fromCharCode(96,96,96),
-              sanitizeForPrompt(reviewInput),
-              String.fromCharCode(96,96,96),
-              ''
-            ].join('\n')
+      const reviewPrompt = [
+        SYSTEM_REVIEW_PROMPT,
+        '',
+        'Subject: intent_system',
+        '',
+        'Input:',
+        '',
+        String.fromCharCode(96,96,96),
+        sanitizeForPrompt(reviewInput),
+        String.fromCharCode(96,96,96),
+        ''
+      ].join('\n');
+      const modelResponse = await runTrinityWritingPipeline({
+        input: {
+          prompt: reviewPrompt,
+          sessionId: typeof req.body.sessionId === 'string' ? req.body.sessionId : undefined,
+          overrideAuditSafe: req.body.overrideAuditSafe,
+          sourceEndpoint: `${endpointName}.system_review`,
+          requestedAction: 'query',
+          body: req.body,
+          executionMode: 'request'
+        },
+        context: {
+          client: openai,
+          requestId,
+          runtimeBudget: createRuntimeBudget(),
+          runOptions: {
+            answerMode: 'audit',
+            requestedVerbosity: 'minimal',
+            maxWords: 600,
+            strictUserVisibleOutput: true
           }
-        ],
-        temperature: 0,
-        stream: false
+        }
       });
 
-      const rawContent = (modelResponse as any)?.output_text ?? (modelResponse as any)?.outputText ?? (modelResponse as any)?.output_text;
+      const rawContent = modelResponse.result;
       //audit Assumption: strict review requires textual JSON payload; failure risk: empty model content; expected invariant: parseable JSON string; handling strategy: hard fail missing content.
       if (typeof rawContent !== 'string' || rawContent.trim().length === 0) {
         return sendGuardedAskResponse(req, res, {

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -551,6 +551,34 @@ function readPayloadRecord(
     : null;
 }
 
+function extractMessageContentText(content: unknown): string | null {
+  if (typeof content === 'string' && content.trim().length > 0) {
+    return content.trim();
+  }
+
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  const parts = content
+    .map((part) => {
+      if (typeof part === 'string') {
+        return part;
+      }
+
+      if (part && typeof part === 'object' && !Array.isArray(part)) {
+        const record = part as Record<string, unknown>;
+        return typeof record.text === 'string' ? record.text : '';
+      }
+
+      return '';
+    })
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  return parts.length > 0 ? parts.join('\n') : null;
+}
+
 function extractPromptTextFromRecord(record: Record<string, unknown> | null): string | null {
   const candidate =
     record?.message ??
@@ -575,12 +603,11 @@ function extractPromptTextFromRecord(record: Record<string, unknown> | null): st
         ? (entry as Record<string, unknown>)
         : null;
 
-    if (
-      normalizedEntry?.role === 'user' &&
-      typeof normalizedEntry.content === 'string' &&
-      normalizedEntry.content.trim().length > 0
-    ) {
-      return normalizedEntry.content.trim();
+    if (normalizedEntry?.role === 'user') {
+      const messageText = extractMessageContentText(normalizedEntry.content);
+      if (messageText) {
+        return messageText;
+      }
     }
   }
 

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -114,6 +114,7 @@ import {
   type GptFastPathModeHint
 } from '@shared/gpt/gptFastPath.js';
 import { ARCANOS_SUPPRESS_TIMEOUT_FALLBACK_FLAG } from '@shared/gpt/gptDirectAction.js';
+import { extractLastUserMessageText } from '@shared/gpt/messageContentText.js';
 import { executeDirectGptAction, executeFastGptPrompt } from '@services/gptFastPath.js';
 import { executeRuntimeInspection } from '@services/runtimeInspectionRoutingService.js';
 import { getWorkerControlStatus } from '@services/workerControlService.js';
@@ -551,34 +552,6 @@ function readPayloadRecord(
     : null;
 }
 
-function extractMessageContentText(content: unknown): string | null {
-  if (typeof content === 'string' && content.trim().length > 0) {
-    return content.trim();
-  }
-
-  if (!Array.isArray(content)) {
-    return null;
-  }
-
-  const parts = content
-    .map((part) => {
-      if (typeof part === 'string') {
-        return part;
-      }
-
-      if (part && typeof part === 'object' && !Array.isArray(part)) {
-        const record = part as Record<string, unknown>;
-        return typeof record.text === 'string' ? record.text : '';
-      }
-
-      return '';
-    })
-    .map((part) => part.trim())
-    .filter(Boolean);
-
-  return parts.length > 0 ? parts.join('\n') : null;
-}
-
 function extractPromptTextFromRecord(record: Record<string, unknown> | null): string | null {
   const candidate =
     record?.message ??
@@ -592,26 +565,7 @@ function extractPromptTextFromRecord(record: Record<string, unknown> | null): st
     return candidate.trim();
   }
 
-  if (!Array.isArray(record?.messages)) {
-    return null;
-  }
-
-  for (let index = record.messages.length - 1; index >= 0; index -= 1) {
-    const entry = record.messages[index];
-    const normalizedEntry =
-      typeof entry === 'object' && entry !== null && !Array.isArray(entry)
-        ? (entry as Record<string, unknown>)
-        : null;
-
-    if (normalizedEntry?.role === 'user') {
-      const messageText = extractMessageContentText(normalizedEntry.content);
-      if (messageText) {
-        return messageText;
-      }
-    }
-  }
-
-  return null;
+  return extractLastUserMessageText(record?.messages);
 }
 
 function extractPromptText(body: unknown): string | null {

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -2838,6 +2838,7 @@ router.post("/:gptId", async (req, res, next) => {
               action: GPT_QUERY_AND_WAIT_ACTION,
               status: 200
             });
+            const shapedDirectResult = shapeClientRouteResult(directEnvelope.result) as Record<string, unknown>;
             return sendGuardedGptJsonResponse(
               req,
               res,
@@ -2847,6 +2848,14 @@ router.post("/:gptId", async (req, res, next) => {
                 action: GPT_QUERY_AND_WAIT_ACTION,
                 status: 'completed',
                 result: extractDispatcherResultText(directEnvelope.result),
+                ...(shapedDirectResult.meta ? { meta: shapedDirectResult.meta } : {}),
+                ...(shapedDirectResult.activeModel ? { activeModel: shapedDirectResult.activeModel } : {}),
+                ...(typeof shapedDirectResult.fallbackFlag === 'boolean'
+                  ? { fallbackFlag: shapedDirectResult.fallbackFlag }
+                  : {}),
+                ...(Array.isArray(shapedDirectResult.routingStages)
+                  ? { routingStages: shapedDirectResult.routingStages }
+                  : {}),
                 routeDecision: directActionRouteDecision,
                 directAction: directEnvelope.directAction,
                 traceId,
@@ -3783,6 +3792,10 @@ router.post("/:gptId", async (req, res, next) => {
           logGptAckSent(routingInfo, (envelope._route.availableActions ?? []).length);
           applyAIDegradedResponseHeaders(res, extractAIDegradedResponseMetadata(envelope.result));
           const resultText = extractDispatcherResultText(envelope.result);
+          const shapedCoreResult =
+            typeof envelope.result === 'object' && envelope.result !== null
+              ? (shapeClientRouteResult(envelope.result) as Record<string, unknown>)
+              : {};
           requestLogger?.info?.("gpt.request.route_result", {
             endpoint: req.originalUrl,
             gptId: incomingGptId,
@@ -3808,6 +3821,14 @@ router.post("/:gptId", async (req, res, next) => {
               gptId: incomingGptId,
               action: GPT_QUERY_ACTION,
               result: resultText,
+              ...(shapedCoreResult.meta ? { meta: shapedCoreResult.meta } : {}),
+              ...(shapedCoreResult.activeModel ? { activeModel: shapedCoreResult.activeModel } : {}),
+              ...(typeof shapedCoreResult.fallbackFlag === 'boolean'
+                ? { fallbackFlag: shapedCoreResult.fallbackFlag }
+                : {}),
+              ...(Array.isArray(shapedCoreResult.routingStages)
+                ? { routingStages: shapedCoreResult.routingStages }
+                : {}),
               traceId,
               _route: {
                 ...envelope._route,

--- a/src/routes/openai-arcanos-pipeline.ts
+++ b/src/routes/openai-arcanos-pipeline.ts
@@ -13,10 +13,22 @@ router.post('/arcanos-pipeline', async (req: Request, res: Response) => {
     const pipelineResult = await executeArcanosPipeline(messages);
 
     if (pipelineResult.fallback) {
-      return res.json({ result: pipelineResult.result, fallback: true });
+      return res.json({
+        result: pipelineResult.result,
+        fallback: true,
+        meta: pipelineResult.meta,
+        activeModel: pipelineResult.activeModel,
+        routingStages: pipelineResult.routingStages
+      });
     }
 
-    res.json({ result: pipelineResult.result, stages: pipelineResult.stages });
+    res.json({
+      result: pipelineResult.result,
+      stages: pipelineResult.stages,
+      meta: pipelineResult.meta,
+      activeModel: pipelineResult.activeModel,
+      routingStages: pipelineResult.routingStages
+    });
   } catch (err: unknown) {
     //audit Assumption: pipeline errors should return 500
     console.error('Pipeline error:', resolveErrorMessage(err));

--- a/src/services/arcanos-core.ts
+++ b/src/services/arcanos-core.ts
@@ -1,6 +1,9 @@
 import OpenAI from 'openai';
 import type { TrinityAnswerMode, TrinityResult, TrinityRunOptions } from '@core/logic/trinity.js';
-import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import {
+  applyTrinityGenerationInvariant,
+  runTrinityWritingPipeline
+} from '@core/logic/trinityWritingPipeline.js';
 import {
   createRuntimeBudgetWithLimit,
   getSafeRemainingMs,
@@ -28,6 +31,8 @@ import {
 import { resolveErrorMessage } from '@core/lib/errors/index.js';
 
 type ArcanosCoreQueryPayload = {
+  action?: string;
+  operation?: string;
   prompt?: string;
   message?: string;
   query?: string;
@@ -38,7 +43,12 @@ type ArcanosCoreQueryPayload = {
   answerMode?: string;
   max_words?: number;
   maxWords?: number;
+  maxOutputTokens?: number;
+  __arcanosGptId?: string;
+  __arcanosSourceEndpoint?: string;
+  __arcanosRequestedAction?: string;
   __arcanosExecutionMode?: string;
+  __arcanosExecutionReason?: string;
   [ARCANOS_SUPPRESS_TIMEOUT_FALLBACK_FLAG]?: boolean | string | number;
 };
 
@@ -75,16 +85,27 @@ export interface RunArcanosCoreQueryParams {
   prompt: string;
   sourceEndpoint: string;
   requestId?: string;
+  gptId?: string;
+  moduleId?: string;
+  requestedAction?: string | null;
+  body?: unknown;
   sessionId?: string;
   overrideAuditSafe?: string;
+  maxOutputTokens?: number;
   runOptions?: Omit<TrinityRunOptions, 'sourceEndpoint'>;
   executionModeOverride?: ArcanosCoreExecutionMode;
+  executionModeReason?: string;
   allowTimeoutFallback?: boolean;
 }
 
 export interface BuildArcanosCoreTimeoutFallbackParams {
   prompt: string;
   requestId?: string | null;
+  sourceEndpoint?: string | null;
+  gptId?: string | null;
+  moduleId?: string | null;
+  requestedAction?: string | null;
+  executionMode?: string | null;
   createdAtMs?: number;
   timeoutPhase?: string | null;
 }
@@ -342,7 +363,7 @@ function buildCoreStaticFallbackResult(params: BuildArcanosCoreTimeoutFallbackPa
       ? params.requestId.trim()
       : `arcanos-core-timeout-${created}`;
 
-  return {
+  const result: TrinityResult = {
     result: [
       'The full ARCANOS analysis path hit its latency guard and returned a bounded fallback response.',
       `Request summary: ${promptPreview}`,
@@ -389,6 +410,14 @@ function buildCoreStaticFallbackResult(params: BuildArcanosCoreTimeoutFallbackPa
     degradedModeReason: ARCANOS_CORE_STATIC_FALLBACK_REASON,
     bypassedSubsystems: [...ARCANOS_CORE_PIPELINE_BYPASSED_SUBSYSTEMS]
   };
+
+  return applyTrinityGenerationInvariant(result, {
+    sourceEndpoint: normalizeTraceString(params.sourceEndpoint) ?? 'gpt.arcanos-core.query',
+    gptId: normalizeTraceString(params.gptId),
+    moduleId: normalizeTraceString(params.moduleId) ?? 'ARCANOS:CORE',
+    requestedAction: params.requestedAction,
+    executionMode: normalizeTraceString(params.executionMode),
+  });
 }
 
 export function buildArcanosCoreTimeoutFallbackResult(
@@ -409,6 +438,10 @@ export function buildArcanosCoreTimeoutFallbackEnvelope(params: {
   const result = buildCoreStaticFallbackResult({
     prompt: params.prompt,
     requestId: params.requestId,
+    sourceEndpoint: 'gpt.arcanos-core.query',
+    gptId: params.gptId,
+    moduleId: 'ARCANOS:CORE',
+    requestedAction: 'query',
     createdAtMs: params.createdAtMs,
     timeoutPhase: params.timeoutPhase
   });
@@ -609,10 +642,20 @@ export async function runArcanosCoreQuery(
         runTrinityWritingPipeline({
           input: {
             prompt: params.prompt,
+            gptId: params.gptId,
+            moduleId: params.moduleId ?? 'ARCANOS:CORE',
             sessionId: params.sessionId,
             overrideAuditSafe: params.overrideAuditSafe,
             sourceEndpoint: primarySourceEndpoint,
-            body: { prompt: params.prompt }
+            requestedAction: params.requestedAction,
+            body: params.body ?? { prompt: params.prompt },
+            maxOutputTokens: params.maxOutputTokens,
+            executionMode: pipelinePlan.executionMode,
+            background: pipelinePlan.executionMode === 'background'
+              ? {
+                  reason: params.executionModeReason ?? 'arcanos_core_background'
+                }
+              : undefined
           },
           context: {
             client: params.client,
@@ -776,10 +819,20 @@ export async function runArcanosCoreQuery(
             return runTrinityWritingPipeline({
               input: {
                 prompt: params.prompt,
+                gptId: params.gptId,
+                moduleId: params.moduleId ?? 'ARCANOS:CORE',
                 sessionId: params.sessionId,
                 overrideAuditSafe: params.overrideAuditSafe,
                 sourceEndpoint: degradedSourceEndpoint,
-                body: { prompt: params.prompt }
+                requestedAction: params.requestedAction,
+                body: params.body ?? { prompt: params.prompt },
+                maxOutputTokens: params.maxOutputTokens,
+                executionMode: pipelinePlan.executionMode,
+                background: pipelinePlan.executionMode === 'background'
+                  ? {
+                      reason: params.executionModeReason ?? 'arcanos_core_background_degraded'
+                    }
+                  : undefined
               },
               context: {
                 client: params.client,
@@ -846,6 +899,11 @@ export async function runArcanosCoreQuery(
         const staticFallback = buildCoreStaticFallbackResult({
           prompt: params.prompt,
           requestId: getRequestAbortContext()?.requestId ?? null,
+          sourceEndpoint: params.sourceEndpoint,
+          gptId: params.gptId,
+          moduleId: params.moduleId ?? 'ARCANOS:CORE',
+          requestedAction: params.requestedAction,
+          executionMode: pipelinePlan.executionMode,
           timeoutPhase,
         });
         logger.warn('[PIPELINE] static fallback engaged', {
@@ -955,6 +1013,16 @@ export const ArcanosCore: ModuleDef = {
           : normalizedPayload.__arcanosExecutionMode === 'request'
           ? 'request'
           : undefined;
+      const gptId = normalizeTraceString(normalizedPayload.__arcanosGptId);
+      const sourceEndpoint =
+        normalizeTraceString(normalizedPayload.__arcanosSourceEndpoint) ??
+        'gpt.arcanos-core.query';
+      const requestedAction =
+        normalizeTraceString(normalizedPayload.__arcanosRequestedAction) ??
+        normalizeTraceString(normalizedPayload.action) ??
+        normalizeTraceString(normalizedPayload.operation) ??
+        'query';
+      const maxOutputTokens = normalizePositiveInteger(normalizedPayload.maxOutputTokens);
       const allowTimeoutFallback = !normalizeBooleanFlagValue(
         normalizedPayload[ARCANOS_SUPPRESS_TIMEOUT_FALLBACK_FLAG]
       );
@@ -962,9 +1030,10 @@ export const ArcanosCore: ModuleDef = {
       emitCoreRuntimeTrace({
         phase: 'gpt_config_loaded',
         startedAt: actionStartedAt,
-        sourceEndpoint: 'gpt.arcanos-core.query',
+        sourceEndpoint,
         extra: {
           hasClient: !!client,
+          gptId: gptId ?? null,
           sessionId: sessionId ?? null,
           answerMode: answerMode ?? null
         }
@@ -978,7 +1047,7 @@ export const ArcanosCore: ModuleDef = {
         emitCoreRuntimeTrace({
           phase: 'response_sent',
           startedAt: actionStartedAt,
-          sourceEndpoint: 'gpt.arcanos-core.query',
+          sourceEndpoint,
           degradedReason: 'mock_response'
         });
         return generateMockResponse(prompt, 'gpt/arcanos-core');
@@ -988,14 +1057,20 @@ export const ArcanosCore: ModuleDef = {
         client,
         prompt,
         requestId: getRequestAbortContext()?.requestId,
+        gptId,
+        moduleId: 'ARCANOS:CORE',
+        requestedAction,
+        body: normalizedPayload,
         sessionId,
         overrideAuditSafe,
-        sourceEndpoint: 'gpt.arcanos-core.query',
+        sourceEndpoint,
+        maxOutputTokens,
         runOptions: {
           ...(answerMode ? { answerMode } : {}),
           ...(maxWords ? { maxWords } : {})
         },
         executionModeOverride,
+        executionModeReason: normalizeTraceString(normalizedPayload.__arcanosExecutionReason),
         allowTimeoutFallback
       });
     },

--- a/src/services/arcanos-core.ts
+++ b/src/services/arcanos-core.ts
@@ -4,6 +4,7 @@ import {
   applyTrinityGenerationInvariant,
   runTrinityWritingPipeline
 } from '@core/logic/trinityWritingPipeline.js';
+import type { TrinityGenerationMessage } from '@core/logic/trinityGenerationFacade.js';
 import {
   createRuntimeBudgetWithLimit,
   getSafeRemainingMs,
@@ -38,6 +39,7 @@ type ArcanosCoreQueryPayload = {
   query?: string;
   text?: string;
   content?: string;
+  messages?: TrinityGenerationMessage[];
   sessionId?: string;
   overrideAuditSafe?: string;
   answerMode?: string;
@@ -92,6 +94,7 @@ export interface RunArcanosCoreQueryParams {
   sessionId?: string;
   overrideAuditSafe?: string;
   maxOutputTokens?: number;
+  messages?: TrinityGenerationMessage[];
   runOptions?: Omit<TrinityRunOptions, 'sourceEndpoint'>;
   executionModeOverride?: ArcanosCoreExecutionMode;
   executionModeReason?: string;
@@ -223,7 +226,7 @@ function resolveCoreFallbackTimeoutPhase(
   return degradedPhase ?? primaryPhase ?? 'pipeline';
 }
 
-function extractPrompt(payload: ArcanosCoreQueryPayload): string {
+function extractDirectPrompt(payload: ArcanosCoreQueryPayload): string | null {
   for (const candidate of [
     payload.prompt,
     payload.message,
@@ -236,16 +239,89 @@ function extractPrompt(payload: ArcanosCoreQueryPayload): string {
     }
   }
 
+  return null;
+}
+
+function extractTextFromMessageContent(content: unknown): string | null {
+  if (typeof content === 'string' && content.trim().length > 0) {
+    return content.trim();
+  }
+
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  const parts = content
+    .map((part) => {
+      if (typeof part === 'string') {
+        return part;
+      }
+
+      if (part && typeof part === 'object' && !Array.isArray(part)) {
+        const record = part as Record<string, unknown>;
+        return typeof record.text === 'string' ? record.text : '';
+      }
+
+      return '';
+    })
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  return parts.length > 0 ? parts.join('\n') : null;
+}
+
+function extractPromptFromMessages(messages: unknown): string | null {
+  if (!Array.isArray(messages)) {
+    return null;
+  }
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message || typeof message !== 'object' || Array.isArray(message)) {
+      continue;
+    }
+
+    const record = message as Record<string, unknown>;
+    if (record.role !== 'user') {
+      continue;
+    }
+
+    const text = extractTextFromMessageContent(record.content);
+    if (text) {
+      return text;
+    }
+  }
+
+  return null;
+}
+
+function readTrinityMessages(messages: unknown): TrinityGenerationMessage[] | undefined {
+  return Array.isArray(messages) && extractPromptFromMessages(messages)
+    ? (messages as TrinityGenerationMessage[])
+    : undefined;
+}
+
+function extractPrompt(payload: ArcanosCoreQueryPayload): string {
+  const directPrompt = extractDirectPrompt(payload);
+  if (directPrompt) {
+    return directPrompt;
+  }
+
+  const messagePrompt = extractPromptFromMessages(payload.messages);
+  if (messagePrompt) {
+    return messagePrompt;
+  }
+
   throw new Error('Prompt is required');
 }
 
 function normalizePositiveInteger(value: unknown): number | undefined {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
     return undefined;
   }
 
   const normalized = Math.trunc(value);
-  return normalized > 0 ? normalized : undefined;
+  return normalized > 0 ? normalized : 1;
 }
 
 function normalizeAnswerMode(value: unknown): TrinityAnswerMode | undefined {
@@ -584,6 +660,8 @@ export async function runArcanosCoreQuery(
     sourceEndpoint: primarySourceEndpoint = params.sourceEndpoint,
     ...primaryRunOptionsWithoutSource
   } = primaryRunOptions;
+  const structuredMessages =
+    params.messages && params.messages.length > 0 ? params.messages : undefined;
 
   emitCoreRuntimeTrace({
     phase: 'route_resolved',
@@ -641,14 +719,14 @@ export async function runArcanosCoreQuery(
       () =>
         runTrinityWritingPipeline({
           input: {
-            prompt: params.prompt,
+            ...(structuredMessages ? { messages: structuredMessages } : { prompt: params.prompt }),
             gptId: params.gptId,
             moduleId: params.moduleId ?? 'ARCANOS:CORE',
             sessionId: params.sessionId,
             overrideAuditSafe: params.overrideAuditSafe,
             sourceEndpoint: primarySourceEndpoint,
             requestedAction: params.requestedAction,
-            body: params.body ?? { prompt: params.prompt },
+            body: params.body ?? (structuredMessages ? { messages: structuredMessages } : { prompt: params.prompt }),
             maxOutputTokens: params.maxOutputTokens,
             executionMode: pipelinePlan.executionMode,
             background: pipelinePlan.executionMode === 'background'
@@ -818,14 +896,14 @@ export async function runArcanosCoreQuery(
 
             return runTrinityWritingPipeline({
               input: {
-                prompt: params.prompt,
+                ...(structuredMessages ? { messages: structuredMessages } : { prompt: params.prompt }),
                 gptId: params.gptId,
                 moduleId: params.moduleId ?? 'ARCANOS:CORE',
                 sessionId: params.sessionId,
                 overrideAuditSafe: params.overrideAuditSafe,
                 sourceEndpoint: degradedSourceEndpoint,
                 requestedAction: params.requestedAction,
-                body: params.body ?? { prompt: params.prompt },
+                body: params.body ?? (structuredMessages ? { messages: structuredMessages } : { prompt: params.prompt }),
                 maxOutputTokens: params.maxOutputTokens,
                 executionMode: pipelinePlan.executionMode,
                 background: pipelinePlan.executionMode === 'background'
@@ -984,6 +1062,8 @@ export const ArcanosCore: ModuleDef = {
         payload && typeof payload === 'object' && !Array.isArray(payload)
           ? (payload as ArcanosCoreQueryPayload)
           : {};
+      const directPrompt = extractDirectPrompt(normalizedPayload);
+      const messages = directPrompt ? undefined : readTrinityMessages(normalizedPayload.messages);
       const prompt = extractPrompt(normalizedPayload);
       emitCoreRuntimeTrace({
         phase: 'prompt_normalization',
@@ -1061,6 +1141,7 @@ export const ArcanosCore: ModuleDef = {
         moduleId: 'ARCANOS:CORE',
         requestedAction,
         body: normalizedPayload,
+        messages,
         sessionId,
         overrideAuditSafe,
         sourceEndpoint,

--- a/src/services/arcanos-core.ts
+++ b/src/services/arcanos-core.ts
@@ -273,7 +273,7 @@ function normalizePositiveInteger(value: unknown): number | undefined {
   }
 
   const normalized = Math.trunc(value);
-  return normalized > 0 ? normalized : 1;
+  return Math.max(1, normalized);
 }
 
 function normalizeAnswerMode(value: unknown): TrinityAnswerMode | undefined {

--- a/src/services/arcanos-core.ts
+++ b/src/services/arcanos-core.ts
@@ -20,6 +20,7 @@ import {
   ARCANOS_SUPPRESS_TIMEOUT_FALLBACK_FLAG,
   normalizeBooleanFlagValue
 } from '@shared/gpt/gptDirectAction.js';
+import { extractLastUserMessageText } from '@shared/gpt/messageContentText.js';
 import type { ModuleDef } from './moduleLoader.js';
 import { executeSystemStateRequest } from './systemState.js';
 import {
@@ -242,57 +243,8 @@ function extractDirectPrompt(payload: ArcanosCoreQueryPayload): string | null {
   return null;
 }
 
-function extractTextFromMessageContent(content: unknown): string | null {
-  if (typeof content === 'string' && content.trim().length > 0) {
-    return content.trim();
-  }
-
-  if (!Array.isArray(content)) {
-    return null;
-  }
-
-  const parts = content
-    .map((part) => {
-      if (typeof part === 'string') {
-        return part;
-      }
-
-      if (part && typeof part === 'object' && !Array.isArray(part)) {
-        const record = part as Record<string, unknown>;
-        return typeof record.text === 'string' ? record.text : '';
-      }
-
-      return '';
-    })
-    .map((part) => part.trim())
-    .filter(Boolean);
-
-  return parts.length > 0 ? parts.join('\n') : null;
-}
-
 function extractPromptFromMessages(messages: unknown): string | null {
-  if (!Array.isArray(messages)) {
-    return null;
-  }
-
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index];
-    if (!message || typeof message !== 'object' || Array.isArray(message)) {
-      continue;
-    }
-
-    const record = message as Record<string, unknown>;
-    if (record.role !== 'user') {
-      continue;
-    }
-
-    const text = extractTextFromMessageContent(record.content);
-    if (text) {
-      return text;
-    }
-  }
-
-  return null;
+  return extractLastUserMessageText(messages);
 }
 
 function readTrinityMessages(messages: unknown): TrinityGenerationMessage[] | undefined {

--- a/src/services/arcanos-sim.ts
+++ b/src/services/arcanos-sim.ts
@@ -1,5 +1,7 @@
 import type OpenAI from 'openai';
-import { createCentralizedCompletion } from "@services/openai.js";
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import { getOpenAIClientOrAdapter } from '@services/openai/clientBridge.js';
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
 import { generateRequestId } from "@shared/idGenerator.js";
 import type { ModuleDef } from './moduleLoader.js';
 import { tryExtractExactLiteralPromptShortcut } from "@services/exactLiteralPromptShortcut.js";
@@ -47,8 +49,6 @@ export interface StreamingSimulationResult {
 export type SimulationExecutionResult =
   | CompletedSimulationResult
   | StreamingSimulationResult;
-
-type CentralizedCompletionResult = Awaited<ReturnType<typeof createCentralizedCompletion>>;
 
 function normalizeSimulationPayload(payload: unknown): SimulationRequestPayload {
   //audit Assumption: dispatcher/module callers should provide structured objects for simulation requests; failure risk: scalar payloads bypass validation and break downstream field extraction; expected invariant: simulation executor receives an object payload; handling strategy: reject non-object inputs with a structured error.
@@ -107,20 +107,8 @@ function buildSimulationPrompt(scenario: string, context?: string): string {
   return `Simulate the following scenario: ${scenario}${context ? `\n\nContext: ${context}` : ''}`;
 }
 
-function isStreamingCompletionResult(
-  response: CentralizedCompletionResult
-): response is AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk> {
-  return !!response && typeof response === 'object' && Symbol.asyncIterator in response;
-}
-
-function isChatCompletionResult(
-  response: CentralizedCompletionResult
-): response is OpenAI.Chat.Completions.ChatCompletion {
-  return !!response && typeof response === 'object' && 'choices' in response;
-}
-
 /**
- * Execute one simulation request using the centralized OpenAI routing layer.
+ * Execute one simulation request using the Trinity generation facade.
  * Inputs/Outputs: simulation payload -> completed result payload or streaming result descriptor.
  * Edge cases: accepts prompt-style aliases when `scenario` is absent and throws explicit validation errors for malformed payloads.
  */
@@ -151,47 +139,43 @@ export async function executeSimulationRequest(
     };
   }
 
-  const response = await createCentralizedCompletion(
-    [
-      {
-        role: 'user',
-        content: buildSimulationPrompt(scenario, context)
-      }
-    ],
-    {
-      temperature: parameters.temperature,
-      max_tokens: parameters.maxTokens,
-      stream: parameters.stream
-    }
-  );
-
-  //audit Assumption: streaming callers expect an async-iterable completion result when `stream` is true; failure risk: route emits malformed SSE or hangs on non-stream responses; expected invariant: stream mode returns an async iterable; handling strategy: validate and fail loudly when provider response shape mismatches.
   if (parameters.stream) {
-    if (!isStreamingCompletionResult(response)) {
-      throw new Error('Simulation stream requested but provider returned a non-stream response.');
+    throw new Error('Simulation streaming is not available through the Trinity generation facade.');
+  }
+
+  const { client } = getOpenAIClientOrAdapter();
+  if (!client) {
+    throw new Error('OpenAI client unavailable for Trinity simulation.');
+  }
+  const prompt = buildSimulationPrompt(scenario, context);
+  const response = await runTrinityWritingPipeline({
+    input: {
+      prompt,
+      moduleId: 'ARCANOS:SIM',
+      sourceEndpoint: 'arcanos-sim',
+      requestedAction: 'run',
+      body: normalizedPayload,
+      tokenLimit: parameters.maxTokens,
+      executionMode: 'request'
+    },
+    context: {
+      client,
+      runtimeBudget: createRuntimeBudget(),
+      runOptions: {
+        answerMode: 'direct',
+        strictUserVisibleOutput: true
+      }
     }
-
-    return {
-      mode: 'stream',
-      scenario,
-      stream: response,
-      metadata
-    };
-  }
-
-  //audit Assumption: non-stream requests should resolve to a chat completion payload; failure risk: unexpected SDK shape leaks into HTTP response formatting; expected invariant: completed simulation requests expose `choices`; handling strategy: validate the response shape before reading content.
-  if (!isChatCompletionResult(response)) {
-    throw new Error('Simulation completion returned an unexpected payload.');
-  }
+  });
 
   return {
     mode: 'complete',
     scenario,
-    result: response.choices[0]?.message?.content || '',
+    result: response.result,
     metadata: {
       ...metadata,
-      model: response.model,
-      tokensUsed: response.usage?.total_tokens || 0
+      model: response.activeModel,
+      tokensUsed: response.meta.tokens?.total_tokens || 0
     }
   };
 }

--- a/src/services/arcanos-sim.ts
+++ b/src/services/arcanos-sim.ts
@@ -2,6 +2,7 @@ import type OpenAI from 'openai';
 import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
 import { getOpenAIClientOrAdapter } from '@services/openai/clientBridge.js';
 import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
+import { createCentralizedCompletion } from "@services/openai.js";
 import { generateRequestId } from "@shared/idGenerator.js";
 import type { ModuleDef } from './moduleLoader.js';
 import { tryExtractExactLiteralPromptShortcut } from "@services/exactLiteralPromptShortcut.js";
@@ -49,6 +50,8 @@ export interface StreamingSimulationResult {
 export type SimulationExecutionResult =
   | CompletedSimulationResult
   | StreamingSimulationResult;
+
+type CentralizedCompletionResult = Awaited<ReturnType<typeof createCentralizedCompletion>>;
 
 function normalizeSimulationPayload(payload: unknown): SimulationRequestPayload {
   //audit Assumption: dispatcher/module callers should provide structured objects for simulation requests; failure risk: scalar payloads bypass validation and break downstream field extraction; expected invariant: simulation executor receives an object payload; handling strategy: reject non-object inputs with a structured error.
@@ -107,6 +110,12 @@ function buildSimulationPrompt(scenario: string, context?: string): string {
   return `Simulate the following scenario: ${scenario}${context ? `\n\nContext: ${context}` : ''}`;
 }
 
+function isStreamingCompletionResult(
+  response: CentralizedCompletionResult
+): response is AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk> {
+  return !!response && typeof response === 'object' && Symbol.asyncIterator in response;
+}
+
 /**
  * Execute one simulation request using the Trinity generation facade.
  * Inputs/Outputs: simulation payload -> completed result payload or streaming result descriptor.
@@ -139,15 +148,40 @@ export async function executeSimulationRequest(
     };
   }
 
-  if (parameters.stream) {
-    throw new Error('Simulation streaming is not available through the Trinity generation facade.');
-  }
+  const prompt = buildSimulationPrompt(scenario, context);
 
   const { client } = getOpenAIClientOrAdapter();
   if (!client) {
     throw new Error('OpenAI client unavailable for Trinity simulation.');
   }
-  const prompt = buildSimulationPrompt(scenario, context);
+
+  if (parameters.stream) {
+    const response = await createCentralizedCompletion(
+      [
+        {
+          role: 'user',
+          content: prompt
+        }
+      ],
+      {
+        temperature: parameters.temperature,
+        max_tokens: parameters.maxTokens,
+        stream: true
+      }
+    );
+
+    if (!isStreamingCompletionResult(response)) {
+      throw new Error('Simulation stream requested but provider returned a non-stream response.');
+    }
+
+    return {
+      mode: 'stream',
+      scenario,
+      stream: response,
+      metadata
+    };
+  }
+
   const response = await runTrinityWritingPipeline({
     input: {
       prompt,

--- a/src/services/arcanosPipeline.ts
+++ b/src/services/arcanosPipeline.ts
@@ -1,83 +1,106 @@
 import type OpenAI from 'openai';
-import { getDefaultModel, getGPT5Model } from './openai.js';
-import { ARCANOS_PIPELINE_PROMPTS } from "@platform/runtime/arcanosPipelinePrompts.js";
+
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import type { TrinityResult } from '@core/logic/trinity.js';
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
 import { requireOpenAIClientOrAdapter } from './openai/clientBridge.js';
 
-const ARC_V2 = getDefaultModel();
-const ARC_V2_FALLBACK = 'gpt-4o-mini';
-const GPT5 = getGPT5Model();
-const GPT35_SUBAGENT = 'gpt-4o-mini';
-
 export interface PipelineStages {
-  arcFirst: OpenAI.Chat.Completions.ChatCompletionMessage;
-  subAgent: OpenAI.Chat.Completions.ChatCompletionMessage;
-  gpt5Reasoning: OpenAI.Chat.Completions.ChatCompletionMessage;
+  trinity: OpenAI.Chat.Completions.ChatCompletionMessage;
 }
 
 export interface PipelineResult {
   result: OpenAI.Chat.Completions.ChatCompletionMessage;
   stages?: PipelineStages;
   fallback: boolean;
+  meta: TrinityResult['meta'];
+  activeModel: string;
+  routingStages?: string[];
+}
+
+function extractMessageContent(message: OpenAI.Chat.Completions.ChatCompletionMessageParam): string {
+  const content = message.content;
+  if (typeof content === 'string') {
+    return content;
+  }
+
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part === 'string') {
+          return part;
+        }
+        if (part && typeof part === 'object' && 'text' in part && typeof part.text === 'string') {
+          return part.text;
+        }
+        return '';
+      })
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  return '';
+}
+
+function messagesToPrompt(messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[]): string {
+  return messages
+    .map((message) => {
+      const role = typeof message.role === 'string' ? message.role : 'message';
+      const content = extractMessageContent(message).trim();
+      return content ? `${role}: ${content}` : '';
+    })
+    .filter(Boolean)
+    .join('\n\n')
+    .trim();
+}
+
+function buildAssistantMessage(content: string): OpenAI.Chat.Completions.ChatCompletionMessage {
+  return {
+    role: 'assistant',
+    content,
+    refusal: null
+  };
 }
 
 export async function executeArcanosPipeline(
   messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[]
 ): Promise<PipelineResult> {
-  const { adapter } = requireOpenAIClientOrAdapter('OpenAI adapter not available');
+  const { client } = requireOpenAIClientOrAdapter('OpenAI adapter not available');
+  const prompt = messagesToPrompt(messages);
 
-  try {
-    const arcFirst = await adapter.responses.create({
-      model: ARC_V2,
-      messages
-    });
-    const arcFirstOutput = arcFirst.choices[0].message;
-
-    const subAgentResp = await adapter.responses.create({
-      model: GPT35_SUBAGENT,
-      messages: [
-        { role: 'system', content: ARCANOS_PIPELINE_PROMPTS.subAgent },
-        { role: 'assistant', content: arcFirstOutput.content || '' }
-      ]
-    });
-    const subAgentOutput = subAgentResp.choices[0].message;
-
-    const gpt5Response = await adapter.responses.create({
-      model: GPT5,
-      messages: [
-        { role: 'system', content: ARCANOS_PIPELINE_PROMPTS.overseer },
-        { role: 'assistant', content: arcFirstOutput.content || '' },
-        { role: 'assistant', content: subAgentOutput.content || '' }
-      ]
-    });
-    const gpt5Reasoning = gpt5Response.choices[0].message;
-
-    const arcFinal = await adapter.responses.create({
-      model: ARC_V2,
-      messages: [
-        ...messages,
-        { role: 'assistant', content: arcFirstOutput.content || '' },
-        { role: 'assistant', content: subAgentOutput.content || '' },
-        { role: 'assistant', content: gpt5Reasoning.content || '' }
-      ]
-    });
-    const finalOutput = arcFinal.choices[0].message;
-
-    return {
-      result: finalOutput,
-      stages: {
-        arcFirst: arcFirstOutput,
-        subAgent: subAgentOutput,
-        gpt5Reasoning
-      },
-      fallback: false
-    };
-  } catch (err) {
-    console.warn('Primary ARCANOS pipeline failed, using fallback model', err);
-    const fallback = await adapter.responses.create({
-      model: ARC_V2_FALLBACK,
-      messages
-    });
-
-    return { result: fallback.choices[0].message, fallback: true };
+  if (!prompt) {
+    throw new Error('Legacy ARCANOS pipeline requires at least one text message.');
   }
+
+  const trinityResult = await runTrinityWritingPipeline({
+    input: {
+      prompt,
+      moduleId: 'ARCANOS:PIPELINE',
+      sourceEndpoint: 'arcanos-pipeline',
+      requestedAction: 'query',
+      body: {
+        messages
+      }
+    },
+    context: {
+      client,
+      runtimeBudget: createRuntimeBudget(),
+      runOptions: {
+        answerMode: 'direct',
+        strictUserVisibleOutput: true
+      }
+    }
+  });
+
+  const result = buildAssistantMessage(trinityResult.result);
+  return {
+    result,
+    stages: {
+      trinity: result
+    },
+    fallback: trinityResult.fallbackFlag,
+    meta: trinityResult.meta,
+    activeModel: trinityResult.activeModel,
+    routingStages: trinityResult.routingStages
+  };
 }

--- a/src/services/arcanosPipeline.ts
+++ b/src/services/arcanosPipeline.ts
@@ -3,10 +3,14 @@ import type OpenAI from 'openai';
 import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
 import type { TrinityResult } from '@core/logic/trinity.js';
 import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
+import { ARCANOS_PIPELINE_PROMPTS } from "@platform/runtime/arcanosPipelinePrompts.js";
+import { resolveErrorMessage } from '@core/lib/errors/index.js';
 import { requireOpenAIClientOrAdapter } from './openai/clientBridge.js';
 
 export interface PipelineStages {
-  trinity: OpenAI.Chat.Completions.ChatCompletionMessage;
+  arcFirst: OpenAI.Chat.Completions.ChatCompletionMessage;
+  subAgent: OpenAI.Chat.Completions.ChatCompletionMessage;
+  gpt5Reasoning: OpenAI.Chat.Completions.ChatCompletionMessage;
 }
 
 export interface PipelineResult {
@@ -18,42 +22,6 @@ export interface PipelineResult {
   routingStages?: string[];
 }
 
-function extractMessageContent(message: OpenAI.Chat.Completions.ChatCompletionMessageParam): string {
-  const content = message.content;
-  if (typeof content === 'string') {
-    return content;
-  }
-
-  if (Array.isArray(content)) {
-    return content
-      .map((part) => {
-        if (typeof part === 'string') {
-          return part;
-        }
-        if (part && typeof part === 'object' && 'text' in part && typeof part.text === 'string') {
-          return part.text;
-        }
-        return '';
-      })
-      .filter(Boolean)
-      .join('\n');
-  }
-
-  return '';
-}
-
-function messagesToPrompt(messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[]): string {
-  return messages
-    .map((message) => {
-      const role = typeof message.role === 'string' ? message.role : 'message';
-      const content = extractMessageContent(message).trim();
-      return content ? `${role}: ${content}` : '';
-    })
-    .filter(Boolean)
-    .join('\n\n')
-    .trim();
-}
-
 function buildAssistantMessage(content: string): OpenAI.Chat.Completions.ChatCompletionMessage {
   return {
     role: 'assistant',
@@ -62,28 +30,34 @@ function buildAssistantMessage(content: string): OpenAI.Chat.Completions.ChatCom
   };
 }
 
-export async function executeArcanosPipeline(
-  messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[]
-): Promise<PipelineResult> {
-  const { client } = requireOpenAIClientOrAdapter('OpenAI adapter not available');
-  const prompt = messagesToPrompt(messages);
+function assistantContent(message: OpenAI.Chat.Completions.ChatCompletionMessage): string {
+  return typeof message.content === 'string' ? message.content : '';
+}
 
-  if (!prompt) {
-    throw new Error('Legacy ARCANOS pipeline requires at least one text message.');
-  }
-
-  const trinityResult = await runTrinityWritingPipeline({
+async function runPipelineStage(params: {
+  client: OpenAI;
+  messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[];
+  stage: string;
+  body?: Record<string, unknown>;
+}): Promise<{ message: OpenAI.Chat.Completions.ChatCompletionMessage; trinity: TrinityResult }> {
+  const trinity = await runTrinityWritingPipeline({
     input: {
-      prompt,
+      messages: params.messages,
       moduleId: 'ARCANOS:PIPELINE',
-      sourceEndpoint: 'arcanos-pipeline',
+      sourceEndpoint: `arcanos-pipeline.${params.stage}`,
       requestedAction: 'query',
       body: {
-        messages
+        stage: params.stage,
+        messages: params.messages,
+        ...(params.body ?? {})
+      },
+      executionMode: 'request',
+      background: {
+        legacyPipelineStage: params.stage
       }
     },
     context: {
-      client,
+      client: params.client,
       runtimeBudget: createRuntimeBudget(),
       runOptions: {
         answerMode: 'direct',
@@ -92,15 +66,84 @@ export async function executeArcanosPipeline(
     }
   });
 
-  const result = buildAssistantMessage(trinityResult.result);
   return {
-    result,
-    stages: {
-      trinity: result
-    },
-    fallback: trinityResult.fallbackFlag,
-    meta: trinityResult.meta,
-    activeModel: trinityResult.activeModel,
-    routingStages: trinityResult.routingStages
+    message: buildAssistantMessage(trinity.result),
+    trinity
   };
+}
+
+export async function executeArcanosPipeline(
+  messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[]
+): Promise<PipelineResult> {
+  const { client } = requireOpenAIClientOrAdapter('OpenAI adapter not available');
+
+  if (!Array.isArray(messages) || messages.length === 0) {
+    throw new Error('Legacy ARCANOS pipeline requires at least one text message.');
+  }
+
+  try {
+    const arcFirst = await runPipelineStage({
+      client,
+      messages,
+      stage: 'arc-first'
+    });
+    const subAgent = await runPipelineStage({
+      client,
+      messages: [
+        { role: 'system', content: ARCANOS_PIPELINE_PROMPTS.subAgent },
+        { role: 'assistant', content: assistantContent(arcFirst.message) }
+      ],
+      stage: 'sub-agent'
+    });
+    const gpt5Reasoning = await runPipelineStage({
+      client,
+      messages: [
+        { role: 'system', content: ARCANOS_PIPELINE_PROMPTS.overseer },
+        { role: 'assistant', content: assistantContent(arcFirst.message) },
+        { role: 'assistant', content: assistantContent(subAgent.message) }
+      ],
+      stage: 'overseer'
+    });
+    const final = await runPipelineStage({
+      client,
+      messages: [
+        ...messages,
+        { role: 'assistant', content: assistantContent(arcFirst.message) },
+        { role: 'assistant', content: assistantContent(subAgent.message) },
+        { role: 'assistant', content: assistantContent(gpt5Reasoning.message) }
+      ],
+      stage: 'final'
+    });
+
+    return {
+      result: final.message,
+      stages: {
+        arcFirst: arcFirst.message,
+        subAgent: subAgent.message,
+        gpt5Reasoning: gpt5Reasoning.message
+      },
+      fallback: false,
+      meta: final.trinity.meta,
+      activeModel: final.trinity.activeModel,
+      routingStages: final.trinity.routingStages
+    };
+  } catch (error) {
+    console.warn('Primary ARCANOS Trinity pipeline failed, using Trinity fallback stage', resolveErrorMessage(error));
+    const fallback = await runPipelineStage({
+      client,
+      messages,
+      stage: 'fallback',
+      body: {
+        fallbackReason: resolveErrorMessage(error)
+      }
+    });
+
+    return {
+      result: fallback.message,
+      fallback: true,
+      meta: fallback.trinity.meta,
+      activeModel: fallback.trinity.activeModel,
+      routingStages: fallback.trinity.routingStages
+    };
+  }
 }

--- a/src/services/arcanosQuery.ts
+++ b/src/services/arcanosQuery.ts
@@ -1,91 +1,42 @@
-import { getDefaultModel, getGPT5Model } from './openai.js';
-import { ARCANOS_PROMPTS, buildMockArcanosResponse } from "@platform/runtime/arcanosPrompts.js";
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
+import { buildMockArcanosResponse } from "@platform/runtime/arcanosPrompts.js";
+import { getDefaultModel } from './openai.js';
 import { getOpenAIClientOrAdapter } from './openai/clientBridge.js';
 
-// Use centralized model configuration
+// Use centralized model configuration for mock compatibility only.
 const FT_MODEL = getDefaultModel();
-const REASONING_MODEL = getGPT5Model();
-const LITERAL_RESPONSE_PATTERNS = [
-  /\b(?:reply|respond|answer|return|output|say)\s+with\s+exactly\b/i,
-  /\b(?:reply|respond|answer|return|output|say)\s+verbatim\b/i,
-  /\bexactly\s+one\s+word\b/i,
-  /\breturn\s+only\b/i,
-];
-
-function buildFineTunedMessages(prompt: string) {
-  return [
-    { role: 'system' as const, content: ARCANOS_PROMPTS.system },
-    { role: 'user' as const, content: prompt }
-  ];
-}
 
 /**
- * Purpose: Detect prompts that require literal or verbatim output preservation.
- * Inputs/Outputs: Accepts the original user prompt and returns true when refinement risks violating explicit output constraints.
- * Edge cases: Treats mixed-case phrasing as equivalent and ignores prompts without strong literal cues.
- */
-function requiresLiteralResponsePreservation(prompt: string): boolean {
-  return LITERAL_RESPONSE_PATTERNS.some((literalPattern) => literalPattern.test(prompt));
-}
-
-/**
- * Purpose: Build the second-stage reasoning prompt with full user intent preserved.
- * Inputs/Outputs: Accepts the original prompt plus the fine-tuned candidate answer and returns chat messages for the reasoning layer.
- * Edge cases: Preserves empty candidate output so the reasoning layer can still attempt recovery when the first pass fails silently.
- */
-function buildReasoningMessages(originalPrompt: string, fineTunedOutput: string) {
-  return [
-    { role: 'system' as const, content: ARCANOS_PROMPTS.reasoningLayer },
-    {
-      role: 'user' as const,
-      content: [
-        `Original user prompt:\n${originalPrompt}`,
-        '',
-        `Candidate fine-tuned output:\n${fineTunedOutput}`,
-        '',
-        'Return the final user-facing answer only.',
-      ].join('\n'),
-    }
-  ];
-}
-
-/**
- * Purpose: Execute the ARCANOS two-stage query pipeline and return the final user-facing answer.
+ * Purpose: Execute the ARCANOS query surface through the canonical Trinity generation facade.
  * Inputs/Outputs: Accepts a text prompt and returns a finalized response string.
- * Edge cases: Falls back to mock output when no adapter is configured and preserves literal-response prompts by skipping the refinement pass.
+ * Edge cases: Falls back to mock output when no client is configured.
  */
 export async function arcanosQuery(prompt: string): Promise<string> {
-  try {
-    const { adapter } = getOpenAIClientOrAdapter();
+  const { client } = getOpenAIClientOrAdapter();
 
-    //audit Assumption: environments without an initialized adapter still need deterministic output for tests/local flows; failure risk: null dereference during local development; expected invariant: mock mode returns a string response; handling strategy: short-circuit to the mock builder.
-    if (!adapter) {
-      // Return mock response when no API key is configured
-      return buildMockArcanosResponse(prompt, FT_MODEL);
-    }
-
-    // Step 1 → Fine-tuned GPT-4.1 (use adapter)
-    const ftResponse = await adapter.responses.create({
-      model: FT_MODEL,
-      messages: buildFineTunedMessages(prompt)
-    });
-
-    const ftOutput = ftResponse.choices[0].message.content || '';
-
-    //audit Assumption: exact/verbatim prompts should not be expanded by the reasoning layer; failure risk: second-pass commentary violates user constraints; expected invariant: literal prompts preserve the first-pass answer when available; handling strategy: bypass refinement for non-empty literal outputs.
-    if (ftOutput.trim().length > 0 && requiresLiteralResponsePreservation(prompt)) {
-      return ftOutput;
-    }
-
-    // Step 2 → Reasoning with GPT-5.1 (use adapter)
-    const reasoningResponse = await adapter.responses.create({
-      model: REASONING_MODEL,
-      messages: buildReasoningMessages(prompt, ftOutput)
-    });
-
-    return reasoningResponse.choices[0].message.content || '';
-  } catch (error) {
-    console.error('ARCANOS error:', error);
-    throw error;
+  if (!client) {
+    return buildMockArcanosResponse(prompt, FT_MODEL);
   }
+
+  const result = await runTrinityWritingPipeline({
+    input: {
+      prompt,
+      moduleId: 'ARCANOS:QUERY',
+      sourceEndpoint: 'arcanosQuery',
+      requestedAction: 'query',
+      body: { prompt },
+      executionMode: 'request'
+    },
+    context: {
+      client,
+      runtimeBudget: createRuntimeBudget(),
+      runOptions: {
+        answerMode: 'direct',
+        strictUserVisibleOutput: true
+      }
+    }
+  });
+
+  return result.result;
 }

--- a/src/services/backstage-booker.ts
+++ b/src/services/backstage-booker.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'crypto';
-import { callOpenAI, getGPT5Model } from "@services/openai.js";
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import { getGPT5Model } from "@services/openai.js";
+import { getOpenAIClientOrAdapter } from '@services/openai/clientBridge.js';
 import { saveWithAuditCheck } from "@services/persistenceManager.js";
 import {
   BACKSTAGE_BOOKER_PERSONA,
@@ -11,6 +13,7 @@ import { getEnv, getEnvNumber } from "@platform/runtime/env.js";
 import { evaluateWithHRC, withHRC } from './hrcWrapper.js';
 import { buildDirectAnswerModeSystemInstruction, shouldPreferDirectAnswerMode } from '@services/directAnswerMode.js';
 import { tryExtractExactLiteralPromptShortcut } from '@services/exactLiteralPromptShortcut.js';
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
 
 export interface Wrestler {
   name: string;
@@ -571,7 +574,34 @@ export async function generateBooking(prompt: string): Promise<string> {
   );
   const instructions = await buildStructuredBookingPrompt(prompt);
   try {
-    const { output } = await callOpenAI(model, instructions, tokenLimit, false);
+    const { client } = getOpenAIClientOrAdapter();
+    if (!client) {
+      throw new Error('OpenAI client unavailable for backstage booking.');
+    }
+    const trinityResult = await runTrinityWritingPipeline({
+      input: {
+        prompt: instructions,
+        moduleId: 'BACKSTAGE:BOOKER',
+        sourceEndpoint: 'backstage-booker.generateBooking',
+        requestedAction: 'generateBooking',
+        body: {
+          prompt,
+          model,
+          tokenLimit
+        },
+        tokenLimit,
+        executionMode: 'request'
+      },
+      context: {
+        client,
+        runtimeBudget: createRuntimeBudget(),
+        runOptions: {
+          answerMode: 'direct',
+          strictUserVisibleOutput: true
+        }
+      }
+    });
+    const output = trinityResult.result;
     const clean = output.replace(/\b(meta|reflection)[:].*$/gi, '').trim();
     //audit Assumption: direct-answer backstage prompts may still pick up model preambles or overlong list structures despite stricter prompt instructions; failure risk: live responses ignore “five short bullets” and reopen simulation-style framing; expected invariant: direct-answer output respects the caller's requested list shape; handling strategy: apply a prompt-aware cleanup pass only when direct-answer mode is active.
     if (shouldPreferDirectAnswerMode(prompt)) {

--- a/src/services/cef/handlers/ai.handler.ts
+++ b/src/services/cef/handlers/ai.handler.ts
@@ -1,5 +1,8 @@
 import { sanitizeInput } from '@platform/runtime/security.js';
-import { createCentralizedCompletion, generateMockResponse, hasValidAPIKey } from '@services/openai.js';
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import { generateMockResponse, hasValidAPIKey } from '@services/openai.js';
+import { getOpenAIClientOrAdapter } from '@services/openai/clientBridge.js';
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
 import { dispatchValidatedHandler, enforceAllowedHandlerMethod } from '../handlerRuntime.js';
 import type { CefHandlerContext, WhitelistedHandlerDispatchResult } from '../types.js';
 import { buildCommandError } from '../commandErrors.js';
@@ -104,28 +107,36 @@ const allowedHandlerActions = {
         throw buildMissingApiKeyError();
       }
 
-      const response = await createCentralizedCompletion([
-        { role: 'user', content: sanitizedPrompt }
-      ]);
-
-      if ('choices' in response) {
-        const firstChoice = response.choices[0];
-        const content = firstChoice?.message?.content ?? '';
-        return {
-          message: 'AI command executed successfully.',
-          output: {
-            result: content,
-            usage: response.usage ?? null,
-            model: response.model
-          }
-        };
+      const { client } = getOpenAIClientOrAdapter();
+      if (!client) {
+        throw buildMissingApiKeyError();
       }
+      const response = await runTrinityWritingPipeline({
+        input: {
+          prompt: sanitizedPrompt,
+          moduleId: 'CEF:AI',
+          sourceEndpoint: 'cef.ai.prompt',
+          requestedAction: 'prompt',
+          body: payload,
+          executionMode: 'request'
+        },
+        context: {
+          client,
+          runtimeBudget: createRuntimeBudget(),
+          runOptions: {
+            answerMode: 'direct',
+            strictUserVisibleOutput: true
+          }
+        }
+      });
 
       return {
-        message: 'Streaming response started.',
+        message: 'AI command executed successfully.',
         output: {
-          result: null,
-          streaming: true
+          result: response.result,
+          usage: response.meta.tokens ?? null,
+          model: response.activeModel,
+          meta: response.meta
         }
       };
     },

--- a/src/services/controlPlane/routeVerification.ts
+++ b/src/services/controlPlane/routeVerification.ts
@@ -54,7 +54,8 @@ function hasConfirmedTrinityStages(evidence: ControlPlaneRouteEvidence): boolean
 }
 
 export function isControlPlaneTrinityEligible(request: Pick<ControlPlaneRequestPayload, 'phase'>): boolean {
-  return request.phase === 'plan';
+  void request;
+  return false;
 }
 
 export function verifyControlPlaneRoute(params: {

--- a/src/services/controlPlane/service.ts
+++ b/src/services/controlPlane/service.ts
@@ -3,9 +3,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
-import { getOpenAIClientOrAdapter } from '@services/openai/clientBridge.js';
-import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
-import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
 import { logExecution } from '@core/db/repositories/executionLogRepository.js';
 import { resolveErrorMessage } from '@core/lib/errors/index.js';
 import { generateRequestId } from '@shared/idGenerator.js';
@@ -280,48 +277,6 @@ const defaultProcessRunner: ControlPlaneProcessRunner = {
 const defaultMcpClient: ControlPlaneMcpClient = {
   listTools: (options) => arcanosMcpService.listTools(options),
   invokeTool: (options) => arcanosMcpService.invokeTool(options)
-};
-
-const defaultTrinityPlanner: ControlPlaneTrinityPlanner = {
-  async plan(request) {
-    const { client } = getOpenAIClientOrAdapter();
-    if (!client) {
-      throw new Error('OpenAI client unavailable for Trinity control-plane planning.');
-    }
-
-    const prompt = [
-      'Summarize this ARCANOS control-plane plan request as deterministic JSON.',
-      'Do not execute commands. Do not claim system changes.',
-      JSON.stringify({
-        adapter: request.adapter,
-        operation: request.operation,
-        phase: request.phase,
-        inputKeys: Object.keys(request.input ?? {}).sort()
-      })
-    ].join('\n');
-
-    return runTrinityWritingPipeline({
-      input: {
-        prompt,
-        sourceEndpoint: 'control-plane.trinity-plan',
-        body: { prompt }
-      },
-      context: {
-        client,
-        requestId: `${request.requestId}:trinity`,
-        runtimeBudget: createRuntimeBudget(),
-        runOptions: {
-          requestedVerbosity: 'minimal',
-          maxWords: 160,
-          answerMode: 'audit',
-          strictUserVisibleOutput: true,
-          toolBackedCapabilities: {
-            verifyProvidedData: true
-          }
-        }
-      }
-    });
-  }
 };
 
 function buildOperationKey(adapter: ControlPlaneAdapter, operation: string): string {
@@ -766,7 +721,6 @@ export async function executeControlPlaneRequest(
   const repositoryRoot = resolveRepositoryRoot(dependencies.repositoryRoot);
   const processRunner = dependencies.processRunner ?? defaultProcessRunner;
   const mcpClient = dependencies.mcpClient ?? defaultMcpClient;
-  const trinityPlanner = dependencies.trinityPlanner ?? defaultTrinityPlanner;
   const auditLogger = dependencies.auditLogger ?? logExecution;
   const auditId = generateRequestId('control_audit');
   let auditLogged = false;
@@ -796,23 +750,8 @@ export async function executeControlPlaneRequest(
       cwd
     }, auditLogger);
 
-    let trinityResponse: unknown;
-    let trinityUnavailable = false;
-    let trinityError: string | undefined;
-    if (request.routePreference !== 'direct' && request.phase === 'plan') {
-      try {
-        trinityResponse = await trinityPlanner.plan(request);
-      } catch (error) {
-        trinityUnavailable = true;
-        trinityError = resolveErrorMessage(error);
-      }
-    }
-
     const route = verifyControlPlaneRoute({
       request,
-      trinityResponse,
-      trinityUnavailable,
-      trinityError,
       now
     });
 

--- a/src/services/gaming.ts
+++ b/src/services/gaming.ts
@@ -1,14 +1,13 @@
 import { getPrompt } from "@platform/runtime/prompts.js";
-import { getDefaultModel, getGPT5Model, generateMockResponse } from "./openai.js";
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import { generateMockResponse } from "./openai.js";
 import { fetchAndClean } from "@shared/webFetcher.js";
 import { getOpenAIClientOrAdapter } from "./openai/clientBridge.js";
-import { getEnv } from "@platform/runtime/env.js";
 import { resolveErrorMessage } from "@core/lib/errors/index.js";
 import { buildDirectAnswerModeSystemInstruction } from "@services/directAnswerMode.js";
 import { tryExtractExactLiteralPromptShortcut } from "@services/exactLiteralPromptShortcut.js";
 import { formatGamingSuccess, type GamingMode, type GamingSuccessEnvelope, type ValidatedGamingRequest } from "@services/gamingModes.js";
-
-const FINETUNE_MODEL = getEnv("FINETUNE_MODEL") || getDefaultModel();
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
 
 type WebSource = GamingSuccessEnvelope["data"]["sources"][number];
 
@@ -114,9 +113,9 @@ async function runGameplayPipeline(params: GameplayPipelineInput): Promise<Gamin
   ];
   const { context: webContext, sources } = await buildWebContext(allUrls);
   const enrichedPrompt = buildGameplayPrompt(params, webContext, allUrls.length > 0);
-  const { adapter } = getOpenAIClientOrAdapter();
+  const { client } = getOpenAIClientOrAdapter();
 
-  if (!adapter) {
+  if (!client) {
     const mock = generateMockResponse(params.prompt, params.mode);
     return formatGamingSuccess({
       mode: params.mode,
@@ -127,34 +126,40 @@ async function runGameplayPipeline(params: GameplayPipelineInput): Promise<Gamin
     });
   }
 
-  const draftResponse = await adapter.responses.create({
-    model: getGPT5Model(),
-    messages: [
-      { role: "system", content: buildGameplaySystemPrompt(params.mode) },
-      { role: "user", content: enrichedPrompt }
-    ],
-    temperature: 0.2
+  const trinityResult = await runTrinityWritingPipeline({
+    input: {
+      prompt: [
+        buildGameplaySystemPrompt(params.mode),
+        '',
+        enrichedPrompt,
+        ...(params.auditEnabled ? ['', gamingPrompts.auditSystem] : [])
+      ].join('\n'),
+      moduleId: 'ARCANOS:GAMING',
+      sourceEndpoint: `arcanos-gaming.${params.mode}`,
+      requestedAction: 'query',
+      body: params,
+      executionMode: 'request'
+    },
+    context: {
+      client,
+      runtimeBudget: createRuntimeBudget(),
+      runOptions: {
+        answerMode: 'direct',
+        strictUserVisibleOutput: true
+      }
+    }
   });
-  const draft = draftResponse.choices[0].message?.content || "";
+  const finalized = trinityResult.result;
 
   if (!params.auditEnabled) {
     return formatGamingSuccess({
       mode: params.mode,
       data: {
-        response: draft,
+        response: finalized,
         sources
       }
     });
   }
-
-  const auditResponse = await adapter.responses.create({
-    model: FINETUNE_MODEL,
-    messages: [
-      { role: "system", content: gamingPrompts.auditSystem },
-      { role: "user", content: draft }
-    ]
-  });
-  const finalized = auditResponse.choices[0].message?.content || draft;
 
   return formatGamingSuccess({
     mode: params.mode,
@@ -162,7 +167,7 @@ async function runGameplayPipeline(params: GameplayPipelineInput): Promise<Gamin
       response: finalized,
       sources,
       auditTrace: {
-        draft,
+        draft: finalized,
         finalized
       }
     }

--- a/src/services/gaming.ts
+++ b/src/services/gaming.ts
@@ -165,11 +165,7 @@ async function runGameplayPipeline(params: GameplayPipelineInput): Promise<Gamin
     mode: params.mode,
     data: {
       response: finalized,
-      sources,
-      auditTrace: {
-        draft: finalized,
-        finalized
-      }
+      sources
     }
   });
 }

--- a/src/services/gptFastPath.ts
+++ b/src/services/gptFastPath.ts
@@ -1,13 +1,12 @@
-import { callTextResponse } from '@arcanos/openai/responses';
 import { getRequestAbortSignal, runWithRequestAbortTimeout } from '@arcanos/runtime';
 
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import type { TrinityResult } from '@core/logic/trinity.js';
 import { resolveErrorMessage } from '@core/lib/errors/index.js';
 import { recordAiOperation } from '@platform/observability/appMetrics.js';
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
 import { getOpenAIClientOrAdapter } from '@services/openai/clientBridge.js';
-import {
-  resolveGptFastPathModel,
-  type GptFastPathDecision
-} from '@shared/gpt/gptFastPath.js';
+import { type GptFastPathDecision } from '@shared/gpt/gptFastPath.js';
 
 export interface ExecuteFastGptPromptInput {
   gptId: string;
@@ -65,7 +64,7 @@ export interface DirectGptActionEnvelope {
   directAction: {
     inline: true;
     queueBypassed: true;
-    orchestrationBypassed: true;
+    orchestrationBypassed: false;
     action: 'query_and_wait';
     timeoutMs: number;
     modelLatencyMs: number;
@@ -81,189 +80,64 @@ export interface DirectGptActionEnvelope {
   };
 }
 
-const FAST_PATH_ROUTING_STAGE = 'GPT-FAST-PATH';
-const FAST_PATH_SYSTEM_INSTRUCTIONS = [
-  'You are ARCANOS fast-path prompt generation.',
-  'Generate the requested prompt directly and concisely.',
-  'Do not describe internal routing, queues, tools, memory, audits, or orchestration.',
-  'Return only the user-facing prompt or prompt text requested by the caller.'
-].join(' ');
-const DIRECT_ACTION_ROUTING_STAGE = 'GPT-DIRECT-ACTION';
-const DIRECT_ACTION_SYSTEM_INSTRUCTIONS = [
-  'You are ARCANOS direct GPT Action execution.',
-  'Answer the caller request directly and concretely.',
-  'Do not describe internal routing, queues, tools, memory, audits, or orchestration.',
-  'Return only the final user-facing result.'
-].join(' ');
-
-function readUsageNumber(usage: unknown, key: string): number {
-  if (!usage || typeof usage !== 'object' || Array.isArray(usage)) {
-    return 0;
+function normalizeUsage(result: TrinityResult): {
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+} {
+  const tokens = result.meta.tokens;
+  if (!tokens) {
+    return {};
   }
 
-  const value = (usage as Record<string, unknown>)[key];
-  return typeof value === 'number' && Number.isFinite(value) && value > 0
-    ? Math.trunc(value)
-    : 0;
-}
-
-function normalizeUsage(usage: unknown): {
-  prompt_tokens: number;
-  completion_tokens: number;
-  total_tokens: number;
-} {
-  const promptTokens =
-    readUsageNumber(usage, 'input_tokens') ||
-    readUsageNumber(usage, 'prompt_tokens');
-  const completionTokens =
-    readUsageNumber(usage, 'output_tokens') ||
-    readUsageNumber(usage, 'completion_tokens');
-  const totalTokens =
-    readUsageNumber(usage, 'total_tokens') ||
-    promptTokens + completionTokens;
-
   return {
-    prompt_tokens: promptTokens,
-    completion_tokens: completionTokens,
-    total_tokens: totalTokens
+    promptTokens: tokens.prompt_tokens,
+    completionTokens: tokens.completion_tokens,
+    totalTokens: tokens.total_tokens
   };
 }
 
-function buildFastPathResult(input: {
-  prompt: string;
-  outputText: string;
-  model: string;
-  requestId?: string;
-  responseId?: string | null;
-  createdAtMs: number;
-  modelLatencyMs: number;
-  totalLatencyMs: number;
-  timeoutMs: number;
-  usage: unknown;
-}): Record<string, unknown> {
-  const usage = normalizeUsage(input.usage);
-  const requestId =
-    input.requestId?.trim() ||
-    input.responseId?.trim() ||
-    `gpt-fast-path-${input.createdAtMs}`;
-
+function decorateFastPathResult(
+  result: TrinityResult,
+  input: ExecuteFastGptPromptInput,
+  totalLatencyMs: number
+): Record<string, unknown> {
   return {
-    result: input.outputText,
-    module: 'fast_path',
-    meta: {
-      id: requestId,
-      created: input.createdAtMs,
-      tokens: usage
-    },
-    activeModel: input.model,
-    fallbackFlag: false,
-    gpt5Used: false,
-    routingStages: [FAST_PATH_ROUTING_STAGE],
-    auditSafe: {
-      mode: false,
-      overrideUsed: false,
-      auditFlags: ['FAST_PATH_MINIMAL_PIPELINE'],
-      processedSafely: true
-    },
-    memoryContext: {
-      entriesAccessed: 0,
-      contextSummary: 'Bypassed for GPT fast path.',
-      memoryEnhanced: false
-    },
-    taskLineage: {
-      requestId,
-      logged: false
-    },
+    ...result,
     fastPath: {
       inline: true,
       queueBypassed: true,
-      orchestrationBypassed: true,
-      modelLatencyMs: input.modelLatencyMs,
-      totalLatencyMs: input.totalLatencyMs,
-      timeoutMs: input.timeoutMs,
-      bypassedSubsystems: [
-        'queue',
-        'worker_orchestration',
-        'dag_planning',
-        'memory_overlay',
-        'research_overlay',
-        'audit_overlay'
-      ]
+      trinityRequired: true,
+      orchestrationBypassed: false,
+      totalLatencyMs,
+      timeoutMs: input.timeoutMs
     }
   };
 }
 
-function buildDirectActionResult(input: {
-  outputText: string;
-  model: string;
-  requestId?: string;
-  responseId?: string | null;
-  createdAtMs: number;
-  modelLatencyMs: number;
-  totalLatencyMs: number;
-  timeoutMs: number;
-  usage: unknown;
-}): Record<string, unknown> {
-  const usage = normalizeUsage(input.usage);
-  const requestId =
-    input.requestId?.trim() ||
-    input.responseId?.trim() ||
-    `gpt-direct-action-${input.createdAtMs}`;
-
+function decorateDirectActionResult(
+  result: TrinityResult,
+  input: ExecuteDirectGptActionInput,
+  totalLatencyMs: number
+): Record<string, unknown> {
   return {
-    result: input.outputText,
-    module: 'direct_action',
-    meta: {
-      id: requestId,
-      created: input.createdAtMs,
-      tokens: usage
-    },
-    activeModel: input.model,
-    fallbackFlag: false,
-    routingStages: [DIRECT_ACTION_ROUTING_STAGE],
-    auditSafe: {
-      mode: false,
-      overrideUsed: false,
-      auditFlags: ['DIRECT_ACTION_MINIMAL_PIPELINE'],
-      processedSafely: true
-    },
-    memoryContext: {
-      entriesAccessed: 0,
-      contextSummary: 'Bypassed for GPT direct action.',
-      memoryEnhanced: false
-    },
-    taskLineage: {
-      requestId,
-      logged: false
-    },
+    ...result,
     directAction: {
       inline: true,
       queueBypassed: true,
-      orchestrationBypassed: true,
-      modelLatencyMs: input.modelLatencyMs,
-      totalLatencyMs: input.totalLatencyMs,
-      timeoutMs: input.timeoutMs,
-      bypassedSubsystems: [
-        'queue',
-        'worker_orchestration',
-        'dag_planning',
-        'trinity_intake',
-        'trinity_reasoning',
-        'trinity_clear_audit',
-        'trinity_reflection',
-        'trinity_final',
-        'memory_overlay',
-        'research_overlay',
-        'audit_overlay'
-      ]
+      trinityRequired: true,
+      orchestrationBypassed: false,
+      action: input.action,
+      modelLatencyMs: totalLatencyMs,
+      totalLatencyMs,
+      timeoutMs: input.timeoutMs
     }
   };
 }
 
 /**
- * Execute one simple GPT prompt-generation request through the minimal inline path.
- * This path intentionally uses the shared OpenAI client but skips queue creation, worker
- * orchestration, DAG planning, memory overlays, research overlays, and audit overlays.
+ * Execute one simple GPT prompt-generation request through the Trinity facade.
+ * This keeps the low-latency HTTP lane, but Trinity remains mandatory for generation.
  */
 export async function executeFastGptPrompt(
   input: ExecuteFastGptPromptInput
@@ -280,68 +154,62 @@ export async function executeFastGptPrompt(
     throw new Error('OpenAI client unavailable for GPT fast path.');
   }
 
-  const model = resolveGptFastPathModel();
-  const parentSignal = input.parentSignal ?? getRequestAbortSignal();
-  let modelLatencyMs = 0;
-
   try {
-    const { response, outputText } = await runWithRequestAbortTimeout(
+    const trinityResult = await runWithRequestAbortTimeout(
       {
         timeoutMs: input.timeoutMs,
         requestId: input.requestId,
-        parentSignal,
-        abortMessage: `GPT fast path timeout after ${input.timeoutMs}ms`
+        parentSignal: input.parentSignal ?? getRequestAbortSignal(),
+        abortMessage: `GPT fast path Trinity timeout after ${input.timeoutMs}ms`
       },
-      async () => {
-        const modelStartedAtMs = Date.now();
-        const activeSignal = getRequestAbortSignal() ?? parentSignal;
-        const result = await callTextResponse(
-          client,
-          {
-            model,
-            instructions: FAST_PATH_SYSTEM_INSTRUCTIONS,
-            input: input.prompt,
-            store: false
+      () => runTrinityWritingPipeline({
+        input: {
+          prompt: input.prompt,
+          gptId: input.gptId,
+          moduleId: 'GPT:FAST_PATH',
+          sourceEndpoint: 'gpt.fast_path',
+          requestedAction: 'query',
+          body: {
+            prompt: input.prompt,
+            gptId: input.gptId,
+            action: 'query',
+            executionMode: 'fast'
           },
-          { signal: activeSignal }
-        );
-        modelLatencyMs = Date.now() - modelStartedAtMs;
-        return result;
-      }
+          outputLimit: input.routeDecision.maxWords ?? undefined,
+          executionMode: 'request'
+        },
+        context: {
+          client,
+          requestId: input.requestId,
+          runtimeBudget: createRuntimeBudget(),
+          runOptions: {
+            requestedVerbosity: 'minimal',
+            answerMode: 'direct',
+            ...(input.routeDecision.maxWords
+              ? { maxWords: input.routeDecision.maxWords }
+              : {}),
+            strictUserVisibleOutput: true,
+            watchdogModelTimeoutMs: input.timeoutMs
+          }
+        }
+      })
     );
-    const normalizedOutputText = outputText.trim();
-    if (!normalizedOutputText) {
-      throw new Error('GPT fast path returned empty output.');
-    }
 
     const totalLatencyMs = Date.now() - startedAtMs;
     recordAiOperation({
       provider: 'openai',
-      operation: 'responses.create',
+      operation: 'trinity.pipeline',
       sourceType: 'gpt_fast_path',
       sourceName: input.gptId,
-      model,
+      model: trinityResult.activeModel,
       outcome: 'ok',
-      durationMs: modelLatencyMs,
-      promptTokens: normalizeUsage(response.usage).prompt_tokens,
-      completionTokens: normalizeUsage(response.usage).completion_tokens,
-      totalTokens: normalizeUsage(response.usage).total_tokens
+      durationMs: totalLatencyMs,
+      ...normalizeUsage(trinityResult)
     });
 
     return {
       ok: true,
-      result: buildFastPathResult({
-        prompt: input.prompt,
-        outputText: normalizedOutputText,
-        model,
-        requestId: input.requestId,
-        responseId: typeof response.id === 'string' ? response.id : null,
-        createdAtMs: Date.now(),
-        modelLatencyMs,
-        totalLatencyMs,
-        timeoutMs: input.timeoutMs,
-        usage: response.usage
-      }),
+      result: decorateFastPathResult(trinityResult, input, totalLatencyMs),
       routeDecision: {
         path: 'fast_path',
         reason: input.routeDecision.reason,
@@ -363,12 +231,11 @@ export async function executeFastGptPrompt(
   } catch (error) {
     recordAiOperation({
       provider: 'openai',
-      operation: 'responses.create',
+      operation: 'trinity.pipeline',
       sourceType: 'gpt_fast_path',
       sourceName: input.gptId,
-      model,
       outcome: 'error',
-      durationMs: modelLatencyMs
+      durationMs: Date.now() - startedAtMs
     });
     input.logger?.warn?.('gpt.fast_path.error', {
       gptId: input.gptId,
@@ -382,9 +249,7 @@ export async function executeFastGptPrompt(
 }
 
 /**
- * Execute a GPT Action query_and_wait request through the minimal synchronous lane.
- * This path intentionally returns provider failures and timeout failures as errors
- * instead of routing through Trinity's degraded/static fallback machinery.
+ * Execute a GPT Action query_and_wait request through Trinity without queueing.
  */
 export async function executeDirectGptAction(
   input: ExecuteDirectGptActionInput
@@ -402,74 +267,64 @@ export async function executeDirectGptAction(
     throw new Error('OpenAI client unavailable for GPT direct action.');
   }
 
-  const model = resolveGptFastPathModel();
-  const parentSignal = input.parentSignal ?? getRequestAbortSignal();
-  let modelLatencyMs = 0;
-
   try {
-    const { response, outputText } = await runWithRequestAbortTimeout(
+    const trinityResult = await runWithRequestAbortTimeout(
       {
         timeoutMs: input.timeoutMs,
         requestId: input.requestId,
-        parentSignal,
-        abortMessage: `GPT direct action timeout after ${input.timeoutMs}ms`
+        parentSignal: input.parentSignal ?? getRequestAbortSignal(),
+        abortMessage: `GPT direct action Trinity timeout after ${input.timeoutMs}ms`
       },
-      async () => {
-        const modelStartedAtMs = Date.now();
-        const activeSignal = getRequestAbortSignal() ?? parentSignal;
-        const result = await callTextResponse(
-          client,
-          {
-            model,
-            instructions: DIRECT_ACTION_SYSTEM_INSTRUCTIONS,
-            input: input.prompt,
-            store: false
+      () => runTrinityWritingPipeline({
+        input: {
+          prompt: input.prompt,
+          gptId: input.gptId,
+          moduleId: 'GPT:DIRECT_ACTION',
+          sourceEndpoint: 'gpt.direct_action',
+          requestedAction: input.action,
+          body: {
+            prompt: input.prompt,
+            gptId: input.gptId,
+            action: input.action
           },
-          { signal: activeSignal }
-        );
-        modelLatencyMs = Date.now() - modelStartedAtMs;
-        return result;
-      }
+          executionMode: 'request'
+        },
+        context: {
+          client,
+          requestId: input.requestId,
+          runtimeBudget: createRuntimeBudget(),
+          runOptions: {
+            requestedVerbosity: 'minimal',
+            answerMode: 'direct',
+            strictUserVisibleOutput: true,
+            watchdogModelTimeoutMs: input.timeoutMs
+          }
+        }
+      })
     );
-    const normalizedOutputText = outputText.trim();
-    if (!normalizedOutputText) {
-      throw new Error('GPT direct action returned empty output.');
-    }
 
     const totalLatencyMs = Date.now() - startedAtMs;
     recordAiOperation({
       provider: 'openai',
-      operation: 'responses.create',
+      operation: 'trinity.pipeline',
       sourceType: 'gpt_direct_action',
       sourceName: input.gptId,
-      model,
+      model: trinityResult.activeModel,
       outcome: 'ok',
-      durationMs: modelLatencyMs,
-      promptTokens: normalizeUsage(response.usage).prompt_tokens,
-      completionTokens: normalizeUsage(response.usage).completion_tokens,
-      totalTokens: normalizeUsage(response.usage).total_tokens
+      durationMs: totalLatencyMs,
+      ...normalizeUsage(trinityResult)
     });
 
     return {
       ok: true,
-      result: buildDirectActionResult({
-        outputText: normalizedOutputText,
-        model,
-        requestId: input.requestId,
-        responseId: typeof response.id === 'string' ? response.id : null,
-        createdAtMs: Date.now(),
-        modelLatencyMs,
-        totalLatencyMs,
-        timeoutMs: input.timeoutMs,
-        usage: response.usage
-      }),
+      result: decorateDirectActionResult(trinityResult, input, totalLatencyMs),
       directAction: {
         inline: true,
         queueBypassed: true,
-        orchestrationBypassed: true,
+        orchestrationBypassed: false,
         action: input.action,
         timeoutMs: input.timeoutMs,
-        modelLatencyMs,
+        modelLatencyMs: totalLatencyMs,
         totalLatencyMs
       },
       _route: {
@@ -484,12 +339,11 @@ export async function executeDirectGptAction(
   } catch (error) {
     recordAiOperation({
       provider: 'openai',
-      operation: 'responses.create',
+      operation: 'trinity.pipeline',
       sourceType: 'gpt_direct_action',
       sourceName: input.gptId,
-      model,
       outcome: 'error',
-      durationMs: modelLatencyMs
+      durationMs: Date.now() - startedAtMs
     });
     input.logger?.error?.('gpt.direct_action.failed', {
       gptId: input.gptId,

--- a/src/services/gptSync.ts
+++ b/src/services/gptSync.ts
@@ -4,14 +4,15 @@
  */
 
 import { getBackendState, SystemState } from './stateManager.js';
-import { getTokenParameter } from "@shared/tokenParameterHelper.js";
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
 import { config } from "@platform/runtime/config.js";
 import { GPT_SYNC_CONFIG } from "@platform/runtime/gptSyncConfig.js";
 import { GPT_SYNC_ERRORS, GPT_SYNC_LOG_MESSAGES, GPT_SYNC_STRINGS } from "@platform/runtime/gptSyncMessages.js";
 import { requireOpenAIClientOrAdapter } from './openai/clientBridge.js';
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
 
-function getRequiredAdapter() {
-  return requireOpenAIClientOrAdapter(GPT_SYNC_ERRORS.clientUnavailable).adapter;
+function getRequiredClient() {
+  return requireOpenAIClientOrAdapter(GPT_SYNC_ERRORS.clientUnavailable).client;
 }
 
 function logSyncInfo(message: string, data?: unknown): void {
@@ -48,20 +49,33 @@ function buildSystemPrompt(
 }
 
 async function createSyncedCompletion(systemPrompt: string, userPrompt: string, model: string) {
-  const adapter = getRequiredAdapter();
-  const tokenParams = getTokenParameter(model, GPT_SYNC_CONFIG.maxCompletionTokens);
+  const client = getRequiredClient();
 
-  const response = await adapter.responses.create({
-    model: model,
-    messages: [
-      { role: 'system', content: systemPrompt },
-      { role: 'user', content: userPrompt }
-    ],
-    ...tokenParams,
-    temperature: GPT_SYNC_CONFIG.temperature
+  const response = await runTrinityWritingPipeline({
+    input: {
+      prompt: [systemPrompt, userPrompt].join('\n\n'),
+      moduleId: 'GPT:SYNC',
+      sourceEndpoint: 'gpt-sync',
+      requestedAction: 'query',
+      body: {
+        model,
+        maxCompletionTokens: GPT_SYNC_CONFIG.maxCompletionTokens,
+        temperature: GPT_SYNC_CONFIG.temperature
+      },
+      tokenLimit: GPT_SYNC_CONFIG.maxCompletionTokens,
+      executionMode: 'request'
+    },
+    context: {
+      client,
+      runtimeBudget: createRuntimeBudget(),
+      runOptions: {
+        answerMode: 'direct',
+        strictUserVisibleOutput: true
+      }
+    }
   });
 
-  return response.choices[0]?.message?.content || GPT_SYNC_CONFIG.fallbackResponse;
+  return response.result || GPT_SYNC_CONFIG.fallbackResponse;
 }
 
 /**

--- a/src/services/openai/imageGeneration.ts
+++ b/src/services/openai/imageGeneration.ts
@@ -1,6 +1,5 @@
 import crypto from 'crypto';
 import { getOpenAIClientOrAdapter } from './clientBridge.js';
-import { callOpenAI } from './chatFlow/index.js';
 import { generateMockResponse } from './mock.js';
 import { logOpenAIEvent } from "@platform/logging/openaiLogger.js";
 import { resolveErrorMessage } from "@core/lib/errors/index.js";
@@ -9,14 +8,46 @@ import { OPENAI_LOG_MESSAGES } from "@platform/runtime/openaiLogMessages.js";
 import { DEFAULT_IMAGE_SIZE, IMAGE_GENERATION_MODEL } from './config.js';
 import type { ImageSize } from './types.js';
 import { buildImageRequest } from './requestBuilders/index.js';
-import { getDefaultModel } from './credentialProvider.js';
 import { IMAGE_PROMPT_TOKEN_LIMIT } from "./constants.js";
 
 const buildEnhancedImagePrompt = async (input: string): Promise<string> => {
   try {
-    const { output } = await callOpenAI(getDefaultModel(), input, IMAGE_PROMPT_TOKEN_LIMIT, false);
-    if (hasContent(output)) {
-      return output.trim();
+    const { client } = getOpenAIClientOrAdapter();
+    if (!client) {
+      return input;
+    }
+
+    const [{ runTrinityWritingPipeline }, { createRuntimeBudget }] = await Promise.all([
+      import('@core/logic/trinityWritingPipeline.js'),
+      import('@platform/resilience/runtimeBudget.js')
+    ]);
+
+    const response = await runTrinityWritingPipeline({
+      input: {
+        prompt: input,
+        moduleId: 'IMAGE_PROMPT',
+        sourceEndpoint: 'openai.imageGeneration.promptEnhancement',
+        requestedAction: 'query',
+        body: {
+          prompt: input,
+          purpose: 'image_prompt_enhancement'
+        },
+        maxOutputTokens: IMAGE_PROMPT_TOKEN_LIMIT,
+        executionMode: 'request'
+      },
+      context: {
+        client,
+        runtimeBudget: createRuntimeBudget(),
+        runOptions: {
+          answerMode: 'direct',
+          strictUserVisibleOutput: true,
+          requestedVerbosity: 'minimal'
+        }
+      }
+    });
+
+    if (hasContent(response.result)) {
+      return response.result.trim();
     }
   } catch (err) {
     logOpenAIEvent('error', OPENAI_LOG_MESSAGES.IMAGE.PROMPT_GENERATION_ERROR, undefined, err as Error);

--- a/src/services/research.ts
+++ b/src/services/research.ts
@@ -1,10 +1,9 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fetchAndClean } from "@shared/webFetcher.js";
-import {
-  createCentralizedCompletion,
-  getDefaultModel
-} from './openai.js';
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
+import { getDefaultModel } from './openai.js';
 import { getOpenAIClientOrAdapter } from './openai/clientBridge.js';
 import { setMemory } from './memory.js';
 import { RESEARCH_SUMMARIZER_PROMPT, RESEARCH_SYNTHESIS_PROMPT } from "@platform/runtime/researchPrompts.js";
@@ -39,6 +38,11 @@ const SUSPICIOUS_INSTRUCTION_PATTERNS = [
   /\breveal\b.+\bsecret\b/i
 ];
 
+type ResearchCompletionMessage = {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+};
+
 function resolveResearchModel(): string {
   const configuredModel = getEnv('RESEARCH_MODEL_ID')?.trim();
   return configuredModel && configuredModel.length > 0 ? configuredModel : getDefaultModel();
@@ -66,18 +70,48 @@ function resolveSourcesDir(topic: string): string {
 }
 
 async function runResearchCompletion(
-  messages: Parameters<typeof createCentralizedCompletion>[0],
+  client: OpenAI,
+  messages: ResearchCompletionMessage[],
   model: string,
   temperature: number,
-  maxTokens: number
+  maxTokens: number,
+  sourceEndpoint: string
 ): Promise<string> {
-  const response = await createCentralizedCompletion(messages, {
-    temperature,
-    max_tokens: maxTokens,
-    model
+  const prompt = messages
+    .map((message) => `${message.role.toUpperCase()}:\n${message.content}`)
+    .join('\n\n');
+
+  const response = await runTrinityWritingPipeline({
+    input: {
+      prompt,
+      moduleId: 'RESEARCH',
+      sourceEndpoint,
+      requestedAction: 'query',
+      body: {
+        messages,
+        requestedModel: model,
+        temperature,
+        maxTokens
+      },
+      maxOutputTokens: maxTokens,
+      executionMode: 'request',
+      background: {
+        requestedModel: model,
+        temperature
+      }
+    },
+    context: {
+      client,
+      runtimeBudget: createRuntimeBudget(),
+      runOptions: {
+        answerMode: 'direct',
+        strictUserVisibleOutput: true,
+        requestedVerbosity: 'minimal'
+      }
+    }
   });
 
-  return extractCompletionText(response);
+  return response.result.trim();
 }
 
 function buildSummariesForSynthesis(summaries: ResearchSourceSummary[]): string {
@@ -127,6 +161,7 @@ function hasSuspiciousInstructions(text: string): boolean {
 }
 
 async function runSynthesisAudit(
+  client: OpenAI,
   topic: string,
   summaries: ResearchSourceSummary[],
   synthesizedInsight: string,
@@ -153,7 +188,14 @@ async function runSynthesisAudit(
   ];
 
   try {
-    const auditRaw = await runResearchCompletion(auditMessages, model, 0, 120);
+    const auditRaw = await runResearchCompletion(
+      client,
+      auditMessages,
+      model,
+      0,
+      120,
+      'research.audit'
+    );
     return parseAuditVerdict(auditRaw);
   } catch {
     //audit Assumption: failed audits must not silently approve potentially compromised synthesis; risk: unsafe insight leak; invariant: audit failure blocks trust; handling: fail closed.
@@ -194,10 +236,10 @@ export async function researchTopic(topic: string, urls: string[] = []): Promise
   }
 
   const generatedAt = new Date().toISOString();
-  const { adapter } = getOpenAIClientOrAdapter();
+  const { client } = getOpenAIClientOrAdapter();
   // Use config for mock detection (adapter boundary pattern)
   const apiKey = getEnv('OPENAI_API_KEY');
-  const useMock = !adapter || apiKey === 'test_key_for_mocking';
+  const useMock = !client || apiKey === 'test_key_for_mocking';
   const researchModel = resolveResearchModel();
 
   //audit Assumption: mock mode when client missing or test key
@@ -224,7 +266,14 @@ export async function researchTopic(topic: string, urls: string[] = []): Promise
           content: `Topic: ${topic}\nSource URL: ${url}\n\nContent (truncated):\n${content}`
         }
       ];
-      const summary = await runResearchCompletion(messages, researchModel, 0.2, 600);
+      const summary = await runResearchCompletion(
+        client,
+        messages,
+        researchModel,
+        0.2,
+        600,
+        'research.summarizeSource'
+      );
       if (summary) {
         summaries.push({ url, summary });
       } else {
@@ -248,11 +297,18 @@ export async function researchTopic(topic: string, urls: string[] = []): Promise
     }
   ];
 
-  const insight = await runResearchCompletion(synthesisMessages, researchModel, 0.25, 900);
+  const insight = await runResearchCompletion(
+    client,
+    synthesisMessages,
+    researchModel,
+    0.25,
+    900,
+    'research.synthesize'
+  );
   let finalInsight = insight || `No insight generated for ${topic}.`;
 
   if (summaries.length > 0) {
-    const auditResult = await runSynthesisAudit(topic, summaries, finalInsight, researchModel);
+    const auditResult = await runSynthesisAudit(client, topic, summaries, finalInsight, researchModel);
     //audit Assumption: synthesis output may still contain injected instructions; risk: compromised downstream guidance; invariant: only audited-safe text is returned; handling: combine heuristic + model audit and fail closed to safe fallback.
     if (!auditResult.safe || hasSuspiciousInstructions(finalInsight)) {
       finalInsight = buildUnsafeInsightFallback(topic, auditResult.reason);
@@ -272,17 +328,6 @@ export async function researchTopic(topic: string, urls: string[] = []): Promise
   await persistResearch(topic, result);
 
   return result;
-}
-
-function extractCompletionText(
-  response: Awaited<ReturnType<typeof createCentralizedCompletion>>
-): string {
-  //audit Assumption: non-stream responses contain choices[0].message.content
-  if (response && typeof response === 'object' && 'choices' in response) {
-    const completion = response as OpenAI.Chat.Completions.ChatCompletion;
-    return completion.choices?.[0]?.message?.content?.trim() || '';
-  }
-  return '';
 }
 
 async function persistResearch(topic: string, result: ResearchResult): Promise<void> {

--- a/src/services/reusableCodeGeneration.ts
+++ b/src/services/reusableCodeGeneration.ts
@@ -1,10 +1,8 @@
-import { getDefaultModel } from './openai/credentialProvider.js';
+import type OpenAI from 'openai';
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
 import { z } from 'zod';
 import { parseModelOutputWithSchema } from './safety/aiOutputBoundary.js';
-import {
-  callStructuredResponse,
-  type OpenAIResponsesClientLike,
-} from '@arcanos/openai';
 
 export type ReusableCodeTarget = 'all' | 'asyncHandler' | 'errorResponse' | 'idGenerator';
 
@@ -38,12 +36,6 @@ const reusableCodeResponseSchema = z.object({
     })
   )
 });
-type ReusableCodeResponsePayload = z.infer<typeof reusableCodeResponseSchema>;
-
-function isReusableCodeResponsePayload(value: unknown): value is ReusableCodeResponsePayload {
-  return reusableCodeResponseSchema.safeParse(value).success;
-}
-
 /**
  * Resolve the requested targets for code generation.
  *
@@ -104,7 +96,7 @@ export function parseReusableCodeResponse(raw: string): ReusableCodeSnippet[] {
 }
 
 /**
- * Generate reusable code snippets using the OpenAI SDK.
+ * Generate reusable code snippets using the Trinity generation facade.
  *
  * @param client - OpenAI SDK client instance.
  * @param request - Generation request details.
@@ -112,39 +104,36 @@ export function parseReusableCodeResponse(raw: string): ReusableCodeSnippet[] {
  * @edgeCases Throws when OpenAI returns invalid JSON.
  */
 export async function generateReusableCodeSnippets(
-  client: OpenAIResponsesClientLike,
+  client: OpenAI,
   request: ReusableCodeGenerationRequest
 ): Promise<ReusableCodeGenerationResult> {
-  const model = getDefaultModel();
   const prompt = buildReusableCodePrompt(request);
-
-  const { response, outputText, outputParsed } = await callStructuredResponse<ReusableCodeResponsePayload>(
-    client,
-    {
-      model,
-      input: [
-        {
-          role: 'system',
-          content: [{ type: 'input_text', text: 'You are a senior TypeScript engineer who responds with JSON only.' }]
-        },
-        {
-          role: 'user',
-          content: [{ type: 'input_text', text: prompt }]
-        }
-      ],
-      text: { format: { type: 'json_object' } },
-      temperature: 0.2
+  const trinityResult = await runTrinityWritingPipeline({
+    input: {
+      prompt: [
+        'You are a senior TypeScript engineer who responds with JSON only.',
+        prompt
+      ].join('\n\n'),
+      moduleId: 'REUSABLE:CODE',
+      sourceEndpoint: 'api.reusables',
+      requestedAction: 'query',
+      body: request,
+      executionMode: 'request'
     },
-    undefined,
-    {
-      validate: isReusableCodeResponsePayload,
-      source: 'reusable code generation'
+    context: {
+      client,
+      runtimeBudget: createRuntimeBudget(),
+      runOptions: {
+        answerMode: 'audit',
+        strictUserVisibleOutput: true
+      }
     }
-  );
+  });
+  const snippets = parseReusableCodeResponse(trinityResult.result);
 
   return {
-    model: response.model ?? model,
-    snippets: outputParsed.snippets,
-    raw: outputText
+    model: trinityResult.activeModel,
+    snippets,
+    raw: trinityResult.result
   };
 }

--- a/src/services/reusableCodeGeneration.ts
+++ b/src/services/reusableCodeGeneration.ts
@@ -95,6 +95,22 @@ export function parseReusableCodeResponse(raw: string): ReusableCodeSnippet[] {
   return parsed.snippets;
 }
 
+function buildReusableCodeRepairPrompt(request: ReusableCodeGenerationRequest, invalidOutput: string): string {
+  const invalidPreview =
+    invalidOutput.length > 2_000 ? `${invalidOutput.slice(0, 2_000)}...[truncated]` : invalidOutput;
+
+  return [
+    'The previous reusable-code response failed JSON parsing.',
+    'Regenerate the requested snippets and return strict JSON only.',
+    'Required shape: {"snippets":[{"name":"","description":"","language":"","code":""}]}',
+    'Do not include markdown fences, prose, caveats, or external-state claims.',
+    'Original request:',
+    buildReusableCodePrompt(request),
+    'Invalid prior output:',
+    invalidPreview
+  ].join('\n\n');
+}
+
 /**
  * Generate reusable code snippets using the Trinity generation facade.
  *
@@ -124,16 +140,47 @@ export async function generateReusableCodeSnippets(
       client,
       runtimeBudget: createRuntimeBudget(),
       runOptions: {
-        answerMode: 'audit',
+        answerMode: 'direct',
         strictUserVisibleOutput: true
       }
     }
   });
-  const snippets = parseReusableCodeResponse(trinityResult.result);
+  let raw = trinityResult.result;
+  let model = trinityResult.activeModel;
+  let snippets: ReusableCodeSnippet[];
+
+  try {
+    snippets = parseReusableCodeResponse(raw);
+  } catch {
+    const repairResult = await runTrinityWritingPipeline({
+      input: {
+        prompt: buildReusableCodeRepairPrompt(request, raw),
+        moduleId: 'REUSABLE:CODE',
+        sourceEndpoint: 'api.reusables.repair',
+        requestedAction: 'query',
+        body: {
+          request,
+          invalidOutputPreview: raw.slice(0, 2_000)
+        },
+        executionMode: 'request'
+      },
+      context: {
+        client,
+        runtimeBudget: createRuntimeBudget(),
+        runOptions: {
+          answerMode: 'direct',
+          strictUserVisibleOutput: true
+        }
+      }
+    });
+    raw = repairResult.result;
+    model = repairResult.activeModel;
+    snippets = parseReusableCodeResponse(raw);
+  }
 
   return {
-    model: trinityResult.activeModel,
+    model,
     snippets,
-    raw: trinityResult.result
+    raw
   };
 }

--- a/src/services/reusableCodeGeneration.ts
+++ b/src/services/reusableCodeGeneration.ts
@@ -72,7 +72,7 @@ export function buildReusableCodePrompt(request: ReusableCodeGenerationRequest):
     `Generate ${language} code for these reusable utilities: ${targetList}.`,
     'Return JSON only with shape:',
     '{"snippets":[{"name":"","description":"","language":"","code":""}]}',
-    'Each snippet must be complete, runnable, and Railway-ready (no hardcoded ports, use envs).',
+    'Each snippet must be complete, runnable TypeScript with no hardcoded ports; use environment variables where a value is environment-specific.',
     'Include //audit comments on conditionals, error handling, security checks, and data transforms.',
     includeDocs
       ? 'Add JSDoc for every public function: purpose, inputs/outputs, edge cases.'
@@ -109,6 +109,77 @@ function buildReusableCodeRepairPrompt(request: ReusableCodeGenerationRequest, i
     'Invalid prior output:',
     invalidPreview
   ].join('\n\n');
+}
+
+function buildDeterministicReusableCodeSnippets(
+  request: ReusableCodeGenerationRequest
+): ReusableCodeSnippet[] {
+  const language = request.language ?? 'typescript';
+  const includeDocs = request.includeDocs ?? true;
+  const snippets: Record<ReusableCodeTarget, ReusableCodeSnippet> = {
+    asyncHandler: {
+      name: 'asyncHandler',
+      description: 'Wrap Express async route handlers and forward rejected promises to next().',
+      language,
+      code: [
+        includeDocs
+          ? '/** Wraps an async Express handler so rejected promises reach the error middleware. */'
+          : '',
+        'export function asyncHandler<TReq, TRes, TNext extends (error?: unknown) => void>(',
+        '  handler: (req: TReq, res: TRes, next: TNext) => Promise<unknown>',
+        ') {',
+        '  return (req: TReq, res: TRes, next: TNext): void => {',
+        '    //audit Assumption: the framework owns final error serialization; invariant: async failures are never dropped.',
+        '    Promise.resolve(handler(req, res, next)).catch(next);',
+        '  };',
+        '}'
+      ].filter(Boolean).join('\n')
+    },
+    errorResponse: {
+      name: 'errorResponse',
+      description: 'Build a stable JSON error envelope for HTTP responses.',
+      language,
+      code: [
+        includeDocs
+          ? '/** Builds a deterministic, client-safe error response body. */'
+          : '',
+        'export function errorResponse(code: string, message: string, details?: unknown) {',
+        '  //audit Assumption: callers pass already-redacted details; invariant: error shape is stable for clients.',
+        '  return {',
+        '    ok: false,',
+        '    error: {',
+        '      code,',
+        '      message,',
+        '      ...(details === undefined ? {} : { details })',
+        '    }',
+        '  };',
+        '}'
+      ].filter(Boolean).join('\n')
+    },
+    idGenerator: {
+      name: 'idGenerator',
+      description: 'Generate sortable, prefixed IDs without relying on external services.',
+      language,
+      code: [
+        includeDocs
+          ? '/** Generates a prefixed, time-sortable identifier for logs and records. */'
+          : '',
+        'export function idGenerator(prefix = "id"): string {',
+        '  //audit Assumption: crypto.randomUUID is available in supported Node runtimes; invariant: IDs are unique enough for request-scale records.',
+        '  const randomPart = crypto.randomUUID().replace(/-/g, "").slice(0, 12);',
+        '  return `${prefix}_${Date.now().toString(36)}_${randomPart}`;',
+        '}'
+      ].filter(Boolean).join('\n')
+    },
+    all: {
+      name: 'all',
+      description: 'Internal aggregate placeholder.',
+      language,
+      code: ''
+    }
+  };
+
+  return resolveReusableTargets(request.target).map((target) => snippets[target]);
 }
 
 /**
@@ -175,7 +246,13 @@ export async function generateReusableCodeSnippets(
     });
     raw = repairResult.result;
     model = repairResult.activeModel;
-    snippets = parseReusableCodeResponse(raw);
+    try {
+      snippets = parseReusableCodeResponse(raw);
+    } catch {
+      snippets = buildDeterministicReusableCodeSnippets(request);
+      raw = JSON.stringify({ snippets });
+      model = `${model}:deterministic-json-fallback`;
+    }
   }
 
   return {

--- a/src/services/reusableCodeGeneration.ts
+++ b/src/services/reusableCodeGeneration.ts
@@ -182,12 +182,14 @@ function buildDeterministicReusableCodeSnippets(
       description: 'Generate sortable, prefixed IDs without relying on external services.',
       language,
       code: [
+        'import { randomUUID } from "node:crypto";',
+        '',
         includeDocs
           ? '/** Generates a prefixed, time-sortable identifier for logs and records. */'
           : '',
         'export function idGenerator(prefix = "id"): string {',
-        '  //audit Assumption: crypto.randomUUID is available in supported Node runtimes; invariant: IDs are unique enough for request-scale records.',
-        '  const randomPart = crypto.randomUUID().replace(/-/g, "").slice(0, 12);',
+        '  //audit Assumption: randomUUID is available from node:crypto in supported Node runtimes; invariant: IDs are unique enough for request-scale records.',
+        '  const randomPart = randomUUID().replace(/-/g, "").slice(0, 12);',
         '  return `${prefix}_${Date.now().toString(36)}_${randomPart}`;',
         '}'
       ].filter(Boolean).join('\n')

--- a/src/services/reusableCodeGeneration.ts
+++ b/src/services/reusableCodeGeneration.ts
@@ -1,5 +1,6 @@
 import type OpenAI from 'openai';
 import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import type { TrinityResult } from '@core/logic/trinity.js';
 import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
 import { z } from 'zod';
 import { parseModelOutputWithSchema } from './safety/aiOutputBoundary.js';
@@ -23,6 +24,26 @@ export interface ReusableCodeGenerationResult {
   model: string;
   snippets: ReusableCodeSnippet[];
   raw: string;
+  meta: ReusableCodeGenerationMeta;
+}
+
+export interface ReusableCodeGenerationMeta {
+  pipeline: 'trinity';
+  bypass: false;
+  sourceEndpoint: string;
+  classification: 'writing';
+  moduleId: 'REUSABLE:CODE';
+  requestedAction: 'query';
+  executionMode: 'request';
+  tokens?: TrinityResult['meta']['tokens'];
+  id?: string;
+  created?: number;
+  tokenLimit?: number;
+  outputLimit?: number;
+  fallbackFlag?: boolean;
+  repairAttempted?: boolean;
+  deterministicJsonFallback?: boolean;
+  degraded?: boolean;
 }
 
 const SUPPORTED_TARGETS: ReusableCodeTarget[] = ['asyncHandler', 'errorResponse', 'idGenerator'];
@@ -182,6 +203,39 @@ function buildDeterministicReusableCodeSnippets(
   return resolveReusableTargets(request.target).map((target) => snippets[target]);
 }
 
+function buildReusableCodeMeta(
+  trinityResult: Partial<TrinityResult> | undefined,
+  fallbackSourceEndpoint: string,
+  extras: Partial<ReusableCodeGenerationMeta> = {}
+): ReusableCodeGenerationMeta {
+  const rawMeta: Partial<TrinityResult['meta']> =
+    trinityResult?.meta && typeof trinityResult.meta === 'object'
+      ? trinityResult.meta
+      : {};
+
+  return {
+    ...(rawMeta.tokens ? { tokens: rawMeta.tokens } : {}),
+    ...(typeof rawMeta.id === 'string' ? { id: rawMeta.id } : {}),
+    ...(typeof rawMeta.created === 'number' ? { created: rawMeta.created } : {}),
+    ...(typeof rawMeta.tokenLimit === 'number' ? { tokenLimit: rawMeta.tokenLimit } : {}),
+    ...(typeof rawMeta.outputLimit === 'number' ? { outputLimit: rawMeta.outputLimit } : {}),
+    pipeline: 'trinity',
+    bypass: false,
+    sourceEndpoint:
+      typeof rawMeta.sourceEndpoint === 'string' && rawMeta.sourceEndpoint.trim().length > 0
+        ? rawMeta.sourceEndpoint
+        : fallbackSourceEndpoint,
+    classification: 'writing',
+    moduleId: 'REUSABLE:CODE',
+    requestedAction: 'query',
+    executionMode: 'request',
+    ...(typeof trinityResult?.fallbackFlag === 'boolean'
+      ? { fallbackFlag: trinityResult.fallbackFlag }
+      : {}),
+    ...extras
+  };
+}
+
 /**
  * Generate reusable code snippets using the Trinity generation facade.
  *
@@ -219,6 +273,7 @@ export async function generateReusableCodeSnippets(
   let raw = trinityResult.result;
   let model = trinityResult.activeModel;
   let snippets: ReusableCodeSnippet[];
+  let meta = buildReusableCodeMeta(trinityResult, 'api.reusables');
 
   try {
     snippets = parseReusableCodeResponse(raw);
@@ -246,18 +301,27 @@ export async function generateReusableCodeSnippets(
     });
     raw = repairResult.result;
     model = repairResult.activeModel;
+    meta = buildReusableCodeMeta(repairResult, 'api.reusables.repair', {
+      repairAttempted: true
+    });
     try {
       snippets = parseReusableCodeResponse(raw);
     } catch {
       snippets = buildDeterministicReusableCodeSnippets(request);
       raw = JSON.stringify({ snippets });
       model = `${model}:deterministic-json-fallback`;
+      meta = buildReusableCodeMeta(repairResult, 'api.reusables.repair', {
+        repairAttempted: true,
+        deterministicJsonFallback: true,
+        degraded: true
+      });
     }
   }
 
   return {
     model,
     snippets,
-    raw
+    raw,
+    meta
   };
 }

--- a/src/services/secureReasoningEngine.ts
+++ b/src/services/secureReasoningEngine.ts
@@ -7,8 +7,9 @@
  */
 
 import type OpenAI from 'openai';
-import { getDefaultModel, createChatCompletionWithFallback } from './openai.js';
-import { getTokenParameter } from "@shared/tokenParameterHelper.js";
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
+import { getDefaultModel } from './openai.js';
 import { generateRequestId } from "@shared/idGenerator.js";
 import { APPLICATION_CONSTANTS } from "@shared/constants.js";
 import {
@@ -74,15 +75,48 @@ export async function executeSecureReasoning(
   console.log(`[🧠 SECURE REASONING] Using model: ${model}`);
 
   try {
-    // Execute reasoning with enhanced error handling
-    const tokenParams = getTokenParameter(model, APPLICATION_CONSTANTS.EXTENDED_TOKEN_LIMIT);
-    const response = await createChatCompletionWithFallback(client, {
-      messages: buildSecureReasoningMessages(fullPrompt),
-      temperature: 0.3, // Balanced for reasoning consistency
-      ...tokenParams
+    const trinityPrompt = [
+      'SYSTEM:',
+      SECURE_REASONING_SYSTEM_PROMPT,
+      '',
+      'USER:',
+      fullPrompt
+    ].join('\n');
+
+    const response = await runTrinityWritingPipeline({
+      input: {
+        prompt: trinityPrompt,
+        moduleId: 'SECURE_REASONING',
+        sourceEndpoint: 'secureReasoning.execute',
+        requestedAction: 'query',
+        body: {
+          userInput: request.userInput,
+          sessionId: request.sessionId,
+          context: request.context,
+          requireDeepAnalysis: request.requireDeepAnalysis,
+          requestedModel: model,
+          maxTokens: APPLICATION_CONSTANTS.EXTENDED_TOKEN_LIMIT
+        },
+        sessionId: request.sessionId,
+        maxOutputTokens: APPLICATION_CONSTANTS.EXTENDED_TOKEN_LIMIT,
+        executionMode: 'request',
+        background: {
+          requestedModel: model,
+          secureReasoning: true
+        }
+      },
+      context: {
+        client,
+        requestId,
+        runtimeBudget: createRuntimeBudget(),
+        runOptions: {
+          answerMode: 'direct',
+          strictUserVisibleOutput: true
+        }
+      }
     });
 
-    const rawAnalysis = response.choices[0]?.message?.content || '';
+    const rawAnalysis = response.result || '';
     const actualModel = response.activeModel || model;
     
     console.log(`[🧠 SECURE REASONING] Analysis completed using ${actualModel}`);
@@ -247,19 +281,6 @@ export async function executeQuickSecureAnalysis(
       compliant: fallbackAnalysis.complianceStatus === 'COMPLIANT'
     };
   }
-}
-
-function buildSecureReasoningMessages(fullPrompt: string): OpenAI.Chat.Completions.ChatCompletionMessageParam[] {
-  return [
-    {
-      role: 'system',
-      content: SECURE_REASONING_SYSTEM_PROMPT
-    },
-    {
-      role: 'user',
-      content: fullPrompt
-    }
-  ];
 }
 
 /**

--- a/src/services/webRag.ts
+++ b/src/services/webRag.ts
@@ -1,5 +1,7 @@
 import { createHash, randomUUID } from 'crypto';
-import { getDefaultModel, hasValidAPIKey } from './openai.js';
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
+import { hasValidAPIKey } from './openai.js';
 import { createEmbedding } from './openai/embeddings.js';
 import { fetchAndClean } from "@shared/webFetcher.js";
 import { cosineSimilarity } from "@shared/vectorUtils.js";
@@ -12,6 +14,7 @@ import {
 } from "@core/db/index.js";
 import { logger } from "@platform/logging/structuredLogging.js";
 import { requireOpenAIClientOrAdapter } from './openai/clientBridge.js';
+import type OpenAI from 'openai';
 
 interface Doc {
   id: string;
@@ -738,6 +741,37 @@ export async function recordPersistentMemorySnippet(options: PersistentMemorySni
   }
 }
 
+async function runRagTrinityText(params: {
+  client: OpenAI;
+  sourceEndpoint: string;
+  prompt: string;
+  maxOutputTokens: number;
+  body: Record<string, unknown>;
+}): Promise<string> {
+  const result = await runTrinityWritingPipeline({
+    input: {
+      prompt: params.prompt,
+      moduleId: 'WEB_RAG',
+      sourceEndpoint: params.sourceEndpoint,
+      requestedAction: 'query',
+      body: params.body,
+      maxOutputTokens: params.maxOutputTokens,
+      executionMode: 'request'
+    },
+    context: {
+      client: params.client,
+      runtimeBudget: createRuntimeBudget(),
+      runOptions: {
+        answerMode: 'direct',
+        strictUserVisibleOutput: true,
+        requestedVerbosity: 'minimal'
+      }
+    }
+  });
+
+  return result.result.trim();
+}
+
 export async function answerQuestion(question: string): Promise<{ answer: string; sources: string[]; verification: string; sourceDetails: SourceDetail[] }> {
   const retrieval = await queryRagDocuments(question, {
     limit: 3,
@@ -763,21 +797,27 @@ export async function answerQuestion(question: string): Promise<{ answer: string
     })
     .join('\n---\n');
 
-  const { adapter } = requireOpenAIClientOrAdapter('OpenAI adapter not initialized');
+  const { client } = requireOpenAIClientOrAdapter('OpenAI adapter not initialized');
 
   let answer = '';
   try {
-    const answerRes = await adapter.responses.create({
-      model: getDefaultModel(),
-      messages: [
-        {
-          role: 'system',
-          content: 'Answer using only the provided context. If context is insufficient, say that explicitly.'
-        },
-        { role: 'user', content: `Question: ${question}\n\nContext:\n${context}` },
-      ],
+    answer = await runRagTrinityText({
+      client,
+      sourceEndpoint: 'webRag.answerQuestion',
+      maxOutputTokens: 700,
+      prompt: [
+        'SYSTEM:',
+        'Answer using only the provided context. If context is insufficient, say that explicitly.',
+        '',
+        'USER:',
+        `Question: ${question}\n\nContext:\n${context}`
+      ].join('\n'),
+      body: {
+        question,
+        contextDocCount: topDocs.length,
+        maxTokens: 700
+      }
     });
-    answer = answerRes.choices[0]?.message?.content || '';
   } catch (error: unknown) {
     ragLogger.warn('Failed to generate RAG answer', {
       operation: 'answerQuestion',
@@ -788,17 +828,24 @@ export async function answerQuestion(question: string): Promise<{ answer: string
 
   let verification = '';
   try {
-    const verifyRes = await adapter.responses.create({
-      model: getDefaultModel(),
-      messages: [
-        {
-          role: 'system',
-          content: 'Verify if the answer is supported by the context. Reply yes or no with a brief reason.'
-        },
-        { role: 'user', content: `Answer: ${answer}\n\nContext:\n${context}` },
-      ],
+    verification = await runRagTrinityText({
+      client,
+      sourceEndpoint: 'webRag.verifyAnswer',
+      maxOutputTokens: 180,
+      prompt: [
+        'SYSTEM:',
+        'Verify if the answer is supported by the context. Reply yes or no with a brief reason.',
+        '',
+        'USER:',
+        `Answer: ${answer}\n\nContext:\n${context}`
+      ].join('\n'),
+      body: {
+        question,
+        answer,
+        contextDocCount: topDocs.length,
+        maxTokens: 180
+      }
     });
-    verification = verifyRes.choices[0]?.message?.content || '';
   } catch (error: unknown) {
     ragLogger.warn('Failed to verify RAG answer', {
       operation: 'answerQuestion',

--- a/src/services/webSearchAgent.ts
+++ b/src/services/webSearchAgent.ts
@@ -1,12 +1,16 @@
 import { createHash } from 'node:crypto';
 import { load } from 'cheerio';
 import { fetchAndCleanDocument } from '@shared/webFetcher.js';
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
 import { buildClear2Summary } from '@services/clear2.js';
-import { createCentralizedCompletion, getDefaultModel, hasValidAPIKey } from '@services/openai.js';
+import { getDefaultModel, hasValidAPIKey } from '@services/openai.js';
+import { getOpenAIClientOrAdapter } from '@services/openai/clientBridge.js';
 import { getEnv, getEnvBoolean, getEnvNumber } from '@platform/runtime/env.js';
 import { resolveErrorMessage } from '@core/lib/errors/index.js';
 import type { ClearScore } from '@shared/types/actionPlan.js';
 import type { FetchAndCleanLinkSummary } from '@shared/webFetcher.js';
+import type OpenAI from 'openai';
 
 export type SearchProviderName =
   | 'auto'
@@ -193,15 +197,6 @@ interface SearxngSearchResult {
 
 interface SearxngSearchResponse {
   results?: SearxngSearchResult[];
-}
-
-interface CompletionResponseLike {
-  content?: unknown;
-  choices?: Array<{
-    message?: {
-      content?: unknown;
-    };
-  }>;
 }
 
 interface FetchedSourcePacketResult {
@@ -551,16 +546,6 @@ function isLikelyTraversableUrl(url: string): boolean {
   }
 }
 
-function extractCompletionText(response: unknown): string {
-  const completion = response as CompletionResponseLike | null | undefined;
-  if (typeof completion?.content === 'string') {
-    return completion.content;
-  }
-
-  const content = completion?.choices?.[0]?.message?.content;
-  return typeof content === 'string' ? content : '';
-}
-
 function escapePromptData(value: string): string {
   return value
     .replace(/&/g, '&amp;')
@@ -799,7 +784,8 @@ function buildSearchClearScore(query: string, options: Required<Omit<WebSearchAg
 async function synthesizeSources(
   query: string,
   sources: SearchSourcePacket[],
-  model: string
+  model: string,
+  client: OpenAI
 ): Promise<SearchSynthesisResult> {
   const usableSources = sources.filter((source) => (source.content ?? source.snapshot.excerpt) && source.metadata.fetchStatus === 'ok');
   const packetText = usableSources.map((source) => {
@@ -848,13 +834,42 @@ async function synthesizeSources(
     }
   ];
 
-  const response = await createCentralizedCompletion(messages, {
-    model,
-    temperature: 0.2,
-    max_tokens: 700
+  const prompt = messages
+    .map((message) => `${message.role.toUpperCase()}:\n${message.content}`)
+    .join('\n\n');
+
+  const response = await runTrinityWritingPipeline({
+    input: {
+      prompt,
+      moduleId: 'WEB_SEARCH:SYNTHESIS',
+      sourceEndpoint: 'webSearchAgent.synthesize',
+      requestedAction: 'query',
+      body: {
+        query,
+        messages,
+        requestedModel: model,
+        sourceCount: usableSources.length,
+        maxTokens: 700
+      },
+      maxOutputTokens: 700,
+      executionMode: 'request',
+      background: {
+        requestedModel: model,
+        sourceCount: usableSources.length
+      }
+    },
+    context: {
+      client,
+      runtimeBudget: createRuntimeBudget(),
+      runOptions: {
+        answerMode: 'direct',
+        strictUserVisibleOutput: true,
+        requestedVerbosity: 'minimal'
+      }
+    }
   });
 
-  const text = extractCompletionText(response);
+  const text = response.result;
 
   return {
     text: text.trim(),
@@ -1175,14 +1190,15 @@ export async function webSearchAgent(query: string, options: WebSearchAgentOptio
 
   let answer: SearchSynthesisResult | null = null;
   if (normalizedOptions.synthesize) {
-    if (!hasValidAPIKey()) {
+    const { client } = getOpenAIClientOrAdapter();
+    if (!hasValidAPIKey() || !client) {
       notes.push('Synthesis skipped because OpenAI credentials are not configured.');
     } else if (clear.decision === 'block') {
       notes.push('Synthesis skipped because CLEAR blocked this search plan.');
     } else {
       const synthesisModel = options.synthesisModel?.trim() || getDefaultModel();
       try {
-        answer = await synthesizeSources(query, sources, synthesisModel);
+        answer = await synthesizeSources(query, sources, synthesisModel, client);
     } catch (error) {
       //audit Assumption: synthesis is an optional enrichment layer; failure risk: upstream model issues hide otherwise useful grounded packets; expected invariant: raw search packets remain available even when synthesis fails; handling strategy: append a note and return answer as null.
       notes.push(`Synthesis failed: ${resolveErrorMessage(error)}`);

--- a/src/shared/gpt/messageContentText.ts
+++ b/src/shared/gpt/messageContentText.ts
@@ -1,0 +1,52 @@
+export function extractMessageContentText(content: unknown): string | null {
+  if (typeof content === 'string' && content.trim().length > 0) {
+    return content.trim();
+  }
+
+  if (!Array.isArray(content)) {
+    return null;
+  }
+
+  const parts = content
+    .map((part) => {
+      if (typeof part === 'string') {
+        return part;
+      }
+
+      if (part && typeof part === 'object' && !Array.isArray(part)) {
+        const record = part as Record<string, unknown>;
+        return typeof record.text === 'string' ? record.text : '';
+      }
+
+      return '';
+    })
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  return parts.length > 0 ? parts.join('\n') : null;
+}
+
+export function extractLastUserMessageText(messages: unknown): string | null {
+  if (!Array.isArray(messages)) {
+    return null;
+  }
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message || typeof message !== 'object' || Array.isArray(message)) {
+      continue;
+    }
+
+    const record = message as Record<string, unknown>;
+    if (record.role !== 'user') {
+      continue;
+    }
+
+    const text = extractMessageContentText(record.content);
+    if (text) {
+      return text;
+    }
+  }
+
+  return null;
+}

--- a/src/shared/http/clientRouteResultShape.ts
+++ b/src/shared/http/clientRouteResultShape.ts
@@ -27,7 +27,66 @@ function pickTrinitySummary(value: Record<string, unknown>): Record<string, unkn
     ...(readString(value.gpt5Model) ? { gpt5Model: readString(value.gpt5Model) } : {}),
     ...(readBoolean(value.dryRun) !== undefined ? { dryRun: readBoolean(value.dryRun) } : {}),
     ...(readString(value.error) ? { error: readString(value.error) } : {}),
+    ...(pickTrinityPublicMeta(value.meta) ? { meta: pickTrinityPublicMeta(value.meta) } : {}),
   };
+}
+
+function pickTrinityPublicMeta(value: unknown): Record<string, unknown> | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const output: Record<string, unknown> = {
+    ...(readString(value.pipeline) ? { pipeline: readString(value.pipeline) } : {}),
+    ...(readBoolean(value.bypass) !== undefined ? { bypass: readBoolean(value.bypass) } : {}),
+    ...(readString(value.sourceEndpoint) ? { sourceEndpoint: readString(value.sourceEndpoint) } : {}),
+    ...(readString(value.classification) ? { classification: readString(value.classification) } : {}),
+    ...(readString(value.gptId) ? { gptId: readString(value.gptId) } : {}),
+    ...(readString(value.moduleId) ? { moduleId: readString(value.moduleId) } : {}),
+    ...(readString(value.requestedAction) ? { requestedAction: readString(value.requestedAction) } : {}),
+    ...(readString(value.executionMode) ? { executionMode: readString(value.executionMode) } : {}),
+    ...(readNumber(value.tokenLimit) !== undefined ? { tokenLimit: readNumber(value.tokenLimit) } : {}),
+    ...(readNumber(value.outputLimit) !== undefined ? { outputLimit: readNumber(value.outputLimit) } : {}),
+    ...(readBoolean(value.cached) !== undefined ? { cached: readBoolean(value.cached) } : {}),
+    ...(readBoolean(value.cacheHit) !== undefined ? { cacheHit: readBoolean(value.cacheHit) } : {}),
+  };
+
+  const tokens = pickTrinityPublicTokenMeta(value.tokens);
+  if (tokens) {
+    output.tokens = tokens;
+  }
+
+  const cache = pickTrinityPublicCacheMeta(value.cache);
+  if (cache) {
+    output.cache = cache;
+  }
+
+  return Object.keys(output).length > 0 ? output : null;
+}
+
+function pickTrinityPublicTokenMeta(value: unknown): Record<string, number> | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const output: Record<string, number> = {};
+  for (const key of ['prompt_tokens', 'completion_tokens', 'total_tokens'] as const) {
+    const numberValue = readNumber(value[key]);
+    if (numberValue !== undefined) {
+      output[key] = numberValue;
+    }
+  }
+
+  return Object.keys(output).length > 0 ? output : null;
+}
+
+function pickTrinityPublicCacheMeta(value: unknown): Record<string, boolean> | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const hit = readBoolean(value.hit);
+  return hit === undefined ? null : { hit };
 }
 
 function pickHealthSummary(value: Record<string, unknown>): Record<string, unknown> | null {

--- a/src/shared/http/clientRouteResultShape.ts
+++ b/src/shared/http/clientRouteResultShape.ts
@@ -17,6 +17,8 @@ function pickTrinitySummary(value: Record<string, unknown>): Record<string, unkn
     return null;
   }
 
+  const trinityMeta = pickTrinityPublicMeta(value.meta);
+
   return {
     result,
     module: moduleName,
@@ -27,7 +29,7 @@ function pickTrinitySummary(value: Record<string, unknown>): Record<string, unkn
     ...(readString(value.gpt5Model) ? { gpt5Model: readString(value.gpt5Model) } : {}),
     ...(readBoolean(value.dryRun) !== undefined ? { dryRun: readBoolean(value.dryRun) } : {}),
     ...(readString(value.error) ? { error: readString(value.error) } : {}),
-    ...(pickTrinityPublicMeta(value.meta) ? { meta: pickTrinityPublicMeta(value.meta) } : {}),
+    ...(trinityMeta ? { meta: trinityMeta } : {}),
   };
 }
 

--- a/src/transport/http/controllers/openaiController.ts
+++ b/src/transport/http/controllers/openaiController.ts
@@ -8,8 +8,8 @@
  */
 
 import { Request, Response } from 'express';
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
 import {
-  callOpenAI,
   getDefaultModel,
   getFallbackModel,
   getGPT5Model,
@@ -34,6 +34,7 @@ import { getConfirmGateConfiguration } from "@transport/http/middleware/confirmG
 import { config } from "@platform/runtime/config.js";
 import { getEnv } from "@platform/runtime/env.js";
 import { runWithRequestAbortTimeout, getRequestAbortSignal } from '@arcanos/runtime';
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
 import {
   extractPromptText,
   recordPromptDebugTrace,
@@ -100,7 +101,7 @@ export async function handlePrompt(
     return;
   }
 
-  const { input: prompt } = validation;
+  const { client: openai, input: prompt, body } = validation;
   const modelOverride = typeof req.body.model === 'string' ? req.body.model.trim() : undefined;
   const model = modelOverride && modelOverride.length > 0 ? modelOverride : getDefaultModel();
   const promptRouteMitigation = getPromptRouteMitigationState();
@@ -233,7 +234,7 @@ export async function handlePrompt(
       });
     }
 
-    const { output, model: activeModel } = await runWithRequestAbortTimeout(
+    const trinityResult = await runWithRequestAbortTimeout(
       {
         timeoutMs: promptRoutePolicy.pipelineTimeoutMs,
         requestId: (req as Request & { requestId?: string }).requestId,
@@ -256,14 +257,30 @@ export async function handlePrompt(
         }
       },
       async () =>
-        callOpenAI(effectiveModel, prompt, effectiveTokenLimit, true, {
-          signal: getRequestAbortSignal(),
-          timeoutMs: promptRoutePolicy.providerTimeoutMs ?? undefined,
-          maxRetries: promptRoutePolicy.maxRetries,
-          metadata: {
-            ...mitigationMetadata,
-            providerTimeoutMs: promptRoutePolicy.providerTimeoutMs,
-            pipelineTimeoutMs: promptRoutePolicy.pipelineTimeoutMs
+        runTrinityWritingPipeline({
+          input: {
+            prompt,
+            moduleId: 'OPENAI:PROMPT',
+            sourceEndpoint: PROMPT_ROUTE_PATH,
+            requestedAction: 'query',
+            body: {
+              ...body,
+              model: effectiveModel,
+              tokenLimit: effectiveTokenLimit,
+              mitigation: mitigationMetadata
+            },
+            tokenLimit: effectiveTokenLimit,
+            executionMode: 'request'
+          },
+          context: {
+            client: openai,
+            requestId,
+            runtimeBudget: createRuntimeBudget(),
+            runOptions: {
+              answerMode: 'direct',
+              strictUserVisibleOutput: true,
+              watchdogModelTimeoutMs: promptRoutePolicy.providerTimeoutMs ?? undefined
+            }
           }
         })
     );
@@ -276,28 +293,25 @@ export async function handlePrompt(
       selectedRoute: PROMPT_ROUTE_PATH,
       selectedModule: 'openai.prompt',
       finalExecutorPayload: {
-        executor: 'callOpenAI',
+        executor: 'runTrinityWritingPipeline',
         model: effectiveModel,
         prompt,
         tokenLimit: effectiveTokenLimit,
-        useCache: true,
         options: {
           timeoutMs: promptRoutePolicy.providerTimeoutMs ?? null,
-          maxRetries: promptRoutePolicy.maxRetries,
           metadata: mitigationMetadata,
         },
       },
     });
     const successPayload = {
-      result: output,
-      model: activeModel,
+      result: trinityResult.result,
+      model: trinityResult.activeModel,
       meta: {
-        id: `prompt_${timestamp}`,
-        created: timestamp,
-        tokens: undefined
+        ...trinityResult.meta,
+        created: trinityResult.meta.created ?? timestamp
       },
-      activeModel,
-      fallbackFlag: promptRoutePolicy.useFallbackModel
+      activeModel: trinityResult.activeModel,
+      fallbackFlag: trinityResult.fallbackFlag || promptRoutePolicy.useFallbackModel
     };
     recordPromptDebugTrace(requestId, 'response', {
       endpoint: PROMPT_ROUTE_PATH,

--- a/src/transport/http/middleware/costControl/defaults.ts
+++ b/src/transport/http/middleware/costControl/defaults.ts
@@ -1,5 +1,6 @@
-import { callOpenAI } from "@services/openai.js";
-import { getDefaultModel } from "@services/openai/credentialProvider.js";
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
+import { getOpenAIClientOrAdapter } from '@services/openai/clientBridge.js';
 import type { CostControlConfig, OpenAIClient, OpenAIRequestPayload } from './types.js';
 
 export const DEFAULT_CONFIG: CostControlConfig = {
@@ -13,11 +14,45 @@ export const DEFAULT_CONFIG: CostControlConfig = {
 
 export function createDefaultOpenAIClient(config: CostControlConfig): OpenAIClient {
   const call = async (payload: OpenAIRequestPayload) => {
-    const model = payload.model ?? getDefaultModel();
+    const { client } = getOpenAIClientOrAdapter();
+    if (!client) {
+      throw new Error('OpenAI client unavailable for cost-control Trinity execution.');
+    }
+
     const tokenLimit = payload.maxTokens ?? config.defaultTokenLimit;
-    //audit Assumption: model/tokenLimit are valid inputs; risk: invalid configuration; invariant: callOpenAI returns a result or throws; handling: propagate errors.
-    return callOpenAI(model, payload.prompt, tokenLimit, true, {
-      metadata: payload.metadata
+    const sourceEndpoint =
+      typeof payload.metadata?.route === 'string' && payload.metadata.route.trim().length > 0
+        ? payload.metadata.route.trim()
+        : 'costControl.defaultOpenAIClient';
+
+    //audit Assumption: prompt middleware traffic is user-facing generation; risk: bypassing write-plane controls; invariant: default cost-control execution enters Trinity; handling: route through the generation facade.
+    return runTrinityWritingPipeline({
+      input: {
+        prompt: payload.prompt,
+        moduleId: 'COST_CONTROL',
+        sourceEndpoint,
+        requestedAction: 'query',
+        body: {
+          prompt: payload.prompt,
+          requestedModel: payload.model,
+          maxTokens: tokenLimit,
+          metadata: payload.metadata
+        },
+        maxOutputTokens: tokenLimit,
+        executionMode: 'request',
+        background: {
+          requestedModel: payload.model ?? null,
+          costControl: true
+        }
+      },
+      context: {
+        client,
+        runtimeBudget: createRuntimeBudget(),
+        runOptions: {
+          answerMode: 'direct',
+          strictUserVisibleOutput: true
+        }
+      }
     });
   };
   const batch = async (payloads: OpenAIRequestPayload[]) => {

--- a/src/trinity/trinity.ts
+++ b/src/trinity/trinity.ts
@@ -1,10 +1,7 @@
-import OpenAI from 'openai';
-
 import { DEFAULT_MODEL } from '../config/openai.js';
-import { runResponse } from '../lib/runResponse.js';
-import { resolveErrorMessage } from '@core/lib/errors/index.js';
-import { logger } from '@platform/logging/structuredLogging.js';
-import { getFallbackModel } from '@services/openai.js';
+import { runTrinityWritingPipeline } from '@core/logic/trinityWritingPipeline.js';
+import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
+import { getOpenAIClientOrAdapter } from '@services/openai/clientBridge.js';
 
 type TrinityOptions = {
   prompt: string;
@@ -14,148 +11,14 @@ type TrinityOptions = {
   latencyBudgetMs?: number;
 };
 
-class ModelLatencyBudgetExceededError extends Error {
-  readonly model: string;
-  readonly latencyBudgetMs: number;
-
-  constructor(model: string, latencyBudgetMs: number) {
-    super(`Model '${model}' exceeded the per-attempt latency budget of ${latencyBudgetMs}ms.`);
-    this.name = 'ModelLatencyBudgetExceededError';
-    this.model = model;
-    this.latencyBudgetMs = latencyBudgetMs;
-  }
-}
-
-function extractOutputText(response: OpenAI.Responses.Response): string | null {
-  const message = response.output.find(
-    (item): item is OpenAI.Responses.ResponseOutputMessage => item.type === 'message'
-  );
-
-  const outputText = message?.content.find(
-    (part): part is OpenAI.Responses.ResponseOutputText => part.type === 'output_text'
-  );
-
-  return outputText?.text ?? null;
-}
-
 function buildStructuredPrompt(prompt: string): string {
   return `${prompt}\n\nReturn a valid JSON object. The word json is intentionally present for JSON response mode.`;
 }
 
-function buildResponseInput(prompt: string, structured: boolean): OpenAI.Responses.ResponseInput {
-  return [
-    {
-      role: 'user',
-      content: structured ? buildStructuredPrompt(prompt) : prompt
-    }
-  ];
-}
-
-function normalizeLatencyBudgetMs(latencyBudgetMs: number | undefined): number | null {
-  //audit Assumption: route-supplied latency budgets must be positive finite integers; failure risk: invalid values disable timeout enforcement or cause immediate aborts; expected invariant: model attempts either run unbounded or with a sane millisecond ceiling; handling strategy: sanitize invalid inputs to `null` and floor valid values.
-  if (typeof latencyBudgetMs !== 'number' || !Number.isFinite(latencyBudgetMs) || latencyBudgetMs <= 0) {
-    return null;
-  }
-
-  return Math.floor(latencyBudgetMs);
-}
-
-function isModelLatencyBudgetExceededError(error: unknown): error is ModelLatencyBudgetExceededError {
-  return error instanceof ModelLatencyBudgetExceededError;
-}
-
-function startLatencyBudgetAbortTimer(
-  model: string,
-  latencyBudgetMs: number
-): {
-  abortSignal: AbortSignal;
-  clearBudgetTimer: () => void;
-  latencyBudgetPromise: Promise<never>;
-} {
-  const abortController = new AbortController();
-  let rejectBudgetPromise: ((error: ModelLatencyBudgetExceededError) => void) | null = null;
-  const latencyBudgetPromise = new Promise<never>((_resolve, reject) => {
-    rejectBudgetPromise = reject as (error: ModelLatencyBudgetExceededError) => void;
-  });
-
-  const timeoutHandle = setTimeout(() => {
-    abortController.abort();
-    rejectBudgetPromise?.(new ModelLatencyBudgetExceededError(model, latencyBudgetMs));
-  }, latencyBudgetMs);
-
-  if (typeof timeoutHandle === 'object' && typeof timeoutHandle.unref === 'function') {
-    timeoutHandle.unref();
-  }
-
-  return {
-    abortSignal: abortController.signal,
-    clearBudgetTimer: () => clearTimeout(timeoutHandle),
-    latencyBudgetPromise
-  };
-}
-
-async function runModelAttemptWithinLatencyBudget(options: {
-  model: string;
-  input: OpenAI.Responses.ResponseInput;
-  temperature: number;
-  structured: boolean;
-  latencyBudgetMs?: number;
-}): Promise<OpenAI.Responses.Response> {
-  const normalizedLatencyBudgetMs = normalizeLatencyBudgetMs(options.latencyBudgetMs);
-
-  if (normalizedLatencyBudgetMs === null) {
-    return runResponse({
-      model: options.model,
-      input: options.input,
-      temperature: options.temperature,
-      json: options.structured
-    });
-  }
-
-  const timedRequest = startLatencyBudgetAbortTimer(options.model, normalizedLatencyBudgetMs);
-  const modelResponsePromise = runResponse({
-    model: options.model,
-    input: options.input,
-    temperature: options.temperature,
-    json: options.structured,
-    requestOptions: {
-      signal: timedRequest.abortSignal
-    }
-  });
-
-  try {
-    return await Promise.race([
-      modelResponsePromise,
-      timedRequest.latencyBudgetPromise
-    ]);
-  } finally {
-    timedRequest.clearBudgetTimer();
-  }
-}
-
-function logLatencyBudgetExceeded(options: {
-  requestedModel: string;
-  activeModel: string;
-  attempt: 'primary' | 'fallback';
-  elapsedMs: number;
-  latencyBudgetMs: number;
-}) {
-  logger.warn('MODEL_LATENCY_BUDGET_EXCEEDED', {
-    module: 'trinity.route',
-    operation: 'model-timeout',
-    stage: 'QUERY_FINETUNE_ROUTE',
-    attempt: options.attempt,
-    requestedModel: options.requestedModel,
-    activeModel: options.activeModel,
-    latencyBudgetMs: options.latencyBudgetMs,
-    elapsedMs: options.elapsedMs
-  });
-}
-
 /**
- * Purpose: execute the lightweight fine-tuned Trinity route with explicit base-model fallback.
- * Inputs/Outputs: prompt + optional model/temperature/structured flag + per-attempt latency budget -> model output plus fallback metadata.
- * Edge cases: when the primary model fails and fallback is distinct, the fallback attempt is logged and returned with `fallbackFlag: true`; timeout-budget overruns emit structured warnings before failover; if both attempts fail, the combined error is thrown.
+ * Purpose: execute the legacy fine-tuned Trinity route through the canonical Trinity generation facade.
+ * Inputs/Outputs: prompt + compatibility options -> legacy response envelope backed by TrinityResult.
+ * Edge cases: `model` and `temperature` are preserved as compatibility metadata; model selection is owned by Trinity.
  */
 export async function runTrinity({
   prompt,
@@ -164,96 +27,45 @@ export async function runTrinity({
   structured = true,
   latencyBudgetMs
 }: TrinityOptions) {
-  const requestedModel = model;
-  const responseInput = buildResponseInput(prompt, structured);
-  const normalizedLatencyBudgetMs = normalizeLatencyBudgetMs(latencyBudgetMs);
-  const primaryAttemptStartedAtMs = Date.now();
-
-  try {
-    const response = await runModelAttemptWithinLatencyBudget({
-      model: requestedModel,
-      input: responseInput as OpenAI.Responses.ResponseInput,
-      temperature,
-      structured,
-      latencyBudgetMs: normalizedLatencyBudgetMs ?? undefined
-    });
-
-    return {
-      requestedModel,
-      model: response.model,
-      activeModel: response.model,
-      output: extractOutputText(response),
-      fallbackFlag: false,
-      raw: response
-    };
-  } catch (primaryError) {
-    const fallbackModel = getFallbackModel();
-    const normalizedRequestedModel = requestedModel.trim();
-    const normalizedFallbackModel = fallbackModel.trim();
-    const fallbackReason = resolveErrorMessage(primaryError);
-
-    //audit Assumption: latency-budget aborts are operationally distinct from generic model failures; failure risk: timeout spikes blend into normal fallback traffic and stay invisible; expected invariant: per-attempt budget breaches emit an explicit structured warning before fallback runs; handling strategy: detect the synthetic budget error and log it with attempt metadata.
-    if (isModelLatencyBudgetExceededError(primaryError)) {
-      logLatencyBudgetExceeded({
-        requestedModel: normalizedRequestedModel,
-        activeModel: normalizedRequestedModel,
-        attempt: 'primary',
-        elapsedMs: Date.now() - primaryAttemptStartedAtMs,
-        latencyBudgetMs: primaryError.latencyBudgetMs
-      });
-    }
-
-    //audit Assumption: fallback should only run when it changes the model choice; failure risk: retry loop silently repeats the same failing model; expected invariant: fallback attempts use a distinct model id; handling strategy: short-circuit and rethrow when no distinct fallback model exists.
-    if (normalizedFallbackModel.length === 0 || normalizedFallbackModel === normalizedRequestedModel) {
-      throw primaryError;
-    }
-
-    logger.warn('MODEL_FALLBACK_TRIGGERED', {
-      module: 'trinity.route',
-      operation: 'model-fallback',
-      stage: 'QUERY_FINETUNE_ROUTE',
-      requestedModel: normalizedRequestedModel,
-      fallbackModel: normalizedFallbackModel,
-      reason: fallbackReason,
-      latencyBudgetMs: normalizedLatencyBudgetMs
-    });
-
-    const fallbackAttemptStartedAtMs = Date.now();
-
-    try {
-      //audit Assumption: a timeout-triggered failover still needs its own bounded attempt window; failure risk: a strict end-to-end budget leaves no time for fallback and converts timeout resilience into immediate 500s; expected invariant: both primary and fallback model calls are individually bounded; handling strategy: reuse the sanitized per-attempt latency budget on the fallback request as well.
-      const fallbackResponse = await runModelAttemptWithinLatencyBudget({
-        model: normalizedFallbackModel,
-        input: responseInput as OpenAI.Responses.ResponseInput,
-        temperature,
-        structured,
-        latencyBudgetMs: normalizedLatencyBudgetMs ?? undefined
-      });
-
-      return {
-        requestedModel: normalizedRequestedModel,
-        model: fallbackResponse.model,
-        activeModel: fallbackResponse.model,
-        output: extractOutputText(fallbackResponse),
-        fallbackFlag: true,
-        fallbackReason,
-        raw: fallbackResponse
-      };
-    } catch (fallbackError) {
-      if (isModelLatencyBudgetExceededError(fallbackError)) {
-        logLatencyBudgetExceeded({
-          requestedModel: normalizedRequestedModel,
-          activeModel: normalizedFallbackModel,
-          attempt: 'fallback',
-          elapsedMs: Date.now() - fallbackAttemptStartedAtMs,
-          latencyBudgetMs: fallbackError.latencyBudgetMs
-        });
-      }
-
-      //audit Assumption: callers need both failure causes when fallback also fails; failure risk: root-cause context is lost behind the second exception; expected invariant: thrown error names both the primary and fallback failures; handling strategy: synthesize a combined error message with both reasons.
-      throw new Error(
-        `Primary model '${normalizedRequestedModel}' failed (${fallbackReason}); fallback model '${normalizedFallbackModel}' failed (${resolveErrorMessage(fallbackError)}).`
-      );
-    }
+  const { client } = getOpenAIClientOrAdapter();
+  if (!client) {
+    throw new Error('OpenAI client unavailable for query-finetune Trinity facade.');
   }
+
+  const trinityResult = await runTrinityWritingPipeline({
+    input: {
+      prompt: structured ? buildStructuredPrompt(prompt) : prompt,
+      moduleId: 'QUERY:FINETUNE',
+      sourceEndpoint: 'query-finetune',
+      requestedAction: 'query',
+      body: {
+        prompt,
+        model,
+        temperature,
+        structured
+      },
+      executionMode: 'request'
+    },
+    context: {
+      client,
+      runtimeBudget: createRuntimeBudget(),
+      runOptions: {
+        answerMode: structured ? 'audit' : 'direct',
+        strictUserVisibleOutput: true,
+        ...(typeof latencyBudgetMs === 'number' && Number.isFinite(latencyBudgetMs) && latencyBudgetMs > 0
+          ? { watchdogModelTimeoutMs: Math.trunc(latencyBudgetMs) }
+          : {})
+      }
+    }
+  });
+
+  return {
+    requestedModel: model,
+    model: trinityResult.activeModel,
+    activeModel: trinityResult.activeModel,
+    output: trinityResult.result,
+    fallbackFlag: trinityResult.fallbackFlag,
+    fallbackReason: trinityResult.fallbackSummary.fallbackReasons.join('; ') || undefined,
+    raw: trinityResult
+  };
 }

--- a/src/workers/jobRunner.ts
+++ b/src/workers/jobRunner.ts
@@ -361,6 +361,26 @@ function hydrateQueuedGptBodyPrompt(
   };
 }
 
+function attachQueuedGptExecutionMetadata(
+  body: Record<string, unknown>,
+  params: {
+    requestPath?: string;
+    executionModeReason?: string;
+    routeHint?: string;
+  }
+): Record<string, unknown> {
+  return {
+    ...body,
+    __arcanosSourceEndpoint: params.requestPath ?? 'worker.gpt.background',
+    ...(params.executionModeReason
+      ? { __arcanosExecutionReason: params.executionModeReason }
+      : {}),
+    ...(params.routeHint
+      ? { __arcanosRequestedAction: params.routeHint }
+      : {})
+  };
+}
+
 async function ensureOpenAIClientForSlot(params: {
   workerId: string;
   currentClient: OpenAIClient | null;
@@ -561,8 +581,24 @@ async function executeQueuedGptRequest(params: {
   }
 
   const routeStartedAtMs = Date.now();
-  const { gptId, body, requestId, prompt, bypassIntentRouting } = parsedGptJobInput.value;
-  const hydratedBody = hydrateQueuedGptBodyPrompt(body, prompt);
+  const {
+    gptId,
+    body,
+    requestId,
+    prompt,
+    bypassIntentRouting,
+    requestPath,
+    executionModeReason,
+    routeHint
+  } = parsedGptJobInput.value;
+  const hydratedBody = attachQueuedGptExecutionMetadata(
+    hydrateQueuedGptBodyPrompt(body, prompt),
+    {
+      requestPath,
+      executionModeReason,
+      routeHint
+    }
+  );
   const latestJob = await getJobById(params.jobId);
   const resolveCancellationReason = async (
     fallbackMessage: string,

--- a/tests/afol-route-cache-metadata.test.ts
+++ b/tests/afol-route-cache-metadata.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const runTrinityWritingPipelineMock = jest.fn();
+const getOpenAIClientOrAdapterMock = jest.fn();
+const recordTraceEventMock = jest.fn();
+const createRuntimeBudgetMock = jest.fn(() => ({ budgetId: 'runtime-budget' }));
+
+jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
+  runTrinityWritingPipeline: runTrinityWritingPipelineMock
+}));
+
+jest.unstable_mockModule('@services/openai.js', () => ({
+  getDefaultModel: jest.fn(() => 'ft:primary-model'),
+  getFallbackModel: jest.fn(() => 'ft:backup-model'),
+  generateMockResponse: jest.fn(() => ({
+    result: 'mock fallback',
+    activeModel: 'mock'
+  }))
+}));
+
+jest.unstable_mockModule('@services/openai/clientBridge.js', () => ({
+  getOpenAIClientOrAdapter: getOpenAIClientOrAdapterMock
+}));
+
+jest.unstable_mockModule('@platform/logging/telemetry.js', () => ({
+  recordTraceEvent: recordTraceEventMock,
+  recordLogEvent: jest.fn()
+}));
+
+jest.unstable_mockModule('@platform/resilience/runtimeBudget.js', () => ({
+  createRuntimeBudget: createRuntimeBudgetMock
+}));
+
+const { executeRoute } = await import('../src/core/afol/routes.js');
+
+const cacheMetadataCases: Array<[string, Record<string, unknown>]> = [
+  ['meta.cached', { cached: true }],
+  ['meta.cacheHit', { cacheHit: true }],
+  ['meta.cache.hit', { cache: { hit: true } }]
+];
+
+describe('AFOL route cache metadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getOpenAIClientOrAdapterMock.mockReturnValue({ client: { responses: {} } });
+  });
+
+  it.each(cacheMetadataCases)('reports Trinity %s as an AFOL cache hit', async (_label, meta) => {
+    runTrinityWritingPipelineMock.mockResolvedValue({
+      result: 'cached AFOL answer',
+      activeModel: 'ft:primary-model',
+      meta
+    });
+
+    const result = await executeRoute(
+      { name: 'primary', reason: 'Primary healthy' },
+      {
+        prompt: 'Explain the cache status.',
+        intent: 'cache-check'
+      }
+    );
+
+    expect(result).toEqual({
+      route: 'primary',
+      input: 'Explain the cache status.',
+      output: 'cached AFOL answer',
+      model: 'ft:primary-model',
+      cached: true,
+      metadata: {
+        routeReason: 'Primary healthy',
+        intent: 'cache-check'
+      }
+    });
+    expect(recordTraceEventMock).toHaveBeenCalledWith('afol.route.success', {
+      route: 'primary',
+      model: 'ft:primary-model',
+      cached: true
+    });
+  });
+});

--- a/tests/api-arcanos.route.test.ts
+++ b/tests/api-arcanos.route.test.ts
@@ -13,7 +13,17 @@ const mockTryExecutePromptRouteShortcut = jest.fn();
 const verificationRouter = express.Router();
 
 jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
-  runTrinityWritingPipeline: mockRunThroughBrain
+  runTrinityWritingPipeline: mockRunThroughBrain,
+  applyTrinityGenerationInvariant: (result: any, params: any) => ({
+    ...result,
+    meta: {
+      ...(result.meta ?? {}),
+      pipeline: 'trinity',
+      bypass: false,
+      sourceEndpoint: params.sourceEndpoint,
+      classification: 'writing'
+    }
+  })
 }));
 
 jest.unstable_mockModule('@transport/http/middleware/confirmGate.js', () => ({

--- a/tests/api-reusable-code.route.test.ts
+++ b/tests/api-reusable-code.route.test.ts
@@ -1,0 +1,70 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const generateReusableCodeSnippetsMock = jest.fn();
+const getOpenAIClientOrAdapterMock = jest.fn();
+
+jest.unstable_mockModule('@services/reusableCodeGeneration.js', () => ({
+  generateReusableCodeSnippets: generateReusableCodeSnippetsMock,
+}));
+
+jest.unstable_mockModule('@services/openai/clientBridge.js', () => ({
+  getOpenAIClientOrAdapter: getOpenAIClientOrAdapterMock,
+}));
+
+const { default: reusableCodeRouter } = await import('../src/routes/api-reusable-code.ts');
+
+describe('/api/reusables route', () => {
+  const app = express();
+  app.use(express.json());
+  app.use(reusableCodeRouter);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getOpenAIClientOrAdapterMock.mockReturnValue({
+      client: { responses: { create: jest.fn() } },
+      adapter: {},
+    });
+    generateReusableCodeSnippetsMock.mockResolvedValue({
+      model: 'gpt-4.1',
+      snippets: [
+        {
+          name: 'idGenerator',
+          description: 'Generate IDs.',
+          language: 'typescript',
+          code: 'export const idGenerator = () => crypto.randomUUID();',
+        },
+      ],
+      raw: '{"snippets":[]}',
+      meta: {
+        pipeline: 'trinity',
+        bypass: false,
+        sourceEndpoint: 'api.reusables',
+        classification: 'writing',
+        moduleId: 'REUSABLE:CODE',
+        requestedAction: 'query',
+        executionMode: 'request',
+      },
+    });
+  });
+
+  it('returns Trinity invariant metadata with successful reusable code output', async () => {
+    const response = await request(app)
+      .post('/api/reusables')
+      .send({ target: 'idGenerator', includeDocs: false, language: 'typescript' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(expect.objectContaining({
+      success: true,
+      model: 'gpt-4.1',
+      snippets: expect.any(Array),
+      meta: expect.objectContaining({
+        pipeline: 'trinity',
+        bypass: false,
+        sourceEndpoint: 'api.reusables',
+        classification: 'writing',
+      }),
+    }));
+  });
+});

--- a/tests/arcanos-core-module.test.ts
+++ b/tests/arcanos-core-module.test.ts
@@ -21,6 +21,16 @@ beforeEach(async () => {
 
   jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
     runTrinityWritingPipeline: mockRunThroughBrain,
+    applyTrinityGenerationInvariant: (result: any, params: any) => ({
+      ...result,
+      meta: {
+        ...(result.meta ?? {}),
+        pipeline: 'trinity',
+        bypass: false,
+        sourceEndpoint: params.sourceEndpoint,
+        classification: 'writing',
+      },
+    }),
   }));
 
   jest.unstable_mockModule('@platform/resilience/runtimeBudget.js', () => ({

--- a/tests/arcanos-core.service.test.ts
+++ b/tests/arcanos-core.service.test.ts
@@ -12,6 +12,16 @@ const getRequestAbortContextMock = jest.fn(() => null);
 
 jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
   runTrinityWritingPipeline: mockRunTrinityWritingPipeline,
+  applyTrinityGenerationInvariant: (result: any, params: any) => ({
+    ...result,
+    meta: {
+      ...(result.meta ?? {}),
+      pipeline: 'trinity',
+      bypass: false,
+      sourceEndpoint: params.sourceEndpoint,
+      classification: 'writing'
+    }
+  }),
 }));
 
 jest.unstable_mockModule('@services/openai.js', () => ({
@@ -77,22 +87,25 @@ describe('ARCANOS:CORE service', () => {
     });
 
     expect(mockRunTrinityWritingPipeline).toHaveBeenCalledWith({
-      input: {
+      input: expect.objectContaining({
         prompt: 'Explain the main pipeline.',
         sessionId: 'sess-core-1',
         overrideAuditSafe: 'allow',
         sourceEndpoint: 'gpt.arcanos-core.query',
-        body: { prompt: 'Explain the main pipeline.' }
-      },
-      context: {
+        moduleId: 'ARCANOS:CORE',
+        requestedAction: 'query',
+        executionMode: 'request',
+        body: expect.objectContaining({ prompt: 'Explain the main pipeline.' })
+      }),
+      context: expect.objectContaining({
         client,
         requestId: 'req-core-1',
         runtimeBudget: { budget: 'runtime' },
-        runOptions: {
+        runOptions: expect.objectContaining({
           answerMode: 'direct',
           maxWords: 42,
-        }
-      }
+        })
+      })
     });
     expect(runWithRequestAbortTimeoutMock).toHaveBeenCalledTimes(1);
     expect(runWithRequestAbortTimeoutMock).toHaveBeenCalledWith(
@@ -168,21 +181,25 @@ describe('ARCANOS:CORE service', () => {
     );
     expect(mockCreateRuntimeBudget).toHaveBeenCalledWith(110_000, 250);
     expect(mockRunTrinityWritingPipeline).toHaveBeenCalledWith({
-      input: {
+      input: expect.objectContaining({
         prompt: 'Process this in worker mode.',
         sessionId: undefined,
         overrideAuditSafe: undefined,
         sourceEndpoint: 'gpt.arcanos-core.query',
-        body: { prompt: 'Process this in worker mode.' }
-      },
-      context: {
+        moduleId: 'ARCANOS:CORE',
+        requestedAction: 'query',
+        executionMode: 'background',
+        background: { reason: 'arcanos_core_background' },
+        body: expect.objectContaining({ prompt: 'Process this in worker mode.' })
+      }),
+      context: expect.objectContaining({
         client,
         requestId: 'req-core-background-1',
         runtimeBudget: { budget: 'runtime' },
-        runOptions: {
+        runOptions: expect.objectContaining({
           watchdogModelTimeoutMs: 110_000
-        }
-      }
+        })
+      })
     });
     expect(loggerInfoMock).toHaveBeenCalledWith(
       '[core] handler.start',

--- a/tests/arcanos-core.service.test.ts
+++ b/tests/arcanos-core.service.test.ts
@@ -147,6 +147,32 @@ describe('ARCANOS:CORE service', () => {
     );
   });
 
+  it('forwards structured messages into Trinity when no explicit prompt is supplied', async () => {
+    const client = { id: 'openai-client' };
+    const messages = [
+      { role: 'system', content: 'You write compact operator notes.' },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Draft a release note for Trinity facade routing.' }
+        ]
+      }
+    ];
+
+    mockGetOpenAIClientOrAdapter.mockReturnValue({ client });
+    mockRunTrinityWritingPipeline.mockResolvedValue({ result: 'core-response' });
+
+    await ArcanosCore.actions.query({
+      messages,
+      maxOutputTokens: 0.2
+    });
+
+    const [{ input }] = mockRunTrinityWritingPipeline.mock.calls[0] as Array<[{ input: Record<string, unknown> }]>;
+    expect(input.prompt).toBeUndefined();
+    expect(input.messages).toBe(messages);
+    expect(input.maxOutputTokens).toBe(1);
+  });
+
   it('falls back to a mock response when the OpenAI client is unavailable', async () => {
     mockGetOpenAIClientOrAdapter.mockReturnValue({ client: null });
     mockGenerateMockResponse.mockReturnValue({ result: 'mock-core-response' });

--- a/tests/arcanos-core.timeout.test.ts
+++ b/tests/arcanos-core.timeout.test.ts
@@ -18,7 +18,17 @@ const getRequestAbortContextMock = jest.fn(() => null);
 const isAbortErrorMock = jest.fn((error: unknown) => error instanceof Error && error.name === 'AbortError');
 
 jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
-  runTrinityWritingPipeline: runTrinityWritingPipelineMock
+  runTrinityWritingPipeline: runTrinityWritingPipelineMock,
+  applyTrinityGenerationInvariant: (result: any, params: any) => ({
+    ...result,
+    meta: {
+      ...(result.meta ?? {}),
+      pipeline: 'trinity',
+      bypass: false,
+      sourceEndpoint: params.sourceEndpoint,
+      classification: 'writing'
+    }
+  })
 }));
 
 jest.unstable_mockModule('@platform/resilience/runtimeBudget.js', () => ({
@@ -206,14 +216,16 @@ describe('runArcanosCoreQuery timeout clamp', () => {
     expect(createRuntimeBudgetWithLimitMock).toHaveBeenNthCalledWith(1, 3000, 250);
     expect(createRuntimeBudgetWithLimitMock).toHaveBeenNthCalledWith(2, 2000, 250);
     expect(runTrinityWritingPipelineMock).toHaveBeenCalledWith({
-      input: {
+      input: expect.objectContaining({
         prompt: 'Summarize the service health quickly.',
         sessionId: undefined,
         overrideAuditSafe: undefined,
         sourceEndpoint: 'api-arcanos.ask.degraded',
+        moduleId: 'ARCANOS:CORE',
+        executionMode: 'request',
         body: { prompt: 'Summarize the service health quickly.' }
-      },
-      context: {
+      }),
+      context: expect.objectContaining({
         client: {} as never,
         requestId: 'req-core-timeout-1',
         runtimeBudget: expect.objectContaining({
@@ -227,7 +239,7 @@ describe('runArcanosCoreQuery timeout clamp', () => {
           strictUserVisibleOutput: true,
           directAnswerModelOverride: 'gpt-4.1-mini'
         })
-      }
+      })
     });
     expect(result).toEqual(expect.objectContaining({
       timeoutKind: 'pipeline_timeout',

--- a/tests/arcanos-pipeline-trinity.test.ts
+++ b/tests/arcanos-pipeline-trinity.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const runTrinityWritingPipelineMock = jest.fn();
+const requireOpenAIClientOrAdapterMock = jest.fn();
+
+jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
+  runTrinityWritingPipeline: runTrinityWritingPipelineMock
+}));
+
+jest.unstable_mockModule('@services/openai/clientBridge.js', () => ({
+  requireOpenAIClientOrAdapter: requireOpenAIClientOrAdapterMock
+}));
+
+const { executeArcanosPipeline } = await import('../src/services/arcanosPipeline.js');
+
+describe('executeArcanosPipeline Trinity orchestration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    requireOpenAIClientOrAdapterMock.mockReturnValue({ client: { responses: {} } });
+    runTrinityWritingPipelineMock.mockImplementation(async (request: { input: { body?: { stage?: string } } }) => {
+      const stage = request.input.body?.stage ?? 'unknown';
+      return {
+        result: `${stage}-output`,
+        activeModel: `trinity-${stage}`,
+        fallbackFlag: false,
+        routingStages: [`TRINITY:${stage}`],
+        meta: {
+          id: `resp-${stage}`,
+          created: 1,
+          pipeline: 'trinity',
+          bypass: false,
+          sourceEndpoint: `arcanos-pipeline.${stage}`,
+          classification: 'writing'
+        }
+      };
+    });
+  });
+
+  it('preserves the legacy multi-stage reasoning chain through Trinity calls', async () => {
+    const result = await executeArcanosPipeline([
+      { role: 'user', content: 'Draft a migration strategy.' }
+    ]);
+
+    expect(runTrinityWritingPipelineMock).toHaveBeenCalledTimes(4);
+    expect(runTrinityWritingPipelineMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        input: expect.objectContaining({
+          messages: [{ role: 'user', content: 'Draft a migration strategy.' }],
+          sourceEndpoint: 'arcanos-pipeline.arc-first'
+        })
+      })
+    );
+    expect(runTrinityWritingPipelineMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        input: expect.objectContaining({
+          sourceEndpoint: 'arcanos-pipeline.sub-agent',
+          messages: expect.arrayContaining([
+            expect.objectContaining({
+              role: 'assistant',
+              content: 'arc-first-output'
+            })
+          ])
+        })
+      })
+    );
+    expect(runTrinityWritingPipelineMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        input: expect.objectContaining({
+          sourceEndpoint: 'arcanos-pipeline.overseer',
+          messages: expect.arrayContaining([
+            expect.objectContaining({
+              role: 'assistant',
+              content: 'sub-agent-output'
+            })
+          ])
+        })
+      })
+    );
+    expect(runTrinityWritingPipelineMock).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        input: expect.objectContaining({
+          sourceEndpoint: 'arcanos-pipeline.final',
+          messages: expect.arrayContaining([
+            expect.objectContaining({
+              role: 'assistant',
+              content: 'overseer-output'
+            })
+          ])
+        })
+      })
+    );
+
+    expect(result).toEqual(expect.objectContaining({
+      fallback: false,
+      activeModel: 'trinity-final',
+      result: expect.objectContaining({
+        role: 'assistant',
+        content: 'final-output'
+      }),
+      stages: expect.objectContaining({
+        arcFirst: expect.objectContaining({ content: 'arc-first-output' }),
+        subAgent: expect.objectContaining({ content: 'sub-agent-output' }),
+        gpt5Reasoning: expect.objectContaining({ content: 'overseer-output' })
+      })
+    }));
+  });
+});

--- a/tests/arcanos-query.test.ts
+++ b/tests/arcanos-query.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 const getDefaultModelMock = jest.fn();
 const getGPT5ModelMock = jest.fn();
 const getOpenAIClientOrAdapterMock = jest.fn();
+const runTrinityWritingPipelineMock = jest.fn();
 
 let arcanosQuery: typeof import('../src/services/arcanosQuery.js').arcanosQuery;
 
@@ -11,6 +12,7 @@ beforeEach(async () => {
   getDefaultModelMock.mockReset();
   getGPT5ModelMock.mockReset();
   getOpenAIClientOrAdapterMock.mockReset();
+  runTrinityWritingPipelineMock.mockReset();
 
   getDefaultModelMock.mockReturnValue('ft:arcanos-test');
   getGPT5ModelMock.mockReturnValue('gpt-5.1-test');
@@ -22,6 +24,11 @@ beforeEach(async () => {
 
   jest.unstable_mockModule('../src/services/openai/clientBridge.js', () => ({
     getOpenAIClientOrAdapter: getOpenAIClientOrAdapterMock,
+    requireOpenAIClientOrAdapter: jest.fn(() => getOpenAIClientOrAdapterMock()),
+  }));
+
+  jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
+    runTrinityWritingPipeline: runTrinityWritingPipelineMock
   }));
 
   ({ arcanosQuery } = await import('../src/services/arcanosQuery.js'));
@@ -29,66 +36,36 @@ beforeEach(async () => {
 
 describe('arcanosQuery', () => {
   it('passes the original user prompt into the reasoning layer', async () => {
-    const responsesCreateMock = jest
-      .fn()
-      .mockResolvedValueOnce({
-        choices: [{ message: { content: 'Draft answer' } }],
-      })
-      .mockResolvedValueOnce({
-        choices: [{ message: { content: 'Final answer' } }],
-      });
+    runTrinityWritingPipelineMock.mockResolvedValue({ result: 'Final answer' });
 
     getOpenAIClientOrAdapterMock.mockReturnValue({
-      adapter: {
-        responses: {
-          create: responsesCreateMock,
-        },
-      },
       client: {},
     });
 
     const result = await arcanosQuery('Explain recursion simply.');
 
     expect(result).toBe('Final answer');
-    expect(responsesCreateMock).toHaveBeenCalledTimes(2);
-    expect(responsesCreateMock.mock.calls[1][0]).toEqual(
-      expect.objectContaining({
-        model: 'gpt-5.1-test',
-        messages: expect.arrayContaining([
-          expect.objectContaining({
-            role: 'user',
-            content: expect.stringContaining('Original user prompt:\nExplain recursion simply.'),
-          }),
-        ]),
+    expect(runTrinityWritingPipelineMock).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({
+        prompt: 'Explain recursion simply.',
+        moduleId: 'ARCANOS:QUERY',
+        sourceEndpoint: 'arcanosQuery',
+        requestedAction: 'query',
+        body: { prompt: 'Explain recursion simply.' }
       })
-    );
-    expect(String(responsesCreateMock.mock.calls[1][0].messages[1].content)).toContain(
-      'Candidate fine-tuned output:\nDraft answer'
-    );
+    }));
   });
 
   it('preserves exact-response prompts by skipping the reasoning layer', async () => {
-    const responsesCreateMock = jest.fn().mockResolvedValue({
-      choices: [{ message: { content: 'OK' } }],
-    });
+    runTrinityWritingPipelineMock.mockResolvedValue({ result: 'OK' });
 
     getOpenAIClientOrAdapterMock.mockReturnValue({
-      adapter: {
-        responses: {
-          create: responsesCreateMock,
-        },
-      },
       client: {},
     });
 
     const result = await arcanosQuery('Reply with exactly OK.');
 
     expect(result).toBe('OK');
-    expect(responsesCreateMock).toHaveBeenCalledTimes(1);
-    expect(responsesCreateMock.mock.calls[0][0]).toEqual(
-      expect.objectContaining({
-        model: 'ft:arcanos-test',
-      })
-    );
+    expect(runTrinityWritingPipelineMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/arcanos-sim.module.test.ts
+++ b/tests/arcanos-sim.module.test.ts
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 const mockRunTrinityWritingPipeline = jest.fn();
 const mockGetOpenAIClientOrAdapter = jest.fn();
 const mockGenerateRequestId = jest.fn();
+const mockCreateCentralizedCompletion = jest.fn();
 
 jest.unstable_mockModule('@services/openai.js', () => ({
   getDefaultModel: jest.fn(() => 'gpt-4.1-mini'),
   getFallbackModel: jest.fn(() => 'gpt-4.1'),
   getGPT5Model: jest.fn(() => 'gpt-5'),
-  generateMockResponse: jest.fn()
+  generateMockResponse: jest.fn(),
+  createCentralizedCompletion: mockCreateCentralizedCompletion
 }));
 
 jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
@@ -30,6 +32,7 @@ describe('ARCANOS:SIM module', () => {
     jest.clearAllMocks();
     mockGenerateRequestId.mockReturnValue('sim_test_id');
     mockGetOpenAIClientOrAdapter.mockReturnValue({ client: { responses: {} } });
+    mockCreateCentralizedCompletion.mockReset();
     mockRunTrinityWritingPipeline.mockResolvedValue({
       result: 'no-simulation',
       activeModel: 'trinity-sim',
@@ -128,6 +131,45 @@ describe('ARCANOS:SIM module', () => {
       metadata: {
         model: 'exact-literal-shortcut',
         tokensUsed: 0,
+        simulationId: 'sim_test_id'
+      }
+    });
+  });
+
+  it('preserves streaming simulation compatibility without invoking completed Trinity generation', async () => {
+    async function* streamChunks() {
+      yield { choices: [{ delta: { content: 'chunk' } }] };
+    }
+    const stream = streamChunks();
+    mockCreateCentralizedCompletion.mockResolvedValue(stream);
+
+    const result = await executeSimulationRequest({
+      scenario: 'Stream the simulated result.',
+      parameters: {
+        stream: true,
+        temperature: 0.4,
+        maxTokens: 77
+      }
+    });
+
+    expect(mockRunTrinityWritingPipeline).not.toHaveBeenCalled();
+    expect(mockCreateCentralizedCompletion).toHaveBeenCalledWith(
+      [
+        {
+          role: 'user',
+          content: 'Simulate the following scenario: Stream the simulated result.'
+        }
+      ],
+      {
+        temperature: 0.4,
+        max_tokens: 77,
+        stream: true
+      }
+    );
+    expect(result).toMatchObject({
+      mode: 'stream',
+      scenario: 'Stream the simulated result.',
+      metadata: {
         simulationId: 'sim_test_id'
       }
     });

--- a/tests/arcanos-sim.module.test.ts
+++ b/tests/arcanos-sim.module.test.ts
@@ -1,10 +1,22 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockCreateCentralizedCompletion = jest.fn();
+const mockRunTrinityWritingPipeline = jest.fn();
+const mockGetOpenAIClientOrAdapter = jest.fn();
 const mockGenerateRequestId = jest.fn();
 
 jest.unstable_mockModule('@services/openai.js', () => ({
-  createCentralizedCompletion: mockCreateCentralizedCompletion
+  getDefaultModel: jest.fn(() => 'gpt-4.1-mini'),
+  getFallbackModel: jest.fn(() => 'gpt-4.1'),
+  getGPT5Model: jest.fn(() => 'gpt-5'),
+  generateMockResponse: jest.fn()
+}));
+
+jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
+  runTrinityWritingPipeline: mockRunTrinityWritingPipeline
+}));
+
+jest.unstable_mockModule('@services/openai/clientBridge.js', () => ({
+  getOpenAIClientOrAdapter: mockGetOpenAIClientOrAdapter
 }));
 
 jest.unstable_mockModule('@shared/idGenerator.js', () => ({
@@ -17,15 +29,31 @@ describe('ARCANOS:SIM module', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGenerateRequestId.mockReturnValue('sim_test_id');
+    mockGetOpenAIClientOrAdapter.mockReturnValue({ client: { responses: {} } });
+    mockRunTrinityWritingPipeline.mockResolvedValue({
+      result: 'no-simulation',
+      activeModel: 'trinity-sim',
+      fallbackFlag: false,
+      routingStages: ['TRINITY'],
+      auditSafe: { mode: 'true', passed: true, flags: [] },
+      taskLineage: [],
+      fallbackSummary: {
+        intakeFallbackUsed: false,
+        gpt5FallbackUsed: false,
+        finalFallbackUsed: false,
+        fallbackReasons: [],
+      },
+      meta: {
+        tokens: { total_tokens: 41 },
+        pipeline: 'trinity',
+        bypass: false,
+        sourceEndpoint: 'arcanos-sim',
+        classification: 'writing',
+      },
+    });
   });
 
-  it('builds centralized completion input from scenario and context', async () => {
-    mockCreateCentralizedCompletion.mockResolvedValue({
-      choices: [{ message: { content: 'no-simulation' } }],
-      model: 'ft:test-sim',
-      usage: { total_tokens: 41 }
-    });
-
+  it('builds Trinity input from scenario and context', async () => {
     const result = await executeSimulationRequest({
       scenario: 'Return exactly the text no-simulation',
       context: 'Do not simulate anything.',
@@ -35,26 +63,29 @@ describe('ARCANOS:SIM module', () => {
       }
     });
 
-    expect(mockCreateCentralizedCompletion).toHaveBeenCalledWith(
-      [
-        {
-          role: 'user',
-          content: 'Simulate the following scenario: Return exactly the text no-simulation\n\nContext: Do not simulate anything.'
-        }
-      ],
-      {
-        temperature: 0.2,
-        max_tokens: 100,
-        stream: false
-      }
-    );
+    expect(mockRunTrinityWritingPipeline).toHaveBeenCalledWith({
+      input: expect.objectContaining({
+        prompt: 'Simulate the following scenario: Return exactly the text no-simulation\n\nContext: Do not simulate anything.',
+        moduleId: 'ARCANOS:SIM',
+        sourceEndpoint: 'arcanos-sim',
+        requestedAction: 'run',
+        tokenLimit: 100,
+      }),
+      context: expect.objectContaining({
+        client: expect.anything(),
+        runOptions: expect.objectContaining({
+          answerMode: 'direct',
+          strictUserVisibleOutput: true,
+        }),
+      }),
+    });
 
     expect(result).toMatchObject({
       mode: 'complete',
       scenario: 'Return exactly the text no-simulation',
       result: 'no-simulation',
       metadata: {
-        model: 'ft:test-sim',
+        model: 'trinity-sim',
         tokensUsed: 41,
         simulationId: 'sim_test_id'
       }
@@ -62,29 +93,22 @@ describe('ARCANOS:SIM module', () => {
   });
 
   it('exposes the dispatcher run action and supports prompt aliases', async () => {
-    mockCreateCentralizedCompletion.mockResolvedValue({
-      choices: [{ message: { content: 'prompt-alias-response' } }],
-      model: 'ft:test-sim',
-      usage: { total_tokens: 12 }
+    mockRunTrinityWritingPipeline.mockResolvedValue({
+      result: 'prompt-alias-response',
+      activeModel: 'trinity-sim',
+      meta: { tokens: { total_tokens: 12 } }
     });
 
     const result = await ArcanosSimModule.actions.run({
       prompt: 'Summarize the dispatcher routing path briefly.'
     });
 
-    expect(mockCreateCentralizedCompletion).toHaveBeenCalledWith(
-      [
-        {
-          role: 'user',
-          content: 'Simulate the following scenario: Summarize the dispatcher routing path briefly.'
-        }
-      ],
-      {
-        temperature: 0.8,
-        max_tokens: 2048,
-        stream: false
-      }
-    );
+    expect(mockRunTrinityWritingPipeline).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({
+        prompt: 'Simulate the following scenario: Summarize the dispatcher routing path briefly.',
+        tokenLimit: 2048
+      })
+    }));
     expect(result).toMatchObject({
       mode: 'complete',
       result: 'prompt-alias-response'
@@ -97,7 +121,7 @@ describe('ARCANOS:SIM module', () => {
         'Answer directly. Do not simulate, role-play, or describe a hypothetical run. Say exactly: live-response-check.'
     });
 
-    expect(mockCreateCentralizedCompletion).not.toHaveBeenCalled();
+    expect(mockRunTrinityWritingPipeline).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       mode: 'complete',
       result: 'live-response-check',

--- a/tests/backstage-booker.generateBooking.test.ts
+++ b/tests/backstage-booker.generateBooking.test.ts
@@ -1,23 +1,31 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockCallOpenAI = jest.fn();
+const mockRunTrinityWritingPipeline = jest.fn();
 const mockGetGPT5Model = jest.fn();
+const mockGetOpenAIClientOrAdapter = jest.fn();
 const mockQuery = jest.fn();
 const mockSaveMemory = jest.fn();
 const mockGetEnv = jest.fn();
 const mockGetEnvNumber = jest.fn();
+const mockGetEnvBoolean = jest.fn();
 
 jest.unstable_mockModule('@services/openai.js', () => ({
-  callOpenAI: mockCallOpenAI,
   getGPT5Model: mockGetGPT5Model,
   getDefaultModel: jest.fn(() => 'gpt-4.1-mini'),
   getFallbackModel: jest.fn(() => 'gpt-4.1'),
   getComplexModel: jest.fn(() => 'gpt-4.1'),
   hasValidAPIKey: jest.fn(() => true),
   default: {
-    callOpenAI: mockCallOpenAI,
     getGPT5Model: mockGetGPT5Model
   }
+}));
+
+jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
+  runTrinityWritingPipeline: mockRunTrinityWritingPipeline
+}));
+
+jest.unstable_mockModule('@services/openai/clientBridge.js', () => ({
+  getOpenAIClientOrAdapter: mockGetOpenAIClientOrAdapter
 }));
 
 jest.unstable_mockModule('@core/db/index.js', () => ({
@@ -27,7 +35,8 @@ jest.unstable_mockModule('@core/db/index.js', () => ({
 
 jest.unstable_mockModule('@platform/runtime/env.js', () => ({
   getEnv: mockGetEnv,
-  getEnvNumber: mockGetEnvNumber
+  getEnvNumber: mockGetEnvNumber,
+  getEnvBoolean: mockGetEnvBoolean
 }));
 
 const { generateBooking } = await import('../src/services/backstage-booker.js');
@@ -37,21 +46,56 @@ describe('backstage-booker generateBooking', () => {
     jest.clearAllMocks();
     mockGetEnv.mockReturnValue(undefined);
     mockGetEnvNumber.mockReturnValue(512);
+    mockGetEnvBoolean.mockReturnValue(false);
     mockGetGPT5Model.mockReturnValue('gpt-5.1-test');
+    mockGetOpenAIClientOrAdapter.mockReturnValue({ client: { responses: {} } });
     mockQuery.mockResolvedValue({ rows: [] });
     mockSaveMemory.mockResolvedValue(undefined);
-    mockCallOpenAI.mockResolvedValue({ output: 'Rivalry matrix output' });
+    mockRunTrinityWritingPipeline.mockResolvedValue({
+      result: 'Rivalry matrix output',
+      activeModel: 'trinity-model',
+      fallbackFlag: false,
+      routingStages: ['TRINITY'],
+      auditSafe: { mode: 'true', passed: true, flags: [] },
+      taskLineage: [],
+      fallbackSummary: {
+        intakeFallbackUsed: false,
+        gpt5FallbackUsed: false,
+        finalFallbackUsed: false,
+        fallbackReasons: [],
+      },
+      meta: {
+        pipeline: 'trinity',
+        bypass: false,
+        sourceEndpoint: 'backstage-booker.generateBooking',
+        classification: 'writing',
+      },
+    });
   });
 
   it('falls back to the shared GPT-5 model when USER_GPT_ID is absent', async () => {
     await expect(generateBooking('Generate three rivalries for RAW after WrestleMania.')).resolves.toBe('Rivalry matrix output');
 
-    expect(mockCallOpenAI).toHaveBeenCalledWith(
-      'gpt-5.1-test',
-      expect.stringContaining('Generate three rivalries for RAW after WrestleMania.'),
-      512,
-      false
-    );
+    expect(mockRunTrinityWritingPipeline).toHaveBeenCalledWith({
+      input: expect.objectContaining({
+        prompt: expect.stringContaining('Generate three rivalries for RAW after WrestleMania.'),
+        moduleId: 'BACKSTAGE:BOOKER',
+        sourceEndpoint: 'backstage-booker.generateBooking',
+        requestedAction: 'generateBooking',
+        tokenLimit: 512,
+        body: expect.objectContaining({
+          model: 'gpt-5.1-test',
+          tokenLimit: 512,
+        }),
+      }),
+      context: expect.objectContaining({
+        client: expect.anything(),
+        runOptions: expect.objectContaining({
+          answerMode: 'direct',
+          strictUserVisibleOutput: true,
+        }),
+      }),
+    });
   });
 
   it('short-circuits exact-literal anti-simulation prompts before OpenAI executes', async () => {
@@ -61,7 +105,7 @@ describe('backstage-booker generateBooking', () => {
       )
     ).resolves.toBe('backstage-check');
 
-    expect(mockCallOpenAI).not.toHaveBeenCalled();
+    expect(mockRunTrinityWritingPipeline).not.toHaveBeenCalled();
   });
 
   it('switches to direct-answer execution mode for anti-simulation booking prompts', async () => {
@@ -71,13 +115,13 @@ describe('backstage-booker generateBooking', () => {
       )
     ).resolves.toBe('Rivalry matrix output');
 
-    expect(mockCallOpenAI).toHaveBeenCalledWith(
-      'gpt-5.1-test',
-      expect.stringContaining('<<EXECUTION_MODE>>'),
-      400,
-      false
-    );
-    const dispatchedPrompt = mockCallOpenAI.mock.calls[0][1] as string;
+    expect(mockRunTrinityWritingPipeline).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({
+        prompt: expect.stringContaining('<<EXECUTION_MODE>>'),
+        tokenLimit: 400,
+      })
+    }));
+    const dispatchedPrompt = (mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } }).input.prompt;
     expect(dispatchedPrompt).not.toContain('<<PERSONA>>');
     expect(dispatchedPrompt).toContain('Return only 5 top-level numbered bullets.');
     expect(dispatchedPrompt).toContain('No sub-bullets, no production notes, no consequences section, and no meta commentary.');
@@ -85,8 +129,8 @@ describe('backstage-booker generateBooking', () => {
   });
 
   it('removes preambles and trims direct-answer output to the requested short bullet count', async () => {
-    mockCallOpenAI.mockResolvedValue({
-      output: [
+    mockRunTrinityWritingPipeline.mockResolvedValue({
+      result: [
         'Gut read: center Punk vs. Drew immediately.',
         '',
         '---',
@@ -121,15 +165,14 @@ describe('backstage-booker generateBooking', () => {
       ].join('\n')
     );
 
-    const dispatchedPrompt = mockCallOpenAI.mock.calls[0][1] as string;
+    const dispatchedPrompt = (mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } }).input.prompt;
     expect(dispatchedPrompt).toContain('Return only 5 top-level numbered bullets.');
     expect(dispatchedPrompt).toContain('No preamble, headings, divider lines, or conclusion.');
     expect(dispatchedPrompt).toContain('Each bullet must be one compact sentence.');
-    expect(mockCallOpenAI).toHaveBeenCalledWith(
-      'gpt-5.1-test',
-      expect.any(String),
-      240,
-      false
-    );
+    expect(mockRunTrinityWritingPipeline).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({
+        tokenLimit: 240
+      })
+    }));
   });
 });

--- a/tests/client-response-guards.test.ts
+++ b/tests/client-response-guards.test.ts
@@ -207,6 +207,28 @@ describe('client response guards', () => {
       gpt5Used: true,
       gpt5Model: 'gpt-5.1',
       dryRun: false,
+      meta: {
+        id: 'resp-hidden',
+        created: 1,
+        pipeline: 'trinity',
+        bypass: false,
+        sourceEndpoint: 'gpt.arcanos-core.query',
+        classification: 'writing',
+        gptId: 'arcanos-core',
+        moduleId: 'ARCANOS:CORE',
+        requestedAction: 'query',
+        executionMode: 'request',
+        tokenLimit: 300,
+        tokens: {
+          prompt_tokens: 10,
+          completion_tokens: 5,
+          total_tokens: 15,
+          private_field: 99,
+        },
+        background: {
+          reason: 'hidden',
+        },
+      },
       taskLineage: { requestId: 'secret' },
       memoryContext: { entriesAccessed: 99 },
       auditSafe: { mode: true },
@@ -222,6 +244,22 @@ describe('client response guards', () => {
       gpt5Used: true,
       gpt5Model: 'gpt-5.1',
       dryRun: false,
+      meta: {
+        pipeline: 'trinity',
+        bypass: false,
+        sourceEndpoint: 'gpt.arcanos-core.query',
+        classification: 'writing',
+        gptId: 'arcanos-core',
+        moduleId: 'ARCANOS:CORE',
+        requestedAction: 'query',
+        executionMode: 'request',
+        tokenLimit: 300,
+        tokens: {
+          prompt_tokens: 10,
+          completion_tokens: 5,
+          total_tokens: 15,
+        },
+      },
     });
   });
 

--- a/tests/command-center.contract.test.ts
+++ b/tests/command-center.contract.test.ts
@@ -7,6 +7,8 @@ let mockedAuditSafeMode: 'true' | 'false' | 'passive' | 'log-only' = 'false';
 
 const mockLogExecution = jest.fn(async () => undefined);
 const mockCreateCentralizedCompletion = jest.fn();
+const mockRunTrinityWritingPipeline = jest.fn();
+const mockGetOpenAIClientOrAdapter = jest.fn(() => ({ client: { responses: {} } }));
 const mockGenerateMockResponse = jest.fn(() => ({
   result: 'mocked-ai-response',
   meta: {
@@ -25,7 +27,8 @@ const mockInterpretCommand = jest.fn(async (instruction: string) => {
 });
 
 jest.unstable_mockModule('@core/db/repositories/executionLogRepository.js', () => ({
-  logExecution: mockLogExecution
+  logExecution: mockLogExecution,
+  logExecutionBatch: jest.fn(async () => undefined)
 }));
 
 jest.unstable_mockModule('@services/openai.js', () => ({
@@ -46,9 +49,18 @@ jest.unstable_mockModule('@services/openai.js', () => ({
   getCircuitBreakerSnapshot: jest.fn(),
   validateClientHealth: jest.fn(),
   createChatCompletionWithFallback: jest.fn(),
+  createSingleChatCompletion: jest.fn(),
   getOpenAIClient: jest.fn(),
   getOpenAIKeySource: jest.fn(),
   runStructuredReasoning: jest.fn()
+}));
+
+jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
+  runTrinityWritingPipeline: mockRunTrinityWritingPipeline
+}));
+
+jest.unstable_mockModule('@services/openai/clientBridge.js', () => ({
+  getOpenAIClientOrAdapter: mockGetOpenAIClientOrAdapter
 }));
 
 jest.unstable_mockModule('@services/auditSafeToggle.js', () => ({
@@ -70,6 +82,28 @@ describe('commandCenter contracts and tracing', () => {
     jest.clearAllMocks();
     mockedAuditSafeMode = 'false';
     mockHasValidApiKey.mockReturnValue(false);
+    mockGetOpenAIClientOrAdapter.mockReturnValue({ client: { responses: {} } });
+    mockRunTrinityWritingPipeline.mockResolvedValue({
+      result: 'mocked-ai-response',
+      activeModel: 'gpt-test',
+      fallbackFlag: false,
+      routingStages: ['TRINITY'],
+      auditSafe: { mode: 'true', passed: true, flags: [] },
+      taskLineage: [],
+      fallbackSummary: {
+        intakeFallbackUsed: false,
+        gpt5FallbackUsed: false,
+        finalFallbackUsed: false,
+        fallbackReasons: [],
+      },
+      meta: {
+        pipeline: 'trinity',
+        bypass: false,
+        sourceEndpoint: 'cef.ai.prompt',
+        classification: 'writing',
+        tokens: { total_tokens: 42 }
+      },
+    });
     mockGenerateMockResponse.mockReturnValue({
       result: 'mocked-ai-response',
       meta: {
@@ -207,20 +241,12 @@ describe('commandCenter contracts and tracing', () => {
 
   it('traces retry and success after a transient AI failure', async () => {
     mockHasValidApiKey.mockReturnValue(true);
-    mockCreateCentralizedCompletion
+    mockRunTrinityWritingPipeline
       .mockRejectedValueOnce(Object.assign(new Error('timeout while calling OpenAI'), { code: 'ETIMEDOUT' }))
       .mockResolvedValueOnce({
-        choices: [
-          {
-            message: {
-              content: 'retried-ai-response'
-            }
-          }
-        ],
-        usage: {
-          total_tokens: 42
-        },
-        model: 'gpt-test'
+        result: 'retried-ai-response',
+        activeModel: 'gpt-test',
+        meta: { tokens: { total_tokens: 42 } }
       });
 
     const result = await executeCommand('ai:prompt', { prompt: 'Retry the AI handler once.' }, {
@@ -238,7 +264,7 @@ describe('commandCenter contracts and tracing', () => {
         model: 'gpt-test'
       })
     );
-    expect(mockCreateCentralizedCompletion).toHaveBeenCalledTimes(2);
+    expect(mockRunTrinityWritingPipeline).toHaveBeenCalledTimes(2);
 
     const retryTraceCall = mockLogExecution.mock.calls.find(call => call[2] === 'cef.handler.retry');
     expect(retryTraceCall?.[3]).toEqual(expect.objectContaining({

--- a/tests/control-plane-route-verification.test.ts
+++ b/tests/control-plane-route-verification.test.ts
@@ -5,7 +5,7 @@ import { verifyControlPlaneRoute } from '../src/services/controlPlane/routeVerif
 const fixedNow = () => new Date('2026-04-26T00:00:00.000Z');
 
 describe('control-plane route verification', () => {
-  it('confirms Trinity only when trace metadata contains the required pipeline stages', () => {
+  it('keeps control-plane planning on the direct fast path even when Trinity is requested', () => {
     const route = verifyControlPlaneRoute({
       request: {
         phase: 'plan',
@@ -22,12 +22,13 @@ describe('control-plane route verification', () => {
       now: fixedNow
     });
 
-    expect(route.status).toBe('TRINITY_CONFIRMED');
-    expect(route.eligibleForTrinity).toBe(true);
-    expect(route.evidence.routingStages).toHaveLength(3);
+    expect(route.requested).toBe('trinity');
+    expect(route.status).toBe('DIRECT_FAST_PATH');
+    expect(route.eligibleForTrinity).toBe(false);
+    expect(route.evidence).toEqual({});
   });
 
-  it('does not claim Trinity when requested metadata is missing Trinity stages', () => {
+  it('does not claim Trinity when requested metadata is present for control-plane planning', () => {
     const route = verifyControlPlaneRoute({
       request: {
         phase: 'plan',
@@ -40,8 +41,9 @@ describe('control-plane route verification', () => {
       now: fixedNow
     });
 
-    expect(route.status).toBe('TRINITY_REQUESTED_BUT_NOT_CONFIRMED');
-    expect(route.reason).toContain('did not prove Trinity pipeline involvement');
+    expect(route.status).toBe('DIRECT_FAST_PATH');
+    expect(route.eligibleForTrinity).toBe(false);
+    expect(route.reason).toContain('system operations');
   });
 
   it('uses the direct fast path for execution and mutation because those are system operations', () => {
@@ -57,7 +59,7 @@ describe('control-plane route verification', () => {
     expect(route.eligibleForTrinity).toBe(false);
   });
 
-  it('reports Trinity as unavailable when planning cannot run the planner', () => {
+  it('does not surface Trinity planner availability for control-plane planning', () => {
     const route = verifyControlPlaneRoute({
       request: {
         phase: 'plan',
@@ -68,11 +70,11 @@ describe('control-plane route verification', () => {
       now: fixedNow
     });
 
-    expect(route.status).toBe('TRINITY_UNAVAILABLE');
-    expect(route.reason).toBe('planner unavailable');
+    expect(route.status).toBe('DIRECT_FAST_PATH');
+    expect(route.eligibleForTrinity).toBe(false);
   });
 
-  it('uses UNKNOWN_ROUTE when planning produced no route metadata and no explicit failure', () => {
+  it('uses the direct fast path when planning produced no route metadata', () => {
     const route = verifyControlPlaneRoute({
       request: {
         phase: 'plan',
@@ -81,6 +83,7 @@ describe('control-plane route verification', () => {
       now: fixedNow
     });
 
-    expect(route.status).toBe('UNKNOWN_ROUTE');
+    expect(route.status).toBe('DIRECT_FAST_PATH');
+    expect(route.eligibleForTrinity).toBe(false);
   });
 });

--- a/tests/control-plane.service.test.ts
+++ b/tests/control-plane.service.test.ts
@@ -46,7 +46,7 @@ describe('executeControlPlaneRequest', () => {
     jest.clearAllMocks();
   });
 
-  it('plans Railway deploy through confirmed Trinity without executing a command', async () => {
+  it('plans Railway deploy directly without executing a command or entering Trinity', async () => {
     const run = jest.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' }));
     const trinityPlanner = {
       plan: jest.fn(async () => ({
@@ -76,8 +76,9 @@ describe('executeControlPlaneRequest', () => {
       cwd: repositoryRoot
     });
     expect(response.approval.required).toBe(false);
-    expect(response.route.status).toBe('TRINITY_CONFIRMED');
-    expect(trinityPlanner.plan).toHaveBeenCalledTimes(1);
+    expect(response.route.status).toBe('DIRECT_FAST_PATH');
+    expect(response.route.eligibleForTrinity).toBe(false);
+    expect(trinityPlanner.plan).not.toHaveBeenCalled();
     expect(run).not.toHaveBeenCalled();
   });
 

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const mockResponsesCreate = jest.fn();
 const mockGetOpenAIClientOrAdapter = jest.fn();
-const mockGetPrompt = jest.fn();
+const mockGetPrompt = jest.fn((_section: string, key: string) => `${key}-prompt`);
 const mockGetDefaultModel = jest.fn();
 const mockGetGPT5Model = jest.fn();
 const mockGenerateMockResponse = jest.fn();
@@ -122,5 +122,27 @@ describe('gaming direct-answer hardening', () => {
     });
     expect(mockResponsesCreate).not.toHaveBeenCalled();
     expect(mockRunTrinityWritingPipeline).not.toHaveBeenCalled();
+  });
+
+  it('does not emit a misleading audit trace when audit is folded into the Trinity prompt', async () => {
+    const result = await runGuidePipeline({
+      prompt: 'Give a direct guide to defensive positioning.',
+      guideUrls: [],
+      auditEnabled: true
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
+      data: expect.not.objectContaining({
+        auditTrace: expect.anything()
+      })
+    }));
+    expect(mockRunTrinityWritingPipeline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          prompt: expect.stringContaining('audit_system-prompt')
+        })
+      })
+    );
   });
 });

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -9,6 +9,8 @@ const mockGenerateMockResponse = jest.fn();
 const mockFetchAndClean = jest.fn();
 const mockGetEnv = jest.fn();
 const mockGetEnvNumber = jest.fn();
+const mockGetEnvBoolean = jest.fn();
+const mockRunTrinityWritingPipeline = jest.fn();
 
 jest.unstable_mockModule('@services/openai/clientBridge.js', () => ({
   getOpenAIClientOrAdapter: mockGetOpenAIClientOrAdapter
@@ -30,7 +32,12 @@ jest.unstable_mockModule('@shared/webFetcher.js', () => ({
 
 jest.unstable_mockModule('@platform/runtime/env.js', () => ({
   getEnv: mockGetEnv,
-  getEnvNumber: mockGetEnvNumber
+  getEnvNumber: mockGetEnvNumber,
+  getEnvBoolean: mockGetEnvBoolean
+}));
+
+jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
+  runTrinityWritingPipeline: mockRunTrinityWritingPipeline
 }));
 
 const { runGuidePipeline } = await import('../src/services/gaming.js');
@@ -41,18 +48,20 @@ describe('gaming direct-answer hardening', () => {
 
     mockGetEnv.mockReturnValue(undefined);
     mockGetEnvNumber.mockReturnValue(512);
+    mockGetEnvBoolean.mockReturnValue(false);
     mockGetDefaultModel.mockReturnValue('ft:test-intake');
     mockGetGPT5Model.mockReturnValue('gpt-5.1-test');
     mockGenerateMockResponse.mockReturnValue({ result: 'mock guide result' });
     mockGetPrompt.mockImplementation((_section: string, key: string) => `${key}-prompt`);
     mockFetchAndClean.mockResolvedValue('clean snippet');
+    mockRunTrinityWritingPipeline.mockResolvedValue({ result: 'Direct gameplay answer' });
     mockGetOpenAIClientOrAdapter.mockReturnValue({
       adapter: {
         responses: {
           create: mockResponsesCreate
         }
       },
-      client: null
+      client: {}
     });
   });
 
@@ -76,17 +85,21 @@ describe('gaming direct-answer hardening', () => {
         sources: []
       })
     }));
-    expect(mockResponsesCreate).toHaveBeenCalledTimes(1);
-    expect(mockResponsesCreate).toHaveBeenCalledWith(
+    expect(mockResponsesCreate).not.toHaveBeenCalled();
+    expect(mockRunTrinityWritingPipeline).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: 'gpt-5.1-test',
-        temperature: 0.2,
-        messages: expect.arrayContaining([
-          expect.objectContaining({
-            role: 'system',
-            content: expect.stringContaining('add hotline banter or theatrical framing')
+        input: expect.objectContaining({
+          moduleId: 'ARCANOS:GAMING',
+          sourceEndpoint: 'arcanos-gaming.guide',
+          requestedAction: 'query',
+          prompt: expect.stringContaining('add hotline banter or theatrical framing')
+        }),
+        context: expect.objectContaining({
+          runOptions: expect.objectContaining({
+            answerMode: 'direct',
+            strictUserVisibleOutput: true
           })
-        ])
+        })
       })
     );
   });
@@ -108,5 +121,6 @@ describe('gaming direct-answer hardening', () => {
       }
     });
     expect(mockResponsesCreate).not.toHaveBeenCalled();
+    expect(mockRunTrinityWritingPipeline).not.toHaveBeenCalled();
   });
 });

--- a/tests/gpt-dispatch-compatibility.test.ts
+++ b/tests/gpt-dispatch-compatibility.test.ts
@@ -186,6 +186,37 @@ describe('gpt dispatch compatibility', () => {
     );
   });
 
+  it('accepts structured message content parts and forwards the original messages', async () => {
+    const messages = [
+      { role: 'system', content: 'You write compact operator notes.' },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Draft a release note for Trinity facade routing.' }
+        ]
+      }
+    ];
+
+    const response = await routeGptRequest({
+      gptId: 'arcanos-core',
+      body: {
+        action: 'query',
+        messages
+      },
+      requestId: 'req_structured_messages_query'
+    });
+
+    expect(response.ok).toBe(true);
+    expect(mockDispatchModuleAction).toHaveBeenCalledWith(
+      'ARCANOS:CORE',
+      'query',
+      expect.objectContaining({
+        messages,
+        prompt: 'Draft a release note for Trinity facade routing.'
+      })
+    );
+  });
+
   it('resolves normalized GPT IDs without executing a module action', async () => {
     const response = await resolveGptRouting(' ARCANOS-CORE ', 'req_resolve_normalized');
 

--- a/tests/gpt-dispatch.backstage-booker.test.ts
+++ b/tests/gpt-dispatch.backstage-booker.test.ts
@@ -116,11 +116,11 @@ describe('routeGptRequest backstage booker auto-routing', () => {
       requestId: 'req-booker-1'
     });
 
-    expect(mockDispatchModuleAction).toHaveBeenCalledWith('BACKSTAGE:BOOKER', 'generateBooking', {
+    expect(mockDispatchModuleAction).toHaveBeenCalledWith('BACKSTAGE:BOOKER', 'generateBooking', expect.objectContaining({
       message: 'Generate three rivalries for RAW after WrestleMania.',
       sessionId: 'RAW_RIVALRY_TEST',
       prompt: 'Generate three rivalries for RAW after WrestleMania.'
-    });
+    }));
     expect(envelope).toEqual(
       expect.objectContaining({
         ok: true,
@@ -143,9 +143,9 @@ describe('routeGptRequest backstage booker auto-routing', () => {
       requestId: 'req-booker-2'
     });
 
-    expect(mockDispatchModuleAction).toHaveBeenCalledWith('BACKSTAGE:BOOKER', 'generateBooking', {
+    expect(mockDispatchModuleAction).toHaveBeenCalledWith('BACKSTAGE:BOOKER', 'generateBooking', expect.objectContaining({
       prompt: 'Book a WWE Raw title-picture rivalry map for the next month.'
-    });
+    }));
     expect(envelope).toEqual(
       expect.objectContaining({
         ok: true,
@@ -169,9 +169,9 @@ describe('routeGptRequest backstage booker auto-routing', () => {
       requestId: 'req-booker-3'
     });
 
-    expect(mockDispatchModuleAction).toHaveBeenCalledWith('BACKSTAGE:BOOKER', 'generateBooking', {
+    expect(mockDispatchModuleAction).toHaveBeenCalledWith('BACKSTAGE:BOOKER', 'generateBooking', expect.objectContaining({
       prompt: 'Answer directly. Do not simulate, role-play, or describe a hypothetical run. Say exactly: backstage-check.'
-    });
+    }));
     expect(envelope).toEqual(
       expect.objectContaining({
         ok: true,

--- a/tests/gpt-dispatch.gaming.test.ts
+++ b/tests/gpt-dispatch.gaming.test.ts
@@ -139,12 +139,12 @@ describe('routeGptRequest gaming routing', () => {
       requestId: 'req-gaming-1',
     });
 
-    expect(mockDispatchModuleAction).toHaveBeenCalledWith('ARCANOS:GAMING', 'query', {
+    expect(mockDispatchModuleAction).toHaveBeenCalledWith('ARCANOS:GAMING', 'query', expect.objectContaining({
       prompt: 'Ping the gaming backend and inspect whether repo tools exist before SWTOR tips ingestion.',
       schema: 'gaming',
       target: 'gaming_guides',
       game: 'SWTOR',
-    });
+    }));
     expect(mockCollectRepoImplementationEvidence).not.toHaveBeenCalled();
     expect(envelope).toEqual(
       expect.objectContaining({
@@ -183,9 +183,9 @@ describe('routeGptRequest gaming routing', () => {
       requestId: 'req-gaming-override-1',
     });
 
-    expect(mockDispatchModuleAction).toHaveBeenCalledWith('ARCANOS:GAMING', 'query', {
+    expect(mockDispatchModuleAction).toHaveBeenCalledWith('ARCANOS:GAMING', 'query', expect.objectContaining({
       prompt: 'Inspect the repo tools before answering my SWTOR guide question.',
-    });
+    }));
     expect(mockCollectRepoImplementationEvidence).not.toHaveBeenCalled();
     expect(envelope).toEqual(
       expect.objectContaining({
@@ -492,9 +492,9 @@ describe('routeGptRequest gaming routing', () => {
       requestId: 'req-gaming-legacy-ask-1',
     });
 
-    expect(mockDispatchModuleAction).toHaveBeenCalledWith('ARCANOS:GAMING', 'query', {
+    expect(mockDispatchModuleAction).toHaveBeenCalledWith('ARCANOS:GAMING', 'query', expect.objectContaining({
       prompt: 'Give me SWTOR gearing help.'
-    });
+    }));
     expect(envelope).toEqual(
       expect.objectContaining({
         ok: true,

--- a/tests/gpt-dispatch.mcp.test.ts
+++ b/tests/gpt-dispatch.mcp.test.ts
@@ -63,7 +63,7 @@ jest.unstable_mockModule('../src/routes/ask/dagTools.js', () => ({
 
 const { routeGptRequest } = await import('../src/routes/_core/gptDispatch.js');
 
-describe('routeGptRequest write-plane guard', () => {
+describe('routeGptRequest write-plane classification', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetGptModuleMap.mockResolvedValue({
@@ -109,11 +109,12 @@ describe('routeGptRequest write-plane guard', () => {
     });
   });
 
-  it('rejects explicit MCP dispatch requests before module routing', async () => {
+  it('defers explicit MCP dispatch requests to the core Trinity boundary', async () => {
     const envelope = await routeGptRequest({
       gptId: 'arcanos-core',
       body: {
         action: 'mcp.invoke',
+        prompt: 'Invoke the modules.list MCP tool.',
         payload: {
           toolName: 'modules.list',
         },
@@ -121,26 +122,33 @@ describe('routeGptRequest write-plane guard', () => {
       requestId: 'req-mcp-1',
     });
 
+    expect(mockDispatchModuleAction).toHaveBeenCalledWith(
+      'ARCANOS:CORE',
+      'query',
+      expect.objectContaining({
+        toolName: 'modules.list',
+        prompt: 'Invoke the modules.list MCP tool.',
+        __arcanosRequestedAction: 'mcp.invoke',
+      })
+    );
     expect(envelope).toEqual(
       expect.objectContaining({
-        ok: false,
-        error: expect.objectContaining({
-          code: 'MCP_CONTROL_REQUIRES_MCP_API',
-        }),
+        ok: true,
         _route: expect.objectContaining({
-          route: 'write_guard',
-          action: 'mcp.invoke',
+          route: 'core',
+          action: 'query',
         }),
       })
     );
-    expect(mockDispatchModuleAction).not.toHaveBeenCalled();
+    expect(mockMcpInvokeTool).not.toHaveBeenCalled();
   });
 
-  it('rejects embedded payload.mcp envelopes before module routing', async () => {
+  it('defers embedded payload.mcp envelopes to the core Trinity boundary', async () => {
     const envelope = await routeGptRequest({
       gptId: 'arcanos-core',
       body: {
         payload: {
+          prompt: 'List the available MCP tools.',
           mcp: {
             action: 'mcp.listTools',
           },
@@ -149,22 +157,30 @@ describe('routeGptRequest write-plane guard', () => {
       requestId: 'req-mcp-2',
     });
 
+    expect(mockDispatchModuleAction).toHaveBeenCalledWith(
+      'ARCANOS:CORE',
+      'query',
+      expect.objectContaining({
+        prompt: 'List the available MCP tools.',
+        mcp: expect.objectContaining({
+          action: 'mcp.listTools',
+        }),
+        __arcanosRequestedAction: 'mcp.list_tools',
+      })
+    );
     expect(envelope).toEqual(
       expect.objectContaining({
-        ok: false,
-        error: expect.objectContaining({
-          code: 'MCP_CONTROL_REQUIRES_MCP_API',
-        }),
+        ok: true,
         _route: expect.objectContaining({
-          route: 'write_guard',
-          action: 'mcp.list_tools',
+          route: 'core',
+          action: 'query',
         }),
       })
     );
-    expect(mockDispatchModuleAction).not.toHaveBeenCalled();
+    expect(mockMcpListTools).not.toHaveBeenCalled();
   });
 
-  it('rejects runtime inspection prompts before they hit the write plane', async () => {
+  it('defers runtime inspection prompts to the core Trinity boundary', async () => {
     const envelope = await routeGptRequest({
       gptId: 'arcanos-core',
       body: {
@@ -173,19 +189,23 @@ describe('routeGptRequest write-plane guard', () => {
       requestId: 'req-runtime-1',
     });
 
+    expect(mockDispatchModuleAction).toHaveBeenCalledWith(
+      'ARCANOS:CORE',
+      'query',
+      expect.objectContaining({
+        message: 'verify in production on the live backend runtime that is currently active',
+        prompt: 'verify in production on the live backend runtime that is currently active',
+      })
+    );
     expect(envelope).toEqual(
       expect.objectContaining({
-        ok: false,
-        error: expect.objectContaining({
-          code: 'CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT',
-        }),
+        ok: true,
         _route: expect.objectContaining({
-          route: 'write_guard',
-          action: 'runtime.inspect',
+          route: 'core',
+          action: 'query',
         }),
       })
     );
-    expect(mockDispatchModuleAction).not.toHaveBeenCalled();
   });
 
   it('keeps workflow-like query prompts on the requested GPT write plane', async () => {
@@ -219,28 +239,34 @@ describe('routeGptRequest write-plane guard', () => {
     expect(mockTryExecuteDeterministicDagTools).not.toHaveBeenCalled();
   });
 
-  it('rejects leaked direct control actions inside the write dispatcher', async () => {
+  it('defers leaked direct control actions to the core Trinity boundary', async () => {
     const envelope = await routeGptRequest({
       gptId: 'arcanos-core',
       body: {
         action: 'system_state',
+        prompt: 'Inspect the current system state.',
       },
       requestId: 'req-control-1',
     });
 
+    expect(mockDispatchModuleAction).toHaveBeenCalledWith(
+      'ARCANOS:CORE',
+      'query',
+      expect.objectContaining({
+        action: 'system_state',
+        prompt: 'Inspect the current system state.',
+        __arcanosRequestedAction: 'system_state',
+      })
+    );
     expect(envelope).toEqual(
       expect.objectContaining({
-        ok: false,
-        error: expect.objectContaining({
-          code: 'WRITING_PLANE_ONLY',
-        }),
+        ok: true,
         _route: expect.objectContaining({
-          route: 'write_guard',
-          action: 'system_state',
+          route: 'core',
+          action: 'query',
         }),
       })
     );
-    expect(mockDispatchModuleAction).not.toHaveBeenCalled();
   });
 
   it('keeps normal writing prompts on module dispatch', async () => {

--- a/tests/gpt-fast-path.service.test.ts
+++ b/tests/gpt-fast-path.service.test.ts
@@ -1,16 +1,17 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const callTextResponseMock = jest.fn();
+const runTrinityWritingPipelineMock = jest.fn();
 const getOpenAIClientOrAdapterMock = jest.fn();
 const recordAiOperationMock = jest.fn();
 
-jest.unstable_mockModule('@arcanos/openai/responses', () => ({
-  callTextResponse: callTextResponseMock,
-}));
-
 jest.unstable_mockModule('@arcanos/runtime', () => ({
+  createAbortError: jest.fn((message: string) => new Error(message)),
   getRequestAbortSignal: jest.fn(() => undefined),
   runWithRequestAbortTimeout: jest.fn(async (_options: unknown, fn: () => Promise<unknown>) => fn()),
+}));
+
+jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
+  runTrinityWritingPipeline: runTrinityWritingPipelineMock,
 }));
 
 jest.unstable_mockModule('../src/services/openai/clientBridge.js', () => ({
@@ -39,25 +40,43 @@ function buildDecision(timeoutMs = 8_000) {
   };
 }
 
+function buildTrinityResult(result = 'Generated prompt text') {
+  return {
+    result,
+    module: 'trinity',
+    activeModel: 'trinity-model',
+    fallbackFlag: false,
+    routingStages: ['TRINITY'],
+    auditSafe: { mode: 'true', passed: true, flags: [] },
+    taskLineage: [],
+    fallbackSummary: {
+      intakeFallbackUsed: false,
+      gpt5FallbackUsed: false,
+      finalFallbackUsed: false,
+      fallbackReasons: [],
+    },
+    meta: {
+      tokens: {
+        prompt_tokens: 5,
+        completion_tokens: 7,
+        total_tokens: 12,
+      },
+      pipeline: 'trinity',
+      bypass: false,
+      sourceEndpoint: 'test',
+      classification: 'writing',
+    },
+  };
+}
+
 describe('executeFastGptPrompt', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    delete process.env.GPT_FAST_PATH_MODEL;
     getOpenAIClientOrAdapterMock.mockReturnValue({ client: { responses: {} } });
-    callTextResponseMock.mockResolvedValue({
-      response: {
-        id: 'resp_fast_test',
-        usage: {
-          input_tokens: 5,
-          output_tokens: 7,
-          total_tokens: 12,
-        },
-      },
-      outputText: 'Generated prompt text',
-    });
+    runTrinityWritingPipelineMock.mockResolvedValue(buildTrinityResult());
   });
 
-  it('uses the lightweight fast-path model by default', async () => {
+  it('routes simple fast-path prompts through Trinity', async () => {
     const result = await executeFastGptPrompt({
       gptId: 'arcanos-core',
       prompt: 'Generate a prompt for a launch email.',
@@ -65,45 +84,40 @@ describe('executeFastGptPrompt', () => {
       routeDecision: buildDecision(),
     });
 
-    expect(callTextResponseMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        model: 'gpt-4.1-mini',
-        store: false,
+    expect(runTrinityWritingPipelineMock).toHaveBeenCalledWith({
+      input: expect.objectContaining({
+        prompt: 'Generate a prompt for a launch email.',
+        gptId: 'arcanos-core',
+        moduleId: 'GPT:FAST_PATH',
+        sourceEndpoint: 'gpt.fast_path',
+        requestedAction: 'query',
       }),
-      expect.anything()
-    );
-    expect(result.result.activeModel).toBe('gpt-4.1-mini');
+      context: expect.objectContaining({
+        client: expect.anything(),
+        runOptions: expect.objectContaining({
+          answerMode: 'direct',
+          strictUserVisibleOutput: true,
+          watchdogModelTimeoutMs: 8_000,
+        }),
+      }),
+    });
+    expect(result.result.activeModel).toBe('trinity-model');
+    expect(result.result.fastPath).toMatchObject({
+      trinityRequired: true,
+      orchestrationBypassed: false,
+      queueBypassed: true,
+    });
     expect(recordAiOperationMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        operation: 'trinity.pipeline',
         sourceType: 'gpt_fast_path',
-        model: 'gpt-4.1-mini',
+        model: 'trinity-model',
         outcome: 'ok',
       })
     );
   });
 
-  it('honors GPT_FAST_PATH_MODEL when operators need a specific inline model', async () => {
-    process.env.GPT_FAST_PATH_MODEL = 'gpt-fast-override';
-
-    const result = await executeFastGptPrompt({
-      gptId: 'arcanos-core',
-      prompt: 'Generate a prompt for a launch email.',
-      timeoutMs: 8_000,
-      routeDecision: buildDecision(),
-    });
-
-    expect(callTextResponseMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ model: 'gpt-fast-override' }),
-      expect.anything()
-    );
-    expect(result.result.activeModel).toBe('gpt-fast-override');
-  });
-
-  it('executes query_and_wait through the generic direct action instructions', async () => {
-    process.env.GPT_FAST_PATH_MODEL = 'gpt-direct-test';
-
+  it('executes query_and_wait direct actions through Trinity', async () => {
     const result = await executeDirectGptAction({
       gptId: 'arcanos-core',
       prompt: 'Summarize deployment health.',
@@ -112,29 +126,38 @@ describe('executeFastGptPrompt', () => {
       requestId: 'req-direct-action',
     });
 
-    expect(callTextResponseMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        model: 'gpt-direct-test',
-        input: 'Summarize deployment health.',
-        store: false,
-        instructions: expect.stringContaining('direct GPT Action execution'),
+    expect(runTrinityWritingPipelineMock).toHaveBeenCalledWith({
+      input: expect.objectContaining({
+        prompt: 'Summarize deployment health.',
+        gptId: 'arcanos-core',
+        moduleId: 'GPT:DIRECT_ACTION',
+        sourceEndpoint: 'gpt.direct_action',
+        requestedAction: 'query_and_wait',
       }),
-      expect.anything()
-    );
+      context: expect.objectContaining({
+        requestId: 'req-direct-action',
+        runOptions: expect.objectContaining({
+          answerMode: 'direct',
+          watchdogModelTimeoutMs: 24_000,
+        }),
+      }),
+    });
     expect(result).toMatchObject({
       ok: true,
       result: {
         result: 'Generated prompt text',
-        module: 'direct_action',
-        activeModel: 'gpt-direct-test',
+        activeModel: 'trinity-model',
         fallbackFlag: false,
-        routingStages: ['GPT-DIRECT-ACTION'],
+        directAction: {
+          trinityRequired: true,
+          orchestrationBypassed: false,
+          action: 'query_and_wait',
+        },
       },
       directAction: {
         inline: true,
         queueBypassed: true,
-        orchestrationBypassed: true,
+        orchestrationBypassed: false,
         action: 'query_and_wait',
         timeoutMs: 24_000,
       },
@@ -147,8 +170,9 @@ describe('executeFastGptPrompt', () => {
     });
     expect(recordAiOperationMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        operation: 'trinity.pipeline',
         sourceType: 'gpt_direct_action',
-        model: 'gpt-direct-test',
+        model: 'trinity-model',
         outcome: 'ok',
       })
     );

--- a/tests/gpt-router-universal-dispatch.test.ts
+++ b/tests/gpt-router-universal-dispatch.test.ts
@@ -595,6 +595,30 @@ describe('gpt router universal dispatch', () => {
     expect(mockExecuteRuntimeInspection).not.toHaveBeenCalled();
   });
 
+  it('accepts structured message content parts for normal writing dispatch', async () => {
+    const messages = [
+      { role: 'system', content: 'You write compact operator notes.' },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Draft a release note for Trinity facade routing.' }
+        ]
+      }
+    ];
+
+    const response = await request(buildApp())
+      .post('/gpt/arcanos-core')
+      .send({ messages });
+
+    expect(response.status).toBe(200);
+    expect(mockRouteGptRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gptId: 'arcanos-core',
+        body: expect.objectContaining({ messages })
+      })
+    );
+  });
+
   it('keeps diagnostics working through POST /gpt/{gptId}', async () => {
     const response = await request(buildApp())
       .post('/gpt/arcanos-core')

--- a/tests/openai-prompt.test.ts
+++ b/tests/openai-prompt.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
 
 const callOpenAI = jest.fn() as jest.MockedFunction<any>;
+const runTrinityWritingPipeline = jest.fn() as jest.MockedFunction<any>;
 const getDefaultModel = jest.fn() as jest.MockedFunction<any>;
 const validateAIRequest = jest.fn() as jest.MockedFunction<any>;
 const handleAIError = jest.fn() as jest.MockedFunction<any>;
@@ -35,8 +36,35 @@ let DEFAULT_PROMPT_ROUTE_PIPELINE_TIMEOUT_MS: number;
 let DEFAULT_PROMPT_ROUTE_PROVIDER_TIMEOUT_MS: number;
 let originalNodeEnv: string | undefined;
 
+function buildTrinityPromptResult(result: string, activeModel: string) {
+  return {
+    result,
+    module: 'trinity',
+    activeModel,
+    fallbackFlag: false,
+    routingStages: ['TRINITY'],
+    auditSafe: { mode: 'true', passed: true, flags: [] },
+    taskLineage: [],
+    fallbackSummary: {
+      intakeFallbackUsed: false,
+      gpt5FallbackUsed: false,
+      finalFallbackUsed: false,
+      fallbackReasons: [],
+    },
+    meta: {
+      id: 'prompt_test',
+      created: 1_234,
+      pipeline: 'trinity',
+      bypass: false,
+      sourceEndpoint: '/api/openai/prompt',
+      classification: 'writing',
+    },
+  };
+}
+
 beforeEach(async () => {
   jest.resetModules();
+  jest.clearAllMocks();
   originalNodeEnv = process.env.NODE_ENV;
   process.env.NODE_ENV = 'test';
 
@@ -49,6 +77,10 @@ beforeEach(async () => {
     getOpenAIKeySource
   }));
 
+  jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
+    runTrinityWritingPipeline
+  }));
+
   jest.unstable_mockModule('../src/transport/http/requestHandler.js', () => ({
     validateAIRequest,
     handleAIError,
@@ -56,6 +88,9 @@ beforeEach(async () => {
   }));
 
   jest.unstable_mockModule('@arcanos/runtime', () => ({
+    OpenAIAbortError: class OpenAIAbortError extends Error {},
+    createAbortError: jest.fn((message: string) => new Error(message)),
+    isAbortError: jest.fn((error: unknown) => error instanceof Error && /abort/i.test(error.message)),
     runWithRequestAbortTimeout: runWithRequestAbortTimeoutMock,
     getRequestAbortSignal: getRequestAbortSignalMock
   }));
@@ -94,27 +129,38 @@ afterEach(() => {
 describe('handlePrompt', () => {
   it('uses provided model when specified', async () => {
     validateAIRequest.mockReturnValue({ input: 'hi', client: {} });
-    callOpenAI.mockResolvedValue({ response: {}, output: 'ok', model: 'ft:custom-model', cached: false });
+    runTrinityWritingPipeline.mockResolvedValue(buildTrinityPromptResult('ok', 'ft:custom-model'));
 
     const req: any = { body: { prompt: 'hi', model: 'ft:custom-model' } };
     const res: any = { json: jest.fn() };
 
     await handlePrompt(req, res);
 
-    expect(callOpenAI).toHaveBeenCalledWith(
-      'ft:custom-model',
-      'hi',
-      256,
-      true,
-      expect.objectContaining({
-        timeoutMs: DEFAULT_PROMPT_ROUTE_PROVIDER_TIMEOUT_MS,
-        maxRetries: 1,
-        metadata: expect.objectContaining({
-          route: '/api/openai/prompt',
-          mitigationMode: 'normal'
+    expect(runTrinityWritingPipeline).toHaveBeenCalledWith({
+      input: expect.objectContaining({
+        prompt: 'hi',
+        moduleId: 'OPENAI:PROMPT',
+        sourceEndpoint: '/api/openai/prompt',
+        requestedAction: 'query',
+        tokenLimit: 256,
+        body: expect.objectContaining({
+          model: 'ft:custom-model',
+          tokenLimit: 256,
+          mitigation: expect.objectContaining({
+            route: '/api/openai/prompt',
+            mitigationMode: 'normal'
+          })
+        })
+      }),
+      context: expect.objectContaining({
+        client: expect.anything(),
+        runOptions: expect.objectContaining({
+          answerMode: 'direct',
+          strictUserVisibleOutput: true,
+          watchdogModelTimeoutMs: DEFAULT_PROMPT_ROUTE_PROVIDER_TIMEOUT_MS
         })
       })
-    );
+    });
     expect(runWithRequestAbortTimeoutMock).toHaveBeenCalledWith(
       expect.objectContaining({
         timeoutMs: DEFAULT_PROMPT_ROUTE_PIPELINE_TIMEOUT_MS,
@@ -141,23 +187,21 @@ describe('handlePrompt', () => {
 
   it('trims provided model names before sending to OpenAI', async () => {
     validateAIRequest.mockReturnValue({ input: 'hi', client: {} });
-    callOpenAI.mockResolvedValue({ response: {}, output: 'ok', model: 'ft:custom-model', cached: false });
+    runTrinityWritingPipeline.mockResolvedValue(buildTrinityPromptResult('ok', 'ft:custom-model'));
 
     const req: any = { body: { prompt: 'hi', model: '  ft:custom-model  ' } };
     const res: any = { json: jest.fn() };
 
     await handlePrompt(req, res);
 
-    expect(callOpenAI).toHaveBeenCalledWith(
-      'ft:custom-model',
-      'hi',
-      256,
-      true,
-      expect.objectContaining({
-        timeoutMs: DEFAULT_PROMPT_ROUTE_PROVIDER_TIMEOUT_MS,
-        maxRetries: 1
+    expect(runTrinityWritingPipeline).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({
+        body: expect.objectContaining({
+          model: 'ft:custom-model',
+          tokenLimit: 256
+        })
       })
-    );
+    }));
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({
         model: 'ft:custom-model',
@@ -169,7 +213,7 @@ describe('handlePrompt', () => {
   it('falls back to default model when none provided', async () => {
     validateAIRequest.mockReturnValue({ input: 'hello', client: {} });
     getDefaultModel.mockReturnValue('ft:default-model');
-    callOpenAI.mockResolvedValue({ response: {}, output: 'ok', model: 'ft:default-model', cached: false });
+    runTrinityWritingPipeline.mockResolvedValue(buildTrinityPromptResult('ok', 'ft:default-model'));
 
     const req: any = { body: { prompt: 'hello' } };
     const res: any = { json: jest.fn() };
@@ -177,16 +221,15 @@ describe('handlePrompt', () => {
     await handlePrompt(req, res);
 
     expect(getDefaultModel).toHaveBeenCalled();
-    expect(callOpenAI).toHaveBeenCalledWith(
-      'ft:default-model',
-      'hello',
-      256,
-      true,
-      expect.objectContaining({
-        timeoutMs: DEFAULT_PROMPT_ROUTE_PROVIDER_TIMEOUT_MS,
-        maxRetries: 1
+    expect(runTrinityWritingPipeline).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({
+        prompt: 'hello',
+        body: expect.objectContaining({
+          model: 'ft:default-model',
+          tokenLimit: 256
+        })
       })
-    );
+    }));
     const payload = res.json.mock.calls[0][0];
     expect(payload).toEqual(
       expect.objectContaining({
@@ -218,7 +261,7 @@ describe('handlePrompt', () => {
 
     await handlePrompt(req, res);
 
-    expect(callOpenAI).not.toHaveBeenCalled();
+    expect(runTrinityWritingPipeline).not.toHaveBeenCalled();
     expect(generateDegradedResponse).toHaveBeenCalledWith('hello', 'prompt');
     expect(req.logger.warn).toHaveBeenCalledWith('prompt.route.mitigated', expect.objectContaining({
       mitigationMode: 'degraded_response',
@@ -251,7 +294,7 @@ describe('handlePrompt', () => {
   it('uses the reduced-latency prompt-route policy when mitigation is active', async () => {
     validateAIRequest.mockReturnValue({ input: 'hello', client: {} });
     activatePromptRouteReducedLatencyMode('timeout storm detected', 256);
-    callOpenAI.mockResolvedValue({ response: {}, output: 'ok', model: 'ft:fallback-model', cached: false });
+    runTrinityWritingPipeline.mockResolvedValue(buildTrinityPromptResult('ok', 'ft:fallback-model'));
 
     const req: any = {
       body: { prompt: 'hello' },
@@ -263,21 +306,26 @@ describe('handlePrompt', () => {
 
     await handlePrompt(req, res);
 
-    expect(callOpenAI).toHaveBeenCalledWith(
-      'ft:fallback-model',
-      'hello',
-      96,
-      true,
-      expect.objectContaining({
-        timeoutMs: 3200,
-        maxRetries: 0,
-        metadata: expect.objectContaining({
-          route: '/api/openai/prompt',
-          mitigationMode: 'reduced_latency',
-          bypassedSubsystems: expect.arrayContaining(['provider_retry', 'long_generation_tail'])
+    expect(runTrinityWritingPipeline).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({
+        prompt: 'hello',
+        tokenLimit: 96,
+        body: expect.objectContaining({
+          model: 'ft:fallback-model',
+          tokenLimit: 96,
+          mitigation: expect.objectContaining({
+            route: '/api/openai/prompt',
+            mitigationMode: 'reduced_latency',
+            bypassedSubsystems: expect.arrayContaining(['provider_retry', 'long_generation_tail'])
+          })
+        })
+      }),
+      context: expect.objectContaining({
+        runOptions: expect.objectContaining({
+          watchdogModelTimeoutMs: 3200
         })
       })
-    );
+    }));
     expect(req.logger.warn).toHaveBeenCalledWith(
       'prompt.route.reduced_latency',
       expect.objectContaining({
@@ -311,7 +359,7 @@ describe('handlePrompt', () => {
   it('fast-trips into reduced latency mode after repeated prompt timeout incidents', async () => {
     validateAIRequest.mockReturnValue({ input: 'hello', client: {} });
     classifyBudgetAbortKind.mockReturnValue('budget_abort');
-    callOpenAI.mockRejectedValue(new Error('Request was aborted.'));
+    runTrinityWritingPipeline.mockRejectedValue(new Error('Request was aborted.'));
 
     const reqFactory = () => ({
       body: { prompt: 'hello' },

--- a/tests/prompt-debug.route.test.ts
+++ b/tests/prompt-debug.route.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 const callOpenAIMock = jest.fn();
+const runTrinityWritingPipelineMock = jest.fn();
 const validateAIRequestMock = jest.fn();
 const handleAIErrorMock = jest.fn();
 
@@ -26,6 +27,10 @@ jest.unstable_mockModule('@transport/http/requestHandler.js', () => ({
   validateAIRequest: validateAIRequestMock,
   handleAIError: handleAIErrorMock,
   classifyBudgetAbortKind: () => null,
+}));
+
+jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
+  runTrinityWritingPipeline: runTrinityWritingPipelineMock,
 }));
 
 jest.unstable_mockModule('@services/openai/promptRouteMitigation.js', () => ({
@@ -87,6 +92,9 @@ jest.unstable_mockModule('@platform/runtime/env.js', () => ({
 }));
 
 jest.unstable_mockModule('@arcanos/runtime', () => ({
+  OpenAIAbortError: class OpenAIAbortError extends Error {},
+  createAbortError: jest.fn((message: string) => new Error(message)),
+  isAbortError: jest.fn((error: unknown) => error instanceof Error && /abort/i.test(error.message)),
   runWithRequestAbortTimeout: async (_options: unknown, operation: () => Promise<unknown>) => operation(),
   getRequestAbortSignal: () => undefined,
 }));
@@ -127,9 +135,25 @@ describe('prompt debug routes', () => {
         prompt: 'verify in production on the live backend runtime that is currently active',
       },
     });
-    callOpenAIMock.mockResolvedValue({
-      output: 'Observed a response.',
-      model: 'gpt-5',
+    runTrinityWritingPipelineMock.mockResolvedValue({
+      result: 'Observed a response.',
+      activeModel: 'gpt-5',
+      fallbackFlag: false,
+      routingStages: ['TRINITY'],
+      auditSafe: { mode: 'true', passed: true, flags: [] },
+      taskLineage: [],
+      fallbackSummary: {
+        intakeFallbackUsed: false,
+        gpt5FallbackUsed: false,
+        finalFallbackUsed: false,
+        fallbackReasons: [],
+      },
+      meta: {
+        pipeline: 'trinity',
+        bypass: false,
+        sourceEndpoint: '/api/openai/prompt',
+        classification: 'writing',
+      },
     });
   });
 
@@ -167,7 +191,7 @@ describe('prompt debug routes', () => {
       preservedConstraints: ['live backend', 'runtime', 'currently active', 'verify in production'],
       droppedConstraints: [],
       finalExecutorPayload: expect.objectContaining({
-        executor: 'callOpenAI',
+        executor: 'runTrinityWritingPipeline',
         model: 'gpt-5',
       }),
       responseReturned: expect.objectContaining({

--- a/tests/query-finetune-trinity.test.ts
+++ b/tests/query-finetune-trinity.test.ts
@@ -1,153 +1,112 @@
-import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const runResponseMock = jest.fn();
-const getFallbackModelMock = jest.fn(() => 'gpt-4.1');
-const loggerWarnMock = jest.fn();
+const runTrinityWritingPipelineMock = jest.fn();
+const getOpenAIClientOrAdapterMock = jest.fn();
+const createRuntimeBudgetMock = jest.fn(() => ({ remainingMs: () => 30_000 }));
 
-jest.unstable_mockModule('../src/lib/runResponse.js', () => ({
-  runResponse: runResponseMock
+jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
+  runTrinityWritingPipeline: runTrinityWritingPipelineMock
 }));
 
-jest.unstable_mockModule('../src/services/openai.js', () => ({
-  getFallbackModel: getFallbackModelMock
+jest.unstable_mockModule('../src/services/openai/clientBridge.js', () => ({
+  getOpenAIClientOrAdapter: getOpenAIClientOrAdapterMock
 }));
 
-jest.unstable_mockModule('../src/platform/logging/structuredLogging.js', () => ({
-  aiLogger: {
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn()
-  },
-  logger: {
-    warn: loggerWarnMock
-  }
+jest.unstable_mockModule('../src/platform/resilience/runtimeBudget.js', () => ({
+  createRuntimeBudget: createRuntimeBudgetMock
 }));
 
 const { runTrinity } = await import('../src/trinity/trinity.js');
 
-describe('runTrinity fine-tuned route fallback', () => {
+function buildTrinityResult(overrides: Record<string, unknown> = {}) {
+  return {
+    result: '{"status":"ok"}',
+    module: 'trinity',
+    activeModel: 'trinity-model',
+    fallbackFlag: false,
+    routingStages: ['TRINITY'],
+    auditSafe: { mode: 'true', passed: true, flags: [] },
+    taskLineage: [],
+    fallbackSummary: {
+      intakeFallbackUsed: false,
+      gpt5FallbackUsed: false,
+      finalFallbackUsed: false,
+      fallbackReasons: [],
+    },
+    meta: {
+      pipeline: 'trinity',
+      bypass: false,
+      sourceEndpoint: 'query-finetune',
+      classification: 'writing',
+    },
+    ...overrides,
+  };
+}
+
+describe('runTrinity fine-tuned route compatibility facade', () => {
   beforeEach(() => {
-    runResponseMock.mockReset();
-    getFallbackModelMock.mockClear();
-    loggerWarnMock.mockClear();
+    jest.clearAllMocks();
+    getOpenAIClientOrAdapterMock.mockReturnValue({ client: { responses: {} } });
+    runTrinityWritingPipelineMock.mockResolvedValue(buildTrinityResult());
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
-  it('includes json wording in structured prompts and falls back to the base model on primary failure', async () => {
-    runResponseMock
-      .mockRejectedValueOnce(new Error('fine-tuned model unavailable'))
-      .mockResolvedValueOnce({
-        model: 'gpt-4.1',
-        output: [
-          {
-            type: 'message',
-            content: [
-              {
-                type: 'output_text',
-                text: '{"status":"ok"}'
-              }
-            ]
-          }
-        ]
-      });
-
+  it('preserves structured JSON prompting while executing through Trinity', async () => {
     const result = await runTrinity({
       prompt: 'health check',
       model: 'ft:custom-model',
       structured: true
     });
 
-    expect(runResponseMock).toHaveBeenCalledTimes(2);
-    expect(runResponseMock.mock.calls[0][0]).toEqual(expect.objectContaining({
-      model: 'ft:custom-model',
-      json: true,
-      input: [
-        {
-          role: 'user',
-          content: expect.stringMatching(/json/i)
-        }
-      ]
-    }));
-    expect(runResponseMock.mock.calls[1][0]).toEqual(expect.objectContaining({
-      model: 'gpt-4.1',
-      json: true
-    }));
+    expect(runTrinityWritingPipelineMock).toHaveBeenCalledTimes(1);
+    expect(runTrinityWritingPipelineMock).toHaveBeenCalledWith({
+      input: expect.objectContaining({
+        prompt: expect.stringMatching(/json/i),
+        moduleId: 'QUERY:FINETUNE',
+        sourceEndpoint: 'query-finetune',
+        requestedAction: 'query',
+        body: expect.objectContaining({
+          prompt: 'health check',
+          model: 'ft:custom-model',
+          structured: true,
+        }),
+      }),
+      context: expect.objectContaining({
+        client: expect.anything(),
+        runOptions: expect.objectContaining({
+          answerMode: 'audit',
+          strictUserVisibleOutput: true,
+        }),
+      }),
+    });
     expect(result).toEqual(expect.objectContaining({
       requestedModel: 'ft:custom-model',
-      activeModel: 'gpt-4.1',
-      fallbackFlag: true,
-      fallbackReason: 'fine-tuned model unavailable',
-      output: '{"status":"ok"}'
-    }));
-    expect(loggerWarnMock).toHaveBeenCalledWith('MODEL_FALLBACK_TRIGGERED', expect.objectContaining({
-      requestedModel: 'ft:custom-model',
-      fallbackModel: 'gpt-4.1'
+      model: 'trinity-model',
+      activeModel: 'trinity-model',
+      fallbackFlag: false,
+      output: '{"status":"ok"}',
+      raw: expect.objectContaining({
+        meta: expect.objectContaining({
+          pipeline: 'trinity',
+          bypass: false,
+        }),
+      }),
     }));
   });
 
-  it('aborts slow primary calls at the latency budget and retries the fallback with its own bounded attempt', async () => {
-    jest.useFakeTimers();
-    runResponseMock
-      .mockImplementationOnce(() => new Promise(() => undefined))
-      .mockResolvedValueOnce({
-        model: 'gpt-4.1',
-        output: [
-          {
-            type: 'message',
-            content: [
-              {
-                type: 'output_text',
-                text: '{"status":"fallback-ok"}'
-              }
-            ]
-          }
-        ]
-      });
-
-    const resultPromise = runTrinity({
+  it('passes latency budgets into Trinity watchdog options', async () => {
+    await runTrinity({
       prompt: 'health check',
       model: 'ft:slow-model',
       structured: true,
       latencyBudgetMs: 25
     });
 
-    await jest.advanceTimersByTimeAsync(25);
-    const result = await resultPromise;
-
-    expect(runResponseMock).toHaveBeenCalledTimes(2);
-    expect(runResponseMock.mock.calls[0][0]).toEqual(expect.objectContaining({
-      model: 'ft:slow-model',
-      requestOptions: expect.objectContaining({
-        signal: expect.objectContaining({
-          aborted: true
+    expect(runTrinityWritingPipelineMock).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({
+        runOptions: expect.objectContaining({
+          watchdogModelTimeoutMs: 25
         })
       })
-    }));
-    expect(runResponseMock.mock.calls[1][0]).toEqual(expect.objectContaining({
-      model: 'gpt-4.1',
-      requestOptions: expect.objectContaining({
-        signal: expect.any(Object)
-      })
-    }));
-    expect(result).toEqual(expect.objectContaining({
-      requestedModel: 'ft:slow-model',
-      activeModel: 'gpt-4.1',
-      fallbackFlag: true,
-      output: '{"status":"fallback-ok"}'
-    }));
-    expect(loggerWarnMock).toHaveBeenCalledWith('MODEL_LATENCY_BUDGET_EXCEEDED', expect.objectContaining({
-      requestedModel: 'ft:slow-model',
-      activeModel: 'ft:slow-model',
-      attempt: 'primary',
-      latencyBudgetMs: 25
-    }));
-    expect(loggerWarnMock).toHaveBeenCalledWith('MODEL_FALLBACK_TRIGGERED', expect.objectContaining({
-      requestedModel: 'ft:slow-model',
-      fallbackModel: 'gpt-4.1',
-      latencyBudgetMs: 25
     }));
   });
 });

--- a/tests/reusable-code-generation.test.ts
+++ b/tests/reusable-code-generation.test.ts
@@ -183,6 +183,8 @@ describe('reusable code generation', () => {
       name: 'idGenerator',
       language: 'typescript',
     }));
+    expect(result.snippets[0]?.code).toContain('import { randomUUID } from "node:crypto";');
+    expect(result.snippets[0]?.code).toContain('randomUUID().replace');
     expect(result.raw).toContain('"snippets"');
   });
 

--- a/tests/reusable-code-generation.test.ts
+++ b/tests/reusable-code-generation.test.ts
@@ -80,6 +80,53 @@ describe('reusable code generation', () => {
     ]);
   });
 
+  it('repairs invalid reusable-code JSON through Trinity before parsing', async () => {
+    const client = { responses: { create: jest.fn() } } as any;
+    runTrinityWritingPipelineMock
+      .mockResolvedValueOnce({
+        result: 'I cannot verify external state.',
+        activeModel: 'trinity-model',
+      })
+      .mockResolvedValueOnce({
+        result: JSON.stringify({
+          snippets: [
+            {
+              name: 'idGenerator',
+              description: 'ID generator',
+              language: 'typescript',
+              code: 'export const id = () => crypto.randomUUID();',
+            },
+          ],
+        }),
+        activeModel: 'repair-model',
+      });
+
+    const result = await generateReusableCodeSnippets(
+      client,
+      { target: 'idGenerator', includeDocs: false, language: 'typescript' }
+    );
+
+    expect(runTrinityWritingPipelineMock).toHaveBeenCalledTimes(2);
+    expect(runTrinityWritingPipelineMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        input: expect.objectContaining({
+          sourceEndpoint: 'api.reusables.repair',
+          moduleId: 'REUSABLE:CODE',
+        }),
+      })
+    );
+    expect(result.model).toBe('repair-model');
+    expect(result.snippets).toEqual([
+      {
+        name: 'idGenerator',
+        description: 'ID generator',
+        language: 'typescript',
+        code: 'export const id = () => crypto.randomUUID();',
+      },
+    ]);
+  });
+
   it('keeps explicit schema parsing for raw JSON helper usage', () => {
     const parsed = parseReusableCodeResponse(
       '{"snippets":[{"name":"idGenerator","description":"IDs","language":"typescript","code":"export const id=() => 1;"}]}'

--- a/tests/reusable-code-generation.test.ts
+++ b/tests/reusable-code-generation.test.ts
@@ -127,6 +127,33 @@ describe('reusable code generation', () => {
     ]);
   });
 
+  it('falls back to deterministic snippets after invalid primary and repair outputs', async () => {
+    const client = { responses: { create: jest.fn() } } as any;
+    runTrinityWritingPipelineMock
+      .mockResolvedValueOnce({
+        result: 'I cannot verify external state.',
+        activeModel: 'trinity-model',
+      })
+      .mockResolvedValueOnce({
+        result: 'Still not JSON.',
+        activeModel: 'repair-model',
+      });
+
+    const result = await generateReusableCodeSnippets(
+      client,
+      { target: 'idGenerator', includeDocs: false, language: 'typescript' }
+    );
+
+    expect(runTrinityWritingPipelineMock).toHaveBeenCalledTimes(2);
+    expect(result.model).toBe('repair-model:deterministic-json-fallback');
+    expect(result.snippets).toHaveLength(1);
+    expect(result.snippets[0]).toEqual(expect.objectContaining({
+      name: 'idGenerator',
+      language: 'typescript',
+    }));
+    expect(result.raw).toContain('"snippets"');
+  });
+
   it('keeps explicit schema parsing for raw JSON helper usage', () => {
     const parsed = parseReusableCodeResponse(
       '{"snippets":[{"name":"idGenerator","description":"IDs","language":"typescript","code":"export const id=() => 1;"}]}'

--- a/tests/reusable-code-generation.test.ts
+++ b/tests/reusable-code-generation.test.ts
@@ -70,6 +70,16 @@ describe('reusable code generation', () => {
     }));
     expect(client.responses.create).not.toHaveBeenCalled();
     expect(result.model).toBe('trinity-model');
+    expect(result.meta).toEqual(expect.objectContaining({
+      pipeline: 'trinity',
+      bypass: false,
+      sourceEndpoint: 'api.reusables',
+      classification: 'writing',
+      moduleId: 'REUSABLE:CODE',
+      requestedAction: 'query',
+      executionMode: 'request',
+      fallbackFlag: false,
+    }));
     expect(result.snippets).toEqual([
       {
         name: 'asyncHandler',
@@ -117,6 +127,16 @@ describe('reusable code generation', () => {
       })
     );
     expect(result.model).toBe('repair-model');
+    expect(result.meta).toEqual(expect.objectContaining({
+      pipeline: 'trinity',
+      bypass: false,
+      sourceEndpoint: 'api.reusables.repair',
+      classification: 'writing',
+      moduleId: 'REUSABLE:CODE',
+      requestedAction: 'query',
+      executionMode: 'request',
+      repairAttempted: true,
+    }));
     expect(result.snippets).toEqual([
       {
         name: 'idGenerator',
@@ -146,6 +166,18 @@ describe('reusable code generation', () => {
 
     expect(runTrinityWritingPipelineMock).toHaveBeenCalledTimes(2);
     expect(result.model).toBe('repair-model:deterministic-json-fallback');
+    expect(result.meta).toEqual(expect.objectContaining({
+      pipeline: 'trinity',
+      bypass: false,
+      sourceEndpoint: 'api.reusables.repair',
+      classification: 'writing',
+      moduleId: 'REUSABLE:CODE',
+      requestedAction: 'query',
+      executionMode: 'request',
+      repairAttempted: true,
+      deterministicJsonFallback: true,
+      degraded: true,
+    }));
     expect(result.snippets).toHaveLength(1);
     expect(result.snippets[0]).toEqual(expect.objectContaining({
       name: 'idGenerator',

--- a/tests/reusable-code-generation.test.ts
+++ b/tests/reusable-code-generation.test.ts
@@ -1,15 +1,21 @@
-import { describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-import {
+const runTrinityWritingPipelineMock = jest.fn();
+
+jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
+  runTrinityWritingPipeline: runTrinityWritingPipelineMock
+}));
+
+const {
   generateReusableCodeSnippets,
   parseReusableCodeResponse,
-} from '../src/services/reusableCodeGeneration.ts';
+} = await import('../src/services/reusableCodeGeneration.ts');
 
 describe('reusable code generation', () => {
-  it('parses reusable snippets through the shared structured response helper', async () => {
-    const create = jest.fn().mockResolvedValue({
-      model: 'gpt-4.1-mini',
-      output_text: JSON.stringify({
+  beforeEach(() => {
+    jest.clearAllMocks();
+    runTrinityWritingPipelineMock.mockResolvedValue({
+      result: JSON.stringify({
         snippets: [
           {
             name: 'asyncHandler',
@@ -19,16 +25,51 @@ describe('reusable code generation', () => {
           },
         ],
       }),
-      output: [],
+      activeModel: 'trinity-model',
+      fallbackFlag: false,
+      routingStages: ['TRINITY'],
+      auditSafe: { mode: 'true', passed: true, flags: [] },
+      taskLineage: [],
+      fallbackSummary: {
+        intakeFallbackUsed: false,
+        gpt5FallbackUsed: false,
+        finalFallbackUsed: false,
+        fallbackReasons: [],
+      },
+      meta: {
+        pipeline: 'trinity',
+        bypass: false,
+        sourceEndpoint: 'api.reusables',
+        classification: 'writing',
+      },
     });
+  });
+
+  it('parses reusable snippets through Trinity', async () => {
+    const client = { responses: { create: jest.fn() } } as any;
 
     const result = await generateReusableCodeSnippets(
-      { responses: { create } } as any,
+      client,
       { target: 'asyncHandler', includeDocs: true, language: 'typescript' }
     );
 
-    expect(create).toHaveBeenCalledTimes(1);
-    expect(result.model).toBe('gpt-4.1-mini');
+    expect(runTrinityWritingPipelineMock).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({
+        moduleId: 'REUSABLE:CODE',
+        sourceEndpoint: 'api.reusables',
+        requestedAction: 'query',
+        body: expect.objectContaining({
+          target: 'asyncHandler',
+          includeDocs: true,
+          language: 'typescript',
+        }),
+      }),
+      context: expect.objectContaining({
+        client,
+      }),
+    }));
+    expect(client.responses.create).not.toHaveBeenCalled();
+    expect(result.model).toBe('trinity-model');
     expect(result.snippets).toEqual([
       {
         name: 'asyncHandler',

--- a/tests/trinity-writing-pipeline.test.ts
+++ b/tests/trinity-writing-pipeline.test.ts
@@ -481,6 +481,34 @@ describe('runTrinityWritingPipeline', () => {
     );
   });
 
+  it('rejects empty prompt input when no message content can be resolved', async () => {
+    await expect(
+      runTrinityWritingPipeline({
+        input: {
+          prompt: '   ',
+          messages: [
+            { role: 'system', content: '   ' },
+            { role: 'user', content: '' }
+          ],
+          sourceEndpoint: 'write.empty',
+          body: {
+            prompt: '   ',
+            messages: [
+              { role: 'system', content: '   ' },
+              { role: 'user', content: '' }
+            ]
+          }
+        },
+        context: {
+          client: {} as never,
+          requestId: 'req-empty-prompt'
+        }
+      })
+    ).rejects.toThrow('Trinity generation requires a non-empty prompt or messages array.');
+
+    expect(runThroughBrainMock).not.toHaveBeenCalled();
+  });
+
   it('normalizes fractional token limits to positive integers without mutating the source result', () => {
     const sourceResult = {
       result: 'ok',
@@ -527,5 +555,76 @@ describe('runTrinityWritingPipeline', () => {
       tokenLimit: 1,
       outputLimit: 1
     }));
+  });
+
+  it('preserves source meta and clones background metadata into the invariant envelope', () => {
+    const background = {
+      reason: 'arcanos_core_background',
+      requestedBy: 'worker'
+    };
+    const sourceResult = {
+      result: 'ok',
+      module: 'trinity',
+      meta: {
+        id: 'resp-background',
+        created: 2,
+        existing: 'preserved'
+      },
+      activeModel: 'gpt-5.1',
+      fallbackFlag: false,
+      dryRun: false,
+      fallbackSummary: {
+        intakeFallbackUsed: false,
+        gpt5FallbackUsed: false,
+        finalFallbackUsed: false,
+        fallbackReasons: []
+      },
+      auditSafe: {
+        mode: true,
+        overrideUsed: false,
+        auditFlags: [],
+        processedSafely: true
+      },
+      memoryContext: {
+        entriesAccessed: 0,
+        contextSummary: '',
+        memoryEnhanced: false,
+        maxRelevanceScore: 0,
+        averageRelevanceScore: 0
+      },
+      taskLineage: {
+        requestId: 'req-background',
+        logged: true
+      }
+    };
+
+    const stamped = applyTrinityGenerationInvariant(sourceResult, {
+      sourceEndpoint: 'write.background',
+      executionMode: 'background',
+      background
+    });
+
+    expect(stamped).not.toBe(sourceResult);
+    expect(sourceResult.meta).toEqual({
+      id: 'resp-background',
+      created: 2,
+      existing: 'preserved'
+    });
+    expect(stamped.meta).toEqual(expect.objectContaining({
+      id: 'resp-background',
+      created: 2,
+      existing: 'preserved',
+      pipeline: 'trinity',
+      sourceEndpoint: 'write.background',
+      executionMode: 'background',
+      background
+    }));
+    expect((stamped.meta as Record<string, unknown>).background).not.toBe(background);
+
+    background.reason = 'mutated-after-stamp';
+    expect((stamped.meta as { background?: Record<string, unknown> }).background).toEqual({
+      reason: 'arcanos_core_background',
+      requestedBy: 'worker'
+    });
   });
 });

--- a/tests/trinity-writing-pipeline.test.ts
+++ b/tests/trinity-writing-pipeline.test.ts
@@ -47,7 +47,8 @@ jest.unstable_mockModule('@platform/logging/structuredLogging.js', () => ({
 
 const {
   runTrinityWritingPipeline,
-  TrinityControlLeakError
+  TrinityControlLeakError,
+  applyTrinityGenerationInvariant
 } = await import('../src/core/logic/trinityWritingPipeline.js');
 
 describe('runTrinityWritingPipeline', () => {
@@ -110,7 +111,17 @@ describe('runTrinityWritingPipeline', () => {
       }
     });
 
-    expect(result).toBe(trinityResult);
+    expect(result).toEqual(expect.objectContaining({
+      ...trinityResult,
+      meta: expect.objectContaining({
+        id: 'resp-1',
+        pipeline: 'trinity',
+        bypass: false,
+        sourceEndpoint: 'write',
+        classification: 'writing'
+      })
+    }));
+    expect(trinityResult.meta).toEqual({ id: 'resp-1', created: expect.any(Number) });
     expect(runThroughBrainMock).toHaveBeenCalledWith(
       client,
       'Write a concise release summary.',
@@ -313,7 +324,15 @@ describe('runTrinityWritingPipeline', () => {
       }
     });
 
-    expect(result).toBe(trinityResult);
+    expect(result).toEqual(expect.objectContaining({
+      ...trinityResult,
+      meta: expect.objectContaining({
+        pipeline: 'trinity',
+        bypass: false,
+        sourceEndpoint: 'write',
+        classification: 'writing'
+      })
+    }));
     expect(runThroughBrainMock).toHaveBeenCalledTimes(1);
     expect(loggerErrorMock).not.toHaveBeenCalledWith(
       'trinity.control_leak_detected',
@@ -395,5 +414,118 @@ describe('runTrinityWritingPipeline', () => {
         action: 'dag.run.create'
       })
     );
+  });
+
+  it('accepts structured chat messages and resolves them at the facade boundary', async () => {
+    runThroughBrainMock.mockResolvedValue({
+      result: 'structured chat output',
+      module: 'trinity',
+      meta: { id: 'resp-messages', created: Date.now() },
+      activeModel: 'gpt-5.1',
+      fallbackFlag: false,
+      dryRun: false,
+      fallbackSummary: {
+        intakeFallbackUsed: false,
+        gpt5FallbackUsed: false,
+        finalFallbackUsed: false,
+        fallbackReasons: []
+      },
+      auditSafe: {
+        mode: true,
+        overrideUsed: false,
+        auditFlags: [],
+        processedSafely: true
+      },
+      memoryContext: {
+        entriesAccessed: 0,
+        contextSummary: '',
+        memoryEnhanced: false,
+        maxRelevanceScore: 0,
+        averageRelevanceScore: 0
+      },
+      taskLineage: {
+        requestId: 'req-messages',
+        logged: true
+      }
+    });
+
+    await runTrinityWritingPipeline({
+      input: {
+        messages: [
+          { role: 'system', content: 'Preserve the policy frame.' },
+          { role: 'user', content: 'Write the response from these chat messages.' }
+        ],
+        sourceEndpoint: 'write.messages',
+        body: {
+          messages: [
+            { role: 'system', content: 'Preserve the policy frame.' },
+            { role: 'user', content: 'Write the response from these chat messages.' }
+          ]
+        }
+      },
+      context: {
+        client: {} as never,
+        requestId: 'req-messages'
+      }
+    });
+
+    expect(runThroughBrainMock).toHaveBeenCalledWith(
+      expect.anything(),
+      '[system]\nPreserve the policy frame.\n\n[user]\nWrite the response from these chat messages.',
+      undefined,
+      undefined,
+      {
+        sourceEndpoint: 'write.messages'
+      },
+      expect.anything()
+    );
+  });
+
+  it('normalizes fractional token limits to positive integers without mutating the source result', () => {
+    const sourceResult = {
+      result: 'ok',
+      module: 'trinity',
+      meta: { id: 'resp-positive', created: 1 },
+      activeModel: 'gpt-5.1',
+      fallbackFlag: false,
+      dryRun: false,
+      fallbackSummary: {
+        intakeFallbackUsed: false,
+        gpt5FallbackUsed: false,
+        finalFallbackUsed: false,
+        fallbackReasons: []
+      },
+      auditSafe: {
+        mode: true,
+        overrideUsed: false,
+        auditFlags: [],
+        processedSafely: true
+      },
+      memoryContext: {
+        entriesAccessed: 0,
+        contextSummary: '',
+        memoryEnhanced: false,
+        maxRelevanceScore: 0,
+        averageRelevanceScore: 0
+      },
+      taskLineage: {
+        requestId: 'req-positive',
+        logged: true
+      }
+    };
+
+    const stamped = applyTrinityGenerationInvariant(sourceResult, {
+      sourceEndpoint: 'write',
+      tokenLimit: 0.5,
+      outputLimit: 0.25
+    });
+
+    expect(stamped).not.toBe(sourceResult);
+    expect(sourceResult.meta).toEqual({ id: 'resp-positive', created: 1 });
+    expect(stamped.meta).toEqual(expect.objectContaining({
+      pipeline: 'trinity',
+      tokenLimit: 1,
+      outputLimit: 1
+    }));
   });
 });

--- a/tests/tutor-logic.prompt-forwarding.test.ts
+++ b/tests/tutor-logic.prompt-forwarding.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const mockResponsesCreate = jest.fn();
+const mockRunTrinityWritingPipeline = jest.fn();
 const mockGetOpenAIClientOrAdapter = jest.fn();
 const mockGetDefaultModel = jest.fn();
 const mockGetGPT5Model = jest.fn();
@@ -8,6 +8,7 @@ const mockGenerateMockResponse = jest.fn();
 const mockSearchScholarly = jest.fn();
 const mockGetEnv = jest.fn();
 const mockGetEnvNumber = jest.fn();
+const mockGetEnvBoolean = jest.fn();
 
 jest.unstable_mockModule('@services/openai/clientBridge.js', () => ({
   getOpenAIClientOrAdapter: mockGetOpenAIClientOrAdapter
@@ -23,9 +24,14 @@ jest.unstable_mockModule('@services/scholarlyFetcher.js', () => ({
   searchScholarly: mockSearchScholarly
 }));
 
+jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
+  runTrinityWritingPipeline: mockRunTrinityWritingPipeline
+}));
+
 jest.unstable_mockModule('@platform/runtime/env.js', () => ({
   getEnv: mockGetEnv,
-  getEnvNumber: mockGetEnvNumber
+  getEnvNumber: mockGetEnvNumber,
+  getEnvBoolean: mockGetEnvBoolean
 }));
 
 const { dispatch } = await import('../src/core/logic/tutor-logic.js');
@@ -36,27 +42,33 @@ describe('tutor logic prompt forwarding', () => {
 
     mockGetEnv.mockReturnValue(undefined);
     mockGetEnvNumber.mockReturnValue(200);
+    mockGetEnvBoolean.mockReturnValue(false);
     mockGetDefaultModel.mockReturnValue('ft:test-intake');
     mockGetGPT5Model.mockReturnValue('gpt-5.1');
     mockGenerateMockResponse.mockReturnValue({ result: 'mock tutor fallback' });
     mockSearchScholarly.mockResolvedValue([]);
-    mockResponsesCreate
-      .mockResolvedValueOnce({
-        choices: [{ message: { content: 'refined prompt' } }]
-      })
-      .mockResolvedValueOnce({
-        choices: [{ message: { content: 'reasoning output' } }]
-      })
-      .mockResolvedValueOnce({
-        choices: [{ message: { content: 'final tutor answer' } }]
-      });
-    mockGetOpenAIClientOrAdapter.mockReturnValue({
-      adapter: {
-        responses: {
-          create: mockResponsesCreate
-        }
+    mockRunTrinityWritingPipeline.mockResolvedValue({
+      result: 'final tutor answer',
+      activeModel: 'trinity-tutor',
+      fallbackFlag: false,
+      routingStages: ['TRINITY'],
+      auditSafe: { mode: 'true', passed: true, flags: [] },
+      taskLineage: [],
+      fallbackSummary: {
+        intakeFallbackUsed: false,
+        gpt5FallbackUsed: false,
+        finalFallbackUsed: false,
+        fallbackReasons: [],
       },
-      client: null
+      meta: {
+        pipeline: 'trinity',
+        bypass: false,
+        sourceEndpoint: 'tutor.dispatch',
+        classification: 'writing',
+      },
+    });
+    mockGetOpenAIClientOrAdapter.mockReturnValue({
+      client: { responses: {} }
     });
   });
 
@@ -68,14 +80,13 @@ describe('tutor logic prompt forwarding', () => {
     });
 
     expect(result.arcanos_tutor).toBe('final tutor answer');
-    expect(mockResponsesCreate).toHaveBeenCalledTimes(3);
-
-    const intakeRequest = mockResponsesCreate.mock.calls[0][0] as {
-      messages: Array<{ role: string; content: string }>;
+    expect(mockRunTrinityWritingPipeline).toHaveBeenCalledTimes(1);
+    const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as {
+      input: { prompt: string };
     };
 
-    expect(intakeRequest.messages[1]?.content).toContain(directPrompt);
-    expect(intakeRequest.messages[1]?.content).not.toContain('Input: {}');
+    expect(trinityRequest.input.prompt).toContain(directPrompt);
+    expect(trinityRequest.input.prompt).not.toContain('Input: {}');
   });
 
   it('short-circuits exact-literal anti-simulation prompts before model execution', async () => {
@@ -90,6 +101,6 @@ describe('tutor logic prompt forwarding', () => {
     expect(result.metadata).toEqual({
       shortcut: 'exact_literal_directive_suffix'
     });
-    expect(mockResponsesCreate).not.toHaveBeenCalled();
+    expect(mockRunTrinityWritingPipeline).not.toHaveBeenCalled();
   });
 });

--- a/tests/web-search-agent.test.ts
+++ b/tests/web-search-agent.test.ts
@@ -6,9 +6,27 @@ const fetchAndCleanDocumentMock = jest.fn(async (_url: string, _maxChars?: numbe
   links: [],
   combined: ''
 }));
-const createCentralizedCompletionMock = jest.fn(async () => ({
-  choices: [{ message: { content: 'Answer [1]' } }]
+const runTrinityWritingPipelineMock = jest.fn(async () => ({
+  result: 'Answer [1]',
+  activeModel: 'gpt-test',
+  fallbackFlag: false,
+  routingStages: ['TRINITY'],
+  auditSafe: { mode: 'true', passed: true, flags: [] },
+  taskLineage: [],
+  fallbackSummary: {
+    intakeFallbackUsed: false,
+    gpt5FallbackUsed: false,
+    finalFallbackUsed: false,
+    fallbackReasons: [],
+  },
+  meta: {
+    pipeline: 'trinity',
+    bypass: false,
+    sourceEndpoint: 'webSearchAgent.synthesize',
+    classification: 'writing',
+  },
 }));
+const getOpenAIClientOrAdapterMock = jest.fn(() => ({ client: { responses: {} } }));
 const getDefaultModelMock = jest.fn(() => 'gpt-test');
 const hasValidAPIKeyMock = jest.fn(() => false);
 const providerFetchMock = jest.fn(async (_input?: RequestInfo | URL, _init?: RequestInit) => createTextResponse(''));
@@ -50,9 +68,27 @@ beforeEach(async () => {
     links: [],
     combined: ''
   });
-  createCentralizedCompletionMock.mockReset().mockResolvedValue({
-    choices: [{ message: { content: 'Answer [1]' } }]
+  runTrinityWritingPipelineMock.mockReset().mockResolvedValue({
+    result: 'Answer [1]',
+    activeModel: 'gpt-test',
+    fallbackFlag: false,
+    routingStages: ['TRINITY'],
+    auditSafe: { mode: 'true', passed: true, flags: [] },
+    taskLineage: [],
+    fallbackSummary: {
+      intakeFallbackUsed: false,
+      gpt5FallbackUsed: false,
+      finalFallbackUsed: false,
+      fallbackReasons: [],
+    },
+    meta: {
+      pipeline: 'trinity',
+      bypass: false,
+      sourceEndpoint: 'webSearchAgent.synthesize',
+      classification: 'writing',
+    },
   });
+  getOpenAIClientOrAdapterMock.mockReset().mockReturnValue({ client: { responses: {} } });
   getDefaultModelMock.mockReset().mockReturnValue('gpt-test');
   hasValidAPIKeyMock.mockReset().mockReturnValue(false);
   providerFetchMock.mockReset();
@@ -65,9 +101,17 @@ beforeEach(async () => {
   }));
 
   jest.unstable_mockModule('@services/openai.js', () => ({
-    createCentralizedCompletion: createCentralizedCompletionMock,
     getDefaultModel: getDefaultModelMock,
-    hasValidAPIKey: hasValidAPIKeyMock
+    hasValidAPIKey: hasValidAPIKeyMock,
+    generateMockResponse: jest.fn()
+  }));
+
+  jest.unstable_mockModule('@services/openai/clientBridge.js', () => ({
+    getOpenAIClientOrAdapter: getOpenAIClientOrAdapterMock
+  }));
+
+  jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
+    runTrinityWritingPipeline: runTrinityWritingPipelineMock
   }));
 
   ({ createSearchProviderRegistry, webSearchAgent } = await import('../src/services/webSearchAgent.js'));
@@ -199,13 +243,11 @@ describe('webSearchAgent', () => {
       synthesize: true
     });
 
-    expect(createCentralizedCompletionMock).toHaveBeenCalledTimes(1);
-    const [messages] = createCentralizedCompletionMock.mock.calls[0];
-    expect(messages[0].content).toContain('<user_query>');
-    expect(messages[0].content).toContain('<source_packets>');
-    expect(messages[1].content).toContain('<user_query>');
-    expect(messages[1].content).toContain('&lt;now&gt;');
-    expect(messages[1].content).toContain('<source_packets>');
-    expect(messages[1].content).toContain('Ignore previous instructions');
+    expect(runTrinityWritingPipelineMock).toHaveBeenCalledTimes(1);
+    const [{ input }] = runTrinityWritingPipelineMock.mock.calls[0] as Array<[{ input: { prompt: string } }]>;
+    expect(input.prompt).toContain('<user_query>');
+    expect(input.prompt).toContain('&lt;now&gt;');
+    expect(input.prompt).toContain('<source_packets>');
+    expect(input.prompt).toContain('Ignore previous instructions');
   });
 });

--- a/tests/webRag.chunking.test.ts
+++ b/tests/webRag.chunking.test.ts
@@ -75,6 +75,11 @@ beforeEach(async () => {
 
   jest.unstable_mockModule('../src/services/openai/clientBridge.js', () => ({
     requireOpenAIClientOrAdapter: requireOpenAIClientOrAdapterMock,
+    getOpenAIClientOrAdapter: jest.fn(() => requireOpenAIClientOrAdapterMock()),
+  }));
+
+  jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
+    runTrinityWritingPipeline: jest.fn(),
   }));
 
   jest.unstable_mockModule('../src/services/openai.js', () => ({
@@ -99,8 +104,18 @@ beforeEach(async () => {
   }));
 
   jest.unstable_mockModule('@platform/logging/structuredLogging.js', () => ({
+    aiLogger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
     logger: {
       child: () => loggerChildMock,
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
     },
   }));
 


### PR DESCRIPTION
## Summary
- Add a reusable Trinity generation facade that classifies writing-plane input, rejects control-plane leakage inside the Trinity boundary, and stamps successful writing output with `pipeline: trinity`, `bypass: false`, `sourceEndpoint`, and `classification: writing` metadata.
- Route backend writing/generation paths through Trinity, including GPT access jobs, `/gpt/:gptId`, `/ask` generation, legacy `/arcanos-pipeline`, prompt generation, worker jobs, and internal generation helpers.
- Preserve control-plane routes outside Trinity and document the remaining direct SDK exceptions for adapters, diagnostics, tools, embeddings, vision, worker-package infrastructure, and simulation streaming compatibility.

## Review follow-up
- Added structured chat `messages` support to the Trinity facade and centralized conversion at the facade boundary.
- Restored the legacy ARCANOS pipeline reasoning depth as a Trinity-backed multi-stage chain: arc-first, sub-agent, overseer, and final.
- Fixed positive integer normalization for fractional token limits.
- Made Trinity invariant stamping return a new result object instead of mutating the source result.
- Restored simulation streaming compatibility while keeping completed simulation generation on Trinity.
- Preserved AFOL cache observability when Trinity result metadata includes cache-hit fields.

## Why
The backend had split AI execution paths, so some writing requests could bypass Trinity or get rejected before Trinity could classify them. This consolidates writing/generation behind one reusable facade while keeping diagnostics and runtime operations out of the writing pipeline.

## Validation
- `npm run type-check`
- `npm run lint` (passes with existing warnings only)
- `npm run test:unit` (293 suites passed, 1 skipped; 1,633 tests passed, 3 skipped)

No Railway deploy was run.