### PR TITLE
[codex] Guard disabled worker runtime loops

### DIFF
--- a/src/workers/jobRunner.ts
+++ b/src/workers/jobRunner.ts
@@ -14,7 +14,7 @@ import {
   initializeDatabaseWithSchema as initializeDatabase,
   getStatus as getDatabaseStatus
 } from '@core/db/index.js';
-import { getConfig } from '@platform/runtime/unifiedConfig.js';
+import { getConfig, getStableWorkerRuntimeMode } from '@platform/runtime/unifiedConfig.js';
 import { getOpenAIAdapter } from '@core/adapters/openai.adapter.js';
 import { resolveErrorMessage } from '@core/lib/errors/index.js';
 import {
@@ -40,9 +40,11 @@ import {
   createNonOverlappingTaskRunner,
   isEntrypointModule,
   isRetryableJobRunnerDatabaseBootstrapError,
+  resolveJobRunnerEntrypointRuntimeMode,
   resolveJobRunnerDatabaseBootstrapSettings,
   resolveProviderPauseMs,
   resolveJobRunnerRuntimeSettings,
+  selectJobRunnerSlotTransientRetryEvent,
   type JobRunnerDatabaseBootstrapSettings,
   type JobRunnerRuntimeSettings,
   type JobRunnerSlotDefinition
@@ -1315,8 +1317,9 @@ async function runWorkerConsumerSlot(
       } catch (error: unknown) {
         if (isRetryableJobRunnerDatabaseBootstrapError(error)) {
           const backoffMs = Math.max(runtimeSettings.idleBackoffMs, 5_000);
+          const retryLogEvent = selectJobRunnerSlotTransientRetryEvent(error);
           logger.warn(
-            'worker.database.transient_error_retry',
+            retryLogEvent,
             {
               module: 'job-runner',
               workerId: slotDefinition.workerId,
@@ -1339,12 +1342,14 @@ async function runWorkerConsumerSlot(
 }
 
 async function run(): Promise<void> {
+  const workerRuntimeMode = getStableWorkerRuntimeMode();
+  const entrypointRuntimeMode = resolveJobRunnerEntrypointRuntimeMode(workerRuntimeMode);
   const runtimeSettings = resolveJobRunnerRuntimeSettings();
   const databaseBootstrapSettings = resolveJobRunnerDatabaseBootstrapSettings();
   logger.info('[worker-runtime] boot config', {
     module: 'job-runner',
-    enabled: true,
-    disabledReason: null,
+    enabled: entrypointRuntimeMode.enabled,
+    disabledReason: entrypointRuntimeMode.disabledReason,
     pollMs: runtimeSettings.pollMs,
     idleBackoffMs: runtimeSettings.idleBackoffMs,
     concurrency: runtimeSettings.concurrency,
@@ -1356,10 +1361,22 @@ async function run(): Promise<void> {
   });
   logger.info('[worker-runtime] enabled/disabled reason', {
     module: 'job-runner',
-    enabled: true,
-    disabledReason: null,
-    reason: 'ARCANOS_PROCESS_KIND=worker starts the dedicated async queue dispatcher'
+    enabled: entrypointRuntimeMode.enabled,
+    disabledReason: entrypointRuntimeMode.disabledReason,
+    reason: entrypointRuntimeMode.reason,
+    processKind: workerRuntimeMode.processKind,
+    requestedRunWorkers: workerRuntimeMode.requestedRunWorkers
   });
+  if (!entrypointRuntimeMode.enabled) {
+    logger.info('[worker-runtime] start skipped', {
+      module: 'job-runner',
+      disabledReason: entrypointRuntimeMode.disabledReason,
+      processKind: workerRuntimeMode.processKind,
+      requestedRunWorkers: workerRuntimeMode.requestedRunWorkers
+    });
+    return;
+  }
+
   logger.info('[worker-runtime] start requested', {
     module: 'job-runner',
     workerId: runtimeSettings.baseWorkerId,

--- a/src/workers/jobRunnerRuntime.ts
+++ b/src/workers/jobRunnerRuntime.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
+import type { WorkerRuntimeModeResolution } from '@platform/runtime/unifiedConfig.js';
 
 export interface JobRunnerRuntimeSettings {
   pollMs: number;
@@ -21,6 +22,12 @@ export interface JobRunnerSlotDefinition {
   workerId: string;
   statsWorkerId: string;
   isInspectorSlot: boolean;
+}
+
+export interface JobRunnerEntrypointRuntimeMode {
+  enabled: boolean;
+  disabledReason: string | null;
+  reason: string;
 }
 
 export interface NonOverlappingTaskSkipEvent {
@@ -54,6 +61,19 @@ const RETRYABLE_DATABASE_BOOTSTRAP_ERROR_MARKERS = [
   'enetwork',
   'enetunreach',
   'ehostunreach'
+];
+
+const DATABASE_ERROR_CONTEXT_MARKERS = [
+  'database',
+  'postgres',
+  'postgresql',
+  'pool',
+  'sql',
+  'job_data',
+  'worker_runtime',
+  'database_url',
+  'database_private_url',
+  'database_public_url'
 ];
 
 function readPositiveIntegerEnvValue(
@@ -209,6 +229,38 @@ export function resolveJobRunnerRuntimeSettings(
 }
 
 /**
+ * Resolve whether the direct job-runner entrypoint may start mutation loops.
+ * Purpose: keep standalone worker startup aligned with the stable process-role resolver.
+ * Inputs/outputs: accepts the stable worker runtime mode and returns a logging-friendly decision.
+ * Edge case behavior: explicit web role wins even when RUN_WORKERS was requested.
+ */
+export function resolveJobRunnerEntrypointRuntimeMode(
+  workerRuntimeMode: Pick<
+    WorkerRuntimeModeResolution,
+    'resolvedRunWorkers' | 'reason'
+  >
+): JobRunnerEntrypointRuntimeMode {
+  if (workerRuntimeMode.resolvedRunWorkers) {
+    return {
+      enabled: true,
+      disabledReason: null,
+      reason: 'ARCANOS_PROCESS_KIND=worker starts the dedicated async queue dispatcher'
+    };
+  }
+
+  const disabledReason =
+    workerRuntimeMode.reason === 'process_kind_web'
+      ? 'RUN_WORKERS disabled for explicit web process role; workers not started.'
+      : 'RUN_WORKERS disabled; workers not started.';
+
+  return {
+    enabled: false,
+    disabledReason,
+    reason: disabledReason
+  };
+}
+
+/**
  * Resolve database bootstrap retry settings for the worker process.
  * Purpose: prevent transient Railway database reachability failures from permanently crashing the worker.
  * Inputs/outputs: accepts an optional environment object and returns normalized retry settings.
@@ -242,6 +294,30 @@ export function isRetryableJobRunnerDatabaseBootstrapError(error: unknown): bool
   return RETRYABLE_DATABASE_BOOTSTRAP_ERROR_MARKERS.some(marker =>
     normalizedMessage.includes(marker)
   );
+}
+
+/**
+ * Select the outer slot retry log event for a retryable transient error.
+ * Purpose: keep the retry/backoff behavior while avoiding database labels for generic provider/network failures.
+ * Inputs/outputs: accepts an error value and returns the structured log event name.
+ * Edge case behavior: retryable transport errors without database context use a generic worker event.
+ */
+export function selectJobRunnerSlotTransientRetryEvent(error: unknown):
+  | 'worker.database.transient_error_retry'
+  | 'worker.transient_error_retry' {
+  const message = error instanceof Error
+    ? error.message
+    : typeof error === 'string'
+      ? error
+      : String(error ?? '');
+  const normalizedMessage = message.toLowerCase();
+  const hasDatabaseContext = DATABASE_ERROR_CONTEXT_MARKERS.some(marker =>
+    normalizedMessage.includes(marker)
+  ) || /\bpg\b/.test(normalizedMessage);
+
+  return hasDatabaseContext
+    ? 'worker.database.transient_error_retry'
+    : 'worker.transient_error_retry';
 }
 
 /**

--- a/src/workers/jobRunnerRuntime.ts
+++ b/src/workers/jobRunnerRuntime.ts
@@ -67,6 +67,7 @@ const DATABASE_ERROR_CONTEXT_MARKERS = [
   'database',
   'postgres',
   'postgresql',
+  'pg_hba.conf',
   'pool',
   'sql',
   'job_data',
@@ -74,6 +75,49 @@ const DATABASE_ERROR_CONTEXT_MARKERS = [
   'database_private_url',
   'database_public_url'
 ];
+
+const POSTGRES_TRANSIENT_ERROR_CONTEXT_MARKERS = [
+  'timeout exceeded when trying to connect',
+  'connection terminated unexpectedly',
+  'server closed the connection unexpectedly',
+  'terminating connection due to administrator command',
+  'remaining connection slots are reserved'
+];
+
+const POSTGRES_TRANSIENT_ERROR_CODES = new Set([
+  '08000',
+  '08001',
+  '08003',
+  '08004',
+  '08006',
+  '08007',
+  '08p01',
+  '53300',
+  '57p01',
+  '57p02',
+  '57p03'
+]);
+
+const NON_DATABASE_TRANSIENT_CONTEXT_MARKERS = [
+  'openai',
+  'provider',
+  'provider probe',
+  'provider request',
+  'provider unavailable',
+  'probing provider',
+  'api key',
+  'authentication',
+  'circuit breaker'
+];
+
+function readStringProperty(value: unknown, propertyName: string): string | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const candidate = (value as Record<string, unknown>)[propertyName];
+  return typeof candidate === 'string' ? candidate : null;
+}
 
 function readPositiveIntegerEnvValue(
   rawValue: string | undefined,
@@ -240,10 +284,17 @@ export function resolveJobRunnerEntrypointRuntimeMode(
   >
 ): JobRunnerEntrypointRuntimeMode {
   if (workerRuntimeMode.resolvedRunWorkers) {
+    const enabledReason =
+      workerRuntimeMode.reason === 'process_kind_worker'
+        ? 'ARCANOS_PROCESS_KIND=worker starts the dedicated async queue dispatcher'
+        : workerRuntimeMode.reason === 'requested'
+          ? 'RUN_WORKERS requested the dedicated async queue dispatcher'
+          : 'Workers enabled; starting the dedicated async queue dispatcher';
+
     return {
       enabled: true,
       disabledReason: null,
-      reason: 'ARCANOS_PROCESS_KIND=worker starts the dedicated async queue dispatcher'
+      reason: enabledReason
     };
   }
 
@@ -310,11 +361,23 @@ export function selectJobRunnerSlotTransientRetryEvent(error: unknown):
       ? error
       : String(error ?? '');
   const normalizedMessage = message.toLowerCase();
-  const hasDatabaseContext = DATABASE_ERROR_CONTEXT_MARKERS.some(marker =>
-    normalizedMessage.includes(marker)
-  ) || /\bpg\b/.test(normalizedMessage);
+  const normalizedCode = (readStringProperty(error, 'code') ?? '').trim().toLowerCase();
+  const hasDirectDatabaseContext =
+    DATABASE_ERROR_CONTEXT_MARKERS.some(marker => normalizedMessage.includes(marker)) ||
+    /\bpg\b/.test(normalizedMessage) ||
+    POSTGRES_TRANSIENT_ERROR_CODES.has(normalizedCode);
+  if (hasDirectDatabaseContext) {
+    return 'worker.database.transient_error_retry';
+  }
 
-  return hasDatabaseContext
+  const hasNonDatabaseContext = NON_DATABASE_TRANSIENT_CONTEXT_MARKERS.some(marker =>
+    normalizedMessage.includes(marker)
+  );
+  const hasPostgresTransientContext = POSTGRES_TRANSIENT_ERROR_CONTEXT_MARKERS.some(marker =>
+    normalizedMessage.includes(marker)
+  );
+
+  return hasPostgresTransientContext && !hasNonDatabaseContext
     ? 'worker.database.transient_error_retry'
     : 'worker.transient_error_retry';
 }

--- a/src/workers/jobRunnerRuntime.ts
+++ b/src/workers/jobRunnerRuntime.ts
@@ -70,7 +70,6 @@ const DATABASE_ERROR_CONTEXT_MARKERS = [
   'pool',
   'sql',
   'job_data',
-  'worker_runtime',
   'database_url',
   'database_private_url',
   'database_public_url'

--- a/src/workers/jobRunnerRuntime.ts
+++ b/src/workers/jobRunnerRuntime.ts
@@ -52,8 +52,10 @@ const RETRYABLE_DATABASE_BOOTSTRAP_ERROR_MARKERS = [
   'connect timeout',
   'connection timeout',
   'connection terminated',
+  'connection reset',
   'connection refused',
   'could not connect',
+  'econnreset',
   'econnrefused',
   'etimedout',
   'enotfound',
@@ -68,7 +70,6 @@ const DATABASE_ERROR_CONTEXT_MARKERS = [
   'postgres',
   'postgresql',
   'pg_hba.conf',
-  'pool',
   'sql',
   'job_data',
   'database_url',
@@ -96,6 +97,17 @@ const POSTGRES_TRANSIENT_ERROR_CODES = new Set([
   '57p01',
   '57p02',
   '57p03'
+]);
+
+const RETRYABLE_TRANSPORT_ERROR_CODES = new Set([
+  'econnreset',
+  'econnrefused',
+  'etimedout',
+  'enotfound',
+  'eai_again',
+  'enetwork',
+  'enetunreach',
+  'ehostunreach'
 ]);
 
 const NON_DATABASE_TRANSIENT_CONTEXT_MARKERS = [
@@ -341,8 +353,17 @@ export function isRetryableJobRunnerDatabaseBootstrapError(error: unknown): bool
       ? error
       : String(error ?? '');
   const normalizedMessage = message.toLowerCase();
-  return RETRYABLE_DATABASE_BOOTSTRAP_ERROR_MARKERS.some(marker =>
-    normalizedMessage.includes(marker)
+  const normalizedCode = (readStringProperty(error, 'code') ?? '').trim().toLowerCase();
+
+  return (
+    RETRYABLE_DATABASE_BOOTSTRAP_ERROR_MARKERS.some(marker =>
+      normalizedMessage.includes(marker)
+    ) ||
+    POSTGRES_TRANSIENT_ERROR_CONTEXT_MARKERS.some(marker =>
+      normalizedMessage.includes(marker)
+    ) ||
+    POSTGRES_TRANSIENT_ERROR_CODES.has(normalizedCode) ||
+    RETRYABLE_TRANSPORT_ERROR_CODES.has(normalizedCode)
   );
 }
 

--- a/tests/job-runner-runtime.test.ts
+++ b/tests/job-runner-runtime.test.ts
@@ -9,9 +9,11 @@ import {
   createNonOverlappingTaskRunner,
   isEntrypointModule,
   isRetryableJobRunnerDatabaseBootstrapError,
+  resolveJobRunnerEntrypointRuntimeMode,
   resolveJobRunnerDatabaseBootstrapSettings,
   resolveProviderPauseMs,
-  resolveJobRunnerRuntimeSettings
+  resolveJobRunnerRuntimeSettings,
+  selectJobRunnerSlotTransientRetryEvent
 } from '../src/workers/jobRunnerRuntime.js';
 
 describe('jobRunnerRuntime', () => {
@@ -104,6 +106,45 @@ describe('jobRunnerRuntime', () => {
     });
   });
 
+  it('disables the direct job runner entrypoint for explicit web runtime mode', () => {
+    const mode = resolveJobRunnerEntrypointRuntimeMode({
+      resolvedRunWorkers: false,
+      reason: 'process_kind_web'
+    });
+
+    expect(mode).toEqual({
+      enabled: false,
+      disabledReason: 'RUN_WORKERS disabled for explicit web process role; workers not started.',
+      reason: 'RUN_WORKERS disabled for explicit web process role; workers not started.'
+    });
+  });
+
+  it('disables the direct job runner entrypoint when RUN_WORKERS resolves false', () => {
+    const mode = resolveJobRunnerEntrypointRuntimeMode({
+      resolvedRunWorkers: false,
+      reason: 'requested'
+    });
+
+    expect(mode).toEqual({
+      enabled: false,
+      disabledReason: 'RUN_WORKERS disabled; workers not started.',
+      reason: 'RUN_WORKERS disabled; workers not started.'
+    });
+  });
+
+  it('enables the direct job runner entrypoint when worker runtime resolves enabled', () => {
+    const mode = resolveJobRunnerEntrypointRuntimeMode({
+      resolvedRunWorkers: true,
+      reason: 'process_kind_worker'
+    });
+
+    expect(mode).toEqual({
+      enabled: true,
+      disabledReason: null,
+      reason: 'ARCANOS_PROCESS_KIND=worker starts the dedicated async queue dispatcher'
+    });
+  });
+
   it('uses indefinite database bootstrap retries by default', () => {
     const retrySettings = resolveJobRunnerDatabaseBootstrapSettings({} as NodeJS.ProcessEnv);
 
@@ -141,6 +182,27 @@ describe('jobRunnerRuntime', () => {
     ).toBe(true);
     expect(isRetryableJobRunnerDatabaseBootstrapError(new Error('ENOTFOUND railway.internal'))).toBe(true);
     expect(isRetryableJobRunnerDatabaseBootstrapError(new Error('relation "job_data" does not exist'))).toBe(false);
+  });
+
+  it('keeps database context on outer slot transient retry logs', () => {
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        new Error('Postgres pool connection timeout while claiming from job_data')
+      )
+    ).toBe('worker.database.transient_error_retry');
+  });
+
+  it('uses a generic outer slot retry log for non-database provider/network transients', () => {
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        new Error('OpenAI provider request ETIMEDOUT')
+      )
+    ).toBe('worker.transient_error_retry');
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        new Error('socket connect timeout while probing provider')
+      )
+    ).toBe('worker.transient_error_retry');
   });
 
   it('skips overlapping interval work while a task is still running', async () => {

--- a/tests/job-runner-runtime.test.ts
+++ b/tests/job-runner-runtime.test.ts
@@ -194,6 +194,21 @@ describe('jobRunnerRuntime', () => {
       )
     ).toBe(true);
     expect(isRetryableJobRunnerDatabaseBootstrapError(new Error('ENOTFOUND railway.internal'))).toBe(true);
+    expect(
+      isRetryableJobRunnerDatabaseBootstrapError(
+        Object.assign(new Error(''), { code: '57P01' })
+      )
+    ).toBe(true);
+    expect(
+      isRetryableJobRunnerDatabaseBootstrapError(
+        Object.assign(new Error(''), { code: '08006' })
+      )
+    ).toBe(true);
+    expect(
+      isRetryableJobRunnerDatabaseBootstrapError(
+        Object.assign(new Error('OpenAI provider ECONNRESET'), { code: 'ECONNRESET' })
+      )
+    ).toBe(true);
     expect(isRetryableJobRunnerDatabaseBootstrapError(new Error('relation "job_data" does not exist'))).toBe(false);
   });
 
@@ -221,6 +236,26 @@ describe('jobRunnerRuntime', () => {
         Object.assign(new Error('terminating connection during claim'), { code: '57P01' })
       )
     ).toBe('worker.database.transient_error_retry');
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        Object.assign(new Error(''), { code: '08006' })
+      )
+    ).toBe('worker.database.transient_error_retry');
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        new Error('DATABASE_URL connection failed')
+      )
+    ).toBe('worker.database.transient_error_retry');
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        new Error('DATABASE_PRIVATE_URL connection failed')
+      )
+    ).toBe('worker.database.transient_error_retry');
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        new Error('no pg_hba.conf entry for host')
+      )
+    ).toBe('worker.database.transient_error_retry');
   });
 
   it('uses a generic outer slot retry log for non-database provider/network transients', () => {
@@ -239,12 +274,40 @@ describe('jobRunnerRuntime', () => {
         new Error('OpenAI timeout exceeded when trying to connect')
       )
     ).toBe('worker.transient_error_retry');
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        Object.assign(new Error('OpenAI provider ECONNRESET'), { code: 'ECONNRESET' })
+      )
+    ).toBe('worker.transient_error_retry');
   });
 
   it('does not infer database context from broad worker runtime labels', () => {
     expect(
       selectJobRunnerSlotTransientRetryEvent(
         new Error('worker_runtime slot failed during provider connect timeout')
+      )
+    ).toBe('worker.transient_error_retry');
+  });
+
+  it('keeps ambiguous transient retry labels generic without database context', () => {
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        new Error('socket timeout while claiming work')
+      )
+    ).toBe('worker.transient_error_retry');
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        new Error('worker thread pool timeout')
+      )
+    ).toBe('worker.transient_error_retry');
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        new Error('pg connection reset')
+      )
+    ).toBe('worker.database.transient_error_retry');
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        Object.assign(new Error(''), { code: 'ECONNRESET' })
       )
     ).toBe('worker.transient_error_retry');
   });

--- a/tests/job-runner-runtime.test.ts
+++ b/tests/job-runner-runtime.test.ts
@@ -145,6 +145,19 @@ describe('jobRunnerRuntime', () => {
     });
   });
 
+  it('reports requested RUN_WORKERS as the direct job runner enablement reason', () => {
+    const mode = resolveJobRunnerEntrypointRuntimeMode({
+      resolvedRunWorkers: true,
+      reason: 'requested'
+    });
+
+    expect(mode).toEqual({
+      enabled: true,
+      disabledReason: null,
+      reason: 'RUN_WORKERS requested the dedicated async queue dispatcher'
+    });
+  });
+
   it('uses indefinite database bootstrap retries by default', () => {
     const retrySettings = resolveJobRunnerDatabaseBootstrapSettings({} as NodeJS.ProcessEnv);
 
@@ -192,6 +205,24 @@ describe('jobRunnerRuntime', () => {
     ).toBe('worker.database.transient_error_retry');
   });
 
+  it('keeps database context for common pg transient connection failures', () => {
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        new Error('timeout exceeded when trying to connect')
+      )
+    ).toBe('worker.database.transient_error_retry');
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        new Error('server closed the connection unexpectedly')
+      )
+    ).toBe('worker.database.transient_error_retry');
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        Object.assign(new Error('terminating connection during claim'), { code: '57P01' })
+      )
+    ).toBe('worker.database.transient_error_retry');
+  });
+
   it('uses a generic outer slot retry log for non-database provider/network transients', () => {
     expect(
       selectJobRunnerSlotTransientRetryEvent(
@@ -201,6 +232,11 @@ describe('jobRunnerRuntime', () => {
     expect(
       selectJobRunnerSlotTransientRetryEvent(
         new Error('socket connect timeout while probing provider')
+      )
+    ).toBe('worker.transient_error_retry');
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        new Error('OpenAI timeout exceeded when trying to connect')
       )
     ).toBe('worker.transient_error_retry');
   });

--- a/tests/job-runner-runtime.test.ts
+++ b/tests/job-runner-runtime.test.ts
@@ -205,6 +205,14 @@ describe('jobRunnerRuntime', () => {
     ).toBe('worker.transient_error_retry');
   });
 
+  it('does not infer database context from broad worker runtime labels', () => {
+    expect(
+      selectJobRunnerSlotTransientRetryEvent(
+        new Error('worker_runtime slot failed during provider connect timeout')
+      )
+    ).toBe('worker.transient_error_retry');
+  });
+
   it('skips overlapping interval work while a task is still running', async () => {
     let nowMs = 0;
     let resolveFirstTask: (() => void) | null = null;


### PR DESCRIPTION
## Summary
- Guard the direct job runner entrypoint so it exits before DB/autonomy/snapshot/liveness/watchdog startup when worker runtime mode resolves disabled.
- Add helper coverage for explicit web mode, RUN_WORKERS=false, and worker-enabled mode.
- Split generic transient retry logging from database-context retry logging so non-DB provider/network failures no longer emit `worker.database.transient_error_retry`.

## Root Cause
A direct `jobRunner` invocation could still enter worker mutation loops even when runtime config resolved workers disabled, such as `ARCANOS_PROCESS_KIND=web` or `RUN_WORKERS=false`. The outer slot retry log also used a database-specific event for all retryable transport-style failures.

## Validation
- `node scripts/run-jest.mjs --testPathPatterns=tests/job-runner-runtime.test.ts --coverage=false`
- `npm run validate:railway`
- `npm run type-check`
- `npm run lint` (passes with existing warnings)

## Notes
Railway live diagnostics were not run from this checkout because the local Railway link points to a deleted environment. No production-mutating commands were run.