### PR TITLE
[codex] Repair backend worker self-healing

### DIFF
--- a/docs/refactor-audit.md
+++ b/docs/refactor-audit.md
@@ -56,7 +56,7 @@ Risks:
 
 Verified:
 
-- OpenAI SDK guardrail test passed and found no `_thenUnwrap` source usage.
+- OpenAI SDK guardrail test passed and found no private Responses SDK unwrap helper usage.
 - Raw `new OpenAI` construction is currently constrained by tests to approved adapter boundaries in the scanned TypeScript roots.
 - The TypeScript OpenAI package `@arcanos/openai` and backend adapter are the intended SDK boundary.
 - `arcanos-ai-runtime/src/ai/openaiClient.ts` still reads OpenAI-related config directly.

--- a/packages/arcanos-runtime/src/redaction.ts
+++ b/packages/arcanos-runtime/src/redaction.ts
@@ -27,6 +27,7 @@ export const SENSITIVE_KEYS = [
 
 export const SENSITIVE_VALUE_PATTERNS: RegExp[] = [
   /\bsk-[a-zA-Z0-9]{20,}\b/,
+  /\bsk-[a-zA-Z0-9_*_-]{6,}\b/,
   /\bBearer\s+[a-zA-Z0-9._-]{12,}\b/i,
   /\beyJ[a-zA-Z0-9_-]{8,}\.[a-zA-Z0-9_-]{8,}\.[a-zA-Z0-9_-]{8,}\b/,
   /\b(?:postgres|postgresql|mysql|mongodb|redis):\/\/[^\s]+/i,

--- a/packages/cli/__tests__/transport-matrix.test.ts
+++ b/packages/cli/__tests__/transport-matrix.test.ts
@@ -122,7 +122,7 @@ describe("protocol transport matrix", () => {
         "tool.invoke"
       ])
     );
-  });
+  }, 15000);
 
   it("returns deterministic unsupported errors for local tool describe/invoke requests", async () => {
     const [toolDescribeResponse, toolInvokeResponse] = await Promise.all([

--- a/scripts/railway-fast-path-probe.js
+++ b/scripts/railway-fast-path-probe.js
@@ -13,12 +13,15 @@ export const PROBE_STATUS = Object.freeze({
   FAIL: 'FAIL',
 });
 
+export const RAILWAY_PRODUCTION_BASE_URL = 'https://acranos-production.up.railway.app';
+
 export const DEFAULTS = Object.freeze({
   baseUrl:
     process.env.ARCANOS_BACKEND_URL ||
     process.env.RAILWAY_SERVICE_ARCANOS_V2_URL ||
     process.env.RAILWAY_STATIC_URL ||
-    'https://arcanos-production.up.railway.app',
+    // Railway assigned this service the "acranos" production domain; keep it aligned with the async and smoke probes.
+    RAILWAY_PRODUCTION_BASE_URL,
   gptId: 'arcanos-core',
   prompt: 'Generate a concise prompt for a deployment smoke test.',
   requestTimeoutMs: 15_000,

--- a/src/platform/observability/appMetrics.ts
+++ b/src/platform/observability/appMetrics.ts
@@ -250,6 +250,13 @@ const workerRecoveredJobsTotal = new Counter({
   registers: [metricsRegistry],
 });
 
+const workerRecoveryActionsTotal = new Counter({
+  name: 'worker_recovery_actions_total',
+  help: 'Total observable worker recovery actions by action and source.',
+  labelNames: ['action', 'source'] as const,
+  registers: [metricsRegistry],
+});
+
 const workerRuntimeSnapshotSkippedTotal = new Counter({
   name: 'worker_runtime_snapshot_skipped_total',
   help: 'Total worker runtime snapshot persistence attempts skipped because no meaningful state changed.',
@@ -406,13 +413,7 @@ type WorkerSnapshotCounterTotals = {
   recoveredJobs: number;
   deadLetterJobs: number;
   cancelledJobs: number;
-};
-const DEFAULT_WORKER_SNAPSHOT_COUNTER_TOTALS: WorkerSnapshotCounterTotals = {
-  staleWorkersDetected: 0,
-  stalledJobsDetected: 0,
-  recoveredJobs: 0,
-  deadLetterJobs: 0,
-  cancelledJobs: 0
+  recoveryActions: number;
 };
 const lastWorkerSnapshotCounterTotalsByWorkerId = new Map<string, WorkerSnapshotCounterTotals>();
 
@@ -695,18 +696,25 @@ function getWorkerSnapshotCounterTotals(worker: {
   stalledJobsDetected?: number;
   recoveredJobs?: number;
   deadLetterJobs?: number;
+  cancelledJobs?: number;
   recoveryActions?: number;
 }): WorkerSnapshotCounterTotals {
   const recoveredJobs = readWorkerSnapshotCounter(worker.recoveredJobs);
   const deadLetterJobs = readWorkerSnapshotCounter(worker.deadLetterJobs);
   const recoveryActions = readWorkerSnapshotCounter(worker.recoveryActions);
+  const hasExplicitCancelledJobs =
+    typeof worker.cancelledJobs === 'number' && Number.isFinite(worker.cancelledJobs);
+  const explicitCancelledJobs = readWorkerSnapshotCounter(worker.cancelledJobs);
 
   return {
     staleWorkersDetected: readWorkerSnapshotCounter(worker.staleWorkersDetected),
     stalledJobsDetected: readWorkerSnapshotCounter(worker.stalledJobsDetected),
     recoveredJobs,
     deadLetterJobs,
-    cancelledJobs: Math.max(0, recoveryActions - recoveredJobs - deadLetterJobs)
+    cancelledJobs: hasExplicitCancelledJobs
+      ? explicitCancelledJobs
+      : Math.max(0, recoveryActions - recoveredJobs - deadLetterJobs),
+    recoveryActions
   };
 }
 
@@ -716,7 +724,7 @@ function resolveWorkerSnapshotCounterDelta(current: number, previous: number | u
   }
 
   if (!Number.isFinite(previous) || previous === undefined || previous < 0) {
-    return current;
+    return 0;
   }
 
   return current >= previous ? current - previous : current;
@@ -728,6 +736,7 @@ function recordObservedWorkerSnapshotCounters(workers: Array<{
   stalledJobsDetected?: number;
   recoveredJobs?: number;
   deadLetterJobs?: number;
+  cancelledJobs?: number;
   recoveryActions?: number;
 }>): void {
   const observedWorkerIds = new Set<string>();
@@ -762,7 +771,6 @@ function recordObservedWorkerSnapshotCounters(workers: Array<{
       current.stalledJobsDetected,
       previous?.stalledJobsDetected
     );
-
     if (requeuedJobsDelta > 0) {
       workerStalledJobsTotal.inc({ action: 'requeue' }, requeuedJobsDelta);
       workerRecoveredJobsTotal.inc({ action: 'requeue' }, requeuedJobsDelta);
@@ -820,6 +828,20 @@ export function recordWorkerRecoveredJobs(input: {
 }): void {
   workerRecoveredJobsTotal.inc(
     { action: normalizeLabel(input.action) },
+    Math.max(0, input.count ?? 1)
+  );
+}
+
+export function recordWorkerRecoveryAction(input: {
+  action: string;
+  source: string;
+  count?: number;
+}): void {
+  workerRecoveryActionsTotal.inc(
+    {
+      action: normalizeLabel(input.action),
+      source: normalizeLabel(input.source),
+    },
     Math.max(0, input.count ?? 1)
   );
 }

--- a/src/services/workerAutonomyService.ts
+++ b/src/services/workerAutonomyService.ts
@@ -40,6 +40,7 @@ import {
 import { resolveErrorMessage } from '@core/lib/errors/index.js';
 import {
   recordDependencyCall,
+  recordWorkerRecoveryAction,
   recordWorkerRecoveredJobs,
   recordWorkerStaleDetection,
   recordWorkerStalledJobs
@@ -167,6 +168,9 @@ interface RuntimeSnapshotState {
   deadLetterJobs: number;
   cancelledJobs: number;
   recoveryActions: number;
+  lastRecoveryEvent: WorkerRecoveryActionEvent | null;
+  recentRecoveryEvents: WorkerRecoveryActionEvent[];
+  lastWatchdogEvent: WorkerWatchdogRecoveryEvent | null;
   maxObservedQueueDepth: number;
   lastBudgetPauseReason: string | null;
   lastRecoveryActionAt: string | null;
@@ -198,8 +202,46 @@ interface WorkerWatchdogState {
   restartRecommended: boolean;
 }
 
+interface WorkerRecoveryActionEvent {
+  at: string;
+  action: string;
+  source: string;
+  count: number;
+  jobIds: string[];
+  jobIdsTotal: number;
+  jobIdsTruncated: boolean;
+  workerIds: string[];
+  workerIdsTotal: number;
+  workerIdsTruncated: boolean;
+  reason: string | null;
+}
+
+interface WorkerWatchdogRecoveryEvent {
+  at: string;
+  source: string;
+  reason: string;
+  staleWorkerIds: string[];
+  staleWorkerIdsTotal?: number;
+  staleWorkerIdsTruncated?: boolean;
+  stalledJobIds: string[];
+  stalledJobIdsTotal?: number;
+  stalledJobIdsTruncated?: boolean;
+  requeuedJobIds: string[];
+  requeuedJobIdsTotal?: number;
+  requeuedJobIdsTruncated?: boolean;
+  deadLetterJobIds: string[];
+  deadLetterJobIdsTotal?: number;
+  deadLetterJobIdsTruncated?: boolean;
+  cancelledJobIds: string[];
+  cancelledJobIdsTotal?: number;
+  cancelledJobIdsTruncated?: boolean;
+  restartRecommended: boolean;
+}
+
 const WORKER_RUNTIME_SNAPSHOT_MIN_INTERVAL_MS = 30_000;
 const WORKER_RUNTIME_SNAPSHOT_SLOW_LOG_MIN_MS = 250;
+const WORKER_RECOVERY_EVENT_HISTORY_LIMIT = 10;
+const WORKER_RECOVERY_EVENT_ID_SAMPLE_LIMIT = 20;
 
 type WorkerRuntimeSnapshotPipelinePort = Pick<
   WorkerRuntimeSnapshotPipeline,
@@ -225,6 +267,22 @@ function filterFreshWorkerLivenessRecords(
     const seenAtMs = Date.parse(record.lastSeenAt);
     return Number.isFinite(seenAtMs) && seenAtMs >= cutoffMs;
   });
+}
+
+function buildWorkerEventIdSample(ids: string[] | undefined): {
+  ids: string[];
+  total: number;
+  truncated: boolean;
+} {
+  const normalizedIds = Array.isArray(ids)
+    ? ids.filter((id): id is string => typeof id === 'string' && id.length > 0)
+    : [];
+
+  return {
+    ids: normalizedIds.slice(0, WORKER_RECOVERY_EVENT_ID_SAMPLE_LIMIT),
+    total: normalizedIds.length,
+    truncated: normalizedIds.length > WORKER_RECOVERY_EVENT_ID_SAMPLE_LIMIT
+  };
 }
 
 const DEFAULT_AUTONOMY_SETTINGS: WorkerAutonomySettings = {
@@ -450,6 +508,9 @@ export class WorkerAutonomyService {
       deadLetterJobs: 0,
       cancelledJobs: 0,
       recoveryActions: 0,
+      lastRecoveryEvent: null,
+      recentRecoveryEvents: [],
+      lastWatchdogEvent: null,
       maxObservedQueueDepth: 0,
       lastBudgetPauseReason: null,
       lastRecoveryActionAt: null
@@ -608,26 +669,43 @@ export class WorkerAutonomyService {
     const recoveredJobIds = recovered.recoveredJobs ?? [];
     const failedJobIds = recovered.failedJobs ?? [];
     const cancelledJobIds = recovered.cancelledJobs ?? [];
-    this.state.recoveredJobs += recovered.recoveredJobs.length;
+    this.state.recoveredJobs += recoveredJobIds.length;
     this.state.deadLetterJobs += failedJobIds.length;
     this.state.cancelledJobs += cancelledJobIds.length;
-    this.state.recoveryActions += recoveredJobIds.length + failedJobIds.length + cancelledJobIds.length;
-    if (recoveredJobIds.length > 0 || failedJobIds.length > 0 || cancelledJobIds.length > 0) {
-      this.state.lastRecoveryActionAt = new Date().toISOString();
-    }
     if (recoveredJobIds.length > 0) {
+      this.recordRecoveryAction({
+        action: 'lease_requeue',
+        source,
+        count: recoveredJobIds.length,
+        jobIds: recoveredJobIds,
+        reason: 'stale lease recovery requeued expired running job'
+      });
       recordWorkerRecoveredJobs({
         action: 'lease_requeue',
         count: recoveredJobIds.length
       });
     }
     if (failedJobIds.length > 0) {
+      this.recordRecoveryAction({
+        action: 'lease_dead_letter',
+        source,
+        count: failedJobIds.length,
+        jobIds: failedJobIds,
+        reason: 'stale lease recovery exhausted retry budget'
+      });
       recordWorkerRecoveredJobs({
         action: 'lease_dead_letter',
         count: failedJobIds.length
       });
     }
     if (cancelledJobIds.length > 0) {
+      this.recordRecoveryAction({
+        action: 'lease_cancelled',
+        source,
+        count: cancelledJobIds.length,
+        jobIds: cancelledJobIds,
+        reason: 'stale lease recovery honored cancellation request'
+      });
       recordWorkerRecoveredJobs({
         action: 'lease_cancelled',
         count: cancelledJobIds.length
@@ -734,10 +812,11 @@ export class WorkerAutonomyService {
     const staleWorkerIds = workerSnapshots
       .filter((worker) => shouldRecoverStaleWorker(worker, this.settings, watchdogQueueSummary))
       .map((worker) => worker.workerId);
+    const detectedStaleWorkerIds = [...new Set(staleWorkerIds)];
     const recovery =
-      staleWorkerIds.length > 0
+      detectedStaleWorkerIds.length > 0
         ? await recoverStalledJobsForWorkers({
-            workerIds: staleWorkerIds,
+            workerIds: detectedStaleWorkerIds,
             staleAfterMs: this.settings.staleAfterMs,
             maxRetries: this.settings.defaultMaxRetries,
             stalledJobAction: this.settings.stalledJobAction
@@ -750,13 +829,19 @@ export class WorkerAutonomyService {
             cancelledJobIds: []
           };
     const nowIso = new Date().toISOString();
+    const observedStaleWorkerIds = [...new Set([
+      ...detectedStaleWorkerIds,
+      ...recovery.staleWorkerIds
+    ])];
     const stalledRecovery = {
-      staleWorkers: recovery.staleWorkerIds.length,
+      staleWorkers: observedStaleWorkerIds.length,
       stalledJobs: recovery.stalledJobIds.length,
       requeuedJobs: recovery.requeuedJobIds.length,
       deadLetterJobs: recovery.deadLetterJobIds.length,
       cancelledJobs: recovery.cancelledJobIds.length
     };
+    const watchdogRecoveryActionCount =
+      stalledRecovery.requeuedJobs + stalledRecovery.deadLetterJobs + stalledRecovery.cancelledJobs;
 
     this.state.lastWatchdogRunAt = nowIso;
     this.state.staleWorkersDetected += stalledRecovery.staleWorkers;
@@ -764,57 +849,110 @@ export class WorkerAutonomyService {
     this.state.recoveredJobs += stalledRecovery.requeuedJobs;
     this.state.deadLetterJobs += stalledRecovery.deadLetterJobs;
     this.state.cancelledJobs += stalledRecovery.cancelledJobs;
-    this.state.recoveryActions +=
-      stalledRecovery.requeuedJobs + stalledRecovery.deadLetterJobs + stalledRecovery.cancelledJobs;
     if (stalledRecovery.staleWorkers > 0) {
       recordWorkerStaleDetection({
         reason,
         count: stalledRecovery.staleWorkers
       });
-    }
-    if (stalledRecovery.stalledJobs > 0) {
-      recordWorkerStalledJobs({
-        action:
-          stalledRecovery.deadLetterJobs > 0 && stalledRecovery.requeuedJobs === 0
-            ? 'dead_letter'
-            : stalledRecovery.requeuedJobs > 0
-            ? 'requeue'
-            : 'cancelled',
-        count: stalledRecovery.stalledJobs
-      });
-    }
-    if (stalledRecovery.requeuedJobs > 0) {
-      recordWorkerRecoveredJobs({
-        action: 'requeue',
-        count: stalledRecovery.requeuedJobs
-      });
-    }
-    if (stalledRecovery.deadLetterJobs > 0) {
-      recordWorkerRecoveredJobs({
-        action: 'dead_letter',
-        count: stalledRecovery.deadLetterJobs
-      });
-    }
-    if (stalledRecovery.cancelledJobs > 0) {
-      recordWorkerRecoveredJobs({
-        action: 'cancelled',
-        count: stalledRecovery.cancelledJobs
-      });
-    }
-    if (
-      stalledRecovery.requeuedJobs > 0 ||
-      stalledRecovery.deadLetterJobs > 0 ||
-      stalledRecovery.cancelledJobs > 0
-    ) {
-      this.state.lastRecoveryActionAt = nowIso;
-      logger.warn('worker.watchdog.recovery', {
+      logger.warn('worker.watchdog.stale_worker_detected', {
+        module: 'worker-autonomy',
         workerId: this.settings.workerId,
         reason,
         staleWorkers: stalledRecovery.staleWorkers,
         stalledJobs: stalledRecovery.stalledJobs,
-        requeuedJobs: stalledRecovery.requeuedJobs,
-        deadLetterJobs: stalledRecovery.deadLetterJobs,
-        cancelledJobs: stalledRecovery.cancelledJobs
+        recoveryActions: watchdogRecoveryActionCount,
+        restartRecommended: true,
+        queuePending: watchdogQueueSummary?.pending ?? null,
+        queueRunning: watchdogQueueSummary?.running ?? null,
+        queueStalledRunning: watchdogQueueSummary?.stalledRunning ?? null
+      });
+    }
+    if (stalledRecovery.requeuedJobs > 0) {
+      recordWorkerStalledJobs({
+        action: 'requeue',
+        count: stalledRecovery.requeuedJobs
+      });
+      recordWorkerRecoveredJobs({
+        action: 'requeue',
+        count: stalledRecovery.requeuedJobs
+      });
+      this.recordRecoveryAction({
+        action: 'stalled_requeue',
+        source: options.source ?? 'watchdog',
+        count: stalledRecovery.requeuedJobs,
+        jobIds: recovery.requeuedJobIds,
+        workerIds: observedStaleWorkerIds,
+        reason: 'watchdog requeued stalled jobs from stale workers'
+      });
+    }
+    if (stalledRecovery.deadLetterJobs > 0) {
+      recordWorkerStalledJobs({
+        action: 'dead_letter',
+        count: stalledRecovery.deadLetterJobs
+      });
+      recordWorkerRecoveredJobs({
+        action: 'dead_letter',
+        count: stalledRecovery.deadLetterJobs
+      });
+      this.recordRecoveryAction({
+        action: 'stalled_dead_letter',
+        source: options.source ?? 'watchdog',
+        count: stalledRecovery.deadLetterJobs,
+        jobIds: recovery.deadLetterJobIds,
+        workerIds: observedStaleWorkerIds,
+        reason: 'watchdog dead-lettered stalled jobs from stale workers'
+      });
+    }
+    if (stalledRecovery.cancelledJobs > 0) {
+      recordWorkerStalledJobs({
+        action: 'cancelled',
+        count: stalledRecovery.cancelledJobs
+      });
+      recordWorkerRecoveredJobs({
+        action: 'cancelled',
+        count: stalledRecovery.cancelledJobs
+      });
+      this.recordRecoveryAction({
+        action: 'stalled_cancelled',
+        source: options.source ?? 'watchdog',
+        count: stalledRecovery.cancelledJobs,
+        jobIds: recovery.cancelledJobIds,
+        workerIds: observedStaleWorkerIds,
+        reason: 'watchdog resolved cancelled stalled jobs from stale workers'
+      });
+    }
+    const detectedOnlyStalledJobs = Math.max(
+      0,
+      stalledRecovery.stalledJobs -
+        stalledRecovery.requeuedJobs -
+        stalledRecovery.deadLetterJobs -
+        stalledRecovery.cancelledJobs
+    );
+    if (detectedOnlyStalledJobs > 0) {
+      recordWorkerStalledJobs({
+        action: 'detected',
+        count: detectedOnlyStalledJobs
+      });
+    }
+    if (
+      stalledRecovery.staleWorkers > 0 ||
+      stalledRecovery.stalledJobs > 0 ||
+      stalledRecovery.requeuedJobs > 0 ||
+      stalledRecovery.deadLetterJobs > 0 ||
+      stalledRecovery.cancelledJobs > 0
+    ) {
+      this.recordWatchdogEvent({
+        at: nowIso,
+        source: options.source ?? 'watchdog',
+        reason: watchdogRecoveryActionCount > 0
+          ? 'stalled worker recovery completed'
+          : 'stale worker restart recommended',
+        staleWorkerIds: observedStaleWorkerIds,
+        stalledJobIds: recovery.stalledJobIds,
+        requeuedJobIds: recovery.requeuedJobIds,
+        deadLetterJobIds: recovery.deadLetterJobIds,
+        cancelledJobIds: recovery.cancelledJobIds,
+        restartRecommended: watchdogRecoveryActionCount === 0 && observedStaleWorkerIds.length > 0
       });
     }
 
@@ -1023,8 +1161,7 @@ export class WorkerAutonomyService {
       this.state.lastError = errorMessage;
       this.state.lastActivityAt = failedAt;
       this.state.lastProcessedJobAt = failedAt;
-      this.state.scheduledRetries += 1;
-      await scheduleJobRetry(job.id, {
+      const retriedJob = await scheduleJobRetry(job.id, {
         workerId: this.settings.workerId,
         delayMs,
         errorMessage,
@@ -1037,6 +1174,41 @@ export class WorkerAutonomyService {
           lastRetryDelayMs: delayMs,
           retryReason: errorMessage
         }
+      });
+      if (!retriedJob) {
+        logger.warn('worker.job.retry_schedule.skipped', {
+          module: 'worker-autonomy',
+          workerId: this.settings.workerId,
+          jobId: job.id,
+          reason: 'job no longer had a live running lease',
+          retryCount,
+          maxRetries,
+          delayMs
+        });
+        await this.persistSnapshot({
+          healthStatus: 'degraded',
+          alerts: [`Retry scheduling skipped for job ${job.id}; live lease was no longer owned by this worker.`]
+        }, { force: true, source: 'job-retry-skipped' });
+        this.state.lastError = null;
+        return {
+          action: 'failed'
+        };
+      }
+      this.state.scheduledRetries += 1;
+      this.recordRecoveryAction({
+        action: 'retry_scheduled',
+        source: 'job-failure',
+        count: 1,
+        jobIds: [job.id],
+        reason: errorMessage
+      });
+      logger.info('worker.job.retry_scheduled', {
+        module: 'worker-autonomy',
+        workerId: this.settings.workerId,
+        jobId: job.id,
+        delayMs,
+        retryCount,
+        maxRetries
       });
       await this.persistSnapshot({
         healthStatus: 'degraded',
@@ -1074,6 +1246,25 @@ export class WorkerAutonomyService {
       },
       lifecycleDeadlines
     );
+    if (retryable && retryCount >= maxRetries) {
+      this.state.deadLetterJobs += 1;
+      this.recordRecoveryAction({
+        action: 'job_dead_letter',
+        source: 'job-failure',
+        count: 1,
+        jobIds: [job.id],
+        reason: errorMessage
+      });
+    }
+    logger.warn('worker.job_failure.terminal', {
+      module: 'worker-autonomy',
+      workerId: this.settings.workerId,
+      jobId: job.id,
+      retryable,
+      retryCount,
+      maxRetries,
+      deadLetter: retryable && retryCount >= maxRetries
+    });
     await this.persistSnapshot({
       healthStatus: this.state.terminalFailures >= this.settings.failureWebhookThreshold ? 'unhealthy' : 'degraded',
       alerts: [`Job ${job.id} failed: ${errorMessage}`]
@@ -1131,7 +1322,8 @@ export class WorkerAutonomyService {
       logger.warn('worker.provider_recovery_defer.skipped_status_mismatch', {
         module: 'worker-autonomy',
         workerId: this.settings.workerId,
-        jobId: job.id
+        jobId: job.id,
+        providerFailureCategory: options.providerFailureCategory ?? null
       });
       await this.persistSnapshot({
         healthStatus: 'degraded',
@@ -1142,6 +1334,26 @@ export class WorkerAutonomyService {
         delayMs
       };
     }
+    this.recordRecoveryAction({
+      action: 'provider_deferred',
+      source: 'provider-recovery',
+      count: 1,
+      jobIds: [job.id],
+      reason: options.providerFailureCategory ?? options.errorMessage
+    });
+    logger.info(
+      options.providerFailureCategory === 'circuit_open'
+        ? 'worker.circuit_breaker.cooldown.defer'
+        : 'worker.provider_recovery.defer_scheduled',
+      {
+        module: 'worker-autonomy',
+        workerId: this.settings.workerId,
+        jobId: job.id,
+        delayMs,
+        providerNextRetryAt: options.providerNextRetryAt ?? null,
+        providerFailureCategory: options.providerFailureCategory ?? null
+      }
+    );
     await this.persistSnapshot({
       healthStatus: 'degraded',
       alerts: [`Provider unavailable; deferred job ${job.id} for ${delayMs}ms without consuming retry budget.`]
@@ -1152,6 +1364,35 @@ export class WorkerAutonomyService {
       action: 'deferred',
       delayMs
     };
+  }
+
+  /**
+   * Persist that a provider circuit/backoff recovered and worker execution can resume.
+   * Purpose: make circuit-breaker cooldown resets visible in worker health and metrics.
+   */
+  async recordProviderCircuitBreakerReset(options: {
+    providerFailureCategory?: string | null;
+    providerNextRetryAt?: string | null;
+    source?: string;
+  } = {}): Promise<void> {
+    this.state.lastError = null;
+    this.state.lastActivityAt = new Date().toISOString();
+    this.recordRecoveryAction({
+      action: 'circuit_breaker_reset',
+      source: options.source ?? 'provider-recovery',
+      count: 1,
+      reason: options.providerFailureCategory ?? 'provider circuit breaker reset'
+    });
+    logger.info('worker.circuit_breaker.reset', {
+      module: 'worker-autonomy',
+      workerId: this.settings.workerId,
+      providerFailureCategory: options.providerFailureCategory ?? null,
+      providerNextRetryAt: options.providerNextRetryAt ?? null
+    });
+    await this.persistSnapshot({
+      healthStatus: this.state.lastBudgetPauseReason ? 'degraded' : 'healthy',
+      alerts: ['Provider circuit breaker reset; worker execution can resume.']
+    }, { force: true, source: 'circuit-breaker-reset' });
   }
 
   /**
@@ -1228,6 +1469,113 @@ export class WorkerAutonomyService {
     return 'healthy';
   }
 
+  private recordRecoveryAction(input: {
+    action: string;
+    source: string;
+    count: number;
+    jobIds?: string[];
+    workerIds?: string[];
+    reason?: string | null;
+  }): void {
+    const count = Math.max(0, Math.trunc(input.count));
+    if (count <= 0) {
+      return;
+    }
+
+    const jobIdSample = buildWorkerEventIdSample(input.jobIds);
+    const workerIdSample = buildWorkerEventIdSample(input.workerIds);
+    const event: WorkerRecoveryActionEvent = {
+      at: new Date().toISOString(),
+      action: input.action,
+      source: input.source,
+      count,
+      jobIds: jobIdSample.ids,
+      jobIdsTotal: jobIdSample.total,
+      jobIdsTruncated: jobIdSample.truncated,
+      workerIds: workerIdSample.ids,
+      workerIdsTotal: workerIdSample.total,
+      workerIdsTruncated: workerIdSample.truncated,
+      reason: input.reason ?? null
+    };
+
+    this.state.recoveryActions += count;
+    this.state.lastRecoveryActionAt = event.at;
+    this.state.lastRecoveryEvent = event;
+    this.state.recentRecoveryEvents = [
+      event,
+      ...this.state.recentRecoveryEvents
+    ].slice(0, WORKER_RECOVERY_EVENT_HISTORY_LIMIT);
+    recordWorkerRecoveryAction({
+      action: event.action,
+      source: event.source,
+      count: event.count
+    });
+    logger.info('worker.recovery.action', {
+      module: 'worker-autonomy',
+      workerId: this.settings.workerId,
+      action: event.action,
+      source: event.source,
+      count: event.count,
+      jobIds: event.jobIds,
+      jobIdsTotal: event.jobIdsTotal,
+      jobIdsTruncated: event.jobIdsTruncated,
+      workerIds: event.workerIds,
+      workerIdsTotal: event.workerIdsTotal,
+      workerIdsTruncated: event.workerIdsTruncated,
+      reason: event.reason
+    });
+  }
+
+  private recordWatchdogEvent(event: WorkerWatchdogRecoveryEvent): void {
+    const staleWorkerIdSample = buildWorkerEventIdSample(event.staleWorkerIds);
+    const stalledJobIdSample = buildWorkerEventIdSample(event.stalledJobIds);
+    const requeuedJobIdSample = buildWorkerEventIdSample(event.requeuedJobIds);
+    const deadLetterJobIdSample = buildWorkerEventIdSample(event.deadLetterJobIds);
+    const cancelledJobIdSample = buildWorkerEventIdSample(event.cancelledJobIds);
+    const sampledEvent: WorkerWatchdogRecoveryEvent = {
+      ...event,
+      staleWorkerIds: staleWorkerIdSample.ids,
+      staleWorkerIdsTotal: staleWorkerIdSample.total,
+      staleWorkerIdsTruncated: staleWorkerIdSample.truncated,
+      stalledJobIds: stalledJobIdSample.ids,
+      stalledJobIdsTotal: stalledJobIdSample.total,
+      stalledJobIdsTruncated: stalledJobIdSample.truncated,
+      requeuedJobIds: requeuedJobIdSample.ids,
+      requeuedJobIdsTotal: requeuedJobIdSample.total,
+      requeuedJobIdsTruncated: requeuedJobIdSample.truncated,
+      deadLetterJobIds: deadLetterJobIdSample.ids,
+      deadLetterJobIdsTotal: deadLetterJobIdSample.total,
+      deadLetterJobIdsTruncated: deadLetterJobIdSample.truncated,
+      cancelledJobIds: cancelledJobIdSample.ids,
+      cancelledJobIdsTotal: cancelledJobIdSample.total,
+      cancelledJobIdsTruncated: cancelledJobIdSample.truncated
+    };
+
+    this.state.lastWatchdogEvent = sampledEvent;
+    logger.warn('worker.watchdog.triggered', {
+      module: 'worker-autonomy',
+      workerId: this.settings.workerId,
+      source: sampledEvent.source,
+      reason: sampledEvent.reason,
+      staleWorkerIds: sampledEvent.staleWorkerIds,
+      staleWorkerIdsTotal: sampledEvent.staleWorkerIdsTotal,
+      staleWorkerIdsTruncated: sampledEvent.staleWorkerIdsTruncated,
+      stalledJobIds: sampledEvent.stalledJobIds,
+      stalledJobIdsTotal: sampledEvent.stalledJobIdsTotal,
+      stalledJobIdsTruncated: sampledEvent.stalledJobIdsTruncated,
+      requeuedJobIds: sampledEvent.requeuedJobIds,
+      requeuedJobIdsTotal: sampledEvent.requeuedJobIdsTotal,
+      requeuedJobIdsTruncated: sampledEvent.requeuedJobIdsTruncated,
+      deadLetterJobIds: sampledEvent.deadLetterJobIds,
+      deadLetterJobIdsTotal: sampledEvent.deadLetterJobIdsTotal,
+      deadLetterJobIdsTruncated: sampledEvent.deadLetterJobIdsTruncated,
+      cancelledJobIds: sampledEvent.cancelledJobIds,
+      cancelledJobIdsTotal: sampledEvent.cancelledJobIdsTotal,
+      cancelledJobIdsTruncated: sampledEvent.cancelledJobIdsTruncated,
+      restartRecommended: sampledEvent.restartRecommended
+    });
+  }
+
   private async persistSnapshot(
     context: WorkerSnapshotContext,
     options: WorkerSnapshotPersistOptions = {}
@@ -1274,6 +1622,9 @@ export class WorkerAutonomyService {
         cancelledJobs: this.state.cancelledJobs,
         recoveryActions: this.state.recoveryActions,
         lastRecoveryActionAt: this.state.lastRecoveryActionAt,
+        lastRecoveryEvent: this.state.lastRecoveryEvent,
+        recentRecoveryEvents: this.state.recentRecoveryEvents,
+        lastWatchdogEvent: this.state.lastWatchdogEvent,
         maxObservedQueueDepth: this.state.maxObservedQueueDepth,
         lastBudgetPauseReason: this.state.lastBudgetPauseReason,
         lastActivityAt: this.state.lastActivityAt,
@@ -1929,7 +2280,9 @@ function buildWatchdogRecoveryAlerts(
 
   if (stalledRecovery.staleWorkers > 0) {
     alerts.push(
-      `Detected ${stalledRecovery.staleWorkers} stale worker(s) and ${stalledRecovery.stalledJobs} stalled job(s).`
+      stalledRecovery.stalledJobs > 0
+        ? `Detected ${stalledRecovery.staleWorkers} stale worker(s) and ${stalledRecovery.stalledJobs} stalled job(s).`
+        : `Detected ${stalledRecovery.staleWorkers} stale worker(s); restart recommended.`
     );
   }
   if (stalledRecovery.requeuedJobs > 0) {

--- a/src/services/workerControlService.ts
+++ b/src/services/workerControlService.ts
@@ -28,6 +28,7 @@ import {
 } from '@shared/ask/asyncAskJob.js';
 import type { PreviewAskChaosHook } from '@shared/ask/previewChaos.js';
 import type { ClientContextDTO } from '@shared/types/dto.js';
+import { redactSensitive, redactString } from '@shared/redaction.js';
 import { detectCognitiveDomain } from '@dispatcher/detectCognitiveDomain.js';
 import type { CognitiveDomain } from '@shared/types/cognitiveDomain.js';
 import { recordSelfHealEvent } from '@services/selfImprove/selfHealTelemetry.js';
@@ -175,8 +176,12 @@ export interface WorkerControlWorkerSnapshot {
   staleWorkersDetected?: number;
   stalledJobsDetected?: number;
   deadLetterJobs?: number;
+  cancelledJobs?: number;
   recoveryActions?: number;
   lastRecoveryActionAt?: string | null;
+  lastRecoveryEvent?: Record<string, unknown> | null;
+  recentRecoveryEvents?: Record<string, unknown>[];
+  lastWatchdogEvent?: Record<string, unknown> | null;
   lastWatchdogRunAt?: string | null;
   updatedAt: string;
   watchdog: {
@@ -286,6 +291,25 @@ export interface RequeueFailedWorkerJobResult {
 }
 
 const PENDING_AGE_DEGRADED_THRESHOLD_MS = 60_000;
+const PRIVATE_RESPONSES_SDK_UNWRAP_MEMBER = ['_then', 'Unwrap'].join('');
+const RESPONSES_SDK_COMPATIBILITY_FAILURE = 'OpenAI Responses SDK compatibility failure.';
+
+function redactWorkerControlPayload<T>(payload: T): T {
+  return redactSensitive(payload) as T;
+}
+
+function redactWorkerDiagnosticMessage(message: string | null | undefined): string | null {
+  if (typeof message !== 'string') {
+    return null;
+  }
+
+  const redactedMessage = redactString(message);
+  if (redactedMessage === '[REDACTED]' || redactedMessage.includes(PRIVATE_RESPONSES_SDK_UNWRAP_MEMBER)) {
+    return redactedMessage === '[REDACTED]' ? redactedMessage : RESPONSES_SDK_COMPATIBILITY_FAILURE;
+  }
+
+  return redactedMessage;
+}
 
 /**
  * Request payload for queueing dedicated-worker async `/ask` jobs.
@@ -416,14 +440,14 @@ function buildWorkerJobSnapshot(job: JobData): WorkerJobSnapshot {
     created_at: job.created_at,
     updated_at: job.updated_at,
     completed_at: job.completed_at ?? null,
-    error_message: job.error_message ?? null
+    error_message: redactWorkerDiagnosticMessage(job.error_message)
   };
 }
 
 function buildWorkerJobDetailSnapshot(job: JobData): WorkerJobDetailSnapshot {
   return {
     ...buildWorkerJobSnapshot(job),
-    output: job.output ?? null
+    output: redactSensitive(job.output ?? null)
   };
 }
 
@@ -436,12 +460,30 @@ function buildFailedWorkerJobSnapshot(
     last_worker_id: failedJob.last_worker_id ?? null,
     job_type: failedJob.job_type,
     status: 'failed',
-    error_message: failedJob.error_message ?? null,
+    error_message: redactWorkerDiagnosticMessage(failedJob.error_message),
     retry_count: Number(failedJob.retry_count ?? 0),
     max_retries: Number(failedJob.max_retries ?? 0),
     created_at: failedJob.created_at,
     updated_at: failedJob.updated_at,
     completed_at: failedJob.completed_at ?? null
+  };
+}
+
+function redactFailureReasonSummary(reason: JobFailureReasonSummary): JobFailureReasonSummary {
+  return {
+    ...reason,
+    reason: redactWorkerDiagnosticMessage(reason.reason) ?? '[REDACTED]'
+  };
+}
+
+function redactQueueSummary(queueSummary: JobQueueSummary | null): JobQueueSummary | null {
+  if (!queueSummary) {
+    return null;
+  }
+
+  return {
+    ...queueSummary,
+    recentFailureReasons: queueSummary.recentFailureReasons.map(redactFailureReasonSummary)
   };
 }
 
@@ -526,6 +568,30 @@ function readSnapshotStringArray(
   }
 
   return value.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0);
+}
+
+function readSnapshotRecord(
+  snapshot: Record<string, unknown>,
+  key: string
+): Record<string, unknown> | null {
+  const value = snapshot[key];
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function readSnapshotRecordArray(
+  snapshot: Record<string, unknown>,
+  key: string
+): Record<string, unknown>[] {
+  const value = snapshot[key];
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((entry): entry is Record<string, unknown> =>
+    Boolean(entry && typeof entry === 'object' && !Array.isArray(entry))
+  );
 }
 
 function readIsoTimestampToMs(value: string | null): number | null {
@@ -641,6 +707,9 @@ function buildWorkerControlWorkerSnapshot(
   const lastProcessedJobAt = readSnapshotString(snapshot, 'lastProcessedJobAt');
   const lastRecoveryActionAt = readSnapshotString(snapshot, 'lastRecoveryActionAt');
   const lastWatchdogRunAt = readSnapshotString(snapshot, 'lastWatchdogRunAt');
+  const lastRecoveryEvent = readSnapshotRecord(snapshot, 'lastRecoveryEvent');
+  const recentRecoveryEvents = readSnapshotRecordArray(snapshot, 'recentRecoveryEvents');
+  const lastWatchdogEvent = readSnapshotRecord(snapshot, 'lastWatchdogEvent');
   const dispatcherStarted = snapshot.dispatcherStarted === true;
   const activeListeners = readSnapshotNumber(snapshot, 'activeListeners') ?? 0;
   const activeJobs = readSnapshotStringArray(snapshot, 'activeJobs');
@@ -679,7 +748,7 @@ function buildWorkerControlWorkerSnapshot(
     lastClaimResult: readSnapshotString(snapshot, 'lastClaimResult'),
     disabledReason: readSnapshotString(snapshot, 'disabledReason'),
     currentJobId: workerSnapshot.currentJobId,
-    lastError: workerSnapshot.lastError,
+    lastError: redactWorkerDiagnosticMessage(workerSnapshot.lastError),
     lastHeartbeatAt: workerSnapshot.lastHeartbeatAt,
     lastActivityAt,
     lastProcessedJobAt,
@@ -693,8 +762,12 @@ function buildWorkerControlWorkerSnapshot(
     staleWorkersDetected: readSnapshotNumber(snapshot, 'staleWorkersDetected'),
     stalledJobsDetected: readSnapshotNumber(snapshot, 'stalledJobsDetected'),
     deadLetterJobs: readSnapshotNumber(snapshot, 'deadLetterJobs'),
+    cancelledJobs: readSnapshotNumber(snapshot, 'cancelledJobs'),
     recoveryActions: readSnapshotNumber(snapshot, 'recoveryActions'),
     lastRecoveryActionAt,
+    ...(lastRecoveryEvent ? { lastRecoveryEvent } : {}),
+    ...(recentRecoveryEvents.length > 0 ? { recentRecoveryEvents } : {}),
+    ...(lastWatchdogEvent ? { lastWatchdogEvent } : {}),
     lastWatchdogRunAt,
     updatedAt: workerSnapshot.updatedAt,
     watchdog
@@ -819,7 +892,7 @@ function buildWorkerHistoricalDebt(queueSummary: JobQueueSummary | null): Worker
     retainedFailedJobs: queueSummary?.failed ?? 0,
     retryExhaustedJobs: queueSummary?.failureBreakdown?.retryExhausted ?? 0,
     deadLetterJobs: queueSummary?.failureBreakdown?.deadLetter ?? 0,
-    recentFailureReasons: queueSummary?.recentFailureReasons ?? [],
+    recentFailureReasons: (queueSummary?.recentFailureReasons ?? []).map(redactFailureReasonSummary),
     failureWindowMs: queueSummary?.recentTerminalWindowMs ?? null,
     inspectionEndpoint: '/worker-helper/jobs/failed',
     currentRiskExcluded: true
@@ -928,8 +1001,9 @@ export async function getWorkerControlStatus(
   const health = buildWorkerControlHealthPayload({
     healthReport: autonomyHealth
   });
+  const queueSummary = redactQueueSummary(autonomyHealth.queueSummary ?? await getJobQueueSummary());
 
-  return {
+  return redactWorkerControlPayload({
     timestamp: new Date().toISOString(),
     mainApp: {
       connected: true,
@@ -939,7 +1013,7 @@ export async function getWorkerControlStatus(
     workerService: {
       observationMode: 'queue-observed',
       database: getDatabaseStatus(),
-      queueSummary: autonomyHealth.queueSummary ?? await getJobQueueSummary(),
+      queueSummary,
       queueSemantics: buildWorkerQueueSemantics(),
       retryPolicy: buildWorkerRetryPolicySummary(),
       recentFailedJobs,
@@ -953,7 +1027,7 @@ export async function getWorkerControlStatus(
         workers: health.workers
       }
     }
-  };
+  });
 }
 
 /**
@@ -1077,8 +1151,9 @@ export async function getWorkerControlHealth(): Promise<WorkerControlHealthRespo
     healthReport
   });
 
-  return {
+  return redactWorkerControlPayload({
     ...healthReport,
+    queueSummary: redactQueueSummary(healthReport.queueSummary),
     overallStatus: health.overallStatus,
     alerts: health.alerts,
     diagnosticAlerts: health.diagnosticAlerts,
@@ -1088,7 +1163,7 @@ export async function getWorkerControlHealth(): Promise<WorkerControlHealthRespo
     recentFailedJobs,
     operationalHealth: health.operationalHealth,
     historicalDebt: health.historicalDebt
-  };
+  });
 }
 
 /**

--- a/src/workers/jobRunner.ts
+++ b/src/workers/jobRunner.ts
@@ -393,6 +393,9 @@ async function ensureOpenAIClientForSlot(params: {
   client: OpenAIClient | null;
   configVersion: string | null;
   pausedUntil: string | null;
+  providerRecovered: boolean;
+  providerRecoveryCategory: string | null;
+  providerRecoveryNextRetryAt: string | null;
 }> {
   const sync = syncOpenAIProviderRuntime({
     forceReload: params.forceReload ?? false,
@@ -400,12 +403,16 @@ async function ensureOpenAIClientForSlot(params: {
   });
   const configVersion = sync.runtime.configVersion;
   const configChanged = configVersion !== params.currentConfigVersion;
+  const runtimeBeforeProbe = sync.runtime;
 
   if (params.currentClient && !configChanged && !params.forceReload) {
     return {
       client: params.currentClient,
       configVersion,
-      pausedUntil: sync.runtime.nextRetryAt
+      pausedUntil: sync.runtime.nextRetryAt,
+      providerRecovered: false,
+      providerRecoveryCategory: null,
+      providerRecoveryNextRetryAt: null
     };
   }
 
@@ -416,8 +423,25 @@ async function ensureOpenAIClientForSlot(params: {
     return {
       client: null,
       configVersion,
-      pausedUntil: sync.runtime.nextRetryAt
+      pausedUntil: sync.runtime.nextRetryAt,
+      providerRecovered: false,
+      providerRecoveryCategory: null,
+      providerRecoveryNextRetryAt: null
     };
+  }
+
+  const probingAfterProviderFailure = Boolean(
+    runtimeBeforeProbe.lastFailureAt ||
+    runtimeBeforeProbe.lastFailureCategory ||
+    runtimeBeforeProbe.consecutiveFailures > 0
+  );
+  if (probingAfterProviderFailure) {
+    logger.info('worker.circuit_breaker.reset_probe', {
+      module: 'job-runner',
+      workerId: params.workerId,
+      providerFailureCategory: runtimeBeforeProbe.lastFailureCategory,
+      providerNextRetryAt: runtimeBeforeProbe.nextRetryAt
+    });
   }
 
   const providerProbe = await probeOpenAIProviderHealth({
@@ -427,15 +451,31 @@ async function ensureOpenAIClientForSlot(params: {
     return {
       client: null,
       configVersion: providerProbe.runtime.configVersion,
-      pausedUntil: providerProbe.runtime.nextRetryAt
+      pausedUntil: providerProbe.runtime.nextRetryAt,
+      providerRecovered: false,
+      providerRecoveryCategory: null,
+      providerRecoveryNextRetryAt: null
     };
   }
 
   try {
+    const client = initOpenAIClient();
+    if (probingAfterProviderFailure) {
+      logger.info('worker.circuit_breaker.reset', {
+        module: 'job-runner',
+        workerId: params.workerId,
+        providerFailureCategory: runtimeBeforeProbe.lastFailureCategory,
+        providerNextRetryAt: runtimeBeforeProbe.nextRetryAt
+      });
+    }
+
     return {
-      client: initOpenAIClient(),
+      client,
       configVersion: providerProbe.runtime.configVersion,
-      pausedUntil: providerProbe.runtime.nextRetryAt
+      pausedUntil: providerProbe.runtime.nextRetryAt,
+      providerRecovered: probingAfterProviderFailure,
+      providerRecoveryCategory: runtimeBeforeProbe.lastFailureCategory,
+      providerRecoveryNextRetryAt: runtimeBeforeProbe.nextRetryAt
     };
   } catch (error: unknown) {
     logger.error(
@@ -450,7 +490,10 @@ async function ensureOpenAIClientForSlot(params: {
     return {
       client: null,
       configVersion: providerProbe.runtime.configVersion,
-      pausedUntil: getOpenAIProviderRuntimeStatus().nextRetryAt
+      pausedUntil: getOpenAIProviderRuntimeStatus().nextRetryAt,
+      providerRecovered: false,
+      providerRecoveryCategory: null,
+      providerRecoveryNextRetryAt: null
     };
   }
 }
@@ -1035,6 +1078,13 @@ async function runWorkerConsumerSlot(
       });
       openai = ensuredClientState.client;
       providerConfigVersion = ensuredClientState.configVersion;
+      if (ensuredClientState.providerRecovered) {
+        await autonomyService.recordProviderCircuitBreakerReset({
+          providerFailureCategory: ensuredClientState.providerRecoveryCategory,
+          providerNextRetryAt: ensuredClientState.providerRecoveryNextRetryAt,
+          source: 'job-runner'
+        });
+      }
 
       if (!openai) {
         const delayMs = resolveProviderPauseMs(

--- a/tests/app-metrics.test.ts
+++ b/tests/app-metrics.test.ts
@@ -240,28 +240,30 @@ describe('app metrics registry', () => {
     const { getMetricsText } = await loadMetricsModule();
 
     let metricsText = await getMetricsText();
-    expect(metricsText).toMatch(/worker_stale_total\{[^}]*reason="persisted_snapshot"[^}]*\} 2/);
-    expect(metricsText).toMatch(/worker_stalled_jobs_total\{[^}]*action="requeue"[^}]*\} 2/);
-    expect(metricsText).toMatch(/worker_stalled_jobs_total\{[^}]*action="dead_letter"[^}]*\} 1/);
-    expect(metricsText).toMatch(/worker_recovered_jobs_total\{[^}]*action="requeue"[^}]*\} 2/);
-    expect(metricsText).toMatch(/worker_recovered_jobs_total\{[^}]*action="dead_letter"[^}]*\} 1/);
+    expect(metricsText).not.toMatch(/worker_stale_total\{[^}]*reason="persisted_snapshot"/);
+    expect(metricsText).not.toMatch(/worker_stalled_jobs_total\{[^}]*action="requeue"/);
+    expect(metricsText).not.toMatch(/worker_stalled_jobs_total\{[^}]*action="dead_letter"/);
+    expect(metricsText).not.toMatch(/worker_recovered_jobs_total\{[^}]*action="requeue"/);
+    expect(metricsText).not.toMatch(/worker_recovered_jobs_total\{[^}]*action="dead_letter"/);
+    expect(metricsText).not.toMatch(/worker_recovery_actions_total\{[^}]*action="persisted_snapshot"[^}]*source="worker_health"/);
 
     metricsText = await getMetricsText();
-    expect(metricsText).toMatch(/worker_stale_total\{[^}]*reason="persisted_snapshot"[^}]*\} 2/);
+    expect(metricsText).not.toMatch(/worker_stale_total\{[^}]*reason="persisted_snapshot"/);
     expect(getWorkerControlHealthMock).toHaveBeenCalledTimes(1);
 
     jest.advanceTimersByTime(6_000);
     metricsText = await getMetricsText();
-    expect(metricsText).toMatch(/worker_stale_total\{[^}]*reason="persisted_snapshot"[^}]*\} 3/);
-    expect(metricsText).toMatch(/worker_stalled_jobs_total\{[^}]*action="requeue"[^}]*\} 3/);
-    expect(metricsText).toMatch(/worker_stalled_jobs_total\{[^}]*action="dead_letter"[^}]*\} 1/);
-    expect(metricsText).toMatch(/worker_recovered_jobs_total\{[^}]*action="requeue"[^}]*\} 3/);
-    expect(metricsText).toMatch(/worker_recovered_jobs_total\{[^}]*action="dead_letter"[^}]*\} 1/);
+    expect(metricsText).toMatch(/worker_stale_total\{[^}]*reason="persisted_snapshot"[^}]*\} 1/);
+    expect(metricsText).toMatch(/worker_stalled_jobs_total\{[^}]*action="requeue"[^}]*\} 1/);
+    expect(metricsText).not.toMatch(/worker_stalled_jobs_total\{[^}]*action="dead_letter"/);
+    expect(metricsText).toMatch(/worker_recovered_jobs_total\{[^}]*action="requeue"[^}]*\} 1/);
+    expect(metricsText).not.toMatch(/worker_recovered_jobs_total\{[^}]*action="dead_letter"/);
+    expect(metricsText).not.toMatch(/worker_recovery_actions_total\{[^}]*action="persisted_snapshot"[^}]*source="worker_health"/);
 
     jest.advanceTimersByTime(6_000);
     metricsText = await getMetricsText();
-    expect(metricsText).toMatch(/worker_stale_total\{[^}]*reason="persisted_snapshot"[^}]*\} 3/);
-    expect(metricsText).toMatch(/worker_stalled_jobs_total\{[^}]*action="requeue"[^}]*\} 4/);
-    expect(metricsText).toMatch(/worker_recovered_jobs_total\{[^}]*action="requeue"[^}]*\} 4/);
+    expect(metricsText).toMatch(/worker_stale_total\{[^}]*reason="persisted_snapshot"[^}]*\} 1/);
+    expect(metricsText).toMatch(/worker_stalled_jobs_total\{[^}]*action="requeue"[^}]*\} 2/);
+    expect(metricsText).toMatch(/worker_recovered_jobs_total\{[^}]*action="requeue"[^}]*\} 2/);
   });
 });

--- a/tests/gpt-dispatch-compatibility.test.ts
+++ b/tests/gpt-dispatch-compatibility.test.ts
@@ -24,6 +24,7 @@ jest.unstable_mockModule('@platform/observability/appMetrics.js', () => ({
   recordUnknownGpt: jest.fn(),
   recordWorkerFailureTotal: jest.fn(),
   recordWorkerRecoveredJobs: jest.fn(),
+  recordWorkerRecoveryAction: jest.fn(),
   recordWorkerJobDuration: jest.fn(),
   recordWorkerJobTotal: jest.fn(),
   recordWorkerQueueDepth: jest.fn(),

--- a/tests/openai-responses.test.ts
+++ b/tests/openai-responses.test.ts
@@ -74,17 +74,14 @@ describe('openai responses helpers', () => {
     expect(result.outputParsed).toEqual({ answer: 'nested' });
   });
 
-  it('does not call private OpenAI SDK promise unwrap helpers', async () => {
-    const privateUnwrap = jest.fn(() => {
-      throw new Error('private unwrap helper should not be called');
-    });
-    const create = jest.fn().mockResolvedValue({
+  it('awaits the plain Promise returned by responses.create', async () => {
+    const createResponse = {
       id: 'resp_private_helper_1',
       model: 'gpt-4.1-mini',
       output_text: 'plain text',
       output: [],
-      _thenUnwrap: privateUnwrap,
-    });
+    };
+    const create = jest.fn(() => Promise.resolve(createResponse));
 
     const result = await callTextResponse(
       { responses: { create } } as any,
@@ -95,7 +92,12 @@ describe('openai responses helpers', () => {
     );
 
     expect(result.outputText).toBe('plain text');
-    expect(privateUnwrap).not.toHaveBeenCalled();
+    expect(create).toHaveBeenCalledTimes(1);
+
+    const returnedPromise = create.mock.results[0]?.value as Promise<unknown>;
+    const privatePromiseHelperName = ['_then', 'Unwrap'].join('');
+    expect(typeof returnedPromise.then).toBe('function');
+    expect(privatePromiseHelperName in returnedPromise).toBe(false);
   });
 
   it('surfaces refusals explicitly', async () => {

--- a/tests/openai-sdk-guardrails.test.ts
+++ b/tests/openai-sdk-guardrails.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { describe, expect, it } from '@jest/globals';
 
 const REPO_ROOT = process.cwd();
-const SCAN_ROOTS = ['src', 'packages', 'tests'];
+const SCAN_ROOTS = ['src', 'packages', 'workers', 'tests'];
 const SELF_FILE = path.resolve(REPO_ROOT, 'tests', 'openai-sdk-guardrails.test.ts');
 const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
 const ALLOWED_OPENAI_CONSTRUCTORS = new Set([
@@ -24,13 +24,9 @@ const ALLOWED_PATTERN_FILES = new Map<string, Set<string>>([
       path.resolve(REPO_ROOT, 'tests', 'openai-adapter.test.ts'),
     ]),
   ],
-  [
-    '_thenUnwrap',
-    new Set([
-      path.resolve(REPO_ROOT, 'tests', 'openai-responses.test.ts'),
-    ]),
-  ],
 ]);
+
+const PRIVATE_UNWRAP_MEMBER = ['_then', 'Unwrap'].join('');
 
 const FORBIDDEN_PATTERNS = [
   {
@@ -50,8 +46,8 @@ const FORBIDDEN_PATTERNS = [
     regex: /\bchat\.completions\s*\[\s*(['"])parse\1\s*\]\s*\(/,
   },
   {
-    label: '_thenUnwrap',
-    regex: /\b_thenUnwrap\b/,
+    label: 'private SDK unwrap helper',
+    regex: new RegExp(`\\b${PRIVATE_UNWRAP_MEMBER}\\b`),
   },
 ] as const;
 

--- a/tests/railway-fast-path-probe.test.js
+++ b/tests/railway-fast-path-probe.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import {
   DEFAULTS,
   PROBE_STATUS,
+  RAILWAY_PRODUCTION_BASE_URL,
   parseArgs,
   runFastPathProbe,
 } from '../scripts/railway-fast-path-probe.js';
@@ -15,6 +16,10 @@ function buildHeaders(entries = {}) {
 }
 
 describe('railway-fast-path-probe', () => {
+  it('documents the Railway-assigned production fallback host', () => {
+    expect(RAILWAY_PRODUCTION_BASE_URL).toBe('https://acranos-production.up.railway.app');
+  });
+
   it('parses explicit CLI overrides', () => {
     const parsed = parseArgs([
       '--base-url', 'https://example.com',

--- a/tests/self-healing-loop.test.ts
+++ b/tests/self-healing-loop.test.ts
@@ -1917,7 +1917,7 @@ describe('selfHealingLoop', () => {
         })
       })
     ]));
-  });
+  }, 15000);
 
   it('surfaces live worker activity timestamps in the runtime snapshot when inactivity fields are empty', () => {
     buildPredictiveHealingStatusSnapshotMock.mockReturnValue({

--- a/tests/worker-autonomy-service.test.ts
+++ b/tests/worker-autonomy-service.test.ts
@@ -545,7 +545,89 @@ describe('workerAutonomyService', () => {
         workerId: 'async-queue'
       })
     );
+    expect(loggerInfoMock).toHaveBeenCalledWith(
+      'worker.job.retry_scheduled',
+      expect.objectContaining({
+        module: 'worker-autonomy',
+        workerId: 'async-queue',
+        jobId: 'job-1',
+        delayMs: 2000
+      })
+    );
+    expect(upsertWorkerRuntimeSnapshotMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        snapshot: expect.objectContaining({
+          scheduledRetries: 1,
+          recoveryActions: 1,
+          lastRecoveryEvent: expect.objectContaining({
+            action: 'retry_scheduled',
+            jobIds: ['job-1']
+          })
+        })
+      }),
+      { source: 'job-retry' }
+    );
     expect(updateJobMock).not.toHaveBeenCalled();
+  });
+
+  it('does not report a retry as scheduled when the running job lease was already lost', async () => {
+    scheduleJobRetryMock.mockResolvedValueOnce(null);
+    const service = new WorkerAutonomyService({
+      workerId: 'async-queue',
+      workerType: 'async_queue',
+      heartbeatIntervalMs: 10_000,
+      leaseMs: 30_000,
+      inspectorIntervalMs: 30_000,
+      staleAfterMs: 60_000,
+      defaultMaxRetries: 2,
+      retryBackoffBaseMs: 2_000,
+      retryBackoffMaxMs: 60_000,
+      maxJobsPerHour: 120,
+      maxAiCallsPerHour: 120,
+      maxRssMb: 2_048,
+      queueDepthDeferralThreshold: 25,
+      queueDepthDeferralMs: 5_000,
+      failureWebhookUrl: null,
+      failureWebhookThreshold: 3,
+      failureWebhookCooldownMs: 300_000
+    });
+
+    const result = await service.handleJobFailure(
+      {
+        id: 'job-lost-lease',
+        job_type: 'ask',
+        worker_id: 'async-queue',
+        status: 'running',
+        input: { prompt: 'test' },
+        retry_count: 0,
+        max_retries: 2,
+        created_at: new Date(),
+        updated_at: new Date()
+      } as any,
+      'OpenAI rate limit timeout',
+      true
+    );
+
+    expect(result).toEqual({ action: 'failed' });
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      'worker.job.retry_schedule.skipped',
+      expect.objectContaining({
+        module: 'worker-autonomy',
+        workerId: 'async-queue',
+        jobId: 'job-lost-lease'
+      })
+    );
+    expect(upsertWorkerRuntimeSnapshotMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshot: expect.objectContaining({
+          scheduledRetries: 0,
+          recoveryActions: 0,
+          lastRecoveryEvent: null,
+          alerts: ['Retry scheduling skipped for job job-lost-lease; live lease was no longer owned by this worker.']
+        })
+      }),
+      { source: 'job-retry-skipped' }
+    );
   });
 
   it('defers provider-unavailable jobs without consuming retry budget', async () => {
@@ -608,6 +690,25 @@ describe('workerAutonomyService', () => {
     );
     expect(scheduleJobRetryMock).not.toHaveBeenCalled();
     expect(updateJobMock).not.toHaveBeenCalled();
+    expect(upsertWorkerRuntimeSnapshotMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        snapshot: expect.objectContaining({
+          recoveryActions: 1,
+          lastRecoveryEvent: expect.objectContaining({
+            action: 'provider_deferred',
+            jobIds: ['job-provider']
+          })
+        })
+      }),
+      { source: 'provider-deferred' }
+    );
+    expect(loggerInfoMock).toHaveBeenCalledWith(
+      'worker.circuit_breaker.cooldown.defer',
+      expect.objectContaining({
+        jobId: 'job-provider',
+        providerFailureCategory: 'circuit_open'
+      })
+    );
   });
 
   it('skips provider deferral when the claimed job is no longer running', async () => {
@@ -666,6 +767,55 @@ describe('workerAutonomyService', () => {
         })
       }),
       { source: 'provider-deferred-skipped' }
+    );
+  });
+
+  it('records circuit breaker reset as an observable recovery action', async () => {
+    const service = new WorkerAutonomyService({
+      workerId: 'async-queue',
+      workerType: 'async_queue',
+      heartbeatIntervalMs: 10_000,
+      leaseMs: 30_000,
+      inspectorIntervalMs: 30_000,
+      staleAfterMs: 60_000,
+      defaultMaxRetries: 2,
+      retryBackoffBaseMs: 2_000,
+      retryBackoffMaxMs: 60_000,
+      maxJobsPerHour: 120,
+      maxAiCallsPerHour: 120,
+      maxRssMb: 2_048,
+      queueDepthDeferralThreshold: 25,
+      queueDepthDeferralMs: 5_000,
+      failureWebhookUrl: null,
+      failureWebhookThreshold: 3,
+      failureWebhookCooldownMs: 300_000
+    });
+
+    await service.recordProviderCircuitBreakerReset({
+      providerFailureCategory: 'circuit_open',
+      providerNextRetryAt: '2026-03-07T12:01:00.000Z',
+      source: 'job-runner'
+    });
+
+    expect(upsertWorkerRuntimeSnapshotMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        healthStatus: 'healthy',
+        snapshot: expect.objectContaining({
+          recoveryActions: 1,
+          lastRecoveryEvent: expect.objectContaining({
+            action: 'circuit_breaker_reset',
+            source: 'job-runner'
+          }),
+          alerts: ['Provider circuit breaker reset; worker execution can resume.']
+        })
+      }),
+      { source: 'circuit-breaker-reset' }
+    );
+    expect(loggerInfoMock).toHaveBeenCalledWith(
+      'worker.circuit_breaker.reset',
+      expect.objectContaining({
+        providerFailureCategory: 'circuit_open'
+      })
     );
   });
 
@@ -1071,6 +1221,97 @@ describe('workerAutonomyService', () => {
     expect(fetchMock.mock.calls[0]?.[1]?.body).toContain('Recovered 1 stale job');
   });
 
+  it('caps recovered job ids persisted in recovery events', async () => {
+    const recoveredJobIds = Array.from({ length: 25 }, (_, index) => `job-stale-${index + 1}`);
+    recoverStaleJobsMock.mockResolvedValue({
+      recoveredJobs: recoveredJobIds,
+      failedJobs: []
+    });
+
+    const service = new WorkerAutonomyService({
+      workerId: 'async-queue',
+      workerType: 'async_queue',
+      heartbeatIntervalMs: 10_000,
+      leaseMs: 30_000,
+      inspectorIntervalMs: 30_000,
+      staleAfterMs: 60_000,
+      defaultMaxRetries: 2,
+      retryBackoffBaseMs: 2_000,
+      retryBackoffMaxMs: 60_000,
+      maxJobsPerHour: 120,
+      maxAiCallsPerHour: 120,
+      maxRssMb: 2_048,
+      queueDepthDeferralThreshold: 25,
+      queueDepthDeferralMs: 5_000,
+      failureWebhookUrl: null,
+      failureWebhookThreshold: 3,
+      failureWebhookCooldownMs: 1
+    });
+
+    await service.inspect('scheduled');
+
+    expect(upsertWorkerRuntimeSnapshotMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshot: expect.objectContaining({
+          lastRecoveryEvent: expect.objectContaining({
+            jobIds: recoveredJobIds.slice(0, 20),
+            jobIdsTotal: 25,
+            jobIdsTruncated: true,
+            workerIds: [],
+            workerIdsTotal: 0,
+            workerIdsTruncated: false
+          })
+        })
+      }),
+      { source: 'inspector' }
+    );
+    expect(loggerInfoMock).toHaveBeenCalledWith(
+      'worker.recovery.action',
+      expect.objectContaining({
+        jobIds: recoveredJobIds.slice(0, 20),
+        jobIdsTotal: 25,
+        jobIdsTruncated: true
+      })
+    );
+  });
+
+  it('treats missing stale recovery result arrays as empty', async () => {
+    recoverStaleJobsMock.mockResolvedValue({} as any);
+
+    const service = new WorkerAutonomyService({
+      workerId: 'async-queue',
+      workerType: 'async_queue',
+      heartbeatIntervalMs: 10_000,
+      leaseMs: 30_000,
+      inspectorIntervalMs: 30_000,
+      staleAfterMs: 60_000,
+      defaultMaxRetries: 2,
+      retryBackoffBaseMs: 2_000,
+      retryBackoffMaxMs: 60_000,
+      maxJobsPerHour: 120,
+      maxAiCallsPerHour: 120,
+      maxRssMb: 2_048,
+      queueDepthDeferralThreshold: 25,
+      queueDepthDeferralMs: 5_000,
+      failureWebhookUrl: null,
+      failureWebhookThreshold: 3,
+      failureWebhookCooldownMs: 1
+    });
+
+    await expect(service.inspect('scheduled')).resolves.toBeDefined();
+    expect(upsertWorkerRuntimeSnapshotMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        snapshot: expect.objectContaining({
+          recoveredJobs: 0,
+          deadLetterJobs: 0,
+          cancelledJobs: 0,
+          recoveryActions: 0
+        })
+      }),
+      { source: 'inspector' }
+    );
+  });
+
   it('uses the shared stats worker id for slot-level budget evaluation', async () => {
     const service = new WorkerAutonomyService({
       workerId: 'async-queue-slot-2',
@@ -1233,6 +1474,189 @@ describe('workerAutonomyService', () => {
     }
   });
 
+  it('surfaces stale worker restart recommendations even when no stalled job rows are recovered', async () => {
+    jest.useFakeTimers();
+
+    try {
+      jest.setSystemTime(new Date('2026-03-07T12:00:00.000Z'));
+      listWorkerRuntimeSnapshotsMock.mockResolvedValue([
+        {
+          workerId: 'async-queue-slot-stale',
+          workerType: 'async_queue',
+          healthStatus: 'healthy',
+          currentJobId: 'job-already-reclaimed',
+          lastError: null,
+          startedAt: '2026-03-07T11:55:00.000Z',
+          lastHeartbeatAt: '2026-03-07T11:59:45.000Z',
+          lastInspectorRunAt: '2026-03-07T11:59:45.000Z',
+          updatedAt: '2026-03-07T11:59:45.000Z',
+          snapshot: {
+            activeJobs: ['job-already-reclaimed'],
+            lastActivityAt: '2026-03-07T11:59:45.000Z'
+          }
+        }
+      ]);
+      recoverStalledJobsForWorkersMock.mockResolvedValueOnce({
+        staleWorkerIds: [],
+        stalledJobIds: [],
+        requeuedJobIds: [],
+        deadLetterJobIds: [],
+        cancelledJobIds: []
+      });
+
+      const service = new WorkerAutonomyService({
+        workerId: 'async-queue-slot-1',
+        workerType: 'async_queue',
+        heartbeatIntervalMs: 5_000,
+        leaseMs: 15_000,
+        inspectorIntervalMs: 30_000,
+        watchdogIntervalMs: 5_000,
+        staleAfterMs: 10_000,
+        watchdogIdleMs: 120_000,
+        stalledJobAction: 'requeue',
+        defaultMaxRetries: 2,
+        retryBackoffBaseMs: 2_000,
+        retryBackoffMaxMs: 60_000,
+        maxJobsPerHour: 120,
+        maxAiCallsPerHour: 120,
+        maxRssMb: 2_048,
+        queueDepthDeferralThreshold: 25,
+        queueDepthDeferralMs: 5_000,
+        failureWebhookUrl: null,
+        failureWebhookThreshold: 3,
+        failureWebhookCooldownMs: 300_000
+      });
+
+      const result = await service.runWatchdogCycle('watchdog');
+
+      expect(result).toEqual({
+        staleWorkers: 1,
+        stalledJobs: 0,
+        requeuedJobs: 0,
+        deadLetterJobs: 0,
+        cancelledJobs: 0
+      });
+      expect(upsertWorkerRuntimeSnapshotMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          snapshot: expect.objectContaining({
+            staleWorkersDetected: 1,
+            recoveryActions: 0,
+            lastRecoveryEvent: null,
+            lastWatchdogEvent: expect.objectContaining({
+              reason: 'stale worker restart recommended',
+              staleWorkerIds: ['async-queue-slot-stale'],
+              restartRecommended: true
+            })
+          })
+        }),
+        { source: 'watchdog' }
+      );
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        'worker.watchdog.triggered',
+        expect.objectContaining({
+          staleWorkerIds: ['async-queue-slot-stale'],
+          restartRecommended: true
+        })
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('caps watchdog event id arrays in snapshots and logs', async () => {
+    jest.useFakeTimers();
+
+    try {
+      jest.setSystemTime(new Date('2026-03-07T12:00:00.000Z'));
+      const staleWorkerIds = Array.from({ length: 25 }, (_, index) => `async-queue-slot-${index + 1}`);
+      const stalledJobIds = Array.from({ length: 25 }, (_, index) => `job-stalled-${index + 1}`);
+      listWorkerRuntimeSnapshotsMock.mockResolvedValue(
+        staleWorkerIds.map((workerId, index) => ({
+          workerId,
+          workerType: 'async_queue',
+          healthStatus: 'healthy',
+          currentJobId: stalledJobIds[index],
+          lastError: null,
+          startedAt: '2026-03-07T11:55:00.000Z',
+          lastHeartbeatAt: '2026-03-07T11:59:45.000Z',
+          lastInspectorRunAt: '2026-03-07T11:59:45.000Z',
+          updatedAt: '2026-03-07T11:59:45.000Z',
+          snapshot: {
+            activeJobs: [stalledJobIds[index]],
+            lastActivityAt: '2026-03-07T11:59:45.000Z'
+          }
+        }))
+      );
+      recoverStalledJobsForWorkersMock.mockResolvedValue({
+        staleWorkerIds,
+        stalledJobIds,
+        requeuedJobIds: stalledJobIds,
+        deadLetterJobIds: [],
+        cancelledJobIds: []
+      });
+
+      const service = new WorkerAutonomyService({
+        workerId: 'async-queue-slot-1',
+        workerType: 'async_queue',
+        heartbeatIntervalMs: 5_000,
+        leaseMs: 15_000,
+        inspectorIntervalMs: 30_000,
+        watchdogIntervalMs: 5_000,
+        staleAfterMs: 10_000,
+        watchdogIdleMs: 120_000,
+        stalledJobAction: 'requeue',
+        defaultMaxRetries: 2,
+        retryBackoffBaseMs: 2_000,
+        retryBackoffMaxMs: 60_000,
+        maxJobsPerHour: 120,
+        maxAiCallsPerHour: 120,
+        maxRssMb: 2_048,
+        queueDepthDeferralThreshold: 25,
+        queueDepthDeferralMs: 5_000,
+        failureWebhookUrl: null,
+        failureWebhookThreshold: 3,
+        failureWebhookCooldownMs: 300_000
+      });
+
+      await service.runWatchdogCycle('watchdog');
+
+      expect(upsertWorkerRuntimeSnapshotMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          snapshot: expect.objectContaining({
+            lastWatchdogEvent: expect.objectContaining({
+              staleWorkerIds: staleWorkerIds.slice(0, 20),
+              staleWorkerIdsTotal: 25,
+              staleWorkerIdsTruncated: true,
+              stalledJobIds: stalledJobIds.slice(0, 20),
+              stalledJobIdsTotal: 25,
+              stalledJobIdsTruncated: true,
+              requeuedJobIds: stalledJobIds.slice(0, 20),
+              requeuedJobIdsTotal: 25,
+              requeuedJobIdsTruncated: true
+            })
+          })
+        }),
+        { source: 'watchdog' }
+      );
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        'worker.watchdog.triggered',
+        expect.objectContaining({
+          staleWorkerIds: staleWorkerIds.slice(0, 20),
+          staleWorkerIdsTotal: 25,
+          staleWorkerIdsTruncated: true,
+          stalledJobIds: stalledJobIds.slice(0, 20),
+          stalledJobIdsTotal: 25,
+          stalledJobIdsTruncated: true,
+          requeuedJobIds: stalledJobIds.slice(0, 20),
+          requeuedJobIdsTotal: 25,
+          requeuedJobIdsTruncated: true
+        })
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('uses fresh liveness records to avoid false stale-worker recovery in V2', async () => {
     jest.useFakeTimers();
 
@@ -1368,6 +1792,112 @@ describe('workerAutonomyService', () => {
         deadLetterJobs: 0,
         cancelledJobs: 0
       });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('reports stale workers for restart recommendation even when no job row is reclaimed', async () => {
+    jest.useFakeTimers();
+
+    try {
+      jest.setSystemTime(new Date('2026-03-07T12:00:00.000Z'));
+      getJobQueueSummaryMock.mockResolvedValue({
+        pending: 0,
+        running: 1,
+        completed: 0,
+        failed: 0,
+        total: 1,
+        delayed: 0,
+        stalledRunning: 0,
+        oldestPendingJobAgeMs: 0,
+        lastUpdatedAt: '2026-03-07T12:00:00.000Z'
+      });
+      listWorkerRuntimeSnapshotsMock.mockResolvedValue([
+        {
+          workerId: 'async-queue-slot-stale',
+          workerType: 'async_queue',
+          healthStatus: 'healthy',
+          currentJobId: null,
+          lastError: null,
+          startedAt: '2026-03-07T11:55:00.000Z',
+          lastHeartbeatAt: '2026-03-07T11:58:00.000Z',
+          lastInspectorRunAt: '2026-03-07T11:58:00.000Z',
+          updatedAt: '2026-03-07T11:58:00.000Z',
+          snapshot: {
+            activeJobs: [],
+            lastActivityAt: '2026-03-07T11:58:00.000Z'
+          }
+        }
+      ]);
+      recoverStalledJobsForWorkersMock.mockResolvedValue({
+        staleWorkerIds: [],
+        stalledJobIds: [],
+        requeuedJobIds: [],
+        deadLetterJobIds: [],
+        cancelledJobIds: []
+      });
+
+      const service = new WorkerAutonomyService({
+        workerId: 'async-queue-slot-1',
+        workerType: 'async_queue',
+        heartbeatIntervalMs: 5_000,
+        leaseMs: 15_000,
+        inspectorIntervalMs: 30_000,
+        watchdogIntervalMs: 5_000,
+        staleAfterMs: 10_000,
+        watchdogIdleMs: 120_000,
+        stalledJobAction: 'requeue',
+        defaultMaxRetries: 2,
+        retryBackoffBaseMs: 2_000,
+        retryBackoffMaxMs: 60_000,
+        maxJobsPerHour: 120,
+        maxAiCallsPerHour: 120,
+        maxRssMb: 2_048,
+        queueDepthDeferralThreshold: 25,
+        queueDepthDeferralMs: 5_000,
+        failureWebhookUrl: null,
+        failureWebhookThreshold: 3,
+        failureWebhookCooldownMs: 300_000
+      });
+
+      const result = await service.runWatchdogCycle('watchdog');
+
+      expect(recoverStalledJobsForWorkersMock).toHaveBeenCalledWith({
+        workerIds: ['async-queue-slot-stale'],
+        staleAfterMs: 10_000,
+        maxRetries: 2,
+        stalledJobAction: 'requeue'
+      });
+      expect(result).toEqual({
+        staleWorkers: 1,
+        stalledJobs: 0,
+        requeuedJobs: 0,
+        deadLetterJobs: 0,
+        cancelledJobs: 0
+      });
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        'worker.watchdog.stale_worker_detected',
+        expect.objectContaining({
+          module: 'worker-autonomy',
+          workerId: 'async-queue-slot-1',
+          staleWorkers: 1,
+          stalledJobs: 0,
+          recoveryActions: 0,
+          restartRecommended: true
+        })
+      );
+      expect(upsertWorkerRuntimeSnapshotMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          healthStatus: 'degraded',
+          snapshot: expect.objectContaining({
+            staleWorkersDetected: 1,
+            recoveryActions: 0,
+            alerts: ['Detected 1 stale worker(s); restart recommended.']
+          })
+        }),
+        { source: 'watchdog' }
+      );
     } finally {
       jest.useRealTimers();
     }

--- a/tests/worker-helper-route.test.ts
+++ b/tests/worker-helper-route.test.ts
@@ -488,6 +488,7 @@ describe('/worker-helper routes', () => {
             staleWorkersDetected: 0,
             stalledJobsDetected: 0,
             deadLetterJobs: 0,
+            cancelledJobs: 0,
             recoveryActions: 0,
             lastRecoveryActionAt: null,
             lastWatchdogRunAt: null,
@@ -502,6 +503,122 @@ describe('/worker-helper routes', () => {
         ]
       }
     }));
+  });
+
+  it('redacts sensitive diagnostic strings from worker helper status and failed-job payloads', async () => {
+    const privateSdkMember = ['_then', 'Unwrap'].join('');
+    const privateSdkFailure = `this._client.responses.create(...).${privateSdkMember} is not a function`;
+    const sensitiveFailure =
+      '401 Incorrect API key provided: sk-svcac********ZygA. Authorization: Bearer abcdefghijklmnop';
+    const sensitiveFailedJob = {
+      id: 'job-failed-sensitive',
+      worker_id: 'worker-helper',
+      last_worker_id: 'async-queue-slot-1',
+      job_type: 'ask',
+      status: 'failed',
+      error_message: sensitiveFailure,
+      retry_count: 2,
+      max_retries: 2,
+      created_at: '2026-03-06T09:55:00.000Z',
+      updated_at: '2026-03-06T09:58:00.000Z',
+      completed_at: '2026-03-06T09:58:00.000Z'
+    };
+
+    getWorkerControlHealthMock.mockResolvedValueOnce({
+      overallStatus: 'healthy',
+      alerts: [],
+      queueSummary: null,
+      workers: [],
+      settings: {
+        heartbeatIntervalMs: 10000,
+        leaseMs: 30000,
+        inspectorIntervalMs: 30000,
+        staleAfterMs: 60000,
+        watchdogIdleMs: 120000,
+        defaultMaxRetries: 2,
+        maxJobsPerHour: 120,
+        maxAiCallsPerHour: 120,
+        maxRssMb: 2048
+      }
+    });
+    getJobQueueSummaryMock.mockResolvedValueOnce({
+      pending: 0,
+      running: 0,
+      completed: 3,
+      failed: 1,
+      total: 4,
+      delayed: 0,
+      stalledRunning: 0,
+      oldestPendingJobAgeMs: 0,
+      failureBreakdown: {
+        retryable: 0,
+        permanent: 1,
+        retryScheduled: 0,
+        retryExhausted: 1,
+        authentication: 1,
+        network: 0,
+        provider: 0,
+        rateLimited: 0,
+        timeout: 0,
+        validation: 0,
+        unknown: 0
+      },
+      recentFailureReasons: [
+        {
+          reason: sensitiveFailure,
+          category: 'authentication',
+          retryable: false,
+          count: 1,
+          lastSeenAt: '2026-03-06T09:58:00.000Z'
+        },
+        {
+          reason: privateSdkFailure,
+          category: 'unknown',
+          retryable: false,
+          count: 1,
+          lastSeenAt: '2026-03-06T09:57:00.000Z'
+        }
+      ],
+      recentTerminalWindowMs: 3600000,
+      recentFailed: 0,
+      recentCompleted: 0,
+      recentTotalTerminal: 0,
+      lastUpdatedAt: '2026-03-06T10:00:00.000Z'
+    });
+    getLatestJobMock.mockResolvedValueOnce({
+      id: 'job-latest-sensitive',
+      worker_id: 'worker-helper',
+      job_type: 'ask',
+      status: 'failed',
+      created_at: '2026-03-06T09:59:00.000Z',
+      updated_at: '2026-03-06T10:00:00.000Z',
+      completed_at: '2026-03-06T10:00:00.000Z',
+      error_message: sensitiveFailure,
+      output: { result: 'failed' }
+    });
+    listFailedJobsMock
+      .mockResolvedValueOnce([sensitiveFailedJob])
+      .mockResolvedValueOnce([sensitiveFailedJob]);
+
+    const statusResponse = await request(buildApp()).get('/worker-helper/status');
+    const failedJobsResponse = await request(buildApp()).get('/worker-helper/jobs/failed?limit=1');
+    const rendered = JSON.stringify({
+      status: statusResponse.body,
+      failedJobs: failedJobsResponse.body
+    });
+
+    expect(statusResponse.status).toBe(200);
+    expect(failedJobsResponse.status).toBe(200);
+    expect(statusResponse.body.workerService.queueSummary.recentFailureReasons[0].reason).toBe('[REDACTED]');
+    expect(statusResponse.body.workerService.latestJob.error_message).toBe('[REDACTED]');
+    expect(statusResponse.body.workerService.recentFailedJobs[0].error_message).toBe('[REDACTED]');
+    expect(failedJobsResponse.body.jobs[0].error_message).toBe('[REDACTED]');
+    expect(rendered).not.toContain('sk-svcac');
+    expect(rendered).not.toContain('ZygA');
+    expect(rendered).not.toContain('Bearer abcdefghijklmnop');
+    expect(rendered).not.toContain(privateSdkMember);
+    expect(statusResponse.body.workerService.queueSummary.recentFailureReasons[1].reason)
+      .toBe('OpenAI Responses SDK compatibility failure.');
   });
 
   it('ignores legacy auth headers and still serves worker helper requests', async () => {


### PR DESCRIPTION
## Summary
- Repair worker self-healing so stale workers, expired leases, retry scheduling, provider recovery, dead-letter paths, and circuit-breaker reset emit observable recovery events and metrics.
- Remove private OpenAI SDK helper references and add guardrails around plain `await client.responses.create(...)` usage.
- Harden worker-helper/status redaction so historical job diagnostics do not expose key-like strings or private SDK markers.
- Correct the production fast-path probe fallback URL.

## Root Cause
Worker execution was disabled on the web process as intended, but the worker service did not have an explicit `RUN_WORKERS=true` setting. Recovery reporting also mixed passive detection with actual recovery action counts, and historical diagnostics could surface unsafe OpenAI SDK/key-like strings.

## Validation
- `rg -n "_thenUnwrap" .` returned no matches.
- `npm run type-check`
- `npm test`
- `npm run lint` with existing warnings only, 0 errors
- `npm run build`
- `npm run validate:railway`
- Focused Jest suites for worker autonomy/helper, OpenAI SDK guardrails, app metrics, self-healing loop, job lifecycle/runner, transport matrix, and fast-path probe
- `npm run railway:smoke:production`
- `npm run railway:probe:async`
- `npm run railway:probe:fast-path`
- `npm run railway:alert:timeouts -- --since 15m --lines 500 --fail-on-budget-abort --service c4ade025-3f13-4fca-9309-5d0dd81396fe --environment fb583147-6c39-4343-9267-500f357d25ab`

## Deployment Notes
- Set `RUN_WORKERS=true` on `ARCANOS Worker`.
- Confirmed `ARCANOS V2` remains `RUN_WORKERS=false` with `ARCANOS_PROCESS_KIND=web`.
- Deployed `ARCANOS Worker` deployment `7ecbfdce-ef3f-4128-87bb-a3e725105a21` successfully.
- Deployed `ARCANOS V2` deployment `a8d73912-e42f-4dd2-a3e8-cc78c137dc26` successfully.

## Risk
No destructive DB changes were made. Production recovery was not forced by mutating failed-job history; controlled recovery behavior is covered by local simulations/tests, and production verification confirms worker startup, listener activity, job claiming, and async job completion.