### PR TITLE
[codex] fix gaming guide truncation

### DIFF
--- a/src/core/adapters/openai.adapter.ts
+++ b/src/core/adapters/openai.adapter.ts
@@ -26,6 +26,11 @@ import type { CreateEmbeddingResponse, EmbeddingCreateParams } from 'openai/reso
 import type { Transcription, TranscriptionCreateParamsNonStreaming } from 'openai/resources/audio/transcriptions.js';
 import type { ImageGenerateParamsNonStreaming, ImagesResponse } from 'openai/resources/images.js';
 import type { Response as OpenAIResponse, ResponseCreateParamsNonStreaming } from 'openai/resources/responses/responses';
+import {
+  attachOpenAIResponsesMetadataToChatCompletion,
+  resolveOpenAIResponsesLegacyFinishReason,
+  type OpenAIResponsesLegacyChatCompletion
+} from './openaiResponsesMetadata.js';
 import { recordDependencyCall } from '@platform/observability/appMetrics.js';
 import {
   assertAiBudgetAllowsCall,
@@ -356,13 +361,14 @@ function buildResponsesRequestFromChatParams(
 function convertResponseToLegacyChatCompletion(
   response: OpenAIResponse,
   requestedModel: string
-): ChatCompletion {
+): OpenAIResponsesLegacyChatCompletion {
   const usage = normalizeUsage(response.usage);
   const outputText = extractResponseText(response);
   const createdAt = (response as { created_at?: unknown }).created_at;
   const created = typeof createdAt === 'number' ? Math.floor(createdAt) : Math.floor(Date.now() / 1000);
+  const finishReason = resolveOpenAIResponsesLegacyFinishReason(response);
 
-  return {
+  const legacyResponse: ChatCompletion = {
     id: response.id || `legacy_${Date.now()}`,
     object: 'chat.completion',
     created,
@@ -375,7 +381,7 @@ function convertResponseToLegacyChatCompletion(
           content: outputText,
           refusal: null
         },
-        finish_reason: 'stop',
+        finish_reason: finishReason,
         logprobs: null
       }
     ],
@@ -385,6 +391,8 @@ function convertResponseToLegacyChatCompletion(
       total_tokens: usage.totalTokens
     }
   };
+
+  return attachOpenAIResponsesMetadataToChatCompletion(legacyResponse, response, finishReason);
 }
 
 /**

--- a/src/core/adapters/openaiResponsesMetadata.ts
+++ b/src/core/adapters/openaiResponsesMetadata.ts
@@ -1,0 +1,117 @@
+import type OpenAI from 'openai';
+import type { Response as OpenAIResponse } from 'openai/resources/responses/responses';
+
+export type OpenAIResponsesLegacyFinishReason =
+  OpenAI.Chat.Completions.ChatCompletion.Choice['finish_reason'];
+
+export interface OpenAIResponsesProviderMetadata {
+  provider: 'openai';
+  api: 'responses';
+  status: string | null;
+  incomplete_details: unknown;
+  usage: unknown;
+  finish_reason: OpenAIResponsesLegacyFinishReason;
+  incomplete: boolean;
+  truncated: boolean;
+  length_truncated: boolean;
+  content_filtered: boolean;
+}
+
+export type OpenAIResponsesLegacyChatCompletion = OpenAI.Chat.Completions.ChatCompletion & {
+  provider_metadata: OpenAIResponsesProviderMetadata;
+  response_status: string | null;
+  incomplete_details: unknown;
+  incomplete: boolean;
+  truncated: boolean;
+  length_truncated: boolean;
+  content_filtered: boolean;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readResponseStatus(response: OpenAIResponse): string | null {
+  const status = (response as unknown as { status?: unknown }).status;
+  return typeof status === 'string' && status.length > 0 ? status : null;
+}
+
+function readIncompleteDetails(response: OpenAIResponse): unknown {
+  return (response as unknown as { incomplete_details?: unknown }).incomplete_details ?? null;
+}
+
+function readIncompleteReason(incompleteDetails: unknown): string | null {
+  if (!isRecord(incompleteDetails)) return null;
+  const reason = incompleteDetails.reason;
+  return typeof reason === 'string' && reason.length > 0 ? reason : null;
+}
+
+function responseContainsToolCall(response: OpenAIResponse): boolean {
+  const output = (response as unknown as { output?: unknown }).output;
+  if (!Array.isArray(output)) return false;
+
+  return output.some((item) => {
+    if (!isRecord(item)) return false;
+    const type = typeof item.type === 'string' ? item.type : '';
+    return type === 'function_call' || type.endsWith('_call') || type.endsWith('_tool_call');
+  });
+}
+
+export function resolveOpenAIResponsesLegacyFinishReason(
+  response: OpenAIResponse
+): OpenAIResponsesLegacyFinishReason {
+  const status = readResponseStatus(response);
+  const incompleteReason = readIncompleteReason(readIncompleteDetails(response));
+
+  if (incompleteReason === 'max_output_tokens') return 'length';
+  if (incompleteReason === 'content_filter') return 'content_filter';
+  if (status === 'incomplete') return 'length';
+  if (responseContainsToolCall(response)) return 'tool_calls';
+
+  return 'stop';
+}
+
+export function buildOpenAIResponsesProviderMetadata(
+  response: OpenAIResponse,
+  finishReason: OpenAIResponsesLegacyFinishReason = resolveOpenAIResponsesLegacyFinishReason(response)
+): OpenAIResponsesProviderMetadata {
+  const status = readResponseStatus(response);
+  const incompleteDetails = readIncompleteDetails(response);
+  const incompleteReason = readIncompleteReason(incompleteDetails);
+  const incomplete = status === 'incomplete' || incompleteDetails !== null;
+  const lengthTruncated = finishReason === 'length' || incompleteReason === 'max_output_tokens';
+  const contentFiltered = finishReason === 'content_filter' || incompleteReason === 'content_filter';
+
+  return {
+    provider: 'openai',
+    api: 'responses',
+    status,
+    incomplete_details: incompleteDetails,
+    usage: (response as unknown as { usage?: unknown }).usage ?? null,
+    finish_reason: finishReason,
+    incomplete,
+    truncated: lengthTruncated,
+    length_truncated: lengthTruncated,
+    content_filtered: contentFiltered
+  };
+}
+
+export function attachOpenAIResponsesMetadataToChatCompletion<
+  TCompletion extends OpenAI.Chat.Completions.ChatCompletion
+>(
+  legacyResponse: TCompletion,
+  response: OpenAIResponse,
+  finishReason: OpenAIResponsesLegacyFinishReason = resolveOpenAIResponsesLegacyFinishReason(response)
+): TCompletion & OpenAIResponsesLegacyChatCompletion {
+  const providerMetadata = buildOpenAIResponsesProviderMetadata(response, finishReason);
+
+  return Object.assign(legacyResponse, {
+    provider_metadata: providerMetadata,
+    response_status: providerMetadata.status,
+    incomplete_details: providerMetadata.incomplete_details,
+    incomplete: providerMetadata.incomplete,
+    truncated: providerMetadata.truncated,
+    length_truncated: providerMetadata.length_truncated,
+    content_filtered: providerMetadata.content_filtered
+  });
+}

--- a/src/core/logic/trinity.ts
+++ b/src/core/logic/trinity.ts
@@ -917,8 +917,27 @@ export async function runThroughBrain(
         capabilityFlags,
         readIntentMode(outputControls)
       );
+      const directAnswerNeedsCurrentStateLimitation =
+        (!capabilityFlags.canVerifyLiveData || !capabilityFlags.canConfirmExternalState) &&
+        /\b(verify|verified|check|checked|confirm|confirmed|latest|current|recent|today|this week|as of now)\b/i.test(prompt) &&
+        /\b(competitors?|market|news|pricing|release|launch|moves?|external|trends?|compan(?:y|ies)|regulation|stocks?|status|events?)\b/i.test(prompt);
+      if (honestyFilteredFinal.blocked || directAnswerNeedsCurrentStateLimitation) {
+        directAnswerReasoningHonesty.responseMode = 'partial_refusal';
+        if (
+          directAnswerNeedsCurrentStateLimitation ||
+          honestyFilteredFinal.blockedCategories.includes('live_verification') ||
+          honestyFilteredFinal.blockedCategories.includes('current_external_state')
+        ) {
+          directAnswerReasoningHonesty.blockedSubtasks.push('verify current external state');
+          directAnswerReasoningHonesty.userVisibleCaveats.push("I can't verify current external state here without live access.");
+        }
+        if (honestyFilteredFinal.blockedCategories.includes('backend_action')) {
+          directAnswerReasoningHonesty.blockedSubtasks.push('confirm backend state or run backend actions');
+          directAnswerReasoningHonesty.userVisibleCaveats.push("I can't confirm backend state or run backend actions here.");
+        }
+      }
       const enforcedFinalOutput = enforceFinalStageHonestyAndMinimalism({
-        text: directAnswerOutput.output,
+        text: honestyFilteredFinal.text,
         userPrompt: prompt,
         capabilityFlags,
         outputControls,

--- a/src/core/logic/trinity.ts
+++ b/src/core/logic/trinity.ts
@@ -78,6 +78,7 @@ import {
   deriveTrinityOutputControls,
   enforceFinalStageHonesty,
   enforceFinalStageHonestyAndMinimalism,
+  validateTrinityAnswerIntegrity,
   readIntentMode
 } from './trinityHonesty.js';
 import { resolveTrinityDirectAnswerPreference } from '@services/directAnswerMode.js';
@@ -924,6 +925,26 @@ export async function runThroughBrain(
         reasoningHonesty: directAnswerReasoningHonesty
       });
       const finalText = applyTrinityDirectAnswerOutputContract(enforcedFinalOutput.text, prompt);
+      const integrity = validateTrinityAnswerIntegrity({
+        text: finalText,
+        reasoningHonesty: directAnswerReasoningHonesty
+      });
+      if (!integrity.valid) {
+        logger.warn('trinity.direct_answer.integrity_failed', {
+          module: 'trinity',
+          operation: 'direct-answer-integrity',
+          requestId,
+          sourceEndpoint: options.sourceEndpoint,
+          issues: integrity.issues,
+          outputChars: finalText.length
+        });
+        const integrityError = new Error('Trinity direct-answer output failed integrity validation.');
+        Object.assign(integrityError, {
+          code: 'TRINITY_OUTPUT_INTEGRITY_FAILED',
+          integrityIssues: integrity.issues
+        });
+        throw integrityError;
+      }
 
       if (honestyFilteredFinal.blocked) {
         auditFlags.push('FINAL_UNSUPPORTED_CLAIM_BLOCKED');
@@ -1014,6 +1035,9 @@ export async function runThroughBrain(
         outputControls,
         directAnswerReasoningHonesty
       );
+      if (directAnswerOutput.provider) {
+        result.meta.provider = directAnswerOutput.provider;
+      }
 
       result.tierInfo = {
         tier,
@@ -1535,6 +1559,9 @@ export async function runThroughBrain(
       reasoningLedger,
       clearAudit
     );
+    if (finalOutput.provider) {
+      result.meta.provider = finalOutput.provider;
+    }
 
     result.tierInfo = {
       tier,

--- a/src/core/logic/trinityGenerationFacade.ts
+++ b/src/core/logic/trinityGenerationFacade.ts
@@ -315,6 +315,14 @@ export async function runTrinityGenerationFacade(
       activeModel: output.activeModel,
       fallbackFlag: output.fallbackFlag,
       intentMode: output.outputControls ? readIntentMode(output.outputControls) : intentMode,
+      finishReason: output.meta.provider?.finishReason ?? 'unknown',
+      responseStatus: output.meta.provider?.responseStatus ?? 'unknown',
+      incompleteReason: output.meta.provider?.incompleteReason ?? 'none',
+      truncated: output.meta.provider?.truncated === true,
+      lengthTruncated: output.meta.provider?.lengthTruncated === true,
+      usagePrompt: output.meta.tokens?.prompt_tokens ?? 0,
+      usageCompletion: output.meta.tokens?.completion_tokens ?? 0,
+      usageTotal: output.meta.tokens?.total_tokens ?? 0,
     });
 
     return output;

--- a/src/core/logic/trinityHonesty.ts
+++ b/src/core/logic/trinityHonesty.ts
@@ -109,6 +109,13 @@ const CURRENT_EXTERNAL_FACT_VERB_PATTERN =
 const SUBSTRING_DUPLICATE_OVERLAP_THRESHOLD = 0.65;
 const SAME_CATEGORY_LIMITATION_DUPLICATE_OVERLAP_THRESHOLD = 0.72;
 const GENERAL_DUPLICATE_OVERLAP_THRESHOLD = 0.9;
+const LIVE_EXTERNAL_STATE_LIMITATION_FALLBACK = "I can't verify current external state here without live access";
+const BACKEND_STATE_LIMITATION_FALLBACK = "I can't confirm backend state or run backend actions here";
+const PERSISTENCE_ACTION_LIMITATION_FALLBACK = "I haven't saved or persisted anything here";
+const GENERIC_LIVE_EXTERNAL_INFORMATION_FALLBACK =
+  'I can help with general guidance, but I cannot verify live or current external information here.';
+const GENERIC_BACKEND_ACTION_FALLBACK =
+  'I have not executed any backend or persistence action here.';
 const SCOPE_DRIFT_QUALIFIER_PATTERN =
   /\s+or your(?: actual)?\s+(tooling|backend|stack|database|systems?|service|services)\b/gi;
 const PROMPT_GENERATION_ACCESS_LIMITATION_FRAGMENT =
@@ -273,6 +280,16 @@ function isNumericSentencePeriod(line: string, index: number): boolean {
   return /\d/.test(previousCharacter) && /\d/.test(nextCharacter);
 }
 
+function isNumberedListMarkerPeriod(line: string, index: number): boolean {
+  const prefix = line.slice(0, index + 1);
+  const nextCharacter = line[index + 1] ?? '';
+  return /^\s*\d+\.$/.test(prefix) && (!nextCharacter || /\s/.test(nextCharacter));
+}
+
+function isCurrentSegmentNumberedListMarker(segment: string, nextCharacter: string): boolean {
+  return /^\d+\.$/.test(segment.trim()) && (!nextCharacter || /\s/.test(nextCharacter));
+}
+
 function splitLineIntoSegments(line: string): string[] {
   const segments: string[] = [];
   let currentSegment = '';
@@ -287,6 +304,14 @@ function splitLineIntoSegments(line: string): string[] {
 
     //audit Assumption: decimal or version-style periods like "GPT-5.1" belong inside a single sentence; failure risk: sentence splitting turns one truthful limitation into a caveat plus an orphaned fragment like "1 system here."; expected invariant: punctuation between digits never creates a new sentence boundary; handling strategy: keep the segment open when a period is flanked by digits.
     if (character === '.' && isNumericSentencePeriod(line, index)) {
+      continue;
+    }
+
+    //audit Assumption: a top-level numbered-list marker is structural text, not a sentence; failure risk: splitting at "1." creates orphaned markers that later compression can return without the item body; expected invariant: "1. Do the thing." is handled as one segment; handling strategy: keep the segment open when the period is the marker delimiter.
+    if (
+      character === '.' &&
+      (isNumberedListMarkerPeriod(line, index) || isCurrentSegmentNumberedListMarker(currentSegment, line[index + 1] ?? ''))
+    ) {
       continue;
     }
 
@@ -379,7 +404,7 @@ function rewriteUnsupportedCurrentExternalStateSections(params: {
       blockedOrRewrittenClaims.push(line);
       if (!liveLimitationAdded) {
         keptLines.push(ensureSingleSentence(buildLimitationSentence({
-          fallbackText: "I can't verify current external state here without live access",
+          fallbackText: LIVE_EXTERNAL_STATE_LIMITATION_FALLBACK,
           existingCaveats: params.reasoningHonesty.userVisibleCaveats,
           blockedSubtasks: params.reasoningHonesty.blockedSubtasks,
           matcher: /\b(live|browse|current|latest|verify|external|competitor|market|news)\b/i
@@ -925,7 +950,7 @@ function rewriteUnsupportedClaims(params: {
     if (impliesBackendAction && !supportsBackendAction) {
       blockedOrRewrittenClaims.push(segment);
       if (!backendLimitationAdded) {
-        rewrittenSegments.push("I can't confirm backend state or run backend actions here.");
+        rewrittenSegments.push(`${BACKEND_STATE_LIMITATION_FALLBACK}.`);
         backendLimitationAdded = true;
       }
       continue;
@@ -934,7 +959,7 @@ function rewriteUnsupportedClaims(params: {
     if (impliesPersistenceAction && !supportsBackendAction && !params.capabilityFlags.canPersistData) {
       blockedOrRewrittenClaims.push(segment);
       if (!persistenceLimitationAdded) {
-        rewrittenSegments.push("I haven't saved or persisted anything here.");
+        rewrittenSegments.push(`${PERSISTENCE_ACTION_LIMITATION_FALLBACK}.`);
         persistenceLimitationAdded = true;
       }
       continue;
@@ -999,21 +1024,21 @@ function buildPreferredLimitationSegment(
   switch (category) {
     case 'live_verification':
       return ensureSingleSentence(buildLimitationSentence({
-        fallbackText: "I can't verify current external state here without live access",
+        fallbackText: LIVE_EXTERNAL_STATE_LIMITATION_FALLBACK,
         existingCaveats: reasoningHonesty.userVisibleCaveats,
         blockedSubtasks: reasoningHonesty.blockedSubtasks,
         matcher: /\b(live|browse|current|latest|verify|external|competitor|market|news)\b/i
       }));
     case 'backend_action':
       return ensureSingleSentence(buildLimitationSentence({
-        fallbackText: "I can't confirm backend state or run backend actions here",
+        fallbackText: BACKEND_STATE_LIMITATION_FALLBACK,
         existingCaveats: reasoningHonesty.userVisibleCaveats,
         blockedSubtasks: reasoningHonesty.blockedSubtasks,
         matcher: /\b(backend|api|endpoint|service|services|call|run)\b/i
       }));
     case 'persistence_action':
       return ensureSingleSentence(buildLimitationSentence({
-        fallbackText: "I haven't saved or persisted anything here",
+        fallbackText: PERSISTENCE_ACTION_LIMITATION_FALLBACK,
         existingCaveats: reasoningHonesty.userVisibleCaveats,
         blockedSubtasks: reasoningHonesty.blockedSubtasks,
         matcher: /\b(save|persist|store|write|database|db|update|insert)\b/i
@@ -1083,6 +1108,49 @@ function dedupeNearDuplicateSegments(text: string): string {
   return normalizeWhitespace(keptSegments.join(' '));
 }
 
+function buildReasoningFallbackSet(reasoningHonesty: TrinityReasoningHonesty): Set<string> {
+  return new Set(
+    [...reasoningHonesty.userVisibleCaveats, ...reasoningHonesty.blockedSubtasks]
+      .map(entry => normalizeSegmentForComparison(entry))
+      .filter(Boolean)
+  );
+}
+
+function buildGenericFallbackSet(): Set<string> {
+  return new Set([
+    normalizeSegmentForComparison(GENERIC_LIVE_EXTERNAL_INFORMATION_FALLBACK),
+    normalizeSegmentForComparison(GENERIC_BACKEND_ACTION_FALLBACK),
+    normalizeSegmentForComparison(LIVE_EXTERNAL_STATE_LIMITATION_FALLBACK),
+    normalizeSegmentForComparison(BACKEND_STATE_LIMITATION_FALLBACK),
+    normalizeSegmentForComparison(PERSISTENCE_ACTION_LIMITATION_FALLBACK)
+  ]);
+}
+
+function isUnrequestedFallbackSplice(
+  segment: string,
+  reasoningFallbacks: Set<string>,
+  genericFallbacks: Set<string>
+): boolean {
+  const normalizedSegment = normalizeSegmentForComparison(segment);
+  return genericFallbacks.has(normalizedSegment) && !reasoningFallbacks.has(normalizedSegment);
+}
+
+function removeFallbackSplicesFromPartialAnswer(text: string, reasoningHonesty: TrinityReasoningHonesty): string {
+  const segments = splitIntoSegments(text);
+  if (segments.length <= 1 || !segments.some(segment => classifyLimitationCategory(segment) === null)) {
+    return normalizeWhitespace(text);
+  }
+
+  const reasoningFallbacks = buildReasoningFallbackSet(reasoningHonesty);
+  const genericFallbacks = buildGenericFallbackSet();
+
+  return normalizeWhitespace(
+    segments
+      .filter(segment => !isUnrequestedFallbackSplice(segment, reasoningFallbacks, genericFallbacks))
+      .join(' ')
+  );
+}
+
 function removeUnrequestedMetaSections(text: string, outputControls: TrinityOutputControls): { text: string; removedMetaSections: string[] } {
   if (outputControls.answerMode === 'audit' || outputControls.answerMode === 'debug') {
     return { text, removedMetaSections: [] };
@@ -1101,13 +1169,13 @@ function resolveEffectiveWordLimit(outputControls: TrinityOutputControls): numbe
   if (typeof outputControls.maxWords === 'number' && outputControls.maxWords > 0) {
     return outputControls.maxWords;
   }
-  return outputControls.requestedVerbosity === 'minimal' || outputControls.answerMode === 'direct' ? 90 : null;
+  return outputControls.requestedVerbosity === 'minimal' ? 90 : null;
 }
 
 function compressToWordLimit(text: string, outputControls: TrinityOutputControls): string {
   const effectiveWordLimit = resolveEffectiveWordLimit(outputControls);
   if (!effectiveWordLimit || countWords(text) <= effectiveWordLimit) {
-    return normalizeWhitespace(text);
+    return repairOrphanNumberedListMarkers(normalizeWhitespace(text));
   }
 
   const indexedSegments = splitIntoSegments(text).map((segment, index) => ({
@@ -1132,15 +1200,92 @@ function compressToWordLimit(text: string, outputControls: TrinityOutputControls
   }
 
   if (selectedIndexes.size === 0 && indexedSegments.length > 0) {
-    return normalizeWhitespace(indexedSegments[0]!.segment.split(/\s+/).slice(0, effectiveWordLimit).join(' '));
+    return repairOrphanNumberedListMarkers(
+      normalizeWhitespace(indexedSegments[0]!.segment.split(/\s+/).slice(0, effectiveWordLimit).join(' '))
+    );
   }
 
-  return normalizeWhitespace(
-    indexedSegments
-      .filter(item => selectedIndexes.has(item.index))
-      .map(item => item.segment)
-      .join(' ')
+  return repairOrphanNumberedListMarkers(
+    normalizeWhitespace(
+      indexedSegments
+        .filter(item => selectedIndexes.has(item.index))
+        .map(item => item.segment)
+        .join(' ')
+    )
   );
+}
+
+function repairOrphanNumberedListMarkers(text: string): string {
+  const segments = splitIntoSegments(text);
+  const repairedSegments = mergeOrphanListMarkerSegments(segments).filter(segment => !/^\d+\.$/.test(segment.trim()));
+  const repairedText = normalizeWhitespace(repairedSegments.join(' '));
+  return /^\d+\.$/.test(repairedText) ? '' : repairedText;
+}
+
+export type TrinityAnswerIntegrityIssue =
+  | 'abrupt_mid_sentence_ending'
+  | 'broken_numbering'
+  | 'fallback_spliced_mid_answer';
+
+export interface TrinityAnswerIntegrityResult {
+  valid: boolean;
+  issues: TrinityAnswerIntegrityIssue[];
+}
+
+function hasAbruptEnding(text: string): boolean {
+  const normalizedText = normalizeWhitespace(text);
+  if (!normalizedText) return true;
+  if (/[.!?)]$/.test(normalizedText)) return false;
+  return /(?:[,;:]|\b(?:and|or|but|because|including|with|for|to|the|a|an|of|in|on|at|by|as|from|while|when|if|is|are|was|were|can|could|should|would|will|must|may|might))$/i
+    .test(normalizedText);
+}
+
+function hasBrokenNumbering(text: string): boolean {
+  const normalizedText = normalizeWhitespace(text);
+  if (/(?:^|\s)\d+\.\s*(?=\d+\.|$)/.test(normalizedText)) {
+    return true;
+  }
+
+  const markers = Array.from(normalizedText.matchAll(/(?:^|\s)(\d+)\.\s+/g))
+    .map(match => Number.parseInt(match[1] ?? '', 10))
+    .filter(Number.isFinite);
+  if (markers.length < 2) {
+    return false;
+  }
+
+  return markers.some((marker, index) => marker !== index + 1);
+}
+
+function hasFallbackSplice(text: string, reasoningHonesty: TrinityReasoningHonesty): boolean {
+  const segments = splitIntoSegments(text);
+  if (segments.length <= 1 || !segments.some(segment => classifyLimitationCategory(segment) === null)) {
+    return false;
+  }
+
+  const reasoningFallbacks = buildReasoningFallbackSet(reasoningHonesty);
+  const genericFallbacks = buildGenericFallbackSet();
+  return segments.some(segment => isUnrequestedFallbackSplice(segment, reasoningFallbacks, genericFallbacks));
+}
+
+export function validateTrinityAnswerIntegrity(params: {
+  text: string;
+  reasoningHonesty?: TrinityReasoningHonesty;
+}): TrinityAnswerIntegrityResult {
+  const issues: TrinityAnswerIntegrityIssue[] = [];
+  if (hasAbruptEnding(params.text)) {
+    issues.push('abrupt_mid_sentence_ending');
+  }
+  if (hasBrokenNumbering(params.text)) {
+    issues.push('broken_numbering');
+  }
+  if (params.reasoningHonesty && hasFallbackSplice(params.text, params.reasoningHonesty)) {
+    issues.push('fallback_spliced_mid_answer');
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues
+  };
 }
 
 /**
@@ -1343,10 +1488,10 @@ export function enforceFinalStageHonesty(
     leadingDisclaimers.push(partialRefusalLead);
   }
   if ((blockedCategories.has('live_verification') || blockedCategories.has('current_external_state')) && !/live or current external information/i.test(text)) {
-    leadingDisclaimers.push('I can help with general guidance, but I cannot verify live or current external information here.');
+    leadingDisclaimers.push(GENERIC_LIVE_EXTERNAL_INFORMATION_FALLBACK);
   }
   if (blockedCategories.has('backend_action') && !/backend or persistence action/i.test(text)) {
-    leadingDisclaimers.push('I have not executed any backend or persistence action here.');
+    leadingDisclaimers.push(GENERIC_BACKEND_ACTION_FALLBACK);
   }
   if (leadingDisclaimers.length > 0) {
     text = `${dedupePreservingOrder(leadingDisclaimers).join(' ')}${text ? `\n\n${text}` : ''}`.trim();
@@ -1533,7 +1678,8 @@ export function enforceFinalStageHonestyAndMinimalism(params: {
     !promptGeneration || shouldPreservePromptGenerationLimitation
       ? compressLimitationSegments(scopeTightenedText, params.reasoningHonesty)
       : scopeTightenedText;
-  const dedupedText = dedupeNearDuplicateSegments(limitationCompressedText);
+  const fallbackSpliceRemovedText = removeFallbackSplicesFromPartialAnswer(limitationCompressedText, params.reasoningHonesty);
+  const dedupedText = dedupeNearDuplicateSegments(fallbackSpliceRemovedText);
   return {
     text: normalizeWhitespace(compressToWordLimit(dedupedText, params.outputControls)),
     removedMetaSections: withoutMetaSections.removedMetaSections,

--- a/src/core/logic/trinityHonesty.ts
+++ b/src/core/logic/trinityHonesty.ts
@@ -968,6 +968,13 @@ function rewriteUnsupportedClaims(params: {
     rewrittenSegments.push(segment);
   }
 
+  if (blockedOrRewrittenClaims.length === sectionRewrite.blockedOrRewrittenClaims.length) {
+    return {
+      text: normalizeWhitespace(sectionRewrite.text),
+      blockedOrRewrittenClaims
+    };
+  }
+
   return {
     text: normalizeWhitespace(rewrittenSegments.join(' ')),
     blockedOrRewrittenClaims
@@ -999,11 +1006,8 @@ function removeOpeningPadding(text: string): string {
     return normalizeWhitespace(text);
   }
   //audit Assumption: disposable opening fillers can appear after an injected limitation sentence, not just as the first segment; failure risk: hard word-limit compression keeps filler instead of the actual answer; expected invariant: standalone padding lines are removed whenever substantive content remains elsewhere; handling strategy: drop only narrow filler segments that match the padding patterns and preserve all other content.
-  return normalizeWhitespace(
-    segments
-      .filter(segment => !isOpeningPaddingSegment(segment))
-      .join(' ')
-  );
+  const keptSegments = segments.filter(segment => !isOpeningPaddingSegment(segment));
+  return keptSegments.length === segments.length ? normalizeWhitespace(text) : normalizeWhitespace(keptSegments.join(' '));
 }
 
 function trimUnrequestedScopeDrift(text: string, userPrompt: string, reasoningHonesty: TrinityReasoningHonesty): string {
@@ -1054,6 +1058,7 @@ function compressLimitationSegments(text: string, reasoningHonesty: TrinityReaso
   const segments = splitIntoSegments(text);
   const seenCategories = new Set<LimitationCategory>();
   const keptSegments: string[] = [];
+  let changed = false;
   for (const segment of segments) {
     const limitationCategory = classifyLimitationCategory(segment);
     if (!limitationCategory) {
@@ -1062,10 +1067,18 @@ function compressLimitationSegments(text: string, reasoningHonesty: TrinityReaso
     }
     //audit Assumption: the final answer should keep at most one concise limitation per limitation category; failure risk: stacked caveats crowd out the achievable answer; expected invariant: duplicate live/backend/persistence limitations collapse to one preferred sentence; handling strategy: keep the first category instance and replace it with the most specific caveat available from reasoning metadata.
     if (seenCategories.has(limitationCategory)) {
+      changed = true;
       continue;
     }
     seenCategories.add(limitationCategory);
-    keptSegments.push(buildPreferredLimitationSegment(limitationCategory, reasoningHonesty) ?? ensureSingleSentence(segment));
+    const preferredSegment = buildPreferredLimitationSegment(limitationCategory, reasoningHonesty) ?? ensureSingleSentence(segment);
+    if (normalizeSegmentForComparison(preferredSegment) !== normalizeSegmentForComparison(segment)) {
+      changed = true;
+    }
+    keptSegments.push(preferredSegment);
+  }
+  if (!changed) {
+    return normalizeWhitespace(text);
   }
   return normalizeWhitespace(keptSegments.join(' '));
 }
@@ -1098,12 +1111,17 @@ function areNearDuplicateSegments(leftSegment: string, rightSegment: string): bo
 
 function dedupeNearDuplicateSegments(text: string): string {
   const keptSegments: string[] = [];
+  let removedDuplicate = false;
   for (const segment of splitIntoSegments(text)) {
     //audit Assumption: near-duplicate segments are accidental padding, not distinct user value; failure risk: repeated caveats or answer lines make the final output sound verbose and unnatural; expected invariant: only the first materially distinct sentence survives; handling strategy: compare normalized token overlap and drop later repeats.
     if (keptSegments.some(existingSegment => areNearDuplicateSegments(existingSegment, segment))) {
+      removedDuplicate = true;
       continue;
     }
     keptSegments.push(segment);
+  }
+  if (!removedDuplicate) {
+    return normalizeWhitespace(text);
   }
   return normalizeWhitespace(keptSegments.join(' '));
 }
@@ -1143,12 +1161,9 @@ function removeFallbackSplicesFromPartialAnswer(text: string, reasoningHonesty: 
 
   const reasoningFallbacks = buildReasoningFallbackSet(reasoningHonesty);
   const genericFallbacks = buildGenericFallbackSet();
+  const keptSegments = segments.filter(segment => !isUnrequestedFallbackSplice(segment, reasoningFallbacks, genericFallbacks));
 
-  return normalizeWhitespace(
-    segments
-      .filter(segment => !isUnrequestedFallbackSplice(segment, reasoningFallbacks, genericFallbacks))
-      .join(' ')
-  );
+  return keptSegments.length === segments.length ? normalizeWhitespace(text) : normalizeWhitespace(keptSegments.join(' '));
 }
 
 function removeUnrequestedMetaSections(text: string, outputControls: TrinityOutputControls): { text: string; removedMetaSections: string[] } {
@@ -1175,7 +1190,7 @@ function resolveEffectiveWordLimit(outputControls: TrinityOutputControls): numbe
 function compressToWordLimit(text: string, outputControls: TrinityOutputControls): string {
   const effectiveWordLimit = resolveEffectiveWordLimit(outputControls);
   if (!effectiveWordLimit || countWords(text) <= effectiveWordLimit) {
-    return repairOrphanNumberedListMarkers(normalizeWhitespace(text));
+    return normalizeWhitespace(text);
   }
 
   const indexedSegments = splitIntoSegments(text).map((segment, index) => ({

--- a/src/core/logic/trinityStages.ts
+++ b/src/core/logic/trinityStages.ts
@@ -14,6 +14,7 @@ import {
 } from "@services/openai.js";
 import { getTokenParameter } from "@shared/tokenParameterHelper.js";
 import { APPLICATION_CONSTANTS } from "@shared/constants.js";
+import { countWords } from '@shared/text/countWords.js';
 import {
   ARCANOS_SYSTEM_PROMPTS,
   buildFinalGpt5AnalysisMessage,
@@ -32,6 +33,7 @@ import type {
   TrinityFinalOutput,
   TrinityDryRunPreview,
   TrinityOutputControls,
+  TrinityProviderCompletionMetadata,
   ReasoningLedger
 } from './trinityTypes.js';
 import type { CognitiveDomain } from "@shared/types/cognitiveDomain.js";
@@ -91,6 +93,70 @@ const DEFAULT_TRINITY_REASONING_STAGE_TIMEOUT_MS = 20_000;
 const DEFAULT_TRINITY_FINAL_STAGE_TIMEOUT_MS = 4_000;
 const MODEL_VALIDATION_CACHE_TTL_MS = 10 * 60_000;
 const validatedModelCache = new Map<string, number>();
+
+function normalizeCompletionProviderMetadata(response: unknown): TrinityProviderCompletionMetadata {
+  const candidate = response && typeof response === 'object'
+    ? response as Record<string, unknown>
+    : {};
+  const providerMetadata = candidate.provider_metadata && typeof candidate.provider_metadata === 'object'
+    ? candidate.provider_metadata as Record<string, unknown>
+    : {};
+  const choice = Array.isArray(candidate.choices) && candidate.choices[0] && typeof candidate.choices[0] === 'object'
+    ? candidate.choices[0] as Record<string, unknown>
+    : {};
+  const incompleteDetails = providerMetadata.incomplete_details && typeof providerMetadata.incomplete_details === 'object'
+    ? providerMetadata.incomplete_details as Record<string, unknown>
+    : candidate.incomplete_details && typeof candidate.incomplete_details === 'object'
+      ? candidate.incomplete_details as Record<string, unknown>
+      : {};
+
+  const finishReason = typeof providerMetadata.finish_reason === 'string'
+    ? providerMetadata.finish_reason
+    : typeof choice.finish_reason === 'string'
+      ? choice.finish_reason
+      : null;
+
+  return {
+    finishReason,
+    responseStatus: typeof providerMetadata.status === 'string'
+      ? providerMetadata.status
+      : typeof candidate.response_status === 'string'
+        ? candidate.response_status
+        : null,
+    incompleteReason: typeof incompleteDetails.reason === 'string' ? incompleteDetails.reason : null,
+    incomplete: providerMetadata.incomplete === true || candidate.incomplete === true,
+    truncated: providerMetadata.truncated === true || candidate.truncated === true || finishReason === 'length',
+    lengthTruncated: providerMetadata.length_truncated === true || candidate.length_truncated === true || finishReason === 'length',
+    contentFiltered: providerMetadata.content_filtered === true || candidate.content_filtered === true || finishReason === 'content_filter'
+  };
+}
+
+function logProviderCompletionMetadata(eventName: string, params: {
+  requestId?: string;
+  model: string;
+  provider: TrinityProviderCompletionMetadata;
+  usage?: TrinityFinalOutput['usage'];
+  output: string;
+}): void {
+  logger.info(eventName, {
+    module: 'trinity',
+    operation: 'provider-completion',
+    requestId: params.requestId,
+    model: params.model,
+    finishReason: params.provider.finishReason ?? 'unknown',
+    responseStatus: params.provider.responseStatus ?? 'unknown',
+    incompleteReason: params.provider.incompleteReason ?? 'none',
+    incomplete: params.provider.incomplete === true,
+    truncated: params.provider.truncated === true,
+    lengthTruncated: params.provider.lengthTruncated === true,
+    contentFiltered: params.provider.contentFiltered === true,
+    usagePrompt: params.usage?.prompt_tokens ?? 0,
+    usageCompletion: params.usage?.completion_tokens ?? 0,
+    usageTotal: params.usage?.total_tokens ?? 0,
+    outputChars: params.output.length,
+    outputWords: countWords(params.output)
+  });
+}
 
 function resolveStageTimeoutMs(
   envName: string,
@@ -515,6 +581,13 @@ export async function runFinalStage(
   const finalText = finalResponse.choices[0]?.message?.content || '';
   const finalModel = finalResponse.activeModel || complexModel;
   const finalFallback = finalResponse.fallbackFlag || false;
+  const provider = normalizeCompletionProviderMetadata(finalResponse);
+  logProviderCompletionMetadata('trinity.final.provider_metadata', {
+    model: finalModel,
+    provider,
+    usage: finalResponse.usage || undefined,
+    output: finalText
+  });
 
   if (finalFallback) {
     logFallbackEvent('ARCANOS-FINAL', complexModel, finalModel, 'Fallback flag set by final completion');
@@ -526,7 +599,8 @@ export async function runFinalStage(
     fallbackUsed: finalFallback,
     usage: finalResponse.usage || undefined,
     responseId: finalResponse.id,
-    created: finalResponse.created
+    created: finalResponse.created,
+    provider
   };
 }
 
@@ -610,6 +684,14 @@ export async function runDirectAnswerStage(
   const directAnswerText = directAnswerResponse.choices[0]?.message?.content || '';
   const actualModel = directAnswerResponse.activeModel || directAnswerModel;
   const fallbackUsed = directAnswerResponse.fallbackFlag || false;
+  const provider = normalizeCompletionProviderMetadata(directAnswerResponse);
+  logProviderCompletionMetadata('trinity.direct_answer.provider_metadata', {
+    requestId,
+    model: actualModel,
+    provider,
+    usage: directAnswerResponse.usage || undefined,
+    output: directAnswerText
+  });
 
   if (fallbackUsed) {
     logFallbackEvent(
@@ -626,7 +708,8 @@ export async function runDirectAnswerStage(
     fallbackUsed,
     usage: directAnswerResponse.usage || undefined,
     responseId: directAnswerResponse.id,
-    created: directAnswerResponse.created
+    created: directAnswerResponse.created,
+    provider
   };
 }
 

--- a/src/core/logic/trinityTypes.ts
+++ b/src/core/logic/trinityTypes.ts
@@ -27,6 +27,16 @@ export interface TrinityMetaTokens {
   total_tokens: number;
 }
 
+export interface TrinityProviderCompletionMetadata {
+  finishReason?: string | null;
+  responseStatus?: string | null;
+  incompleteReason?: string | null;
+  incomplete?: boolean;
+  truncated?: boolean;
+  lengthTruncated?: boolean;
+  contentFiltered?: boolean;
+}
+
 export type TrinityRequestedVerbosity = 'minimal' | 'normal' | 'detailed';
 export type TrinityAnswerMode = 'direct' | 'explained' | 'audit' | 'debug';
 export type TrinityIntentMode = IntentMode;
@@ -100,6 +110,7 @@ export interface TrinityResult {
     tokenLimit?: number;
     outputLimit?: number;
     background?: Record<string, unknown>;
+    provider?: TrinityProviderCompletionMetadata;
   };
   activeModel: string;
   fallbackFlag: boolean;
@@ -252,4 +263,5 @@ export interface TrinityFinalOutput {
   usage?: TrinityMetaTokens | undefined;
   responseId?: string;
   created?: number;
+  provider?: TrinityProviderCompletionMetadata;
 }

--- a/src/services/arcanos-gaming.ts
+++ b/src/services/arcanos-gaming.ts
@@ -4,11 +4,53 @@ import { resolveErrorMessage } from "@core/lib/errors/index.js";
 import {
   formatGamingError,
   type GamingErrorEnvelope,
+  type GamingMode,
   type GamingSuccessEnvelope,
   validateGamingRequest
 } from "@services/gamingModes.js";
 
 type GamingEnvelope = GamingSuccessEnvelope | GamingErrorEnvelope;
+
+function readSafeErrorString(error: unknown, key: string): string | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+  const value = (error as Record<string, unknown>)[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readSafeErrorBoolean(error: unknown, key: string): boolean | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+  const value = (error as Record<string, unknown>)[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function formatKnownGenerationFailure(mode: GamingMode, error: unknown): GamingErrorEnvelope | null {
+  const code = readSafeErrorString(error, "code");
+  if (code !== "OPENAI_COMPLETION_INCOMPLETE" && code !== "TRINITY_OUTPUT_INTEGRITY_FAILED") {
+    return null;
+  }
+
+  return formatGamingError({
+    mode,
+    error: {
+      code: code === "OPENAI_COMPLETION_INCOMPLETE" ? "GENERATION_INCOMPLETE" : "GENERATION_INTEGRITY_FAILED",
+      message: "Gaming generation did not complete cleanly; no partial answer was returned.",
+      details: {
+        finishReason: readSafeErrorString(error, "finishReason"),
+        incompleteReason: readSafeErrorString(error, "incompleteReason"),
+        truncated: readSafeErrorBoolean(error, "truncated"),
+        lengthTruncated: readSafeErrorBoolean(error, "lengthTruncated"),
+        contentFiltered: readSafeErrorBoolean(error, "contentFiltered"),
+        integrityIssues: Array.isArray((error as { integrityIssues?: unknown }).integrityIssues)
+          ? (error as { integrityIssues: unknown[] }).integrityIssues.filter((issue): issue is string => typeof issue === "string")
+          : undefined
+      }
+    }
+  });
+}
 
 async function handleGamingRequest(payload: unknown): Promise<GamingEnvelope> {
   const validation = validateGamingRequest(payload);
@@ -18,12 +60,21 @@ async function handleGamingRequest(payload: unknown): Promise<GamingEnvelope> {
 
   const { mode, prompt, game, guideUrl, guideUrls, auditEnabled, hrcEnabled } = validation.value;
 
-  let response =
-    mode === "guide"
-      ? await runGuidePipeline({ prompt, game, guideUrl, guideUrls, auditEnabled })
-      : mode === "build"
-      ? await runBuildPipeline({ prompt, game, guideUrl, guideUrls, auditEnabled })
-      : await runMetaPipeline({ prompt, game, guideUrl, guideUrls, auditEnabled });
+  let response: GamingSuccessEnvelope;
+  try {
+    response =
+      mode === "guide"
+        ? await runGuidePipeline({ prompt, game, guideUrl, guideUrls, auditEnabled })
+        : mode === "build"
+        ? await runBuildPipeline({ prompt, game, guideUrl, guideUrls, auditEnabled })
+        : await runMetaPipeline({ prompt, game, guideUrl, guideUrls, auditEnabled });
+  } catch (error: unknown) {
+    const knownGenerationFailure = formatKnownGenerationFailure(mode, error);
+    if (knownGenerationFailure) {
+      return knownGenerationFailure;
+    }
+    throw error;
+  }
 
   if (!hrcEnabled) {
     return response;

--- a/src/services/gaming.ts
+++ b/src/services/gaming.ts
@@ -54,7 +54,7 @@ function rewriteGuideDirectAnswerCues(prompt: string): string {
     .replace(/\b(?:do\s+not|don't|no|without)\s+role-?play\b/gi, 'avoid roleplay framing')
     .replace(/\b(?:do\s+not|don't|no|without)\s+pretend\b/gi, 'avoid pretending to play')
     .replace(/\bno\s+hypothetical(?:\s+runs?)?\b/gi, 'avoid hypothetical run narration')
-    .replace(/\bhypothetical\s+run\b/gi, 'run narration')
+    .replace(/\bhypothetical\s+run\b(?!\s+narration)/gi, 'run narration')
     .trim();
 }
 

--- a/src/services/gaming.ts
+++ b/src/services/gaming.ts
@@ -44,6 +44,20 @@ const modeInstructions: Record<GamingMode, string> = {
   meta: "Return a meta overview with current assumptions, tradeoffs, counters, and explicit uncertainty when patch/version context is missing."
 };
 
+function rewriteGuideDirectAnswerCues(prompt: string): string {
+  return prompt
+    .replace(/\b(?:answer|respond|reply)\s+directly\b/gi, 'give practical guidance')
+    .replace(/\bjust\s+answer\b/gi, 'focus on the answer')
+    .replace(/\b(?:do\s+not|don't)\s+simulate\b/gi, 'avoid gameplay reenactment')
+    .replace(/\bno\s+simulation\b/gi, 'avoid gameplay reenactment')
+    .replace(/\bwithout\s+simulation\b/gi, 'without gameplay reenactment')
+    .replace(/\b(?:do\s+not|don't|no|without)\s+role-?play\b/gi, 'avoid roleplay framing')
+    .replace(/\b(?:do\s+not|don't|no|without)\s+pretend\b/gi, 'avoid pretending to play')
+    .replace(/\bno\s+hypothetical(?:\s+runs?)?\b/gi, 'avoid hypothetical run narration')
+    .replace(/\bhypothetical\s+run\b/gi, 'run narration')
+    .trim();
+}
+
 async function buildWebContext(urls: string[]): Promise<{ context: string; sources: WebSource[] }> {
   if (urls.length === 0) {
     return { context: "", sources: [] };
@@ -70,6 +84,17 @@ async function buildWebContext(urls: string[]): Promise<{ context: string; sourc
 }
 
 function buildGameplaySystemPrompt(mode: GamingMode): string {
+  if (mode === "guide") {
+    return [
+      "You are ARCANOS:GAMING:GUIDE.",
+      modeInstructions.guide,
+      "Give concrete guidance with enough structure to complete the requested guide.",
+      "Avoid gameplay reenactment, roleplay framing, invented live patch details, hotline banter, and theatrical framing.",
+      "If the user requests an exact literal response, return only that literal.",
+      "State missing game, platform, class, or version details plainly instead of guessing."
+    ].join(" ");
+  }
+
   return buildDirectAnswerModeSystemInstruction({
     moduleLabel: `ARCANOS:GAMING:${mode.toUpperCase()}`,
     domainGuidance: modeInstructions[mode],
@@ -86,13 +111,29 @@ function buildGameplaySystemPrompt(mode: GamingMode): string {
 function buildGameplayPrompt(params: GameplayPipelineInput, webContext: string, hadSources: boolean): string {
   const modeLabel = `[MODE]\n${params.mode}`;
   const gameLabel = params.game ? `\n\n[GAME]\n${params.game}` : "";
+  const requestPrompt = params.mode === "guide" ? rewriteGuideDirectAnswerCues(params.prompt) : params.prompt;
   const webLabel = webContext
     ? `\n\n[WEB CONTEXT]\n${webContext}\n\n${gamingPrompts.webContextInstruction}`
     : hadSources
     ? `\n\n[WEB CONTEXT]\nGuides were provided but no usable snippets were retrieved.\n\n${gamingPrompts.webUncertaintyGuidance}`
     : "";
 
-  return `${modeLabel}${gameLabel}\n\n[REQUEST]\n${params.prompt}${webLabel}`;
+  return `${modeLabel}${gameLabel}\n\n[REQUEST]\n${requestPrompt}${webLabel}`;
+}
+
+function buildGameplayRunOptions(mode: GamingMode) {
+  if (mode === "guide") {
+    return {
+      answerMode: "explained" as const,
+      requestedVerbosity: "detailed" as const,
+      strictUserVisibleOutput: true
+    };
+  }
+
+  return {
+    answerMode: "direct" as const,
+    strictUserVisibleOutput: true
+  };
 }
 
 async function runGameplayPipeline(params: GameplayPipelineInput): Promise<GamingSuccessEnvelope> {
@@ -143,10 +184,7 @@ async function runGameplayPipeline(params: GameplayPipelineInput): Promise<Gamin
     context: {
       client,
       runtimeBudget: createRuntimeBudget(),
-      runOptions: {
-        answerMode: 'direct',
-        strictUserVisibleOutput: true
-      }
+      runOptions: buildGameplayRunOptions(params.mode)
     }
   });
   const finalized = trinityResult.result;

--- a/src/services/openai/chatFallbacks.ts
+++ b/src/services/openai/chatFallbacks.ts
@@ -13,6 +13,7 @@ import { getTokenParameter } from "@shared/tokenParameterHelper.js";
 import { formatErrorMessage } from "@core/lib/errors/reusable.js";
 import { aiLogger } from "@platform/logging/structuredLogging.js";
 import { buildResponsesRequest, convertResponseToLegacyChatCompletion } from './requestBuilders/index.js';
+import type { OpenAIResponsesProviderMetadata } from './requestBuilders/index.js';
 import {
   buildFailureContext,
   buildFinalFallbackReason,
@@ -68,6 +69,130 @@ interface ChatCompletionWithFallback extends ChatCompletionResponse {
   retryUsed?: boolean;
   fallbackReason?: string;
   gpt5Used?: boolean;
+}
+
+const ALLOWED_FINISH_REASONS = new Set(['stop', 'length', 'tool_calls', 'content_filter', 'function_call']);
+const ALLOWED_INCOMPLETE_REASONS = new Set(['max_output_tokens', 'content_filter', 'unknown', 'none']);
+
+type CompletionMetadataSnapshot = {
+  finishReason: string;
+  responseStatus: string;
+  incompleteReason: string;
+  incomplete: boolean;
+  truncated: boolean;
+  lengthTruncated: boolean;
+  contentFiltered: boolean;
+  usage: {
+    prompt: number;
+    completion: number;
+    total: number;
+  };
+};
+
+function normalizeSafeEnum(value: unknown, allowed: Set<string>, fallback: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    return fallback;
+  }
+  return allowed.has(value) ? value : fallback;
+}
+
+function readUsageCounters(response: ChatCompletionResponse): CompletionMetadataSnapshot['usage'] {
+  return {
+    prompt: response.usage?.prompt_tokens ?? 0,
+    completion: response.usage?.completion_tokens ?? 0,
+    total: response.usage?.total_tokens ?? 0
+  };
+}
+
+function readCompletionMetadata(response: ChatCompletionResponse): CompletionMetadataSnapshot {
+  const candidate = response as ChatCompletionResponse & {
+    provider_metadata?: Partial<OpenAIResponsesProviderMetadata>;
+    response_status?: unknown;
+    incomplete_details?: unknown;
+    incomplete?: unknown;
+    truncated?: unknown;
+    length_truncated?: unknown;
+    content_filtered?: unknown;
+  };
+  const providerMetadata = candidate.provider_metadata ?? {};
+  const incompleteDetails = providerMetadata.incomplete_details && typeof providerMetadata.incomplete_details === 'object'
+    ? providerMetadata.incomplete_details as { reason?: unknown }
+    : candidate.incomplete_details && typeof candidate.incomplete_details === 'object'
+      ? candidate.incomplete_details as { reason?: unknown }
+      : {};
+  const finishReason = normalizeSafeEnum(
+    providerMetadata.finish_reason ?? response.choices[0]?.finish_reason,
+    ALLOWED_FINISH_REASONS,
+    'unknown'
+  );
+  const incompleteReason = normalizeSafeEnum(
+    incompleteDetails.reason,
+    ALLOWED_INCOMPLETE_REASONS,
+    incompleteDetails.reason ? 'unknown' : 'none'
+  );
+
+  return {
+    finishReason,
+    responseStatus: typeof providerMetadata.status === 'string'
+      ? providerMetadata.status
+      : typeof candidate.response_status === 'string'
+        ? candidate.response_status
+        : 'unknown',
+    incompleteReason,
+    incomplete: providerMetadata.incomplete === true || candidate.incomplete === true,
+    truncated: providerMetadata.truncated === true || candidate.truncated === true || finishReason === 'length',
+    lengthTruncated: providerMetadata.length_truncated === true || candidate.length_truncated === true || finishReason === 'length',
+    contentFiltered: providerMetadata.content_filtered === true || candidate.content_filtered === true || finishReason === 'content_filter',
+    usage: readUsageCounters(response)
+  };
+}
+
+function buildCompletionLogContext(model: string, startedAt: number, response: ChatCompletionResponse) {
+  const metadata = readCompletionMetadata(response);
+  return {
+    model,
+    latencyMs: Date.now() - startedAt,
+    finishReason: metadata.finishReason,
+    responseStatus: metadata.responseStatus,
+    incompleteReason: metadata.incompleteReason,
+    incomplete: metadata.incomplete,
+    truncated: metadata.truncated,
+    lengthTruncated: metadata.lengthTruncated,
+    contentFiltered: metadata.contentFiltered,
+    usagePrompt: metadata.usage.prompt,
+    usageCompletion: metadata.usage.completion,
+    usageTotal: metadata.usage.total
+  };
+}
+
+function createIncompleteProviderOutputError(model: string, metadata: CompletionMetadataSnapshot): Error {
+  const error = new Error(
+    `OpenAI completion for ${model} ended before a complete answer was available.`
+  );
+  Object.assign(error, {
+    code: 'OPENAI_COMPLETION_INCOMPLETE',
+    providerStatus: metadata.responseStatus,
+    finishReason: metadata.finishReason,
+    incompleteReason: metadata.incompleteReason,
+    truncated: metadata.truncated,
+    lengthTruncated: metadata.lengthTruncated,
+    contentFiltered: metadata.contentFiltered
+  });
+  return error;
+}
+
+function throwIfCompletionIncomplete(model: string, response: ChatCompletionResponse): void {
+  const metadata = readCompletionMetadata(response);
+  if (
+    metadata.incomplete ||
+    metadata.truncated ||
+    metadata.lengthTruncated ||
+    metadata.contentFiltered ||
+    metadata.finishReason === 'length' ||
+    metadata.finishReason === 'content_filter'
+  ) {
+    throw createIncompleteProviderOutputError(model, metadata);
+  }
 }
 
 const getTokensFromParams = (params: ChatCompletionParams): number =>
@@ -163,10 +288,14 @@ async function attemptModelCall(
       model,
     })
   );
-  aiLogger.info(`${logPrefix} Success with ${model}`, {
-    model,
-    latencyMs: Date.now() - startedAt
-  });
+  const logContext = buildCompletionLogContext(model, startedAt, response);
+  try {
+    throwIfCompletionIncomplete(model, response);
+  } catch (error) {
+    aiLogger.warn(`${logPrefix} Incomplete response from ${model}`, logContext);
+    throw error;
+  }
+  aiLogger.info(`${logPrefix} Success with ${model}`, logContext);
   return { response, model };
 }
 
@@ -188,10 +317,14 @@ async function attemptGPT5Call(
   const response = await executeWithResilience(() =>
     executeChatCompletionRequest(clientOrAdapter, gpt5Payload)
   );
-  aiLogger.info(buildGpt5SuccessLog(gpt5Model), {
-    model: gpt5Model,
-    latencyMs: Date.now() - startedAt
-  });
+  const logContext = buildCompletionLogContext(gpt5Model, startedAt, response);
+  try {
+    throwIfCompletionIncomplete(gpt5Model, response);
+  } catch (error) {
+    aiLogger.warn(`${CHAT_FALLBACK_LOG_PREFIXES.gpt5} Incomplete response from ${gpt5Model}`, logContext);
+    throw error;
+  }
+  aiLogger.info(buildGpt5SuccessLog(gpt5Model), logContext);
   return { response, model: gpt5Model };
 }
 

--- a/src/services/openai/requestBuilders/convert.ts
+++ b/src/services/openai/requestBuilders/convert.ts
@@ -9,6 +9,11 @@ import {
   extractResponseOutputText as extractResponseText
 } from '@arcanos/openai/responseParsing';
 import { shouldStoreOpenAIResponses } from '@config/openaiStore.js';
+import {
+  attachOpenAIResponsesMetadataToChatCompletion,
+  resolveOpenAIResponsesLegacyFinishReason,
+  type OpenAIResponsesLegacyChatCompletion
+} from '@core/adapters/openaiResponsesMetadata.js';
 
 import type {
   NormalizedResponsesRequest,
@@ -29,6 +34,11 @@ function isReasoningModel(model: string): boolean {
 function extractUsage(usage: unknown): { promptTokens: number; completionTokens: number; totalTokens: number } {
   return normalizeOpenAIUsage(usage);
 }
+
+export type {
+  OpenAIResponsesLegacyChatCompletion,
+  OpenAIResponsesProviderMetadata
+} from '@core/adapters/openaiResponsesMetadata.js';
 
 export function convertNormalizedResponsesToRequest(
   normalized: NormalizedResponsesRequest
@@ -192,15 +202,16 @@ export function extractResponseOutputText(response: unknown, fallback = ''): str
 export function convertResponseToLegacyChatCompletion(
   response: OpenAIResponse,
   requestedModel: string
-): OpenAI.Chat.Completions.ChatCompletion {
+): OpenAIResponsesLegacyChatCompletion {
   const outputText = extractResponseOutputText(response, '');
   const usage = extractUsage((response as unknown as { usage?: unknown }).usage);
   const createdSource = (response as { created_at?: unknown }).created_at;
   const created = typeof createdSource === 'number'
     ? Math.floor(createdSource)
     : Math.floor(Date.now() / 1000);
+  const finishReason = resolveOpenAIResponsesLegacyFinishReason(response);
 
-  return {
+  const legacyResponse: OpenAI.Chat.Completions.ChatCompletion = {
     id: response.id || `legacy_${Date.now()}`,
     object: 'chat.completion',
     created,
@@ -213,7 +224,7 @@ export function convertResponseToLegacyChatCompletion(
           content: outputText,
           refusal: null
         },
-        finish_reason: 'stop',
+        finish_reason: finishReason,
         logprobs: null
       }
     ],
@@ -223,4 +234,6 @@ export function convertResponseToLegacyChatCompletion(
       total_tokens: usage.totalTokens
     }
   };
+
+  return attachOpenAIResponsesMetadataToChatCompletion(legacyResponse, response, finishReason);
 }

--- a/src/services/openai/requestBuilders/index.ts
+++ b/src/services/openai/requestBuilders/index.ts
@@ -66,6 +66,10 @@ import {
 } from './validate.js';
 
 export type { ChatParams, VisionParams, TranscriptionParams, ImageParams, EmbeddingParams };
+export type {
+  OpenAIResponsesLegacyChatCompletion,
+  OpenAIResponsesProviderMetadata
+} from './convert.js';
 
 /**
  * Build a Responses API payload from chat-style params.

--- a/tests/arcanos-gaming.modes.test.ts
+++ b/tests/arcanos-gaming.modes.test.ts
@@ -143,4 +143,40 @@ describe("ArcanosGaming mode routing", () => {
       },
     });
   });
+
+  it("returns an incomplete generation error instead of a partial guide when the provider truncates", async () => {
+    const incompleteError = Object.assign(new Error("provider output incomplete"), {
+      code: "OPENAI_COMPLETION_INCOMPLETE",
+      finishReason: "length",
+      incompleteReason: "max_output_tokens",
+      truncated: true,
+      lengthTruncated: true,
+      contentFiltered: false
+    });
+    mockRunGuidePipeline.mockRejectedValueOnce(incompleteError);
+
+    const result = await ArcanosGaming.actions.query({
+      mode: "guide",
+      game: "Star Wars: The Old Republic",
+      prompt: "Beginner to intermediate guide for tanking in Star Wars The Old Republic including mechanics, threat management, mitigation, positioning, and group play tips."
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      route: "gaming",
+      mode: "guide",
+      error: {
+        code: "GENERATION_INCOMPLETE",
+        message: "Gaming generation did not complete cleanly; no partial answer was returned.",
+        details: {
+          finishReason: "length",
+          incompleteReason: "max_output_tokens",
+          truncated: true,
+          lengthTruncated: true,
+          contentFiltered: false,
+          integrityIssues: undefined
+        }
+      }
+    });
+  });
 });

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -71,7 +71,7 @@ describe('gaming guide output hardening', () => {
     });
 
     const result = await runGuidePipeline({
-      prompt: 'Answer directly. Do not simulate, role-play, or describe a hypothetical run. How do I beat the temple boss?',
+      prompt: 'Answer directly. Do not simulate, no role-play, no hypothetical runs. How do I beat the temple boss?',
       guideUrls: [],
       auditEnabled: false
     });
@@ -106,6 +106,8 @@ describe('gaming guide output hardening', () => {
     const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
     expect(trinityRequest.input.prompt).not.toContain('Answer directly');
     expect(trinityRequest.input.prompt).not.toContain('Do not simulate');
+    expect(trinityRequest.input.prompt).toContain('avoid hypothetical run narration');
+    expect(trinityRequest.input.prompt).not.toContain('avoid run narration narration');
   });
 
   it('keeps SWTOR guide requests on an uncapped guide output path', async () => {

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -42,7 +42,7 @@ jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
 
 const { runGuidePipeline } = await import('../src/services/gaming.js');
 
-describe('gaming direct-answer hardening', () => {
+describe('gaming guide output hardening', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -65,7 +65,7 @@ describe('gaming direct-answer hardening', () => {
     });
   });
 
-  it('bypasses the hotline persona pipeline for anti-simulation prompts', async () => {
+  it('routes anti-simulation guide prompts without enabling the implicit direct-answer cap', async () => {
     mockResponsesCreate.mockResolvedValue({
       choices: [{ message: { content: 'Direct gameplay answer' } }]
     });
@@ -92,16 +92,96 @@ describe('gaming direct-answer hardening', () => {
           moduleId: 'ARCANOS:GAMING',
           sourceEndpoint: 'arcanos-gaming.guide',
           requestedAction: 'query',
-          prompt: expect.stringContaining('add hotline banter or theatrical framing')
+          prompt: expect.stringContaining('Avoid gameplay reenactment')
         }),
         context: expect.objectContaining({
           runOptions: expect.objectContaining({
-            answerMode: 'direct',
+            answerMode: 'explained',
+            requestedVerbosity: 'detailed',
             strictUserVisibleOutput: true
           })
         })
       })
     );
+    const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
+    expect(trinityRequest.input.prompt).not.toContain('Answer directly');
+    expect(trinityRequest.input.prompt).not.toContain('Do not simulate');
+  });
+
+  it('keeps SWTOR guide requests on an uncapped guide output path', async () => {
+    mockRunTrinityWritingPipeline.mockResolvedValueOnce({
+      result: [
+        '1. Set your role and discipline.',
+        '2. Gear around your current item rating.',
+        '3. Practice interrupts and defensive cooldowns.',
+        '4. Use companions and travel unlocks to reduce downtime.'
+      ].join('\n')
+    });
+
+    const result = await runGuidePipeline({
+      prompt: 'Answer directly. Do not simulate. Give me a complete SWTOR guide for gearing, combat basics, and daily progression.',
+      game: 'SWTOR',
+      guideUrls: [],
+      auditEnabled: false
+    });
+
+    expect(result.data.response).toContain('1. Set your role and discipline.');
+    expect(mockRunTrinityWritingPipeline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          runOptions: {
+            answerMode: 'explained',
+            requestedVerbosity: 'detailed',
+            strictUserVisibleOutput: true
+          }
+        })
+      })
+    );
+  });
+
+  it('preserves the original SWTOR guide request as direct guide output without fallback splicing', async () => {
+    const swtorGuide = [
+      '1. Mechanics: face enemies away from the group and learn boss swap tells before they matter.',
+      '2. Threat: open with high-threat tools, tab through packs, and save taunts for swaps or loose enemies.',
+      '3. Mitigation: rotate cooldowns before spikes and keep defensive buffs active instead of panic-stacking everything.',
+      '4. Positioning: hold enemies still, move early out of ground effects, and keep cleaves away from allies.',
+      '5. Group play: communicate swaps, protect healers, mark priority targets, and ask damage dealers for a setup beat.'
+    ].join('\n');
+    mockRunTrinityWritingPipeline.mockResolvedValueOnce({ result: swtorGuide });
+
+    const result = await runGuidePipeline({
+      game: 'Star Wars: The Old Republic',
+      prompt: 'Beginner to intermediate guide for tanking in Star Wars The Old Republic including mechanics, threat management, mitigation, positioning, and group play tips.',
+      guideUrls: [],
+      auditEnabled: false
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
+      mode: 'guide',
+      data: {
+        response: swtorGuide,
+        sources: []
+      }
+    }));
+    expect(result.data.response).not.toContain('bounded fallback response');
+    expect(result.data.response).not.toContain('Retry with a narrower scope');
+    expect(mockRunTrinityWritingPipeline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          prompt: expect.stringContaining('Beginner to intermediate guide for tanking in Star Wars The Old Republic'),
+          sourceEndpoint: 'arcanos-gaming.guide'
+        }),
+        context: expect.objectContaining({
+          runOptions: expect.objectContaining({
+            answerMode: 'explained',
+            requestedVerbosity: 'detailed',
+            strictUserVisibleOutput: true
+          })
+        })
+      })
+    );
+    expect(mockResponsesCreate).not.toHaveBeenCalled();
   });
 
   it('short-circuits exact-literal prompts before any provider call', async () => {

--- a/tests/openai-adapter.test.ts
+++ b/tests/openai-adapter.test.ts
@@ -80,6 +80,48 @@ describe('openai adapter', () => {
     expect(responsesCreateMock.mock.calls[0][1]).toEqual({ signal, headers });
   });
 
+  it('preserves Responses incomplete metadata when converting adapter chat results', async () => {
+    const rawUsage = { input_tokens: 3, output_tokens: 16, total_tokens: 19 };
+    responsesCreateMock.mockResolvedValue({
+      id: 'resp_incomplete_1',
+      created_at: 1,
+      model: 'gpt-4.1-mini',
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      output_text: 'partial answer',
+      output: [],
+      usage: rawUsage,
+    });
+
+    const adapter = createOpenAIAdapter({ apiKey: 'test-key' });
+    const result = await adapter.chat.completions.create({
+      model: 'gpt-4.1-mini',
+      messages: [{ role: 'user', content: 'hello' }],
+    } as any) as any;
+
+    expect(result.choices[0].finish_reason).toBe('length');
+    expect(result.usage).toEqual({
+      prompt_tokens: 3,
+      completion_tokens: 16,
+      total_tokens: 19
+    });
+    expect(result.provider_metadata).toEqual(expect.objectContaining({
+      provider: 'openai',
+      api: 'responses',
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      usage: rawUsage,
+      finish_reason: 'length',
+      incomplete: true,
+      truncated: true,
+      length_truncated: true,
+      content_filtered: false
+    }));
+    expect(result.response_status).toBe('incomplete');
+    expect(result.incomplete).toBe(true);
+    expect(result.truncated).toBe(true);
+  });
+
   it('routes image generation through adapter images surface with options', async () => {
     imagesGenerateMock.mockResolvedValue({
       created: 1700000000,

--- a/tests/openai-fallback-sequence.test.ts
+++ b/tests/openai-fallback-sequence.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, it, expect, beforeEach, jest } from '@jest/globals';
-import { createChatCompletionWithFallback, getDefaultModel, getGPT5Model, getFallbackModel } from '../src/services/openai.js';
+import {
+  createChatCompletionWithFallback,
+  createSingleChatCompletion,
+  getDefaultModel,
+  getGPT5Model,
+  getFallbackModel
+} from '../src/services/openai.js';
 import { runWithRequestAbortTimeout } from '@arcanos/runtime';
 
 describe('createChatCompletionWithFallback', () => {
@@ -38,6 +44,79 @@ describe('createChatCompletionWithFallback', () => {
     expect(createSpy.mock.calls[3][0].model).toBe(finalModel);
     expect(result.activeModel).toBe(finalModel);
     expect(result.fallbackFlag).toBe(true);
+  });
+
+  it('does not return incomplete provider output as a successful single completion', async () => {
+    const createSpy = jest.fn().mockResolvedValue({
+      id: 'resp_incomplete_single',
+      model: 'gpt-4.1',
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      output_text: '1. Open with threat. 2. Keep mitigation',
+      output: [],
+      usage: { input_tokens: 8, output_tokens: 16, total_tokens: 24 }
+    });
+
+    const client = {
+      responses: {
+        create: createSpy
+      }
+    } as any;
+
+    await expect(
+      createSingleChatCompletion(client, {
+        model: 'gpt-4.1',
+        messages: [{ role: 'user', content: 'SWTOR tanking guide' }]
+      })
+    ).rejects.toMatchObject({
+      code: 'OPENAI_COMPLETION_INCOMPLETE',
+      finishReason: 'length',
+      incompleteReason: 'max_output_tokens',
+      truncated: true,
+      lengthTruncated: true
+    });
+  });
+
+  it('falls through to another model when a fallback-sequence attempt is incomplete', async () => {
+    const primaryModel = getDefaultModel();
+    const gpt5Model = getGPT5Model();
+
+    const createSpy = jest
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'resp_incomplete_primary',
+        model: primaryModel,
+        status: 'incomplete',
+        incomplete_details: { reason: 'max_output_tokens' },
+        output_text: 'partial guide',
+        output: [],
+        usage: { input_tokens: 8, output_tokens: 16, total_tokens: 24 }
+      })
+      .mockResolvedValueOnce({
+        id: 'resp_complete_retry',
+        model: primaryModel,
+        status: 'completed',
+        output_text: 'Complete guide answer.',
+        output: [],
+        usage: { input_tokens: 8, output_tokens: 20, total_tokens: 28 }
+      });
+
+    const client = {
+      responses: {
+        create: createSpy
+      }
+    } as any;
+
+    const result = await createChatCompletionWithFallback(client, {
+      messages: [{ role: 'user', content: 'SWTOR tanking guide' }]
+    });
+
+    expect(createSpy).toHaveBeenCalledTimes(2);
+    expect(createSpy.mock.calls[0][0].model).toBe(primaryModel);
+    expect(createSpy.mock.calls[1][0].model).toBe(primaryModel);
+    expect(createSpy.mock.calls[1][0].model).not.toBe(gpt5Model);
+    expect(result.choices[0]?.message.content).toBe('Complete guide answer.');
+    expect(result.choices[0]?.finish_reason).toBe('stop');
   });
 
   it('stops fallback expansion once the active request is aborted', async () => {

--- a/tests/openai-response-conversion.test.ts
+++ b/tests/openai-response-conversion.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { convertResponseToLegacyChatCompletion } from '../src/services/openai/requestBuilders/convert.js';
+
+describe('OpenAI Responses conversion metadata', () => {
+  it('maps max_output_tokens incomplete responses to length and surfaces provider metadata', () => {
+    const rawUsage = { input_tokens: 5, output_tokens: 16, total_tokens: 21 };
+
+    const result = convertResponseToLegacyChatCompletion({
+      id: 'resp_length_1',
+      created_at: 1710000000,
+      model: 'gpt-4.1-mini',
+      object: 'response',
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      output_text: 'partial',
+      output: [],
+      usage: rawUsage
+    } as any, 'fallback-model');
+
+    expect(result.choices[0]?.finish_reason).toBe('length');
+    expect(result.usage).toEqual({
+      prompt_tokens: 5,
+      completion_tokens: 16,
+      total_tokens: 21
+    });
+    expect(result.provider_metadata).toEqual(expect.objectContaining({
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      usage: rawUsage,
+      finish_reason: 'length',
+      incomplete: true,
+      truncated: true,
+      length_truncated: true,
+      content_filtered: false
+    }));
+    expect(result.response_status).toBe('incomplete');
+    expect(result.incomplete).toBe(true);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('maps content-filter incomplete responses without marking them length-truncated', () => {
+    const result = convertResponseToLegacyChatCompletion({
+      id: 'resp_filter_1',
+      created_at: 1710000000,
+      model: 'gpt-4.1-mini',
+      object: 'response',
+      status: 'incomplete',
+      incomplete_details: { reason: 'content_filter' },
+      output_text: '',
+      output: [],
+      usage: { input_tokens: 2, output_tokens: 0, total_tokens: 2 }
+    } as any, 'fallback-model');
+
+    expect(result.choices[0]?.finish_reason).toBe('content_filter');
+    expect(result.provider_metadata).toEqual(expect.objectContaining({
+      finish_reason: 'content_filter',
+      incomplete: true,
+      truncated: false,
+      length_truncated: false,
+      content_filtered: true
+    }));
+    expect(result.content_filtered).toBe(true);
+  });
+});

--- a/tests/trinity-direct-answer-mode.test.ts
+++ b/tests/trinity-direct-answer-mode.test.ts
@@ -38,6 +38,36 @@ describe('trinityDirectAnswerMode', () => {
     ].join('\n'));
   });
 
+  it('keeps SWTOR numbered guide answers top-level and sequential when the model adds nested detail', () => {
+    const normalizedOutput = applyTrinityDirectAnswerOutputContract(
+      [
+        'Here is the direct answer:',
+        '1. Start with class-story quests on the starter planet.',
+        '   - Treat exploration missions as optional XP padding, not required progression.',
+        '2. Move to fleet once the story sends you there.',
+        '   - Pick up crew skill trainers only if you actually plan to craft.',
+        '3. Keep your companion in healing stance while soloing heroics.',
+        '4. Replace gear at major level brackets instead of after every drop.',
+        '5. Use quick travel and stronghold travel to cut planet downtime.',
+        '6. Extra note that should not leak into a five-step answer.'
+      ].join('\n'),
+      'SWTOR leveling guide for a returning solo player. Answer directly in five short numbered bullets.'
+    );
+
+    const lines = normalizedOutput.split('\n');
+    expect(lines).toHaveLength(5);
+    expect(lines.map((line) => line.match(/^\d+\./)?.[0])).toEqual([
+      '1.',
+      '2.',
+      '3.',
+      '4.',
+      '5.'
+    ]);
+    expect(normalizedOutput).toContain('optional XP padding');
+    expect(normalizedOutput).not.toContain('6. Extra note');
+    expect(normalizedOutput).not.toMatch(/^\s+[-*]/m);
+  });
+
   it('parses bullet contracts and reduces token budgets for compact direct-answer prompts', () => {
     expect(
       parseTrinityDirectAnswerOutputContract('Do not simulate. Answer directly in five short bullets.')

--- a/tests/trinity-direct-answer-stage.test.ts
+++ b/tests/trinity-direct-answer-stage.test.ts
@@ -94,6 +94,32 @@ describe('runDirectAnswerStage', () => {
     );
   });
 
+  it('derives truncation flags from provider finish_reason length', async () => {
+    createSingleChatCompletionMock.mockResolvedValue({
+      choices: [{ message: { content: 'Partial answer' }, finish_reason: 'length' }],
+      activeModel: 'gpt-4.1',
+      fallbackFlag: false,
+      usage: { total_tokens: 42 },
+      id: 'resp_direct_answer_length',
+      created: 123
+    });
+
+    const result = await runDirectAnswerStage(
+      {} as never,
+      'No relevant memory context is available.',
+      'Write a guide.',
+      undefined,
+      undefined,
+      'trinity_req_direct_answer_length'
+    );
+
+    expect(result.provider).toEqual(expect.objectContaining({
+      finishReason: 'length',
+      truncated: true,
+      lengthTruncated: true
+    }));
+  });
+
   it('fails fast when the direct-answer stage exceeds the bounded stage timeout', async () => {
     process.env.TRINITY_DIRECT_ANSWER_STAGE_TIMEOUT_MS = '25';
     jest.useFakeTimers();

--- a/tests/trinityHonesty.test.ts
+++ b/tests/trinityHonesty.test.ts
@@ -771,6 +771,36 @@ describe('Trinity honesty controls', () => {
     expect(enforcementResult.text).not.toMatch(/\b3\.\s+4\./);
   });
 
+  it('preserves numbered-list line breaks when no compression or rewrite is needed', () => {
+    const guide = [
+      '1. Pick a tank discipline and learn its defensive resource.',
+      '2. Use taunts for swaps, loose enemies, or planned threat windows.',
+      '3. Keep enemies faced away from allies and move early for ground effects.'
+    ].join('\n');
+
+    const enforcementResult = enforceFinalStageHonestyAndMinimalism({
+      text: guide,
+      userPrompt: 'Give me SWTOR tanking guide steps.',
+      capabilityFlags: deriveTrinityCapabilityFlags(),
+      outputControls: {
+        requestedVerbosity: 'normal',
+        maxWords: null,
+        answerMode: 'direct',
+        debugPipeline: false,
+        strictUserVisibleOutput: true
+      },
+      reasoningHonesty: {
+        responseMode: 'answer',
+        achievableSubtasks: ['Give SWTOR tanking guide steps'],
+        blockedSubtasks: [],
+        userVisibleCaveats: [],
+        evidenceTags: []
+      }
+    });
+
+    expect(enforcementResult.text).toBe(guide);
+  });
+
   it('does not splice generic fallback text into a partial answer that still has useful content', () => {
     const honestyResult = enforceFinalStageHonesty(
       'I verified the latest SWTOR patch state today. Start with your class discipline, then follow the conquest and flashpoint gearing loop.',

--- a/tests/trinityHonesty.test.ts
+++ b/tests/trinityHonesty.test.ts
@@ -10,6 +10,7 @@ import {
   readIntentMode,
   resolveIntentMode,
   shouldExposePipelineDebug,
+  validateTrinityAnswerIntegrity,
   type TrinityReasoningHonesty
 } from '../src/core/logic/trinityHonesty.js';
 
@@ -703,5 +704,112 @@ describe('Trinity honesty controls', () => {
     expect(enforcementResult.text.match(/I can't verify current competitor moves without live browsing\./g)).toHaveLength(1);
     expect(enforcementResult.text).not.toContain('I can help with that.');
     expect(enforcementResult.text).toContain('Roll out behind a feature flag.');
+  });
+
+  it('keeps numbered list markers attached to their item text during compression', () => {
+    const enforcementResult = enforceFinalStageHonestyAndMinimalism({
+      text: [
+        '1. Choose your SWTOR class and discipline before chasing gear.',
+        '2. Finish the current story chapter, then run conquest and flashpoints.',
+        '3. Upgrade only the pieces that raise your item rating efficiently.'
+      ].join('\n'),
+      userPrompt: 'Give me SWTOR guide steps under 18 words.',
+      capabilityFlags: deriveTrinityCapabilityFlags(),
+      outputControls: {
+        requestedVerbosity: 'minimal',
+        maxWords: 18,
+        answerMode: 'direct',
+        debugPipeline: false,
+        strictUserVisibleOutput: true
+      },
+      reasoningHonesty: {
+        responseMode: 'answer',
+        achievableSubtasks: ['Give SWTOR guide steps'],
+        blockedSubtasks: [],
+        userVisibleCaveats: [],
+        evidenceTags: []
+      }
+    });
+
+    expect(enforcementResult.text).not.toMatch(/(?:^|\s)\d+\.$/);
+    expect(enforcementResult.text).toMatch(/1\. Choose your SWTOR class/);
+  });
+
+  it('does not apply an implicit short cap merely because answerMode is direct', () => {
+    const longGuide = [
+      '1. Mechanics: learn boss tells, face enemies away from the group, and interrupt dangerous casts before they hit healers.',
+      '2. Threat: open with high-threat abilities, tab through packs, and save taunts for swaps or enemies leaving your control.',
+      '3. Mitigation: rotate cooldowns before damage spikes, keep defensive buffs active, and avoid spending every tool at once.',
+      '4. Positioning: hold enemies still, keep cleaves pointed away from the group, and move early when ground effects appear.',
+      '5. Group play: communicate swaps, protect healers, mark priority targets, and let damage dealers know when threat is unstable.',
+      '6. Practice: run veteran flashpoints with patient groups, review deaths after each boss, and adjust one habit at a time.',
+      '7. Mindset: your job is to make enemy behavior predictable so the healer and damage dealers can make clean decisions.'
+    ].join('\n');
+
+    const enforcementResult = enforceFinalStageHonestyAndMinimalism({
+      text: longGuide,
+      userPrompt: 'Beginner to intermediate guide for tanking in Star Wars The Old Republic including mechanics, threat management, mitigation, positioning, and group play tips.',
+      capabilityFlags: deriveTrinityCapabilityFlags(),
+      outputControls: {
+        requestedVerbosity: 'normal',
+        maxWords: null,
+        answerMode: 'direct',
+        debugPipeline: false,
+        strictUserVisibleOutput: true
+      },
+      reasoningHonesty: {
+        responseMode: 'answer',
+        achievableSubtasks: ['Give the SWTOR tanking guide'],
+        blockedSubtasks: [],
+        userVisibleCaveats: [],
+        evidenceTags: []
+      }
+    });
+
+    expect(countWords(enforcementResult.text)).toBeGreaterThan(90);
+    expect(enforcementResult.text).toContain('5. Group play');
+    expect(enforcementResult.text).not.toMatch(/\b3\.\s+4\./);
+  });
+
+  it('does not splice generic fallback text into a partial answer that still has useful content', () => {
+    const honestyResult = enforceFinalStageHonesty(
+      'I verified the latest SWTOR patch state today. Start with your class discipline, then follow the conquest and flashpoint gearing loop.',
+      createDefaultTrinityReasoningHonesty(),
+      deriveTrinityCapabilityFlags()
+    );
+    const enforcementResult = enforceFinalStageHonestyAndMinimalism({
+      text: honestyResult.text,
+      userPrompt: 'Give me a SWTOR progression guide.',
+      capabilityFlags: deriveTrinityCapabilityFlags(),
+      outputControls: deriveTrinityOutputControls('Give me a SWTOR progression guide.', {}),
+      reasoningHonesty: createDefaultTrinityReasoningHonesty()
+    });
+
+    expect(enforcementResult.text).toContain('Start with your class discipline');
+    expect(enforcementResult.text).not.toContain('I can help with general guidance, but I cannot verify live or current external information here.');
+  });
+
+  it('flags malformed generated answers before they are treated as complete', () => {
+    const integrity = validateTrinityAnswerIntegrity({
+      text: "1. Mechanics: face enemies away. 3. 4. I can't verify current external state here without live access.",
+      reasoningHonesty: createDefaultTrinityReasoningHonesty()
+    });
+
+    expect(integrity.valid).toBe(false);
+    expect(integrity.issues).toEqual(expect.arrayContaining([
+      'broken_numbering',
+      'fallback_spliced_mid_answer'
+    ]));
+  });
+
+  it('flags abrupt endings that stop on auxiliary verbs', () => {
+    const integrity = validateTrinityAnswerIntegrity({
+      text: 'The tank should'
+    });
+
+    expect(integrity).toEqual({
+      valid: false,
+      issues: ['abrupt_mid_sentence_ending']
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the confirmed ARCANOS Gaming backend truncation issue where long guide responses could be compressed into malformed output such as orphaned numbered markers and spliced fallback text.

## Changes

- Move Gaming `guide` mode onto a detailed guide path instead of Trinity direct-answer mode so long guides are not implicitly capped.
- Repair numbered-list segmentation and add generated-answer integrity validation for abrupt endings, broken numbering, and fallback splices.
- Preserve Responses API provider metadata, including finish reason, status, incomplete details, usage, and truncation flags.
- Treat incomplete, length-truncated, or content-filtered provider output as failure instead of returning partial text as complete.
- Add focused regressions for the original SWTOR tanking guide request and provider truncation conversion.

## Validation

- `node scripts/run-jest.mjs --testPathPatterns="tests/gaming.direct-answer.test.ts|tests/trinityHonesty.test.ts|tests/openai-response-conversion.test.ts|tests/openai-adapter.test.ts|tests/openai-fallback-sequence.test.ts|tests/arcanos-gaming.modes.test.ts|tests/trinity-direct-answer-mode.test.ts" --coverage=false`
- `npm run type-check`
- `npx eslint src/core/logic/trinity.ts src/core/logic/trinityGenerationFacade.ts src/core/logic/trinityHonesty.ts src/core/logic/trinityStages.ts src/core/logic/trinityTypes.ts src/services/arcanos-gaming.ts src/services/gaming.ts src/services/openai/chatFallbacks.ts src/services/openai/requestBuilders/convert.ts src/services/openai/requestBuilders/index.ts src/core/adapters/openai.adapter.ts tests/arcanos-gaming.modes.test.ts tests/gaming.direct-answer.test.ts tests/openai-adapter.test.ts tests/openai-fallback-sequence.test.ts tests/openai-response-conversion.test.ts tests/trinity-direct-answer-mode.test.ts tests/trinityHonesty.test.ts`

## Rollout Notes

No Railway config was changed and no deploy was performed. For production rollout, run the normal release validation and deploy sequence after review approval.