### PR TITLE
[codex] fix gaming guide provider timeout handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,12 @@ TRINITY_BASE_SOFT_CAP_MS=60000
 TRINITY_MULT_SIMPLE=1.0
 TRINITY_MULT_COMPLEX=1.4
 TRINITY_MULT_CRITICAL=1.8
+# Gaming module provider budgets. Generic values apply to guide/build/meta;
+# guide-specific values override guide mode and stay below ARCANOS:GAMING's 60s module budget.
+# ARCANOS_GAMING_PIPELINE_TIMEOUT_MS=35000
+# ARCANOS_GAMING_GUIDE_PIPELINE_TIMEOUT_MS=50000
+# ARCANOS_GAMING_STAGE_TIMEOUT_MS=12000
+# ARCANOS_GAMING_GUIDE_STAGE_TIMEOUT_MS=15000
 # Route queued Trinity DAG node execution through the GPT Access gateway job path.
 # Leave unset to enable automatically only when worker slots are greater than DAG_MAX_CONCURRENT_NODES.
 # Set true only after provisioning nested queue capacity; unsafe forced routing fails clearly.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -279,6 +279,10 @@ This table mirrors the highest-impact runtime keys in `.env.example`. Use `.env.
 | `TRINITY_MULT_SIMPLE` | `1.0` | Multiplier for simple Trinity calls. |
 | `TRINITY_MULT_COMPLEX` | `1.4` | Multiplier for complex Trinity calls. |
 | `TRINITY_MULT_CRITICAL` | `1.8` | Multiplier for critical Trinity calls. |
+| `ARCANOS_GAMING_PIPELINE_TIMEOUT_MS` | `35000` (commented) | Generic Gaming provider pipeline timeout for guide/build/meta when a mode-specific override is not set. |
+| `ARCANOS_GAMING_GUIDE_PIPELINE_TIMEOUT_MS` | `50000` (commented) | Guide-mode Gaming provider pipeline timeout; kept below the module dispatch timeout so provider stalls become controlled generation timeouts. |
+| `ARCANOS_GAMING_STAGE_TIMEOUT_MS` | `12000` (commented) | Generic Gaming provider stage/model timeout for guide/build/meta when a mode-specific override is not set. |
+| `ARCANOS_GAMING_GUIDE_STAGE_TIMEOUT_MS` | `15000` (commented) | Guide-mode Gaming provider stage/model timeout; clamped below the guide pipeline timeout with request headroom. |
 | `RAILWAY_API_TOKEN` | `` | Railway API token used by optional automation/ops routes. |
 | `ARC_LOG_PATH` | `/tmp/arc/log` | Filesystem path for logs (if file logging enabled). |
 | `ARC_MEMORY_PATH` | `/tmp/arc/memory` | Filesystem path for memory persistence. |

--- a/src/routes/_core/gptDispatch.ts
+++ b/src/routes/_core/gptDispatch.ts
@@ -413,7 +413,12 @@ function isDispatchCancellationError(err: unknown): boolean {
   }
 
   const normalizedMessage = resolveErrorMessage(err).toLowerCase();
-  return normalizedMessage.includes('cancel');
+  return (
+    normalizedMessage.includes('cancel') ||
+    normalizedMessage.includes('client disconnected') ||
+    normalizedMessage.includes('request_aborted') ||
+    normalizedMessage.includes('outer request was aborted')
+  );
 }
 
 function buildDispatchTimeoutMessage(timeoutMs?: number, scope: 'module' | 'mcp' = 'module'): string {

--- a/src/services/arcanos-gaming.ts
+++ b/src/services/arcanos-gaming.ts
@@ -53,11 +53,12 @@ function formatGenerationTimeout(mode: GamingMode, error: unknown): GamingErrorE
 
 function formatKnownGenerationFailure(mode: GamingMode, error: unknown): GamingErrorEnvelope | null {
   const code = readSafeErrorString(error, "code");
-  if (code === "GAMING_PROVIDER_TIMEOUT") {
+  const requestAborted = getRequestAbortSignal()?.aborted === true;
+  if (code === "GAMING_PROVIDER_TIMEOUT" && !requestAborted) {
     return formatGenerationTimeout(mode, error);
   }
 
-  if (isAbortError(error) && !getRequestAbortSignal()?.aborted) {
+  if (isAbortError(error) && !requestAborted) {
     return formatGenerationTimeout(mode, error);
   }
 

--- a/src/services/arcanos-gaming.ts
+++ b/src/services/arcanos-gaming.ts
@@ -1,6 +1,7 @@
 import { runBuildPipeline, runGuidePipeline, runMetaPipeline } from "@services/gaming.js";
 import { evaluateWithHRC } from "./hrcWrapper.js";
 import { resolveErrorMessage } from "@core/lib/errors/index.js";
+import { getRequestAbortSignal, isAbortError } from "@arcanos/runtime";
 import {
   formatGamingError,
   type GamingErrorEnvelope,
@@ -27,8 +28,39 @@ function readSafeErrorBoolean(error: unknown, key: string): boolean | undefined 
   return typeof value === "boolean" ? value : undefined;
 }
 
+function readSafeErrorNumber(error: unknown, key: string): number | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+  const value = (error as Record<string, unknown>)[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function formatGenerationTimeout(mode: GamingMode, error: unknown): GamingErrorEnvelope {
+  return formatGamingError({
+    mode,
+    error: {
+      code: "GENERATION_TIMEOUT",
+      message: "Gaming generation timed out before a complete answer was available.",
+      details: {
+        timeoutMs: readSafeErrorNumber(error, "timeoutMs"),
+        stageTimeoutMs: readSafeErrorNumber(error, "stageTimeoutMs"),
+        timeoutPhase: readSafeErrorString(error, "timeoutPhase")
+      }
+    }
+  });
+}
+
 function formatKnownGenerationFailure(mode: GamingMode, error: unknown): GamingErrorEnvelope | null {
   const code = readSafeErrorString(error, "code");
+  if (code === "GAMING_PROVIDER_TIMEOUT") {
+    return formatGenerationTimeout(mode, error);
+  }
+
+  if (isAbortError(error) && !getRequestAbortSignal()?.aborted) {
+    return formatGenerationTimeout(mode, error);
+  }
+
   if (code !== "OPENAI_COMPLETION_INCOMPLETE" && code !== "TRINITY_OUTPUT_INTEGRITY_FAILED") {
     return null;
   }

--- a/src/services/gaming.ts
+++ b/src/services/gaming.ts
@@ -109,24 +109,25 @@ function createGamingProviderTimeoutError(
   mode: GamingMode,
   error: unknown,
   timeoutMs: number,
-  stageTimeoutMs: number
+  stageTimeoutMs: number,
+  timeoutPhase = readTimeoutPhase(error) ?? "provider"
 ): Error {
   const timeoutError = new Error(`Gaming ${mode} generation timed out before a complete response was available.`);
   Object.assign(timeoutError, {
     code: "GAMING_PROVIDER_TIMEOUT",
     timeoutMs,
     stageTimeoutMs,
-    timeoutPhase: readTimeoutPhase(error)
+    timeoutPhase
   });
   return timeoutError;
 }
 
-function estimateResponseBytes(response: GamingSuccessEnvelope): number | null {
-  try {
-    return Buffer.byteLength(JSON.stringify(response), "utf8");
-  } catch {
-    return null;
-  }
+function estimateResponsePayloadChars(response: string, sources: WebSource[]): number {
+  return sources.reduce(
+    (total, source) =>
+      total + source.url.length + (source.snippet?.length ?? 0) + (source.error?.length ?? 0),
+    response.length
+  );
 }
 
 function formatGameplaySuccessWithLogs(params: {
@@ -159,11 +160,11 @@ function formatGameplaySuccessWithLogs(params: {
   });
 
   const serializationStartedAt = Date.now();
-  const responseBytes = estimateResponseBytes(envelope);
+  const responsePayloadChars = estimateResponsePayloadChars(params.response, params.sources);
   logger.info("gaming.response.serialization", {
     ...params.logContext,
     serializationMs: Date.now() - serializationStartedAt,
-    responseBytes
+    responsePayloadChars
   });
   logger.info("gaming.request.end", {
     ...params.logContext,
@@ -298,7 +299,7 @@ async function runGameplayPipeline(params: GameplayPipelineInput): Promise<Gamin
   const requestStartedAt = Date.now();
   const sourceEndpoint = `arcanos-gaming.${params.mode}`;
   const requestId = getRequestAbortContext()?.requestId;
-  const initialGuideSourceCount = (params.guideUrl ? 1 : 0) + params.guideUrls.length;
+  const initialGuideSourceCount = (params.guideUrl ? 1 : 0) + (params.guideUrls?.length ?? 0);
   const baseLogContext: GamingLogContext = {
     module: "ARCANOS:GAMING",
     route: "gaming",
@@ -325,7 +326,7 @@ async function runGameplayPipeline(params: GameplayPipelineInput): Promise<Gamin
 
   const allUrls = [
     ...(params.guideUrl ? [params.guideUrl] : []),
-    ...params.guideUrls
+    ...(params.guideUrls ?? [])
   ];
   const { context: webContext, sources } = await buildWebContext(allUrls);
   const enrichedPrompt = buildGameplayPrompt(params, webContext, allUrls.length > 0);
@@ -411,13 +412,14 @@ async function runGameplayPipeline(params: GameplayPipelineInput): Promise<Gamin
     });
 
     if (isAbortError(error)) {
+      const timeoutPhase = readTimeoutPhase(error) ?? "provider";
       logger.warn("gaming.provider.timeout", {
         ...baseLogContext,
         provider: "trinity",
         timeoutMs: pipelineTimeoutMs,
         stageTimeoutMs,
         elapsedMs,
-        timeoutPhase: readTimeoutPhase(error) ?? "provider",
+        timeoutPhase,
         errorName: error instanceof Error ? error.name : typeof error,
         errorCode: readErrorString(error, "code")
       });
@@ -427,7 +429,7 @@ async function runGameplayPipeline(params: GameplayPipelineInput): Promise<Gamin
         totalElapsedMs: Date.now() - requestStartedAt,
         errorCode: "GAMING_PROVIDER_TIMEOUT"
       });
-      throw createGamingProviderTimeoutError(params.mode, error, pipelineTimeoutMs, stageTimeoutMs);
+      throw createGamingProviderTimeoutError(params.mode, error, pipelineTimeoutMs, stageTimeoutMs, timeoutPhase);
     }
 
     logger.error("gaming.provider.error", {

--- a/src/services/gaming.ts
+++ b/src/services/gaming.ts
@@ -105,6 +105,34 @@ function readErrorString(error: unknown, key: string): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
 }
 
+const PROVIDER_TIMEOUT_ERROR_MARKERS = [
+  "openai_call_aborted_due_to_budget",
+  "runtime_budget_exhausted",
+  "runtimebudgetexceeded",
+  "budgetexceeded",
+  "watchdog threshold",
+  "execution aborted by watchdog"
+];
+
+function isGamingProviderTimeoutError(error: unknown): boolean {
+  if (isAbortError(error)) {
+    return true;
+  }
+
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const candidate = error as { name?: unknown; code?: unknown; message?: unknown };
+  const values = [candidate.name, candidate.code, candidate.message]
+    .filter((value): value is string => typeof value === "string")
+    .map((value) => value.toLowerCase());
+
+  return values.some((value) =>
+    PROVIDER_TIMEOUT_ERROR_MARKERS.some((marker) => value.includes(marker))
+  );
+}
+
 function createGamingProviderTimeoutError(
   mode: GamingMode,
   error: unknown,
@@ -412,7 +440,7 @@ async function runGameplayPipeline(params: GameplayPipelineInput): Promise<Gamin
       elapsedMs
     });
 
-    if (isAbortError(error)) {
+    if (isGamingProviderTimeoutError(error)) {
       if (getRequestAbortSignal()?.aborted) {
         logger.info("gaming.request.end", {
           ...baseLogContext,

--- a/src/services/gaming.ts
+++ b/src/services/gaming.ts
@@ -159,11 +159,12 @@ function formatGameplaySuccessWithLogs(params: {
     sourceCount: params.sources.length
   });
 
-  const serializationStartedAt = Date.now();
+  const payloadEstimateStartedAt = Date.now();
   const responsePayloadChars = estimateResponsePayloadChars(params.response, params.sources);
   logger.info("gaming.response.serialization", {
     ...params.logContext,
-    serializationMs: Date.now() - serializationStartedAt,
+    serializedByTransport: true,
+    payloadEstimateMs: Date.now() - payloadEstimateStartedAt,
     responsePayloadChars
   });
   logger.info("gaming.request.end", {
@@ -412,6 +413,16 @@ async function runGameplayPipeline(params: GameplayPipelineInput): Promise<Gamin
     });
 
     if (isAbortError(error)) {
+      if (getRequestAbortSignal()?.aborted) {
+        logger.info("gaming.request.end", {
+          ...baseLogContext,
+          ok: false,
+          totalElapsedMs: Date.now() - requestStartedAt,
+          errorCode: "REQUEST_ABORTED"
+        });
+        throw error;
+      }
+
       const timeoutPhase = readTimeoutPhase(error) ?? "provider";
       logger.warn("gaming.provider.timeout", {
         ...baseLogContext,

--- a/src/services/gaming.ts
+++ b/src/services/gaming.ts
@@ -7,7 +7,15 @@ import { resolveErrorMessage } from "@core/lib/errors/index.js";
 import { buildDirectAnswerModeSystemInstruction } from "@services/directAnswerMode.js";
 import { tryExtractExactLiteralPromptShortcut } from "@services/exactLiteralPromptShortcut.js";
 import { formatGamingSuccess, type GamingMode, type GamingSuccessEnvelope, type ValidatedGamingRequest } from "@services/gamingModes.js";
-import { createRuntimeBudget } from '@platform/resilience/runtimeBudget.js';
+import { logger } from "@platform/logging/structuredLogging.js";
+import { createRuntimeBudgetWithLimit } from '@platform/resilience/runtimeBudget.js';
+import {
+  getRequestAbortContext,
+  getRequestAbortSignal,
+  getRequestRemainingMs,
+  isAbortError,
+  runWithRequestAbortTimeout
+} from "@arcanos/runtime";
 
 type WebSource = GamingSuccessEnvelope["data"]["sources"][number];
 
@@ -15,6 +23,156 @@ type GameplayPipelineInput = Pick<
   ValidatedGamingRequest,
   "mode" | "prompt" | "game" | "guideUrl" | "guideUrls" | "auditEnabled"
 >;
+
+const DEFAULT_GAMING_PIPELINE_TIMEOUT_MS = 35_000;
+const DEFAULT_GAMING_GUIDE_PIPELINE_TIMEOUT_MS = 50_000;
+const DEFAULT_GAMING_STAGE_TIMEOUT_MS = 12_000;
+const DEFAULT_GAMING_GUIDE_STAGE_TIMEOUT_MS = 15_000;
+const GAMING_REQUEST_TIMEOUT_HEADROOM_MS = 1_000;
+const GAMING_RUNTIME_BUDGET_SAFETY_BUFFER_MS = 500;
+
+type GamingLogContext = {
+  module: "ARCANOS:GAMING";
+  route: "gaming";
+  mode: GamingMode;
+  sourceEndpoint: string;
+  requestId?: string;
+  promptLength: number;
+  gameProvided: boolean;
+  guideSourceCount: number;
+};
+
+function readPositiveIntegerEnv(name: string, fallback: number): number {
+  const value = Number.parseInt(process.env[name] ?? "", 10);
+  return Number.isFinite(value) && value > 0 ? Math.trunc(value) : fallback;
+}
+
+function clampToRequestRemaining(timeoutMs: number, headroomMs = 0): number {
+  const remainingRequestMs = getRequestRemainingMs();
+  if (remainingRequestMs === null) {
+    return timeoutMs;
+  }
+
+  return Math.max(1, Math.min(timeoutMs, remainingRequestMs - headroomMs));
+}
+
+function resolveGamingPipelineTimeoutMs(mode: GamingMode): number {
+  const fallback =
+    mode === "guide" ? DEFAULT_GAMING_GUIDE_PIPELINE_TIMEOUT_MS : DEFAULT_GAMING_PIPELINE_TIMEOUT_MS;
+  const genericTimeoutMs = readPositiveIntegerEnv("ARCANOS_GAMING_PIPELINE_TIMEOUT_MS", fallback);
+  const modeTimeoutMs = readPositiveIntegerEnv(
+    `ARCANOS_GAMING_${mode.toUpperCase()}_PIPELINE_TIMEOUT_MS`,
+    genericTimeoutMs
+  );
+
+  return clampToRequestRemaining(modeTimeoutMs, GAMING_REQUEST_TIMEOUT_HEADROOM_MS);
+}
+
+function resolveGamingStageTimeoutMs(mode: GamingMode, pipelineTimeoutMs: number): number {
+  const fallback =
+    mode === "guide" ? DEFAULT_GAMING_GUIDE_STAGE_TIMEOUT_MS : DEFAULT_GAMING_STAGE_TIMEOUT_MS;
+  const genericTimeoutMs = readPositiveIntegerEnv("ARCANOS_GAMING_STAGE_TIMEOUT_MS", fallback);
+  const modeTimeoutMs = readPositiveIntegerEnv(
+    `ARCANOS_GAMING_${mode.toUpperCase()}_STAGE_TIMEOUT_MS`,
+    genericTimeoutMs
+  );
+
+  return Math.max(1, Math.min(modeTimeoutMs, Math.max(1, pipelineTimeoutMs - GAMING_REQUEST_TIMEOUT_HEADROOM_MS)));
+}
+
+function readTimeoutPhase(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+
+  const candidate = error as Record<string, unknown>;
+  for (const key of ["timeoutPhase", "trinityStage", "stage"]) {
+    const value = candidate[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+
+  return undefined;
+}
+
+function readErrorString(error: unknown, key: string): string | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+
+  const value = (error as Record<string, unknown>)[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function createGamingProviderTimeoutError(
+  mode: GamingMode,
+  error: unknown,
+  timeoutMs: number,
+  stageTimeoutMs: number
+): Error {
+  const timeoutError = new Error(`Gaming ${mode} generation timed out before a complete response was available.`);
+  Object.assign(timeoutError, {
+    code: "GAMING_PROVIDER_TIMEOUT",
+    timeoutMs,
+    stageTimeoutMs,
+    timeoutPhase: readTimeoutPhase(error)
+  });
+  return timeoutError;
+}
+
+function estimateResponseBytes(response: GamingSuccessEnvelope): number | null {
+  try {
+    return Buffer.byteLength(JSON.stringify(response), "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function formatGameplaySuccessWithLogs(params: {
+  mode: GamingMode;
+  response: string;
+  sources: WebSource[];
+  logContext: GamingLogContext;
+  requestStartedAt: number;
+}): GamingSuccessEnvelope {
+  const postprocessStartedAt = Date.now();
+  logger.info("gaming.postprocess.start", {
+    ...params.logContext,
+    responseChars: params.response.length,
+    sourceCount: params.sources.length
+  });
+
+  const envelope = formatGamingSuccess({
+    mode: params.mode,
+    data: {
+      response: params.response,
+      sources: params.sources
+    }
+  });
+
+  logger.info("gaming.postprocess.end", {
+    ...params.logContext,
+    postprocessMs: Date.now() - postprocessStartedAt,
+    responseChars: params.response.length,
+    sourceCount: params.sources.length
+  });
+
+  const serializationStartedAt = Date.now();
+  const responseBytes = estimateResponseBytes(envelope);
+  logger.info("gaming.response.serialization", {
+    ...params.logContext,
+    serializationMs: Date.now() - serializationStartedAt,
+    responseBytes
+  });
+  logger.info("gaming.request.end", {
+    ...params.logContext,
+    ok: true,
+    totalElapsedMs: Date.now() - params.requestStartedAt
+  });
+
+  return envelope;
+}
 
 function stringifyMockResult(result: unknown): string {
   if (typeof result === "string") {
@@ -137,14 +295,31 @@ function buildGameplayRunOptions(mode: GamingMode) {
 }
 
 async function runGameplayPipeline(params: GameplayPipelineInput): Promise<GamingSuccessEnvelope> {
+  const requestStartedAt = Date.now();
+  const sourceEndpoint = `arcanos-gaming.${params.mode}`;
+  const requestId = getRequestAbortContext()?.requestId;
+  const initialGuideSourceCount = (params.guideUrl ? 1 : 0) + params.guideUrls.length;
+  const baseLogContext: GamingLogContext = {
+    module: "ARCANOS:GAMING",
+    route: "gaming",
+    mode: params.mode,
+    sourceEndpoint,
+    ...(requestId ? { requestId } : {}),
+    promptLength: params.prompt.length,
+    gameProvided: Boolean(params.game),
+    guideSourceCount: initialGuideSourceCount
+  };
+
+  logger.info("gaming.request.start", baseLogContext);
+
   const exactLiteralShortcut = tryExtractExactLiteralPromptShortcut(params.prompt);
   if (exactLiteralShortcut) {
-    return formatGamingSuccess({
+    return formatGameplaySuccessWithLogs({
       mode: params.mode,
-      data: {
-        response: exactLiteralShortcut.literal,
-        sources: []
-      }
+      response: exactLiteralShortcut.literal,
+      sources: [],
+      logContext: baseLogContext,
+      requestStartedAt
     });
   }
 
@@ -157,54 +332,152 @@ async function runGameplayPipeline(params: GameplayPipelineInput): Promise<Gamin
   const { client } = getOpenAIClientOrAdapter();
 
   if (!client) {
+    logger.warn("gaming.provider.unavailable", {
+      ...baseLogContext,
+      provider: "openai",
+      fallback: "mock"
+    });
     const mock = generateMockResponse(params.prompt, params.mode);
-    return formatGamingSuccess({
+    return formatGameplaySuccessWithLogs({
       mode: params.mode,
-      data: {
-        response: stringifyMockResult(mock.result),
-        sources
-      }
+      response: stringifyMockResult(mock.result),
+      sources,
+      logContext: baseLogContext,
+      requestStartedAt
     });
   }
 
-  const trinityResult = await runTrinityWritingPipeline({
-    input: {
-      prompt: [
-        buildGameplaySystemPrompt(params.mode),
-        '',
-        enrichedPrompt,
-        ...(params.auditEnabled ? ['', gamingPrompts.auditSystem] : [])
-      ].join('\n'),
-      moduleId: 'ARCANOS:GAMING',
-      sourceEndpoint: `arcanos-gaming.${params.mode}`,
-      requestedAction: 'query',
-      body: params,
-      executionMode: 'request'
-    },
-    context: {
-      client,
-      runtimeBudget: createRuntimeBudget(),
-      runOptions: buildGameplayRunOptions(params.mode)
+  const pipelineTimeoutMs = resolveGamingPipelineTimeoutMs(params.mode);
+  const stageTimeoutMs = resolveGamingStageTimeoutMs(params.mode, pipelineTimeoutMs);
+  const providerStartedAt = Date.now();
+  logger.info("gaming.provider.start", {
+    ...baseLogContext,
+    provider: "trinity",
+    timeoutMs: pipelineTimeoutMs,
+    stageTimeoutMs
+  });
+  logger.info("gaming.stream.start", {
+    ...baseLogContext,
+    provider: "trinity",
+    streaming: false
+  });
+
+  let trinityResult: Awaited<ReturnType<typeof runTrinityWritingPipeline>>;
+  try {
+    trinityResult = await runWithRequestAbortTimeout(
+      {
+        timeoutMs: pipelineTimeoutMs,
+        requestId,
+        parentSignal: getRequestAbortSignal(),
+        abortMessage: `Gaming ${params.mode} pipeline timed out after ${pipelineTimeoutMs}ms`
+      },
+      () =>
+        runTrinityWritingPipeline({
+          input: {
+            prompt: [
+              buildGameplaySystemPrompt(params.mode),
+              '',
+              enrichedPrompt,
+              ...(params.auditEnabled ? ['', gamingPrompts.auditSystem] : [])
+            ].join('\n'),
+            moduleId: 'ARCANOS:GAMING',
+            sourceEndpoint,
+            requestedAction: 'query',
+            body: params,
+            executionMode: 'request'
+          },
+          context: {
+            client,
+            ...(requestId ? { requestId } : {}),
+            runtimeBudget: createRuntimeBudgetWithLimit(
+              pipelineTimeoutMs,
+              GAMING_RUNTIME_BUDGET_SAFETY_BUFFER_MS
+            ),
+            runOptions: {
+              ...buildGameplayRunOptions(params.mode),
+              watchdogModelTimeoutMs: stageTimeoutMs
+            }
+          }
+        })
+    );
+  } catch (error) {
+    const elapsedMs = Date.now() - providerStartedAt;
+    logger.info("gaming.stream.end", {
+      ...baseLogContext,
+      provider: "trinity",
+      streaming: false,
+      ok: false,
+      elapsedMs
+    });
+
+    if (isAbortError(error)) {
+      logger.warn("gaming.provider.timeout", {
+        ...baseLogContext,
+        provider: "trinity",
+        timeoutMs: pipelineTimeoutMs,
+        stageTimeoutMs,
+        elapsedMs,
+        timeoutPhase: readTimeoutPhase(error) ?? "provider",
+        errorName: error instanceof Error ? error.name : typeof error,
+        errorCode: readErrorString(error, "code")
+      });
+      logger.info("gaming.request.end", {
+        ...baseLogContext,
+        ok: false,
+        totalElapsedMs: Date.now() - requestStartedAt,
+        errorCode: "GAMING_PROVIDER_TIMEOUT"
+      });
+      throw createGamingProviderTimeoutError(params.mode, error, pipelineTimeoutMs, stageTimeoutMs);
     }
+
+    logger.error("gaming.provider.error", {
+      ...baseLogContext,
+      provider: "trinity",
+      elapsedMs,
+      errorName: error instanceof Error ? error.name : typeof error,
+      errorCode: readErrorString(error, "code")
+    });
+    logger.info("gaming.request.end", {
+      ...baseLogContext,
+      ok: false,
+      totalElapsedMs: Date.now() - requestStartedAt,
+      errorCode: "GAMING_PROVIDER_ERROR"
+    });
+    throw error;
+  }
+
+  logger.info("gaming.stream.end", {
+    ...baseLogContext,
+    provider: "trinity",
+    streaming: false,
+    ok: true,
+    elapsedMs: Date.now() - providerStartedAt
+  });
+  logger.info("gaming.provider.end", {
+    ...baseLogContext,
+    provider: "trinity",
+    elapsedMs: Date.now() - providerStartedAt,
+    activeModel: trinityResult.activeModel,
+    finishReason: trinityResult.meta?.provider?.finishReason ?? "unknown"
   });
   const finalized = trinityResult.result;
 
   if (!params.auditEnabled) {
-    return formatGamingSuccess({
+    return formatGameplaySuccessWithLogs({
       mode: params.mode,
-      data: {
-        response: finalized,
-        sources
-      }
+      response: finalized,
+      sources,
+      logContext: baseLogContext,
+      requestStartedAt
     });
   }
 
-  return formatGamingSuccess({
+  return formatGameplaySuccessWithLogs({
     mode: params.mode,
-    data: {
-      response: finalized,
-      sources
-    }
+    response: finalized,
+    sources,
+    logContext: baseLogContext,
+    requestStartedAt
   });
 }
 

--- a/tests/arcanos-gaming.modes.test.ts
+++ b/tests/arcanos-gaming.modes.test.ts
@@ -179,4 +179,36 @@ describe("ArcanosGaming mode routing", () => {
       }
     });
   });
+
+  it("returns a controlled generation timeout when the provider aborts before module dispatch expires", async () => {
+    const timeoutError = Object.assign(new Error("Request was aborted."), {
+      name: "AbortError",
+      code: "GAMING_PROVIDER_TIMEOUT",
+      timeoutMs: 50_000,
+      stageTimeoutMs: 15_000,
+      timeoutPhase: "intake"
+    });
+    mockRunGuidePipeline.mockRejectedValueOnce(timeoutError);
+
+    const result = await ArcanosGaming.actions.query({
+      mode: "guide",
+      game: "Star Wars: The Old Republic",
+      prompt: "Regression check only: Beginner to intermediate guide for tanking in Star Wars The Old Republic including mechanics, threat management, mitigation, positioning, and group play tips. Return a complete coherent answer with valid numbering."
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      route: "gaming",
+      mode: "guide",
+      error: {
+        code: "GENERATION_TIMEOUT",
+        message: "Gaming generation timed out before a complete answer was available.",
+        details: {
+          timeoutMs: 50_000,
+          stageTimeoutMs: 15_000,
+          timeoutPhase: "intake"
+        }
+      }
+    });
+  });
 });

--- a/tests/arcanos-gaming.modes.test.ts
+++ b/tests/arcanos-gaming.modes.test.ts
@@ -16,6 +16,7 @@ jest.unstable_mockModule("../src/services/hrcWrapper.js", () => ({
 }));
 
 const { ArcanosGaming } = await import("../src/services/arcanos-gaming.js");
+const { runWithRequestAbortContext } = await import("@arcanos/runtime");
 
 describe("ArcanosGaming mode routing", () => {
   beforeEach(() => {
@@ -210,5 +211,30 @@ describe("ArcanosGaming mode routing", () => {
         }
       }
     });
+  });
+
+  it("preserves parent request aborts instead of mapping them to generation timeouts", async () => {
+    const timeoutError = Object.assign(new Error("Outer request was aborted."), {
+      name: "AbortError",
+      code: "GAMING_PROVIDER_TIMEOUT",
+      timeoutMs: 50_000,
+      stageTimeoutMs: 15_000,
+      timeoutPhase: "request"
+    });
+    mockRunGuidePipeline.mockRejectedValueOnce(timeoutError);
+    const controller = new AbortController();
+    controller.abort(timeoutError);
+
+    await expect(runWithRequestAbortContext({
+      requestId: "req-gaming-parent-abort",
+      controller,
+      signal: controller.signal,
+      deadlineAt: Date.now(),
+      timeoutMs: 1
+    }, () => ArcanosGaming.actions.query({
+      mode: "guide",
+      game: "Star Wars: The Old Republic",
+      prompt: "Smoke test: give three short tanking tips with valid numbering."
+    }))).rejects.toBe(timeoutError);
   });
 });

--- a/tests/arcanos-gaming.modes.test.ts
+++ b/tests/arcanos-gaming.modes.test.ts
@@ -213,6 +213,36 @@ describe("ArcanosGaming mode routing", () => {
     });
   });
 
+  it("returns a controlled generation timeout when the runtime budget expires before module dispatch", async () => {
+    const timeoutError = Object.assign(new Error("Gaming guide generation timed out."), {
+      code: "GAMING_PROVIDER_TIMEOUT",
+      timeoutMs: 50_000,
+      stageTimeoutMs: 15_000,
+      timeoutPhase: "reasoning"
+    });
+    mockRunGuidePipeline.mockRejectedValueOnce(timeoutError);
+
+    const result = await ArcanosGaming.actions.query({
+      mode: "guide",
+      game: "Star Wars: The Old Republic",
+      prompt: "Regression check only: Beginner to intermediate guide for tanking in Star Wars The Old Republic including mechanics, threat management, mitigation, positioning, and group play tips. Return a complete coherent answer with valid numbering."
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: false,
+      route: "gaming",
+      mode: "guide",
+      error: expect.objectContaining({
+        code: "GENERATION_TIMEOUT",
+        details: {
+          timeoutMs: 50_000,
+          stageTimeoutMs: 15_000,
+          timeoutPhase: "reasoning"
+        }
+      })
+    }));
+  });
+
   it("preserves parent request aborts instead of mapping them to generation timeouts", async () => {
     const timeoutError = Object.assign(new Error("Outer request was aborted."), {
       name: "AbortError",

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -283,6 +283,26 @@ describe('gaming guide output hardening', () => {
     });
   });
 
+  it('converts runtime budget exhaustion into a bounded gaming timeout error', async () => {
+    const budgetError = Object.assign(new Error('runtime_budget_exhausted'), {
+      name: 'RuntimeBudgetExceededError',
+      timeoutPhase: 'reasoning'
+    });
+    mockRunTrinityWritingPipeline.mockRejectedValueOnce(budgetError);
+
+    await expect(runGuidePipeline({
+      game: 'Star Wars: The Old Republic',
+      prompt: 'Regression check only: Beginner to intermediate guide for tanking in Star Wars The Old Republic including mechanics, threat management, mitigation, positioning, and group play tips. Return a complete coherent answer with valid numbering.',
+      guideUrls: [],
+      auditEnabled: false
+    })).rejects.toMatchObject({
+      code: 'GAMING_PROVIDER_TIMEOUT',
+      timeoutMs: 50_000,
+      stageTimeoutMs: 15_000,
+      timeoutPhase: 'reasoning'
+    });
+  });
+
   it('defaults missing provider timeout phase consistently', async () => {
     const providerAbort = Object.assign(new Error('Request was aborted.'), {
       name: 'AbortError'
@@ -320,6 +340,37 @@ describe('gaming guide output hardening', () => {
       auditEnabled: false
     }))).rejects.toBe(parentAbort);
     expect(mockRunTrinityWritingPipeline).not.toHaveBeenCalled();
+  });
+
+  it('clamps guide stage timeout below the guide pipeline timeout when env overrides exceed the budget', async () => {
+    process.env.ARCANOS_GAMING_GUIDE_PIPELINE_TIMEOUT_MS = '9000';
+    process.env.ARCANOS_GAMING_GUIDE_STAGE_TIMEOUT_MS = '25000';
+    mockRunTrinityWritingPipeline.mockResolvedValueOnce({
+      result: '1. Hold threat. 2. Face enemies away. 3. Use mitigation before spikes.',
+      activeModel: 'gpt-test',
+      meta: { provider: { finishReason: 'stop' } }
+    });
+
+    await runGuidePipeline({
+      game: 'Star Wars: The Old Republic',
+      prompt: 'Smoke test: give three short tanking tips with valid numbering.',
+      guideUrls: [],
+      auditEnabled: false
+    });
+
+    const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as {
+      context: {
+        runtimeBudget: { watchdogLimit: number; safetyBuffer: number };
+        runOptions: { watchdogModelTimeoutMs?: number };
+      };
+    };
+    expect(trinityRequest.context.runtimeBudget).toEqual(expect.objectContaining({
+      watchdogLimit: 9000,
+      safetyBuffer: 500
+    }));
+    expect(trinityRequest.context.runOptions).toEqual(expect.objectContaining({
+      watchdogModelTimeoutMs: 8000
+    }));
   });
 
   it('short-circuits exact-literal prompts before any provider call', async () => {

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -41,6 +41,7 @@ jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
 }));
 
 const { runGuidePipeline } = await import('../src/services/gaming.js');
+const { runWithRequestAbortContext } = await import('@arcanos/runtime');
 
 describe('gaming guide output hardening', () => {
   beforeEach(() => {
@@ -297,6 +298,28 @@ describe('gaming guide output hardening', () => {
       code: 'GAMING_PROVIDER_TIMEOUT',
       timeoutPhase: 'provider'
     });
+  });
+
+  it('preserves parent request aborts instead of reporting provider timeouts', async () => {
+    const parentAbort = Object.assign(new Error('Outer request was aborted.'), {
+      name: 'AbortError'
+    });
+    const controller = new AbortController();
+    controller.abort(parentAbort);
+
+    await expect(runWithRequestAbortContext({
+      requestId: 'req-gaming-parent-abort',
+      controller,
+      signal: controller.signal,
+      deadlineAt: Date.now(),
+      timeoutMs: 1
+    }, () => runGuidePipeline({
+      game: 'Star Wars: The Old Republic',
+      prompt: 'Smoke test: give three short tanking tips with valid numbering.',
+      guideUrls: [],
+      auditEnabled: false
+    }))).rejects.toBe(parentAbort);
+    expect(mockRunTrinityWritingPipeline).not.toHaveBeenCalled();
   });
 
   it('short-circuits exact-literal prompts before any provider call', async () => {

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -45,6 +45,10 @@ const { runGuidePipeline } = await import('../src/services/gaming.js');
 describe('gaming guide output hardening', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    delete process.env.ARCANOS_GAMING_PIPELINE_TIMEOUT_MS;
+    delete process.env.ARCANOS_GAMING_GUIDE_PIPELINE_TIMEOUT_MS;
+    delete process.env.ARCANOS_GAMING_STAGE_TIMEOUT_MS;
+    delete process.env.ARCANOS_GAMING_GUIDE_STAGE_TIMEOUT_MS;
 
     mockGetEnv.mockReturnValue(undefined);
     mockGetEnvNumber.mockReturnValue(512);
@@ -131,11 +135,11 @@ describe('gaming guide output hardening', () => {
     expect(mockRunTrinityWritingPipeline).toHaveBeenCalledWith(
       expect.objectContaining({
         context: expect.objectContaining({
-          runOptions: {
+          runOptions: expect.objectContaining({
             answerMode: 'explained',
             requestedVerbosity: 'detailed',
             strictUserVisibleOutput: true
-          }
+          })
         })
       })
     );
@@ -178,12 +182,104 @@ describe('gaming guide output hardening', () => {
           runOptions: expect.objectContaining({
             answerMode: 'explained',
             requestedVerbosity: 'detailed',
-            strictUserVisibleOutput: true
+            strictUserVisibleOutput: true,
+            watchdogModelTimeoutMs: 15_000
           })
         })
       })
     );
     expect(mockResponsesCreate).not.toHaveBeenCalled();
+  });
+
+  it('uses a bounded guide budget for the reported SWTOR regression prompt', async () => {
+    const swtorGuide = [
+      '1. Mechanics: learn swap cues, cleaves, interrupts, and avoidable ground effects before they hit the group.',
+      '2. Threat: open decisively, tab through packs, and reserve taunts for swaps or enemies that peel away.',
+      '3. Mitigation: rotate short cooldowns before spikes and keep class mitigation active instead of panic-stacking.',
+      '4. Positioning: face enemies away, hold them still when possible, and move early when mechanics force movement.',
+      '5. Group play: mark priorities, communicate defensive gaps, and protect healers during add waves.'
+    ].join('\n');
+    mockRunTrinityWritingPipeline.mockResolvedValueOnce({
+      result: swtorGuide,
+      activeModel: 'gpt-test',
+      meta: { provider: { finishReason: 'stop' } }
+    });
+
+    const result = await runGuidePipeline({
+      game: 'Star Wars: The Old Republic',
+      prompt: 'Regression check only: Beginner to intermediate guide for tanking in Star Wars The Old Republic including mechanics, threat management, mitigation, positioning, and group play tips. Return a complete coherent answer with valid numbering.',
+      guideUrls: [],
+      auditEnabled: false
+    });
+
+    expect(result.data.response).toBe(swtorGuide);
+    const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as {
+      input: { prompt: string };
+      context: {
+        runtimeBudget: { watchdogLimit: number; safetyBuffer: number };
+        runOptions: { watchdogModelTimeoutMs?: number };
+      };
+    };
+    expect(trinityRequest.input.prompt).toContain('Regression check only');
+    expect(trinityRequest.context.runtimeBudget).toEqual(expect.objectContaining({
+      watchdogLimit: 50_000,
+      safetyBuffer: 500
+    }));
+    expect(trinityRequest.context.runOptions).toEqual(expect.objectContaining({
+      watchdogModelTimeoutMs: 15_000
+    }));
+  });
+
+  it('passes a small guide smoke request through the bounded guide path', async () => {
+    mockRunTrinityWritingPipeline.mockResolvedValueOnce({
+      result: '1. Hold threat. 2. Face enemies away. 3. Use mitigation before spikes.',
+      activeModel: 'gpt-test',
+      meta: { provider: { finishReason: 'stop' } }
+    });
+
+    const result = await runGuidePipeline({
+      game: 'Star Wars: The Old Republic',
+      prompt: 'Smoke test: give three short tanking tips with valid numbering.',
+      guideUrls: [],
+      auditEnabled: false
+    });
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
+      mode: 'guide',
+      data: expect.objectContaining({
+        response: '1. Hold threat. 2. Face enemies away. 3. Use mitigation before spikes.'
+      })
+    }));
+    expect(mockRunTrinityWritingPipeline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          runOptions: expect.objectContaining({
+            watchdogModelTimeoutMs: 15_000
+          })
+        })
+      })
+    );
+  });
+
+  it('converts a provider abort into a bounded gaming timeout error', async () => {
+    const providerAbort = Object.assign(new Error('Request was aborted.'), {
+      name: 'AbortError',
+      timeoutPhase: 'intake'
+    });
+    mockRunTrinityWritingPipeline.mockRejectedValueOnce(providerAbort);
+
+    await expect(runGuidePipeline({
+      game: 'Star Wars: The Old Republic',
+      prompt: 'Regression check only: Beginner to intermediate guide for tanking in Star Wars The Old Republic including mechanics, threat management, mitigation, positioning, and group play tips. Return a complete coherent answer with valid numbering.',
+      guideUrls: [],
+      auditEnabled: false
+    })).rejects.toMatchObject({
+      code: 'GAMING_PROVIDER_TIMEOUT',
+      timeoutMs: 50_000,
+      stageTimeoutMs: 15_000,
+      timeoutPhase: 'intake'
+    });
   });
 
   it('short-circuits exact-literal prompts before any provider call', async () => {

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -282,6 +282,23 @@ describe('gaming guide output hardening', () => {
     });
   });
 
+  it('defaults missing provider timeout phase consistently', async () => {
+    const providerAbort = Object.assign(new Error('Request was aborted.'), {
+      name: 'AbortError'
+    });
+    mockRunTrinityWritingPipeline.mockRejectedValueOnce(providerAbort);
+
+    await expect(runGuidePipeline({
+      game: 'Star Wars: The Old Republic',
+      prompt: 'Smoke test: give three short tanking tips with valid numbering.',
+      guideUrls: [],
+      auditEnabled: false
+    })).rejects.toMatchObject({
+      code: 'GAMING_PROVIDER_TIMEOUT',
+      timeoutPhase: 'provider'
+    });
+  });
+
   it('short-circuits exact-literal prompts before any provider call', async () => {
     const result = await runGuidePipeline({
       prompt: 'Answer directly. Do not simulate, role-play, or describe a hypothetical run. Say exactly: no-simulation.',

--- a/tests/gpt-dispatch.gaming.test.ts
+++ b/tests/gpt-dispatch.gaming.test.ts
@@ -387,6 +387,110 @@ describe('routeGptRequest gaming routing', () => {
     }
   });
 
+  it('preserves a controlled gaming generation timeout envelope instead of surfacing MODULE_TIMEOUT', async () => {
+    mockDispatchModuleAction.mockResolvedValueOnce({
+      ok: false,
+      route: 'gaming',
+      mode: 'guide',
+      error: {
+        code: 'GENERATION_TIMEOUT',
+        message: 'Gaming generation timed out before a complete answer was available.',
+        details: {
+          timeoutMs: 50_000,
+          stageTimeoutMs: 15_000,
+          timeoutPhase: 'reasoning',
+        },
+      },
+    });
+
+    const envelope = await routeGptRequest({
+      gptId: 'arcanos-gaming',
+      body: {
+        action: 'query',
+        payload: {
+          mode: 'guide',
+          prompt: 'Give me SWTOR gearing help.',
+        },
+      },
+      requestId: 'req-gaming-generation-timeout-envelope',
+    });
+
+    expect(envelope).toEqual(
+      expect.objectContaining({
+        ok: true,
+        result: expect.objectContaining({
+          ok: false,
+          route: 'gaming',
+          mode: 'guide',
+          error: expect.objectContaining({
+            code: 'GENERATION_TIMEOUT',
+          }),
+        }),
+        _route: expect.objectContaining({
+          module: 'ARCANOS:GAMING',
+          action: 'query',
+          route: 'gaming',
+        }),
+      })
+    );
+    expect(envelope).not.toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: expect.objectContaining({
+          code: 'MODULE_TIMEOUT',
+        }),
+      })
+    );
+  });
+
+  it('preserves parent request aborts instead of classifying them as module timeouts', async () => {
+    const logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    const controller = new AbortController();
+    controller.abort(Object.assign(new Error('GPT route client disconnected'), {
+      name: 'AbortError',
+    }));
+
+    const envelope = await routeGptRequest({
+      gptId: 'arcanos-gaming',
+      body: {
+        action: 'query',
+        payload: {
+          mode: 'guide',
+          prompt: 'Give me SWTOR gearing help.',
+        },
+      },
+      requestId: 'req-gaming-parent-abort-dispatch',
+      logger,
+      parentAbortSignal: controller.signal,
+    });
+
+    expect(mockDispatchModuleAction).not.toHaveBeenCalled();
+    expect(envelope).toEqual(
+      expect.objectContaining({
+        ok: false,
+        error: expect.objectContaining({
+          code: 'REQUEST_ABORTED',
+        }),
+        _route: expect.objectContaining({
+          module: 'ARCANOS:GAMING',
+          action: 'query',
+          route: 'gaming',
+        }),
+      })
+    );
+    expect(envelope).not.toEqual(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: 'MODULE_TIMEOUT',
+        }),
+      })
+    );
+  });
+
   it('rejects missing gptId before dispatch resolution', async () => {
     const envelope = await routeGptRequest({
       gptId: '',


### PR DESCRIPTION
## Summary

Fixes the ARCANOS Gaming guide timeout path by adding an internal provider budget below the module dispatch timeout and converting provider aborts into controlled Gaming errors instead of surfacing as `MODULE_TIMEOUT`.

## Root cause

Read-only Railway logs for `trace_1777697122078_4kvyf` showed the request reached `ARCANOS V2`, entered `arcanos-gaming.guide`, passed model validation, then aborted during Trinity `intake` after about 6 seconds. The dispatcher classified that abort as `MODULE_TIMEOUT`, which made the failure look like the 60 second module budget had expired.

## Changes

- Add Gaming pipeline and stage timeout controls, with guide defaults of `50_000ms` pipeline and `15_000ms` provider stage.
- Run the Trinity guide provider call through request-aware abort timeout handling and a matching runtime budget.
- Convert provider aborts into `GAMING_PROVIDER_TIMEOUT`, then return a structured `GENERATION_TIMEOUT` Gaming envelope when the outer request has not already been aborted.
- Add safe structured logs for request start/end, provider start/end/timeout, stream start/end, post-processing, serialization, and total elapsed time.
- Add regression coverage for the reported SWTOR guide prompt, a small guide smoke request, provider abort conversion, and module-level controlled timeout response.

## Validation

- `node scripts/run-jest.mjs --testPathPatterns=tests/gaming.direct-answer.test.ts tests/arcanos-gaming.modes.test.ts tests/gpt-dispatch.gaming.test.ts --coverage=false` PASS: 3 suites, 40 tests
- `npm run build` PASS
- `npm run type-check` PASS
- `npm run validate:backend-cli:contract` PASS
- `npm run validate:backend-cli:offline` PASS
- Commit guard PASS

## Rollout notes

No production deploy or mutation was performed. Before deploy, run `npm run validate:railway`. With deploy approval, run `railway up`, then verify with `npm run railway:smoke:production` and `npm run railway:alert:timeouts -- --since 15m --lines 500 --fail-on-budget-abort`. After deploy, check logs for `gaming.provider.start`, `gaming.provider.end` or `gaming.provider.timeout`, and `gaming.request.end`.