### PR TITLE
[codex] Add natural-language GPT Access dispatcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/pg": "^8.15.5",
         "ajv": "^8.18.0",
         "async-mutex": "^0.5.0",
-        "axios": "https://codeload.github.com/axios/axios/tar.gz/refs/tags/v1.15.0",
+        "axios": "https://codeload.github.com/axios/axios/tar.gz/refs/tags/v1.15.2",
         "busboy": "^1.6.0",
         "cheerio": "^1.1.0",
         "cors": "^2.8.5",
@@ -3649,9 +3649,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://codeload.github.com/axios/axios/tar.gz/refs/tags/v1.15.0",
-      "integrity": "sha512-xE4G6EokhBlryt10RN/C2l0mmxZibZiZY4ZOQsqoYx0/toQllEmygH//r5rro3XOF6avlhu2/+9fpmS0fZpIeQ==",
+      "version": "1.15.2",
+      "resolved": "https://codeload.github.com/axios/axios/tar.gz/refs/tags/v1.15.2",
+      "integrity": "sha512-qVLqknFBrT3tJgK1AptlqbfcMDJBShY7BJDr3FGgGeO1GjhpArE3kEBvZoIWBJS5gFwOeYWfrY+BpsOy2ivVdw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@types/pg": "^8.15.5",
     "ajv": "^8.18.0",
     "async-mutex": "^0.5.0",
-    "axios": "https://codeload.github.com/axios/axios/tar.gz/refs/tags/v1.15.0",
+    "axios": "https://codeload.github.com/axios/axios/tar.gz/refs/tags/v1.15.2",
     "busboy": "^1.6.0",
     "cheerio": "^1.1.0",
     "cors": "^2.8.5",

--- a/src/dispatcher/naturalLanguage/confirmation.ts
+++ b/src/dispatcher/naturalLanguage/confirmation.ts
@@ -16,8 +16,8 @@ export function readDispatchConfirmationTokenField(value: unknown):
   }
 
   const trimmed = value.trim();
-  if (trimmed.length === 0 || /\s/u.test(trimmed)) {
-    return { ok: false, message: 'confirmation_token must be a single non-empty token value.' };
+  if (trimmed.length === 0) {
+    return { ok: false, message: 'confirmation_token must be a non-empty string when provided.' };
   }
 
   const confirmationChallengeId = trimmed.toLowerCase().startsWith(CONFIRMATION_HEADER_TOKEN_PREFIX)

--- a/src/dispatcher/naturalLanguage/confirmation.ts
+++ b/src/dispatcher/naturalLanguage/confirmation.ts
@@ -1,0 +1,49 @@
+const CONFIRMATION_TOKEN_BODY_KEY = 'confirmation_token';
+const CONFIRMATION_HEADER_TOKEN_PREFIX = 'token:';
+
+export const DISPATCH_RUN_BODY_KEYS = new Set([
+  'utterance',
+  'context',
+  'dryRun',
+  CONFIRMATION_TOKEN_BODY_KEY
+]);
+
+export function readDispatchConfirmationTokenField(value: unknown):
+  | { ok: true; confirmationChallengeId: string }
+  | { ok: false; message: string } {
+  if (typeof value !== 'string') {
+    return { ok: false, message: 'confirmation_token must be a non-empty string when provided.' };
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || /\s/u.test(trimmed)) {
+    return { ok: false, message: 'confirmation_token must be a single non-empty token value.' };
+  }
+
+  const confirmationChallengeId = trimmed.toLowerCase().startsWith(CONFIRMATION_HEADER_TOKEN_PREFIX)
+    ? trimmed.slice(CONFIRMATION_HEADER_TOKEN_PREFIX.length).trim()
+    : trimmed;
+
+  if (confirmationChallengeId.length === 0 || /\s/u.test(confirmationChallengeId)) {
+    return { ok: false, message: 'confirmation_token must be a single non-empty token value.' };
+  }
+
+  return { ok: true, confirmationChallengeId };
+}
+
+export function stripDispatchConfirmationToken(body: Record<string, unknown>): {
+  body: Record<string, unknown>;
+  confirmationToken?: unknown;
+} {
+  if (!Object.prototype.hasOwnProperty.call(body, CONFIRMATION_TOKEN_BODY_KEY)) {
+    return { body };
+  }
+
+  const nextBody = { ...body };
+  const confirmationToken = nextBody[CONFIRMATION_TOKEN_BODY_KEY];
+  delete nextBody[CONFIRMATION_TOKEN_BODY_KEY];
+  return {
+    body: nextBody,
+    confirmationToken
+  };
+}

--- a/src/dispatcher/naturalLanguage/index.ts
+++ b/src/dispatcher/naturalLanguage/index.ts
@@ -1,0 +1,7 @@
+export * from './types.js';
+export * from './registry.js';
+export * from './resolver.js';
+export * from './planner.js';
+export * from './policy.js';
+export * from './confirmation.js';
+export * from './runner.js';

--- a/src/dispatcher/naturalLanguage/planner.ts
+++ b/src/dispatcher/naturalLanguage/planner.ts
@@ -1,0 +1,9 @@
+import { resolveRuleBasedDispatchPlan } from './resolver.js';
+import type { DispatchPlan, ResolveDispatchPlanInput } from './types.js';
+
+export async function resolveDispatchPlan(input: ResolveDispatchPlanInput): Promise<DispatchPlan> {
+  return resolveRuleBasedDispatchPlan({
+    utterance: input.utterance,
+    registry: input.registry
+  });
+}

--- a/src/dispatcher/naturalLanguage/policy.ts
+++ b/src/dispatcher/naturalLanguage/policy.ts
@@ -7,8 +7,17 @@ import {
   type DispatchRegistryAction
 } from './types.js';
 
-const PROHIBITED_ACTION_PATTERN =
-  /\b(shell|terminal|exec|execute_command|raw_sql|sql|deploy|restart|rollback|delete|self[-_.]?heal|proxy|url|file|filesystem)\b/iu;
+const PROHIBITED_ACTION_PATTERNS = [
+  /\b(?:shell|terminal|exec|execute_command|raw[-_.]?sql|filesystem)\b/iu,
+  /\b(?:deploy|restart|rollback|delete)\b/iu,
+  /(?:^|[._:-])(?:sql[-_.]?(?:exec|execute|run|write|delete|mutate)|(?:exec|execute|run|write|delete|mutate)[-_.]?sql)(?:$|[._:-])/iu,
+  /(?:^|[._:-])(?:proxy[-_.]?url|url[-_.]?proxy|file[-_.]?(?:access|system|write|delete)|(?:read|write|delete)[-_.]?file)(?:$|[._:-])/iu,
+  /(?:^|[._:-])self[-_.]?heal(?:$|[._:-](?:run|execute|exec|apply|repair|restart|rollback|delete|mutate|write|fix)(?:$|[._:-]))/iu
+];
+
+function isProhibitedActionName(action: string): boolean {
+  return PROHIBITED_ACTION_PATTERNS.some((pattern) => pattern.test(action));
+}
 
 function buildDecision(input: {
   status: DispatchPolicyDecision['status'];
@@ -58,7 +67,7 @@ export function evaluateDispatchPolicy(input: {
     });
   }
 
-  if (registryAction.risk === 'destructive' || PROHIBITED_ACTION_PATTERN.test(registryAction.action)) {
+  if (registryAction.risk === 'destructive' || isProhibitedActionName(registryAction.action)) {
     return buildDecision({
       status: 'blocked',
       allowed: false,

--- a/src/dispatcher/naturalLanguage/policy.ts
+++ b/src/dispatcher/naturalLanguage/policy.ts
@@ -1,0 +1,124 @@
+import {
+  DISPATCH_CONFIDENCE_THRESHOLD,
+  INTENT_CLARIFICATION_REQUIRED,
+  type CapabilityRegistry,
+  type DispatchPlan,
+  type DispatchPolicyDecision,
+  type DispatchRegistryAction
+} from './types.js';
+
+const PROHIBITED_ACTION_PATTERN =
+  /\b(shell|terminal|exec|execute_command|raw_sql|sql|deploy|restart|rollback|delete|self[-_.]?heal|proxy|url|file|filesystem)\b/iu;
+
+function buildDecision(input: {
+  status: DispatchPolicyDecision['status'];
+  allowed: boolean;
+  requiresConfirmation: boolean;
+  shouldExecute: boolean;
+  action: string;
+  reason: string;
+  code?: string;
+  requiredScope?: string;
+  registryAction?: DispatchRegistryAction;
+}): DispatchPolicyDecision {
+  return input;
+}
+
+export function evaluateDispatchPolicy(input: {
+  plan: DispatchPlan;
+  registry: CapabilityRegistry;
+  confidenceThreshold?: number;
+  isScopeAllowed?: (scope: string) => boolean;
+  isModuleActionAllowed?: (moduleName: string, action: string) => boolean;
+}): DispatchPolicyDecision {
+  const threshold = input.confidenceThreshold ?? DISPATCH_CONFIDENCE_THRESHOLD;
+
+  if (input.plan.action === INTENT_CLARIFICATION_REQUIRED || input.plan.confidence < threshold) {
+    return buildDecision({
+      status: 'clarification_required',
+      allowed: false,
+      requiresConfirmation: false,
+      shouldExecute: false,
+      action: input.plan.action,
+      reason: input.plan.reason ?? 'intent_clarification_required',
+      code: INTENT_CLARIFICATION_REQUIRED
+    });
+  }
+
+  const registryAction = input.registry.getAction(input.plan.action);
+  if (!registryAction) {
+    return buildDecision({
+      status: 'blocked',
+      allowed: false,
+      requiresConfirmation: false,
+      shouldExecute: false,
+      action: input.plan.action,
+      reason: 'dispatch_action_not_registered',
+      code: 'DISPATCH_ACTION_NOT_REGISTERED'
+    });
+  }
+
+  if (registryAction.risk === 'destructive' || PROHIBITED_ACTION_PATTERN.test(registryAction.action)) {
+    return buildDecision({
+      status: 'blocked',
+      allowed: false,
+      requiresConfirmation: false,
+      shouldExecute: false,
+      action: input.plan.action,
+      reason: 'dispatch_action_prohibited',
+      code: 'DISPATCH_ACTION_PROHIBITED',
+      registryAction
+    });
+  }
+
+  if (registryAction.requiredScope && input.isScopeAllowed && !input.isScopeAllowed(registryAction.requiredScope)) {
+    return buildDecision({
+      status: 'blocked',
+      allowed: false,
+      requiresConfirmation: false,
+      shouldExecute: false,
+      action: input.plan.action,
+      reason: 'gpt_access_scope_denied',
+      code: 'GPT_ACCESS_SCOPE_DENIED',
+      requiredScope: registryAction.requiredScope,
+      registryAction
+    });
+  }
+
+  if (registryAction.runner.kind === 'gpt-access-capability' && input.isModuleActionAllowed) {
+    const allowed = input.isModuleActionAllowed(
+      registryAction.runner.capabilityId,
+      registryAction.runner.capabilityAction
+    );
+    if (!allowed) {
+      return buildDecision({
+        status: 'blocked',
+        allowed: false,
+        requiresConfirmation: false,
+        shouldExecute: false,
+        action: input.plan.action,
+        reason: 'module_action_not_allowlisted',
+        code: 'GPT_ACCESS_CAPABILITY_ACTION_DENIED',
+        requiredScope: registryAction.requiredScope,
+        registryAction
+      });
+    }
+  }
+
+  const requiresConfirmation = Boolean(
+    input.plan.requiresConfirmation
+    || registryAction.requiresConfirmation
+    || registryAction.risk !== 'readonly'
+  );
+
+  return buildDecision({
+    status: requiresConfirmation ? 'confirmation_required' : 'allowed',
+    allowed: true,
+    requiresConfirmation,
+    shouldExecute: !requiresConfirmation,
+    action: input.plan.action,
+    reason: requiresConfirmation ? 'confirmation_required' : 'policy_allowed',
+    requiredScope: registryAction.requiredScope,
+    registryAction
+  });
+}

--- a/src/dispatcher/naturalLanguage/registry.ts
+++ b/src/dispatcher/naturalLanguage/registry.ts
@@ -1,0 +1,119 @@
+import {
+  type CapabilityRegistry,
+  type DispatchRegistryAction
+} from './types.js';
+
+export type ModuleCapabilitySummary = {
+  id: string;
+  description?: string | null;
+  route?: string | null;
+  actions: string[];
+};
+
+const DEFAULT_GPT_ACCESS_ACTIONS: DispatchRegistryAction[] = [
+  {
+    action: 'workers.status',
+    description: 'Read worker and queue-observed status through GPT Access MCP control.',
+    requiredScope: 'mcp.approved_readonly',
+    risk: 'readonly',
+    runner: {
+      kind: 'gpt-access-mcp',
+      tool: 'workers.status'
+    }
+  },
+  {
+    action: 'queue.inspect',
+    description: 'Inspect the durable GPT/job queue through GPT Access MCP control.',
+    requiredScope: 'mcp.approved_readonly',
+    risk: 'readonly',
+    runner: {
+      kind: 'gpt-access-mcp',
+      tool: 'queue.inspect'
+    }
+  },
+  {
+    action: 'runtime.inspect',
+    description: 'Read runtime health through GPT Access MCP control.',
+    requiredScope: 'mcp.approved_readonly',
+    risk: 'readonly',
+    runner: {
+      kind: 'gpt-access-mcp',
+      tool: 'runtime.inspect'
+    }
+  },
+  {
+    action: 'diagnostics.run',
+    description: 'Run approved deep diagnostics through GPT Access.',
+    payload: {
+      includeDb: true,
+      includeWorkers: true,
+      includeLogs: true,
+      includeQueue: true
+    },
+    requiredScope: 'diagnostics.read',
+    risk: 'readonly',
+    runner: {
+      kind: 'gpt-access-diagnostics'
+    }
+  }
+];
+
+function normalizeActionKey(action: string): string {
+  return action.trim().toLowerCase();
+}
+
+export function buildModuleCapabilityActionId(capabilityId: string, action: string): string {
+  return `${capabilityId}.${action}`;
+}
+
+export class StaticCapabilityRegistry implements CapabilityRegistry {
+  private readonly actionsByKey: Map<string, DispatchRegistryAction>;
+
+  constructor(actions: readonly DispatchRegistryAction[]) {
+    this.actionsByKey = new Map(
+      actions.map((action) => [normalizeActionKey(action.action), action])
+    );
+  }
+
+  getAction(action: string): DispatchRegistryAction | null {
+    return this.actionsByKey.get(normalizeActionKey(action)) ?? null;
+  }
+
+  hasAction(action: string): boolean {
+    return this.actionsByKey.has(normalizeActionKey(action));
+  }
+
+  listActions(): readonly DispatchRegistryAction[] {
+    return Array.from(this.actionsByKey.values());
+  }
+}
+
+export function createCapabilityRegistry(
+  actions: readonly DispatchRegistryAction[]
+): CapabilityRegistry {
+  return new StaticCapabilityRegistry(actions);
+}
+
+export function createGptAccessDispatchRegistry(
+  modules: readonly ModuleCapabilitySummary[] = []
+): CapabilityRegistry {
+  const moduleActions = modules.flatMap((module) =>
+    module.actions.map<DispatchRegistryAction>((action) => ({
+      action: buildModuleCapabilityActionId(module.id, action),
+      description: module.description ?? `Run ${action} on ${module.id}.`,
+      requiredScope: 'capabilities.run',
+      risk: 'privileged',
+      requiresConfirmation: true,
+      runner: {
+        kind: 'gpt-access-capability',
+        capabilityId: module.id,
+        capabilityAction: action
+      }
+    }))
+  );
+
+  return createCapabilityRegistry([
+    ...DEFAULT_GPT_ACCESS_ACTIONS,
+    ...moduleActions
+  ]);
+}

--- a/src/dispatcher/naturalLanguage/resolver.ts
+++ b/src/dispatcher/naturalLanguage/resolver.ts
@@ -1,0 +1,196 @@
+import {
+  DISPATCH_CONFIDENCE_THRESHOLD,
+  INTENT_CLARIFICATION_REQUIRED,
+  type CapabilityRegistry,
+  type DispatchPlan
+} from './types.js';
+
+type RuleMatch = {
+  action: string;
+  confidence: number;
+  reason: string;
+  payload?: unknown;
+};
+
+type DispatchRule = {
+  action: string;
+  confidence: number;
+  reason: string;
+  payload?: unknown;
+  test: (normalizedUtterance: string) => boolean;
+};
+
+const CLOSE_CANDIDATE_DELTA = 0.05;
+
+const DISPATCH_RULES: DispatchRule[] = [
+  {
+    action: 'diagnostics.run',
+    confidence: 0.95,
+    reason: 'matched_full_health_check',
+    payload: {
+      includeDb: true,
+      includeWorkers: true,
+      includeLogs: true,
+      includeQueue: true
+    },
+    test: (utterance) =>
+      /\b(full|deep|complete)\b.*\b(health|diagnostic|check)\b/u.test(utterance)
+      || /\b(run|perform)\b.*\b(diagnostics?|health check)\b/u.test(utterance)
+  },
+  {
+    action: 'workers.status',
+    confidence: 0.93,
+    reason: 'matched_worker_status',
+    test: (utterance) =>
+      /\b(check|show|get|read|are|is)\b.*\b(workers?|job runners?)\b/u.test(utterance)
+      || /\b(workers?|job runners?)\b.*\b(alive|healthy|status|up|running)\b/u.test(utterance)
+  },
+  {
+    action: 'queue.inspect',
+    confidence: 0.92,
+    reason: 'matched_queue_inspection',
+    test: (utterance) =>
+      /\b(queue|backlog|pending jobs?)\b.*\b(backed up|inspect|show|status|pending|depth)\b/u.test(utterance)
+      || /\b(show|inspect|check|get)\b.*\b(queue|backlog|pending jobs?)\b/u.test(utterance)
+  },
+  {
+    action: 'runtime.inspect',
+    confidence: 0.9,
+    reason: 'matched_runtime_status',
+    test: (utterance) =>
+      /\b(runtime|backend|server|app)\b.*\b(status|health|healthy|alive|up)\b/u.test(utterance)
+      || /\b(status|health)\b.*\b(runtime|backend|server|app)\b/u.test(utterance)
+  }
+];
+
+function normalizeUtterance(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9:_./-]+/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim();
+}
+
+function normalizeActionPhrase(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, ' ')
+    .replace(/\s+/gu, ' ')
+    .trim();
+}
+
+function toCandidateList(matches: readonly RuleMatch[]): DispatchPlan['candidates'] {
+  return matches.map((match) => ({
+    action: match.action,
+    confidence: match.confidence,
+    reason: match.reason
+  }));
+}
+
+function buildClarificationPlan(reason: string, matches: readonly RuleMatch[]): DispatchPlan {
+  const topConfidence = matches[0]?.confidence ?? 0;
+  return {
+    action: INTENT_CLARIFICATION_REQUIRED,
+    payload: {},
+    confidence: topConfidence,
+    source: 'rules',
+    requiresConfirmation: false,
+    reason,
+    candidates: toCandidateList(matches)
+  };
+}
+
+function collectExactRegistryMatches(
+  normalizedUtterance: string,
+  registry: CapabilityRegistry
+): RuleMatch[] {
+  const normalizedPhrase = normalizeActionPhrase(normalizedUtterance);
+  const matches: RuleMatch[] = [];
+
+  for (const action of registry.listActions()) {
+    const normalizedAction = normalizeActionPhrase(action.action);
+    if (
+      normalizedPhrase === normalizedAction
+      || normalizedPhrase === `run ${normalizedAction}`
+      || normalizedPhrase === `execute ${normalizedAction}`
+    ) {
+      matches.push({
+        action: action.action,
+        confidence: 1,
+        reason: 'matched_exact_registered_action',
+        payload: action.payload
+      });
+    }
+  }
+
+  return matches;
+}
+
+function collectRuleMatches(normalizedUtterance: string): RuleMatch[] {
+  return DISPATCH_RULES
+    .filter((rule) => rule.test(normalizedUtterance))
+    .map((rule) => ({
+      action: rule.action,
+      confidence: rule.confidence,
+      reason: rule.reason,
+      payload: rule.payload
+    }));
+}
+
+function sortMatches(matches: readonly RuleMatch[]): RuleMatch[] {
+  return [...matches].sort((left, right) => {
+    const confidenceDelta = right.confidence - left.confidence;
+    return confidenceDelta !== 0 ? confidenceDelta : left.action.localeCompare(right.action);
+  });
+}
+
+function dedupeMatches(matches: readonly RuleMatch[]): RuleMatch[] {
+  const byAction = new Map<string, RuleMatch>();
+  for (const match of matches) {
+    const existing = byAction.get(match.action);
+    if (!existing || match.confidence > existing.confidence) {
+      byAction.set(match.action, match);
+    }
+  }
+
+  return sortMatches(Array.from(byAction.values()));
+}
+
+export function resolveRuleBasedDispatchPlan(input: {
+  utterance: string;
+  registry: CapabilityRegistry;
+}): DispatchPlan {
+  const normalizedUtterance = normalizeUtterance(input.utterance);
+  if (normalizedUtterance.length === 0) {
+    return buildClarificationPlan('empty_utterance', []);
+  }
+
+  const matches = dedupeMatches([
+    ...collectExactRegistryMatches(normalizedUtterance, input.registry),
+    ...collectRuleMatches(normalizedUtterance)
+  ]).filter((match) => input.registry.hasAction(match.action));
+
+  if (matches.length === 0) {
+    return buildClarificationPlan('no_registered_intent_match', []);
+  }
+
+  const [topMatch, secondMatch] = matches;
+  if (!topMatch || topMatch.confidence < DISPATCH_CONFIDENCE_THRESHOLD) {
+    return buildClarificationPlan('confidence_below_threshold', matches);
+  }
+
+  if (secondMatch && topMatch.confidence - secondMatch.confidence <= CLOSE_CANDIDATE_DELTA) {
+    return buildClarificationPlan('multiple_close_intent_candidates', matches);
+  }
+
+  const registryAction = input.registry.getAction(topMatch.action);
+  return {
+    action: topMatch.action,
+    payload: topMatch.payload ?? registryAction?.payload ?? {},
+    confidence: topMatch.confidence,
+    source: 'rules',
+    requiresConfirmation: Boolean(registryAction?.requiresConfirmation),
+    reason: topMatch.reason,
+    candidates: toCandidateList(matches)
+  };
+}

--- a/src/dispatcher/naturalLanguage/runner.ts
+++ b/src/dispatcher/naturalLanguage/runner.ts
@@ -1,0 +1,73 @@
+import {
+  INTENT_CLARIFICATION_REQUIRED,
+  type CapabilityRegistry,
+  type DispatchExecutionResult,
+  type DispatchPlan
+} from './types.js';
+
+export type DispatchRunnerHandlers = {
+  runMcpTool: (body: { tool: string; args: Record<string, unknown> }) => Promise<DispatchExecutionResult>;
+  runDiagnostics: (payload: unknown) => Promise<DispatchExecutionResult>;
+  runCapability: (input: {
+    capabilityId: string;
+    action: string;
+    payload: unknown;
+  }) => Promise<DispatchExecutionResult>;
+};
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+export async function runDispatchPlan(input: {
+  plan: DispatchPlan;
+  registry: CapabilityRegistry;
+  handlers: DispatchRunnerHandlers;
+}): Promise<DispatchExecutionResult> {
+  if (input.plan.action === INTENT_CLARIFICATION_REQUIRED) {
+    return {
+      statusCode: 422,
+      payload: {
+        ok: false,
+        error: {
+          code: INTENT_CLARIFICATION_REQUIRED,
+          message: 'Intent clarification is required before dispatch execution.'
+        },
+        plan: input.plan
+      }
+    };
+  }
+
+  const action = input.registry.getAction(input.plan.action);
+  if (!action) {
+    return {
+      statusCode: 403,
+      payload: {
+        ok: false,
+        error: {
+          code: 'DISPATCH_ACTION_NOT_REGISTERED',
+          message: 'Dispatch action is not registered.'
+        },
+        plan: input.plan
+      }
+    };
+  }
+
+  switch (action.runner.kind) {
+    case 'gpt-access-mcp':
+      return input.handlers.runMcpTool({
+        tool: action.runner.tool,
+        args: toRecord(input.plan.payload)
+      });
+    case 'gpt-access-diagnostics':
+      return input.handlers.runDiagnostics(input.plan.payload);
+    case 'gpt-access-capability':
+      return input.handlers.runCapability({
+        capabilityId: action.runner.capabilityId,
+        action: action.runner.capabilityAction,
+        payload: input.plan.payload
+      });
+  }
+}

--- a/src/dispatcher/naturalLanguage/types.ts
+++ b/src/dispatcher/naturalLanguage/types.ts
@@ -1,4 +1,5 @@
 export const DISPATCH_CONFIDENCE_THRESHOLD = 0.8;
+export const DISPATCH_UTTERANCE_MAX_LENGTH = 1000;
 export const INTENT_CLARIFICATION_REQUIRED = 'INTENT_CLARIFICATION_REQUIRED';
 
 export type DispatchPlanSource = 'rules' | 'llm' | 'legacy';

--- a/src/dispatcher/naturalLanguage/types.ts
+++ b/src/dispatcher/naturalLanguage/types.ts
@@ -1,0 +1,79 @@
+export const DISPATCH_CONFIDENCE_THRESHOLD = 0.8;
+export const INTENT_CLARIFICATION_REQUIRED = 'INTENT_CLARIFICATION_REQUIRED';
+
+export type DispatchPlanSource = 'rules' | 'llm' | 'legacy';
+
+export type DispatchPlan = {
+  action: string;
+  payload: unknown;
+  confidence: number;
+  source: DispatchPlanSource;
+  requiresConfirmation: boolean;
+  reason?: string;
+  candidates?: Array<{
+    action: string;
+    confidence: number;
+    reason?: string;
+  }>;
+};
+
+export type DispatchRiskLevel = 'readonly' | 'privileged' | 'destructive';
+
+export type DispatchRunner =
+  | {
+      kind: 'gpt-access-mcp';
+      tool: string;
+    }
+  | {
+      kind: 'gpt-access-diagnostics';
+    }
+  | {
+      kind: 'gpt-access-capability';
+      capabilityId: string;
+      capabilityAction: string;
+    };
+
+export type DispatchRegistryAction = {
+  action: string;
+  description?: string;
+  payload?: unknown;
+  requiredScope?: string;
+  risk: DispatchRiskLevel;
+  requiresConfirmation?: boolean;
+  runner: DispatchRunner;
+};
+
+export interface CapabilityRegistry {
+  getAction(action: string): DispatchRegistryAction | null;
+  hasAction(action: string): boolean;
+  listActions(): readonly DispatchRegistryAction[];
+}
+
+export type DispatchPolicyStatus =
+  | 'allowed'
+  | 'blocked'
+  | 'confirmation_required'
+  | 'clarification_required';
+
+export type DispatchPolicyDecision = {
+  status: DispatchPolicyStatus;
+  allowed: boolean;
+  requiresConfirmation: boolean;
+  shouldExecute: boolean;
+  action: string;
+  reason: string;
+  code?: string;
+  requiredScope?: string;
+  registryAction?: DispatchRegistryAction;
+};
+
+export type ResolveDispatchPlanInput = {
+  utterance: string;
+  registry: CapabilityRegistry;
+  context?: Record<string, unknown>;
+};
+
+export type DispatchExecutionResult = {
+  statusCode: number;
+  payload: unknown;
+};

--- a/src/routes/gpt-access.ts
+++ b/src/routes/gpt-access.ts
@@ -7,6 +7,19 @@ import {
   securityHeaders
 } from '@platform/runtime/security.js';
 import { confirmGate } from '@transport/http/middleware/confirmGate.js';
+import {
+  DISPATCH_RUN_BODY_KEYS,
+  INTENT_CLARIFICATION_REQUIRED,
+  createGptAccessDispatchRegistry,
+  evaluateDispatchPolicy,
+  readDispatchConfirmationTokenField,
+  resolveDispatchPlan,
+  runDispatchPlan,
+  stripDispatchConfirmationToken,
+  type DispatchExecutionResult,
+  type DispatchPolicyDecision,
+  type DispatchPlan
+} from '@dispatcher/naturalLanguage/index.js';
 import { isModuleActionAllowed } from '../mcp/modulesAllowlist.js';
 import {
   dispatchModuleAction,
@@ -18,8 +31,7 @@ import {
 import {
   asyncHandler,
   sendBadRequestPayload,
-  sendInternalErrorPayload,
-  sendNotFoundPayload
+  sendInternalErrorPayload
 } from '@shared/http/index.js';
 import { getWorkerControlHealth, getWorkerControlStatus } from '@services/workerControlService.js';
 import {
@@ -30,14 +42,17 @@ import {
   getGptAccessSelfHealStatus,
   explainApprovedQuery,
   getGptAccessJobResult,
+  GPT_ACCESS_SCOPES,
   gptAccessAuthMiddleware,
+  isGptAccessScopeAllowed,
   queryBackendLogs,
   requireGptAccessScope,
   resolveGptAccessOpenApiServerUrl,
   runDeepDiagnostics,
   runGptAccessMcpTool,
   sanitizeGptAccessPayload,
-  sendGptAccessResult
+  sendGptAccessResult,
+  type GptAccessScope
 } from '@services/gptAccessGateway.js';
 
 const router = express.Router();
@@ -47,10 +62,20 @@ type CapabilityMetadata = NonNullable<ReturnType<typeof getModuleMetadata>>;
 type CapabilityRunBody =
   | { ok: true; action: unknown; payload: unknown }
   | { ok: false; message: string };
+type DispatchRunBody =
+  | {
+      ok: true;
+      utterance: string;
+      context?: Record<string, unknown>;
+      dryRun: boolean;
+    }
+  | { ok: false; message: string };
 
 const CAPABILITY_CONFIRMATION_TOKEN_BODY_KEY = 'confirmation_token';
 const CAPABILITY_CONFIRMATION_HEADER_TOKEN_PREFIX = 'token:';
 const CAPABILITY_RUN_BODY_KEYS = new Set(['action', 'payload']);
+const GPT_ACCESS_SCOPE_NAMES = new Set<string>(GPT_ACCESS_SCOPES);
+const DISPATCH_UTTERANCE_MAX_LENGTH = 1000;
 const CAPABILITY_PAYLOAD_MAX_DEPTH = 32;
 const UNSAFE_CAPABILITY_PAYLOAD_FIELDS = new Set([
   '__arcanosExecutionMode',
@@ -190,6 +215,54 @@ function readCapabilityRunBody(body: unknown): CapabilityRunBody {
   };
 }
 
+function readDispatchRunBody(body: unknown): DispatchRunBody {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return { ok: false, message: 'request body must be a JSON object.' };
+  }
+
+  const record = body as Record<string, unknown>;
+  const unsupportedKey = Object.keys(record).find((key) => !DISPATCH_RUN_BODY_KEYS.has(key));
+  if (unsupportedKey) {
+    return {
+      ok: false,
+      message: 'request body may only include utterance, context, dryRun, and confirmation_token.'
+    };
+  }
+
+  if (typeof record.utterance !== 'string' || record.utterance.trim().length === 0) {
+    return { ok: false, message: 'utterance must be a non-empty string.' };
+  }
+
+  const utterance = record.utterance.trim();
+  if (utterance.length > DISPATCH_UTTERANCE_MAX_LENGTH) {
+    return {
+      ok: false,
+      message: `utterance must be ${DISPATCH_UTTERANCE_MAX_LENGTH} characters or fewer.`
+    };
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(record, 'context')
+    && (!record.context || typeof record.context !== 'object' || Array.isArray(record.context))
+  ) {
+    return { ok: false, message: 'context must be a JSON object when provided.' };
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(record, 'dryRun')
+    && typeof record.dryRun !== 'boolean'
+  ) {
+    return { ok: false, message: 'dryRun must be a boolean when provided.' };
+  }
+
+  return {
+    ok: true,
+    utterance,
+    context: record.context as Record<string, unknown> | undefined,
+    dryRun: record.dryRun === true
+  };
+}
+
 function readCapabilityConfirmationTokenField(value: unknown):
   | { ok: true; confirmationChallengeId: string }
   | { ok: false; message: string } {
@@ -275,35 +348,43 @@ function mapCapabilityRunConfirmationToken(
   next();
 }
 
+function mapDispatchRunConfirmationToken(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction
+): void {
+  if (!req.body || typeof req.body !== 'object' || Array.isArray(req.body)) {
+    next();
+    return;
+  }
+
+  const { body, confirmationToken } = stripDispatchConfirmationToken(req.body as Record<string, unknown>);
+  req.body = body;
+
+  if (confirmationToken === undefined) {
+    next();
+    return;
+  }
+
+  const tokenResult = readDispatchConfirmationTokenField(confirmationToken);
+  if (!tokenResult.ok) {
+    sendGptAccessBadRequest(res, tokenResult.message);
+    return;
+  }
+
+  if (!req.header('x-confirmed')) {
+    req.headers['x-confirmed'] = `token:${tokenResult.confirmationChallengeId}`;
+  }
+
+  next();
+}
+
 function sendGptAccessBadRequest(res: express.Response, message: string): void {
   sendBadRequestPayload(res, {
     ok: false,
     error: {
       code: 'GPT_ACCESS_VALIDATION_ERROR',
       message
-    }
-  });
-}
-
-function sendGptAccessNotFound(res: express.Response, code: string, message: string): void {
-  sendNotFoundPayload(res, {
-    ok: false,
-    error: {
-      code,
-      message
-    }
-  });
-}
-
-function sendGptAccessForbidden(res: express.Response, code: string, message: string): void {
-  sendGptAccessResult(res, {
-    statusCode: 403,
-    payload: {
-      ok: false,
-      error: {
-        code,
-        message
-      }
     }
   });
 }
@@ -339,6 +420,10 @@ function sendGptAccessUnavailable(
 
 function isModuleDispatchNotFoundError(error: unknown): boolean {
   return error instanceof ModuleNotFoundError || error instanceof ModuleActionNotFoundError;
+}
+
+function isDispatchGptAccessScopeAllowed(scope: string): boolean {
+  return GPT_ACCESS_SCOPE_NAMES.has(scope) && isGptAccessScopeAllowed(scope as GptAccessScope);
 }
 
 const listGptAccessCapabilities = asyncHandler(async (_req, res) => {
@@ -391,6 +476,104 @@ const getGptAccessCapability = asyncHandler(async (req, res) => {
   });
 });
 
+async function runGptAccessCapabilityAction(input: {
+  capabilityId: string;
+  action: string;
+  payload: unknown;
+}): Promise<DispatchExecutionResult> {
+  let metadata;
+  try {
+    metadata = getModuleMetadata(input.capabilityId);
+  } catch {
+    return {
+      statusCode: 503,
+      payload: {
+        ok: false,
+        status: 'unavailable',
+        service: 'gpt-access',
+        error: {
+          code: 'GPT_ACCESS_MCP_TOOL_UNAVAILABLE',
+          message: 'Capability registry is unavailable.'
+        }
+      }
+    };
+  }
+
+  if (!metadata) {
+    return {
+      statusCode: 404,
+      payload: {
+        ok: false,
+        error: {
+          code: 'GPT_ACCESS_CAPABILITY_NOT_FOUND',
+          message: 'Capability not found.'
+        }
+      }
+    };
+  }
+
+  if (!metadata.actions.includes(input.action)) {
+    return {
+      statusCode: 404,
+      payload: {
+        ok: false,
+        error: {
+          code: 'GPT_ACCESS_ACTION_NOT_FOUND',
+          message: 'Capability action not found.'
+        }
+      }
+    };
+  }
+
+  if (!isModuleActionAllowed(metadata.name, input.action)) {
+    return {
+      statusCode: 403,
+      payload: {
+        ok: false,
+        error: {
+          code: 'GPT_ACCESS_CAPABILITY_ACTION_DENIED',
+          message: 'Capability action is not allowlisted for GPT Access execution.'
+        }
+      }
+    };
+  }
+
+  try {
+    const result = await dispatchModuleAction(metadata.name, input.action, input.payload);
+    return {
+      statusCode: 200,
+      payload: {
+        ok: true,
+        result: sanitizeGptAccessPayload(result)
+      }
+    };
+  } catch (error) {
+    if (isModuleDispatchNotFoundError(error)) {
+      return {
+        statusCode: 404,
+        payload: {
+          ok: false,
+          error: {
+            code: 'GPT_ACCESS_CAPABILITY_NOT_FOUND',
+            message: 'Capability or action not found.'
+          }
+        }
+      };
+    }
+
+    return {
+      statusCode: 500,
+      payload: {
+        ok: false,
+        error: {
+          code: 'GPT_ACCESS_INTERNAL_ERROR',
+          message: 'Capability execution failed.'
+        }
+      }
+    };
+  }
+}
+
 const runGptAccessCapability = asyncHandler(async (req, res) => {
   const body = readCapabilityRunBody(req.body);
   if (!body.ok) {
@@ -405,52 +588,142 @@ const runGptAccessCapability = asyncHandler(async (req, res) => {
     return;
   }
 
-  const normalizedAction = action.trim();
-  let metadata;
-  try {
-    metadata = getModuleMetadata(req.params.id);
-  } catch {
-    sendGptAccessUnavailable(
-      res,
-      'GPT_ACCESS_MCP_TOOL_UNAVAILABLE',
-      'Capability registry is unavailable.'
-    );
+  sendGptAccessResult(
+    res,
+    await runGptAccessCapabilityAction({
+      capabilityId: req.params.id,
+      action: action.trim(),
+      payload
+    })
+  );
+});
+
+function toDispatchPolicyResponse(policy: DispatchPolicyDecision) {
+  return {
+    status: policy.status,
+    allowed: policy.allowed,
+    requiresConfirmation: policy.requiresConfirmation,
+    shouldExecute: policy.shouldExecute,
+    action: policy.action,
+    reason: policy.reason,
+    code: policy.code,
+    requiredScope: policy.requiredScope ?? null
+  };
+}
+
+function sendDispatchPolicyBlock(
+  res: express.Response,
+  plan: DispatchPlan,
+  policy: DispatchPolicyDecision
+): void {
+  const statusCode = policy.status === 'clarification_required' ? 422 : 403;
+  sendGptAccessResult(res, {
+    statusCode,
+    payload: {
+      ok: false,
+      error: {
+        code: policy.code ?? (
+          policy.status === 'clarification_required'
+            ? INTENT_CLARIFICATION_REQUIRED
+            : 'DISPATCH_POLICY_DENIED'
+        ),
+        message: policy.reason
+      },
+      plan,
+      policy: toDispatchPolicyResponse(policy)
+    }
+  });
+}
+
+async function executeDispatchRun(
+  req: express.Request,
+  res: express.Response,
+  plan: DispatchPlan,
+  policy: DispatchPolicyDecision
+): Promise<void> {
+  if (!policy.registryAction) {
+    sendDispatchPolicyBlock(res, plan, policy);
     return;
   }
 
-  if (!metadata) {
-    sendGptAccessNotFound(res, 'GPT_ACCESS_CAPABILITY_NOT_FOUND', 'Capability not found.');
+  const result = await runDispatchPlan({
+    plan,
+    registry: createGptAccessDispatchRegistry(getModulesForRegistry()),
+    handlers: {
+      runMcpTool: (body) => runGptAccessMcpTool(body),
+      runDiagnostics: (payload) => runDeepDiagnostics(payload),
+      runCapability: (input) => runGptAccessCapabilityAction({
+        capabilityId: input.capabilityId,
+        action: input.action,
+        payload: input.payload
+      })
+    }
+  });
+
+  sendGptAccessResult(res, {
+    statusCode: result.statusCode,
+    payload: {
+      ok: result.statusCode >= 200 && result.statusCode < 300,
+      plan,
+      policy: toDispatchPolicyResponse(policy),
+      result: sanitizeGptAccessPayload(result.payload)
+    }
+  });
+}
+
+const runGptAccessDispatch = asyncHandler(async (req, res) => {
+  const body = readDispatchRunBody(req.body);
+  if (!body.ok) {
+    sendGptAccessBadRequest(res, body.message);
     return;
   }
 
-  if (!metadata.actions.includes(normalizedAction)) {
-    sendGptAccessNotFound(res, 'GPT_ACCESS_ACTION_NOT_FOUND', 'Capability action not found.');
-    return;
-  }
+  const registry = createGptAccessDispatchRegistry(getModulesForRegistry());
+  const plan = await resolveDispatchPlan({
+    utterance: body.utterance,
+    registry,
+    context: body.context
+  });
+  const policy = evaluateDispatchPolicy({
+    plan,
+    registry,
+    isScopeAllowed: isDispatchGptAccessScopeAllowed,
+    isModuleActionAllowed
+  });
 
-  if (!isModuleActionAllowed(metadata.name, normalizedAction)) {
-    sendGptAccessForbidden(
-      res,
-      'GPT_ACCESS_CAPABILITY_ACTION_DENIED',
-      'Capability action is not allowlisted for GPT Access execution.'
-    );
-    return;
-  }
-
-  try {
-    const result = await dispatchModuleAction(metadata.name, normalizedAction, payload);
+  if (body.dryRun) {
     res.json({
       ok: true,
-      result: sanitizeGptAccessPayload(result)
+      dryRun: true,
+      plan,
+      policy: toDispatchPolicyResponse(policy)
     });
-  } catch (error) {
-    if (isModuleDispatchNotFoundError(error)) {
-      sendGptAccessNotFound(res, 'GPT_ACCESS_CAPABILITY_NOT_FOUND', 'Capability or action not found.');
-      return;
-    }
-
-    sendGptAccessInternalError(res, 'Capability execution failed.');
+    return;
   }
+
+  if (!policy.allowed) {
+    sendDispatchPolicyBlock(res, plan, policy);
+    return;
+  }
+
+  if (policy.requiresConfirmation) {
+    confirmGate(req, res, () => {
+      void executeDispatchRun(req, res, plan, {
+        ...policy,
+        shouldExecute: true
+      }).catch((error) => {
+        req.logger?.error?.('gpt_access.dispatch.failed', {
+          error: error instanceof Error ? error.message : String(error)
+        });
+        if (!res.headersSent) {
+          sendGptAccessInternalError(res, 'Dispatch execution failed.');
+        }
+      });
+    });
+    return;
+  }
+
+  await executeDispatchRun(req, res, plan, policy);
 });
 
 router.use('/gpt-access', securityHeaders);
@@ -628,6 +901,12 @@ router.post(
   asyncHandler(async (req, res) => {
     sendGptAccessResult(res, await runGptAccessMcpTool(req.body));
   })
+);
+
+router.post(
+  '/gpt-access/dispatch/run',
+  mapDispatchRunConfirmationToken,
+  runGptAccessDispatch
 );
 
 router.use('/gpt-access', (req, res) => {

--- a/src/routes/gpt-access.ts
+++ b/src/routes/gpt-access.ts
@@ -9,6 +9,7 @@ import {
 import { confirmGate } from '@transport/http/middleware/confirmGate.js';
 import {
   DISPATCH_RUN_BODY_KEYS,
+  DISPATCH_UTTERANCE_MAX_LENGTH,
   INTENT_CLARIFICATION_REQUIRED,
   createGptAccessDispatchRegistry,
   evaluateDispatchPolicy,
@@ -75,7 +76,6 @@ const CAPABILITY_CONFIRMATION_TOKEN_BODY_KEY = 'confirmation_token';
 const CAPABILITY_CONFIRMATION_HEADER_TOKEN_PREFIX = 'token:';
 const CAPABILITY_RUN_BODY_KEYS = new Set(['action', 'payload']);
 const GPT_ACCESS_SCOPE_NAMES = new Set<string>(GPT_ACCESS_SCOPES);
-const DISPATCH_UTTERANCE_MAX_LENGTH = 1000;
 const CAPABILITY_PAYLOAD_MAX_DEPTH = 32;
 const UNSAFE_CAPABILITY_PAYLOAD_FIELDS = new Set([
   '__arcanosExecutionMode',
@@ -611,6 +611,25 @@ function toDispatchPolicyResponse(policy: DispatchPolicyDecision) {
   };
 }
 
+function toDispatchPolicyErrorMessage(policy: DispatchPolicyDecision): string {
+  switch (policy.code) {
+    case INTENT_CLARIFICATION_REQUIRED:
+      return 'Dispatch intent could not be resolved confidently. Please clarify the requested action.';
+    case 'DISPATCH_ACTION_NOT_REGISTERED':
+      return 'Dispatch action is not registered for GPT Access.';
+    case 'DISPATCH_ACTION_PROHIBITED':
+      return 'Dispatch action is prohibited by GPT Access policy.';
+    case 'GPT_ACCESS_SCOPE_DENIED':
+      return 'GPT Access scope is not allowed for this dispatch action.';
+    case 'GPT_ACCESS_CAPABILITY_ACTION_DENIED':
+      return 'GPT Access capability action is not allowlisted.';
+    default:
+      return policy.status === 'clarification_required'
+        ? 'Dispatch intent could not be resolved confidently. Please clarify the requested action.'
+        : 'Dispatch request was denied by policy.';
+  }
+}
+
 function sendDispatchPolicyBlock(
   res: express.Response,
   plan: DispatchPlan,
@@ -627,7 +646,7 @@ function sendDispatchPolicyBlock(
             ? INTENT_CLARIFICATION_REQUIRED
             : 'DISPATCH_POLICY_DENIED'
         ),
-        message: policy.reason
+        message: toDispatchPolicyErrorMessage(policy)
       },
       plan,
       policy: toDispatchPolicyResponse(policy)
@@ -708,10 +727,14 @@ const runGptAccessDispatch = asyncHandler(async (req, res) => {
 
   if (policy.requiresConfirmation) {
     confirmGate(req, res, () => {
-      void executeDispatchRun(req, res, plan, {
+      const confirmedPolicy: DispatchPolicyDecision = {
         ...policy,
-        shouldExecute: true
-      }).catch((error) => {
+        status: 'allowed',
+        requiresConfirmation: false,
+        shouldExecute: true,
+        reason: 'confirmation_satisfied'
+      };
+      void executeDispatchRun(req, res, plan, confirmedPolicy).catch((error) => {
         req.logger?.error?.('gpt_access.dispatch.failed', {
           error: error instanceof Error ? error.message : String(error)
         });

--- a/src/services/gptAccessGateway.ts
+++ b/src/services/gptAccessGateway.ts
@@ -590,22 +590,24 @@ function isGptAccessScopeExplicitlyConfigured(scope: GptAccessScope): boolean {
 
 export function requireGptAccessScope(scope: GptAccessScope) {
   return (_req: Request, res: Response, next: NextFunction): void => {
-    if (
-      GPT_ACCESS_SCOPES_REQUIRING_EXPLICIT_CONFIG.has(scope)
-      && !isGptAccessScopeExplicitlyConfigured(scope)
-    ) {
-      sendGatewayError(res, 403, 'GPT_ACCESS_SCOPE_DENIED', 'GPT access scope denied.');
-      return;
-    }
-
-    const { configuredScopes } = resolveConfiguredAccessScopes();
-    if (!configuredScopes.has(scope)) {
+    if (!isGptAccessScopeAllowed(scope)) {
       sendGatewayError(res, 403, 'GPT_ACCESS_SCOPE_DENIED', 'GPT access scope denied.');
       return;
     }
 
     next();
   };
+}
+
+export function isGptAccessScopeAllowed(scope: GptAccessScope): boolean {
+  if (
+    GPT_ACCESS_SCOPES_REQUIRING_EXPLICIT_CONFIG.has(scope)
+    && !isGptAccessScopeExplicitlyConfigured(scope)
+  ) {
+    return false;
+  }
+
+  return resolveConfiguredAccessScopes().configuredScopes.has(scope);
 }
 
 export function buildGptAccessHealthPayload() {
@@ -2080,6 +2082,85 @@ export function buildGptAccessOpenApiDocument(options: { serverUrl?: string } = 
           required: ['ok', 'tool'],
           additionalProperties: true
         },
+        DispatchPlan: {
+          type: 'object',
+          properties: {
+            action: { type: 'string' },
+            payload: {},
+            confidence: { type: 'number', minimum: 0, maximum: 1 },
+            source: { type: 'string', enum: ['rules', 'llm', 'legacy'] },
+            requiresConfirmation: { type: 'boolean' },
+            reason: { type: 'string' },
+            candidates: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  action: { type: 'string' },
+                  confidence: { type: 'number', minimum: 0, maximum: 1 },
+                  reason: { type: 'string' }
+                },
+                required: ['action', 'confidence'],
+                additionalProperties: false
+              }
+            }
+          },
+          required: ['action', 'payload', 'confidence', 'source', 'requiresConfirmation'],
+          additionalProperties: false
+        },
+        DispatchPolicyDecision: {
+          type: 'object',
+          properties: {
+            status: {
+              type: 'string',
+              enum: ['allowed', 'blocked', 'confirmation_required', 'clarification_required']
+            },
+            allowed: { type: 'boolean' },
+            requiresConfirmation: { type: 'boolean' },
+            shouldExecute: { type: 'boolean' },
+            action: { type: 'string' },
+            reason: { type: 'string' },
+            code: { type: 'string' },
+            requiredScope: { type: ['string', 'null'] }
+          },
+          required: ['status', 'allowed', 'requiresConfirmation', 'shouldExecute', 'action', 'reason', 'requiredScope'],
+          additionalProperties: false
+        },
+        DispatchRunRequest: {
+          type: 'object',
+          description: 'Natural-language dispatch request. The utterance is resolved into a DispatchPlan, policy checked, and only then executed through GPT Access capability/control runners. This replaces natural-language dispatch behavior without restoring /ask.',
+          properties: {
+            utterance: { type: 'string', minLength: 1, maxLength: 1000 },
+            context: {
+              type: 'object',
+              additionalProperties: true
+            },
+            dryRun: {
+              type: 'boolean',
+              default: false,
+              description: 'When true, returns the DispatchPlan and policy decision without executing.'
+            },
+            confirmation_token: {
+              type: 'string',
+              minLength: 1,
+              description: 'Raw confirmationChallenge.id for one retry when a privileged dispatch returns CONFIRMATION_REQUIRED.'
+            }
+          },
+          required: ['utterance'],
+          additionalProperties: false
+        },
+        DispatchRunResponse: {
+          type: 'object',
+          properties: {
+            ok: { type: 'boolean' },
+            dryRun: { type: 'boolean' },
+            plan: { '$ref': '#/components/schemas/DispatchPlan' },
+            policy: { '$ref': '#/components/schemas/DispatchPolicyDecision' },
+            result: {}
+          },
+          required: ['ok', 'plan', 'policy'],
+          additionalProperties: true
+        },
         CapabilityV1Summary: {
           type: 'object',
           properties: {
@@ -2561,6 +2642,50 @@ export function buildGptAccessOpenApiDocument(options: { serverUrl?: string } = 
             '401': { description: 'Unauthorized.', content: { 'application/json': { schema: { '$ref': '#/components/schemas/ErrorResponse' } } } },
             '403': { description: 'Tool denied.', content: { 'application/json': { schema: { '$ref': '#/components/schemas/ErrorResponse' } } } },
             '503': { description: 'Tool unavailable.', content: { 'application/json': { schema: { '$ref': '#/components/schemas/ErrorResponse' } } } }
+          }
+        }
+      },
+      '/gpt-access/dispatch/run': {
+        post: {
+          operationId: 'runDispatch',
+          summary: 'Resolve and run a natural-language GPT Access dispatch.',
+          description: 'Canonical natural-language dispatch entryway. Resolves utterance -> DispatchPlan -> registry validation -> scope/allowlist/risk policy -> confirmation when required -> existing GPT Access capability/control runner. This replaces old natural-language dispatch behavior without restoring /ask.',
+          security: protectedSecurity,
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: { '$ref': '#/components/schemas/DispatchRunRequest' }
+              }
+            }
+          },
+          responses: {
+            '200': {
+              description: 'Dispatch dry-run or successful execution response.',
+              content: {
+                'application/json': {
+                  schema: { '$ref': '#/components/schemas/DispatchRunResponse' }
+                }
+              }
+            },
+            '400': { description: 'Invalid request.', content: { 'application/json': { schema: { '$ref': '#/components/schemas/ErrorResponse' } } } },
+            '401': { description: 'Unauthorized.', content: { 'application/json': { schema: { '$ref': '#/components/schemas/ErrorResponse' } } } },
+            '403': {
+              description: 'Policy denied, scope denied, allowlist denied, or confirmation required.',
+              content: {
+                'application/json': {
+                  schema: {
+                    oneOf: [
+                      { '$ref': '#/components/schemas/ErrorResponse' },
+                      { '$ref': '#/components/schemas/ConfirmationRequiredResponse' },
+                      { '$ref': '#/components/schemas/DispatchRunResponse' }
+                    ]
+                  }
+                }
+              }
+            },
+            '422': { description: 'Intent clarification required.', content: { 'application/json': { schema: { '$ref': '#/components/schemas/DispatchRunResponse' } } } },
+            '500': { description: 'Unexpected dispatch execution failure.', content: { 'application/json': { schema: { '$ref': '#/components/schemas/ErrorResponse' } } } }
           }
         }
       },

--- a/src/services/gptAccessGateway.ts
+++ b/src/services/gptAccessGateway.ts
@@ -24,9 +24,11 @@ import { getWorkerControlHealth, getWorkerControlStatus } from '@services/worker
 import { planAutonomousWorkerJob } from '@services/workerAutonomyService.js';
 import { buildSafetySelfHealSnapshot } from '@services/selfHealRuntimeInspectionService.js';
 import { getWorkerRuntimeStatus } from '@platform/runtime/workerConfig.js';
+import { DISPATCH_UTTERANCE_MAX_LENGTH } from '@dispatcher/naturalLanguage/types.js';
 
 const SERVICE_VERSION = '1.0.0';
 const TOKEN_ENV_NAME = 'ARCANOS_GPT_ACCESS_TOKEN';
+const DISPATCH_CONFIRMATION_TOKEN_PREFIX = 'token:';
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const MAX_TOKEN_LENGTH = 4096;
 const LOG_LIMIT_MAX = 500;
@@ -2130,7 +2132,7 @@ export function buildGptAccessOpenApiDocument(options: { serverUrl?: string } = 
           type: 'object',
           description: 'Natural-language dispatch request. The utterance is resolved into a DispatchPlan, policy checked, and only then executed through GPT Access capability/control runners. This replaces natural-language dispatch behavior without restoring /ask.',
           properties: {
-            utterance: { type: 'string', minLength: 1, maxLength: 1000 },
+            utterance: { type: 'string', minLength: 1, maxLength: DISPATCH_UTTERANCE_MAX_LENGTH },
             context: {
               type: 'object',
               additionalProperties: true
@@ -2143,7 +2145,11 @@ export function buildGptAccessOpenApiDocument(options: { serverUrl?: string } = 
             confirmation_token: {
               type: 'string',
               minLength: 1,
-              description: 'Raw confirmationChallenge.id for one retry when a privileged dispatch returns CONFIRMATION_REQUIRED.'
+              description: `Confirmation token for one retry when a privileged dispatch returns CONFIRMATION_REQUIRED. Accepted formats are either the raw confirmationChallenge.id or the prefixed form ${DISPATCH_CONFIRMATION_TOKEN_PREFIX}<confirmationChallenge.id>.`,
+              examples: [
+                'example-confirmation-challenge-id',
+                `${DISPATCH_CONFIRMATION_TOKEN_PREFIX}example-confirmation-challenge-id`
+              ]
             }
           },
           required: ['utterance'],

--- a/tests/dispatcher-natural-language.test.ts
+++ b/tests/dispatcher-natural-language.test.ts
@@ -5,6 +5,7 @@ import {
   createCapabilityRegistry,
   createGptAccessDispatchRegistry,
   evaluateDispatchPolicy,
+  readDispatchConfirmationTokenField,
   resolveDispatchPlan
 } from '../src/dispatcher/naturalLanguage/index.js';
 
@@ -58,6 +59,61 @@ describe('natural-language dispatcher', () => {
 
     expect(policy.allowed).toBe(false);
     expect(policy.code).toBe('DISPATCH_ACTION_PROHIBITED');
+  });
+
+  it.each([
+    'self_heal.status',
+    'show_sql_stats',
+    'fetch_url_content'
+  ])('allows registered read-only action name %s through policy', async (action) => {
+    const registry = createCapabilityRegistry([
+      {
+        action,
+        risk: 'readonly',
+        runner: {
+          kind: 'gpt-access-mcp',
+          tool: action
+        }
+      }
+    ]);
+    const plan = await resolveDispatchPlan({ utterance: action, registry });
+
+    const policy = evaluateDispatchPolicy({ plan, registry });
+
+    expect(policy.allowed).toBe(true);
+    expect(policy.status).toBe('allowed');
+  });
+
+  it.each([
+    'raw_sql.query',
+    'self_heal.execute'
+  ])('blocks prohibited action name %s before execution', async (action) => {
+    const registry = createCapabilityRegistry([
+      {
+        action,
+        risk: 'privileged',
+        runner: {
+          kind: 'gpt-access-capability',
+          capabilityId: 'ARCANOS:CORE',
+          capabilityAction: 'query'
+        }
+      }
+    ]);
+    const plan = await resolveDispatchPlan({ utterance: action, registry });
+
+    const policy = evaluateDispatchPolicy({ plan, registry });
+
+    expect(policy.allowed).toBe(false);
+    expect(policy.code).toBe('DISPATCH_ACTION_PROHIBITED');
+  });
+
+  it('normalizes token-prefixed confirmation values before validating the challenge token', () => {
+    const prefixedChallengeId = ['tok', 'en: ', 'challenge-id'].join('');
+
+    expect(readDispatchConfirmationTokenField(prefixedChallengeId)).toEqual({
+      ok: true,
+      confirmationChallengeId: 'challenge-id'
+    });
   });
 
   it('requires confirmation for registered GPT Access capability actions', async () => {

--- a/tests/dispatcher-natural-language.test.ts
+++ b/tests/dispatcher-natural-language.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  INTENT_CLARIFICATION_REQUIRED,
+  createCapabilityRegistry,
+  createGptAccessDispatchRegistry,
+  evaluateDispatchPolicy,
+  resolveDispatchPlan
+} from '../src/dispatcher/naturalLanguage/index.js';
+
+describe('natural-language dispatcher', () => {
+  it.each([
+    ['check workers', 'workers.status'],
+    ['are workers alive', 'workers.status'],
+    ['is the queue backed up', 'queue.inspect'],
+    ['show queue', 'queue.inspect'],
+    ['runtime status', 'runtime.inspect'],
+    ['health of backend', 'runtime.inspect'],
+    ['run full health check', 'diagnostics.run']
+  ])('resolves "%s" to %s', async (utterance, action) => {
+    const registry = createGptAccessDispatchRegistry();
+
+    const plan = await resolveDispatchPlan({ utterance, registry });
+
+    expect(plan.action).toBe(action);
+    expect(plan.confidence).toBeGreaterThanOrEqual(0.8);
+    expect(plan.source).toBe('rules');
+  });
+
+  it('returns clarification for unknown utterances', async () => {
+    const registry = createGptAccessDispatchRegistry();
+
+    const plan = await resolveDispatchPlan({
+      utterance: 'please do the vague thing',
+      registry
+    });
+
+    expect(plan.action).toBe(INTENT_CLARIFICATION_REQUIRED);
+    expect(plan.requiresConfirmation).toBe(false);
+  });
+
+  it('blocks prohibited registered actions before execution', async () => {
+    const registry = createCapabilityRegistry([
+      {
+        action: 'shell.run',
+        risk: 'destructive',
+        requiredScope: 'capabilities.run',
+        runner: {
+          kind: 'gpt-access-capability',
+          capabilityId: 'SHELL',
+          capabilityAction: 'run'
+        }
+      }
+    ]);
+    const plan = await resolveDispatchPlan({ utterance: 'shell.run', registry });
+
+    const policy = evaluateDispatchPolicy({ plan, registry });
+
+    expect(policy.allowed).toBe(false);
+    expect(policy.code).toBe('DISPATCH_ACTION_PROHIBITED');
+  });
+
+  it('requires confirmation for registered GPT Access capability actions', async () => {
+    const registry = createGptAccessDispatchRegistry([
+      {
+        id: 'ARCANOS:CORE',
+        description: 'Core runtime capability',
+        route: 'core',
+        actions: ['query']
+      }
+    ]);
+    const plan = await resolveDispatchPlan({ utterance: 'ARCANOS:CORE.query', registry });
+
+    const policy = evaluateDispatchPolicy({
+      plan,
+      registry,
+      isScopeAllowed: () => true,
+      isModuleActionAllowed: () => true
+    });
+
+    expect(plan.action).toBe('ARCANOS:CORE.query');
+    expect(policy.allowed).toBe(true);
+    expect(policy.status).toBe('confirmation_required');
+    expect(policy.requiresConfirmation).toBe(true);
+  });
+});

--- a/tests/gpt-access-gateway.test.ts
+++ b/tests/gpt-access-gateway.test.ts
@@ -893,6 +893,116 @@ describe('/gpt-access gateway', () => {
     expect(dispatchModuleActionMock).not.toHaveBeenCalled();
   });
 
+  it('dry-runs natural-language dispatch without executing the resolved action', async () => {
+    const response = await authorized(request(buildApp()).post('/gpt-access/dispatch/run'))
+      .send({
+        utterance: 'are workers alive',
+        dryRun: true
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(expect.objectContaining({
+      ok: true,
+      dryRun: true,
+      plan: expect.objectContaining({
+        action: 'workers.status',
+        confidence: expect.any(Number)
+      }),
+      policy: expect.objectContaining({
+        status: 'allowed',
+        allowed: true,
+        shouldExecute: true
+      })
+    }));
+    expect(getWorkerControlStatusMock).not.toHaveBeenCalled();
+    expect(dispatchModuleActionMock).not.toHaveBeenCalled();
+  });
+
+  it('runs read-only natural-language dispatch through GPT Access control runners', async () => {
+    const response = await authorized(request(buildApp()).post('/gpt-access/dispatch/run'))
+      .send({
+        utterance: 'show queue'
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.plan.action).toBe('queue.inspect');
+    expect(response.body.policy.status).toBe('allowed');
+    expect(response.body.result).toEqual(expect.objectContaining({
+      ok: true,
+      tool: 'queue.inspect'
+    }));
+    expect(dispatchModuleActionMock).not.toHaveBeenCalled();
+  });
+
+  it('returns clarification for low-confidence natural-language dispatch', async () => {
+    const response = await authorized(request(buildApp()).post('/gpt-access/dispatch/run'))
+      .send({
+        utterance: 'please handle whatever seems appropriate'
+      });
+
+    expect(response.status).toBe(422);
+    expect(response.body.error.code).toBe('INTENT_CLARIFICATION_REQUIRED');
+    expect(response.body.plan.action).toBe('INTENT_CLARIFICATION_REQUIRED');
+    expect(dispatchModuleActionMock).not.toHaveBeenCalled();
+  });
+
+  it('blocks dispatch capability actions that are not allowlisted', async () => {
+    process.env.ARCANOS_GPT_ACCESS_SCOPES = 'capabilities.run';
+    delete process.env.MCP_ALLOW_MODULE_ACTIONS;
+
+    const response = await authorized(request(buildApp()).post('/gpt-access/dispatch/run'))
+      .send({
+        utterance: 'ARCANOS:CORE.query'
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toEqual({
+      code: 'GPT_ACCESS_CAPABILITY_ACTION_DENIED',
+      message: 'module_action_not_allowlisted'
+    });
+    expect(dispatchModuleActionMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the existing confirmation challenge for privileged dispatch actions', async () => {
+    allowCapabilityRun();
+
+    const response = await authorized(request(buildApp()).post('/gpt-access/dispatch/run'))
+      .send({
+        utterance: 'ARCANOS:CORE.query'
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body.code).toBe('CONFIRMATION_REQUIRED');
+    expect(response.body.confirmationChallenge).toEqual(expect.objectContaining({
+      id: expect.any(String)
+    }));
+    expect(dispatchModuleActionMock).not.toHaveBeenCalled();
+  });
+
+  it('uses the existing confirmation retry mechanism before privileged dispatch execution', async () => {
+    allowCapabilityRun();
+    const app = buildApp();
+
+    const challengeResponse = await authorized(request(app).post('/gpt-access/dispatch/run'))
+      .send({
+        utterance: 'ARCANOS:CORE.query'
+      });
+    const challengeId = challengeResponse.body.confirmationChallenge?.id;
+    expect(challengeResponse.status).toBe(403);
+    expect(typeof challengeId).toBe('string');
+
+    const response = await authorized(request(app).post('/gpt-access/dispatch/run'))
+      .send({
+        utterance: 'ARCANOS:CORE.query',
+        confirmation_token: challengeId
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.plan.action).toBe('ARCANOS:CORE.query');
+    expect(response.body.policy.requiresConfirmation).toBe(true);
+    expect(dispatchModuleActionMock).toHaveBeenCalledWith('ARCANOS:CORE', 'query', {});
+  });
+
   it('maps typed module dispatch misses to not found responses', async () => {
     allowCapabilityRun();
     dispatchModuleActionMock.mockRejectedValueOnce(new MockModuleNotFoundError('Module not found: ARCANOS:CORE'));
@@ -2207,6 +2317,27 @@ describe('/gpt-access gateway', () => {
     expect(response.body.paths['/gpt-access/mcp'].post.requestBody.content['application/json'].schema).toEqual({
       '$ref': '#/components/schemas/McpControlRequest'
     });
+    expect(response.body.paths['/gpt-access/dispatch/run'].post.operationId).toBe('runDispatch');
+    expect(response.body.paths['/gpt-access/dispatch/run'].post.description).toContain('DispatchPlan');
+    expect(response.body.paths['/gpt-access/dispatch/run'].post.description).toContain('without restoring /ask');
+    expect(response.body.paths['/gpt-access/dispatch/run'].post.requestBody.content['application/json'].schema).toEqual({
+      '$ref': '#/components/schemas/DispatchRunRequest'
+    });
+    expect(response.body.components.schemas.DispatchRunRequest).toEqual(expect.objectContaining({
+      required: ['utterance'],
+      additionalProperties: false
+    }));
+    expect(response.body.components.schemas.DispatchRunResponse.properties.plan).toEqual({
+      '$ref': '#/components/schemas/DispatchPlan'
+    });
+    expect(response.body.components.schemas.DispatchPlan.required).toEqual([
+      'action',
+      'payload',
+      'confidence',
+      'source',
+      'requiresConfirmation'
+    ]);
+    expect(response.body.paths['/ask']).toBeUndefined();
   });
 
   it('does not derive the public OpenAPI server URL from spoofable request hosts', async () => {

--- a/tests/gpt-access-gateway.test.ts
+++ b/tests/gpt-access-gateway.test.ts
@@ -994,7 +994,7 @@ describe('/gpt-access gateway', () => {
     const response = await authorized(request(app).post('/gpt-access/dispatch/run'))
       .send({
         utterance: 'ARCANOS:CORE.query',
-        confirmation_token: challengeId
+        confirmation_token: `token: ${challengeId}`
       });
 
     expect(response.status).toBe(200);

--- a/tests/gpt-access-gateway.test.ts
+++ b/tests/gpt-access-gateway.test.ts
@@ -942,6 +942,9 @@ describe('/gpt-access gateway', () => {
 
     expect(response.status).toBe(422);
     expect(response.body.error.code).toBe('INTENT_CLARIFICATION_REQUIRED');
+    expect(response.body.error.message).toBe(
+      'Dispatch intent could not be resolved confidently. Please clarify the requested action.'
+    );
     expect(response.body.plan.action).toBe('INTENT_CLARIFICATION_REQUIRED');
     expect(dispatchModuleActionMock).not.toHaveBeenCalled();
   });
@@ -958,8 +961,9 @@ describe('/gpt-access gateway', () => {
     expect(response.status).toBe(403);
     expect(response.body.error).toEqual({
       code: 'GPT_ACCESS_CAPABILITY_ACTION_DENIED',
-      message: 'module_action_not_allowlisted'
+      message: 'GPT Access capability action is not allowlisted.'
     });
+    expect(response.body.policy.reason).toBe('module_action_not_allowlisted');
     expect(dispatchModuleActionMock).not.toHaveBeenCalled();
   });
 
@@ -999,7 +1003,12 @@ describe('/gpt-access gateway', () => {
 
     expect(response.status).toBe(200);
     expect(response.body.plan.action).toBe('ARCANOS:CORE.query');
-    expect(response.body.policy.requiresConfirmation).toBe(true);
+    expect(response.body.policy).toEqual(expect.objectContaining({
+      status: 'allowed',
+      requiresConfirmation: false,
+      shouldExecute: true,
+      reason: 'confirmation_satisfied'
+    }));
     expect(dispatchModuleActionMock).toHaveBeenCalledWith('ARCANOS:CORE', 'query', {});
   });
 
@@ -2327,6 +2336,13 @@ describe('/gpt-access gateway', () => {
       required: ['utterance'],
       additionalProperties: false
     }));
+    const confirmationTokenExamplePrefix = ['tok', 'en:'].join('');
+    expect(response.body.components.schemas.DispatchRunRequest.properties.utterance.maxLength).toBe(1000);
+    expect(response.body.components.schemas.DispatchRunRequest.properties.confirmation_token.description).toContain(`${confirmationTokenExamplePrefix}<confirmationChallenge.id>`);
+    expect(response.body.components.schemas.DispatchRunRequest.properties.confirmation_token.examples).toEqual([
+      'example-confirmation-challenge-id',
+      `${confirmationTokenExamplePrefix}example-confirmation-challenge-id`
+    ]);
     expect(response.body.components.schemas.DispatchRunResponse.properties.plan).toEqual({
       '$ref': '#/components/schemas/DispatchPlan'
     });


### PR DESCRIPTION
## Summary
- Add a reusable natural-language dispatcher module under `src/dispatcher/naturalLanguage` that resolves utterances into `DispatchPlan` objects.
- Add `POST /gpt-access/dispatch/run` with dry-run support, policy checks, confirmation retry support, and execution through existing GPT Access control/capability runners.
- Extend GPT Access OpenAPI and tests for resolver mappings, dry runs, low-confidence clarification, policy denial, confirmation, and no `/ask` restoration.

## Validation
- `node scripts/run-jest.mjs --testPathPatterns=tests/dispatcher-natural-language.test.ts --coverage=false`
- `node scripts/run-jest.mjs --testPathPatterns=tests/gpt-access-gateway.test.ts --coverage=false`
- `npm run build`
- `npm run lint` (passes with existing warnings)
- `npm test`
- `npm run validate:railway`

## Railway Readiness
- `railway --version`: 4.30.2
- `railway status --json`: linked to `Arcanos`
- `railway variables --json`: failed with `No service linked`

No Railway mutation or deploy commands were run.