### PR TITLE
[codex] Add CLI daemon UX context summary

### DIFF
--- a/daemon-python/arcanos/agentic/agent_loop.py
+++ b/daemon-python/arcanos/agentic/agent_loop.py
@@ -8,6 +8,7 @@ from rich.markdown import Markdown
 
 from ..config import Config
 from ..assistant.translator import translate_response
+from ..cli.cli_policy import redact_output
 from .history_db import HistoryDB
 from .patch_orchestrator import PatchOrchestrator
 from .policy_guard import PolicyGuard
@@ -96,30 +97,32 @@ def run_agentic_loop(cli: Any, user_message: str, *, domain: Optional[str], from
             results.append(ToolResult("patch", res.ok, {"rollback_id": res.rollback_id, "files": res.files, "error": res.error}))
 
         for c in commands:
+            display_command = redact_output(c.command)
             cli.console.print("\n[bold]=== ARCANOS COMMAND PROPOSAL ===[/bold]")
-            cli.console.print(f"Command:\n{c.command}\nReason: {c.reason}")
+            cli.console.print(f"Command:\n{display_command}\nReason: {c.reason}")
+            cli.console.print("[dim]Safety: policy checked, explicit confirmation required, output redacted in history.[/dim]")
             if _contains_high_risk_shell_tokens(c.command):
                 # //audit assumption: agentic commands should be single-step and non-chained; risk: prompt-injected multi-command execution; invariant: high-risk shell token commands are blocked; strategy: deny and require manual rewrite.
                 reason = "High-risk shell chaining token detected in command proposal"
                 cli.console.print(f"[red]Blocked:[/red] {reason}")
-                results.append(ToolResult("command", False, {"command": c.command, "blocked": reason}))
+                results.append(ToolResult("command", False, {"command": display_command, "blocked": reason}))
                 continue
             is_safe, reason = cli.terminal.is_command_safe(c.command)
             if not is_safe:
                 cli.console.print(f"[red]Blocked:[/red] {reason}")
-                results.append(ToolResult("command", False, {"command": c.command, "blocked": reason}))
+                results.append(ToolResult("command", False, {"command": display_command, "blocked": reason}))
                 continue
 
             # //audit assumption: command execution proposals require explicit human confirmation; failure risk: piped/non-interactive sessions auto-run commands; expected invariant: commands are denied when TTY confirmation is unavailable; handling strategy: fail closed with structured denial.
             if not sys.stdin or not sys.stdin.isatty():
                 denial_reason = "non_interactive_confirmation_unavailable"
                 cli.console.print("[yellow]Non-interactive session: command proposal auto-denied.[/yellow]")
-                results.append(ToolResult("command", False, {"command": c.command, "denied": True, "reason": denial_reason}))
+                results.append(ToolResult("command", False, {"command": display_command, "denied": True, "reason": denial_reason}))
                 continue
 
             ans = input("\nRun command? [y/N] ").strip().lower()
             if ans not in ("y", "yes"):
-                results.append(ToolResult("command", False, {"command": c.command, "denied": True}))
+                results.append(ToolResult("command", False, {"command": display_command, "denied": True}))
                 continue
 
             out, err, rc = cli.terminal.execute(
@@ -134,7 +137,18 @@ def run_agentic_loop(cli: Any, user_message: str, *, domain: Optional[str], from
             else:
                 guard.record_failure(cli.instance_id, "command", {"command": c.command, "return_code": rc})
             cli.console.print(f"[green]Command finished[/green] rc={rc}")
-            results.append(ToolResult("command", rc == 0, {"command": c.command, "return_code": rc, "stdout": out, "stderr": err}))
+            results.append(
+                ToolResult(
+                    "command",
+                    rc == 0,
+                    {
+                        "command": display_command,
+                        "return_code": rc,
+                        "stdout": redact_output(out or ""),
+                        "stderr": redact_output(err or ""),
+                    },
+                )
+            )
 
         prompt = _format_followup(results)
         # snapshot state for audit/replay

--- a/daemon-python/arcanos/agentic/patch_orchestrator.py
+++ b/daemon-python/arcanos/agentic/patch_orchestrator.py
@@ -105,7 +105,11 @@ class PatchOrchestrator:
             return ApplyResult(ok=False, rollback_id=rollback_id, files=files, backups={}, error=decision.reason)
 
         self.console.print("\n[bold]=== ARCANOS PATCH PROPOSAL ===[/bold]")
-        self.console.print(f"[dim]patch_sha256={patch_decision.patch_hash} files={len(files)}[/dim]")
+        self.console.print(
+            f"[dim]patch_sha256={patch_decision.patch_hash} files={len(files)} "
+            f"added={patch_decision.added_lines} removed={patch_decision.removed_lines}[/dim]"
+        )
+        self.console.print("[dim]Safety: redacted preview, exact hash confirmation, rollback backup before apply.[/dim]")
         self.console.print(Syntax(patch_decision.redacted_preview, "diff", line_numbers=False))
 
         # //audit assumption: patch application requires explicit operator confirmation; failure risk: non-interactive sessions apply changes without review; expected invariant: patches are denied when confirmation input is unavailable; handling strategy: fail closed before prompts.

--- a/daemon-python/arcanos/cli/cli.py
+++ b/daemon-python/arcanos/cli/cli.py
@@ -239,6 +239,9 @@ class ArcanosCLI:
     def _render_system_state_table(self, state_payload: Mapping[str, Any]) -> None:
         return ui_ops.render_system_state_table(self, state_payload)
 
+    def _render_execution_context_summary(self) -> None:
+        return ui_ops.render_execution_context_summary(self)
+
     def _is_working_context_query(self, message: str) -> bool:
         return state.is_working_context_query(message)
 
@@ -262,6 +265,14 @@ class ArcanosCLI:
         state.hydrate_session_from_backend_state(self, state_payload)
         ui_ops.render_system_state_table(self, state_payload)
         return True
+
+    def handle_context(self) -> None:
+        """
+        Purpose: Show local daemon execution context and safety boundaries.
+        Inputs/Outputs: None; renders user-facing summary.
+        Edge cases: Does not require backend connectivity.
+        """
+        return ui_ops.handle_context(self)
 
     def _registry_cache_is_valid(self) -> bool:
         return state.registry_cache_is_valid(self)
@@ -830,7 +841,7 @@ def main() -> None:
     parser.add_argument(
         "command",
         nargs="?",
-        help="Run a one-shot command such as `status`, `bridge`, or a protocol command and exit.",
+        help="Run a one-shot command such as `status`, `context`, `bridge`, or a protocol command and exit.",
     )
     parser.add_argument(
         "protocol_target",
@@ -923,6 +934,13 @@ def main() -> None:
     if args.command == "status":
         succeeded = cli.handle_status()
         sys.exit(0 if succeeded else 1)
+    if args.command == "context":
+        if args.json:
+            sys.stdout.write(json.dumps(ui_ops.build_execution_context_summary(cli), sort_keys=True))
+            sys.stdout.write("\n")
+        else:
+            cli.handle_context()
+        sys.exit(0)
 
     cli.run(debug_mode=args.debug_mode)
 

--- a/daemon-python/arcanos/cli/cli.py
+++ b/daemon-python/arcanos/cli/cli.py
@@ -11,6 +11,7 @@ import sys
 import threading
 import time
 import uuid
+from types import SimpleNamespace
 from typing import Any, Callable, Mapping, Optional
 
 if sys.platform == "win32":
@@ -919,6 +920,11 @@ def main() -> None:
     if args.command == "bridge":
         run_local_bridge(host=args.bridge_host, port=args.bridge_port)
         return
+    if args.command == "context" and args.json:
+        summary = ui_ops.build_execution_context_summary(SimpleNamespace(_daemon_running=False))
+        sys.stdout.write(json.dumps(summary, sort_keys=True))
+        sys.stdout.write("\n")
+        return
 
     try:
         bootstrap_credentials()
@@ -935,11 +941,7 @@ def main() -> None:
         succeeded = cli.handle_status()
         sys.exit(0 if succeeded else 1)
     if args.command == "context":
-        if args.json:
-            sys.stdout.write(json.dumps(ui_ops.build_execution_context_summary(cli), sort_keys=True))
-            sys.stdout.write("\n")
-        else:
-            cli.handle_context()
+        cli.handle_context()
         sys.exit(0)
 
     cli.run(debug_mode=args.debug_mode)

--- a/daemon-python/arcanos/cli/cli_policy.py
+++ b/daemon-python/arcanos/cli/cli_policy.py
@@ -13,6 +13,8 @@ from arcanos.debug import log_audit_event
 
 BIDI_CONTROL_PATTERN = re.compile(r"[\u202A-\u202E\u2066-\u2069]")
 DEFAULT_POLICY_PATH = Path(__file__).resolve().parents[3] / "config" / "cli-policy.json"
+_POLICY_CACHE: dict[str, Any] | None = None
+_POLICY_CACHE_KEY: tuple[str, int, int] | None = None
 
 
 @dataclass(frozen=True)
@@ -36,7 +38,13 @@ class PatchDecision:
 
 
 def load_cli_policy() -> dict[str, Any]:
+    global _POLICY_CACHE, _POLICY_CACHE_KEY
     policy_path = Path(os.environ.get("ARCANOS_CLI_POLICY_PATH") or DEFAULT_POLICY_PATH)
+    policy_stat = policy_path.stat()
+    cache_key = (str(policy_path.resolve()), policy_stat.st_mtime_ns, policy_stat.st_size)
+    if _POLICY_CACHE is not None and _POLICY_CACHE_KEY == cache_key:
+        return _POLICY_CACHE
+
     raw = policy_path.read_text(encoding="utf-8")
     policy = json.loads(raw)
     log_audit_event(
@@ -47,6 +55,8 @@ def load_cli_policy() -> dict[str, Any]:
         allow_prefix_count=len(policy.get("commandPolicy", {}).get("allowPrefixes") or []),
         deny_pattern_count=len(policy.get("commandPolicy", {}).get("denyPatterns") or []),
     )
+    _POLICY_CACHE = policy
+    _POLICY_CACHE_KEY = cache_key
     return policy
 
 

--- a/daemon-python/arcanos/cli/ui_ops.py
+++ b/daemon-python/arcanos/cli/ui_ops.py
@@ -110,18 +110,22 @@ def build_execution_context_summary(cli: "ArcanosCLI") -> dict[str, Any]:
             if str(prefix).strip()
         ]
     except Exception as exc:
-        error_logger.warning("Execution context policy resolution failed: %s", exc)
+        error_logger.warning("Execution context policy resolution failed: %s", type(exc).__name__)
         sandbox_root = "unknown"
         allow_prefixes = []
 
     backend_configured = bool(Config.BACKEND_URL)
     daemon_connected = bool(getattr(cli, "_daemon_running", False))
     railway_runtime = _is_railway_runtime()
-    local_bridge_enabled = bool(os.environ.get("ARCANOS_CLI_BRIDGE_TOKEN"))
+    bridge_token_configured = bool((os.environ.get("ARCANOS_CLI_BRIDGE_TOKEN") or "").strip())
+    local_bridge_enabled = os.environ.get("ARCANOS_CLI_BRIDGE_ENABLED", "").strip().lower() == "true"
+    local_desktop_daemon_ready = bool(
+        local_bridge_enabled and bridge_token_configured and daemon_connected and not railway_runtime
+    )
 
     if railway_runtime:
         mode = "Production Runtime"
-    elif local_bridge_enabled:
+    elif local_desktop_daemon_ready:
         mode = "Local Desktop Daemon"
     elif not backend_configured:
         mode = "Disabled"
@@ -134,8 +138,10 @@ def build_execution_context_summary(cli: "ArcanosCLI") -> dict[str, Any]:
         daemon_state = "Connected"
     elif backend_configured:
         daemon_state = "Configured, not connected"
+    elif local_bridge_enabled and not bridge_token_configured:
+        daemon_state = "Local desktop bridge enabled, token missing"
     elif local_bridge_enabled:
-        daemon_state = "Local bridge token configured"
+        daemon_state = "Local desktop daemon configured, not connected"
     else:
         daemon_state = "Not configured"
 
@@ -143,13 +149,28 @@ def build_execution_context_summary(cli: "ArcanosCLI") -> dict[str, Any]:
     if not allow_prefixes:
         execution_mode = "Read-only"
 
-    can_access = ["deployed runtime" if railway_runtime or backend_configured else "local CLI runtime"]
+    if railway_runtime:
+        runtime_label = "deployed runtime"
+    elif local_desktop_daemon_ready:
+        runtime_label = "local desktop daemon"
+    elif daemon_connected:
+        runtime_label = "local CLI runtime"
+    else:
+        runtime_label = None
+
+    can_access = [runtime_label] if runtime_label else []
     if sandbox_root != "unknown":
         can_access.append(f"{sandbox_root} workspace")
     can_access.extend(_capability_labels(allow_prefixes))
 
     cannot_access = [
-        "your personal desktop" if railway_runtime else "paths outside the configured sandbox",
+        "your personal desktop"
+        if railway_runtime
+        else (
+            "paths outside the configured sandbox"
+            if local_desktop_daemon_ready
+            else "your personal desktop through the local desktop daemon"
+        ),
         "unrestricted shell",
         "raw secrets or environment variables",
         "patches touching secret files",
@@ -169,8 +190,8 @@ def build_execution_context_summary(cli: "ArcanosCLI") -> dict[str, Any]:
             if railway_runtime
             else None
         ),
-        "canAccessPersonalDesktop": bool(local_bridge_enabled and not railway_runtime),
-        "localDesktopDaemonReady": local_bridge_enabled,
+        "canAccessPersonalDesktop": local_desktop_daemon_ready,
+        "localDesktopDaemonReady": local_desktop_daemon_ready,
     }
 
 

--- a/daemon-python/arcanos/cli/ui_ops.py
+++ b/daemon-python/arcanos/cli/ui_ops.py
@@ -4,6 +4,7 @@ User-interface rendering and speech operations for the CLI.
 
 from __future__ import annotations
 
+import os
 from typing import Any, Mapping, Optional, TYPE_CHECKING
 
 from rich.markdown import Markdown
@@ -11,9 +12,11 @@ from rich.table import Table
 
 from ..cli_ui import build_help_panel, build_stats_table
 from ..config import Config
+from ..error_handler import logger as error_logger
 from ..voice_boundary import Persona, apply_voice_boundary
 from ..cli_intents import truncate_for_tts
 from .context import _UNSET_FILTER
+from .cli_policy import load_cli_policy, resolve_workspace_root
 
 if TYPE_CHECKING:
     from .cli import ArcanosCLI
@@ -92,6 +95,144 @@ def render_system_state_table(cli: "ArcanosCLI", state_payload: Mapping[str, Any
     cli.console.print(table)
 
 
+def build_execution_context_summary(cli: "ArcanosCLI") -> dict[str, Any]:
+    """
+    Purpose: Build a user-facing daemon execution context without exposing secrets.
+    Inputs/Outputs: CLI instance; returns deterministic summary fields for rendering or JSON.
+    Edge cases: Policy loading failures degrade to unknown sandbox/capabilities.
+    """
+    try:
+        policy = load_cli_policy()
+        sandbox_root = resolve_workspace_root(policy)
+        allow_prefixes = [
+            str(prefix)
+            for prefix in policy.get("commandPolicy", {}).get("allowPrefixes") or []
+            if str(prefix).strip()
+        ]
+    except Exception as exc:
+        error_logger.warning("Execution context policy resolution failed: %s", exc)
+        sandbox_root = "unknown"
+        allow_prefixes = []
+
+    backend_configured = bool(Config.BACKEND_URL)
+    daemon_connected = bool(getattr(cli, "_daemon_running", False))
+    railway_runtime = _is_railway_runtime()
+    local_bridge_enabled = bool(os.environ.get("ARCANOS_CLI_BRIDGE_TOKEN"))
+
+    if railway_runtime:
+        mode = "Production Runtime"
+    elif local_bridge_enabled:
+        mode = "Local Desktop Daemon"
+    elif not backend_configured:
+        mode = "Disabled"
+    elif daemon_connected:
+        mode = "Local CLI Runtime"
+    else:
+        mode = "Unavailable"
+
+    if daemon_connected:
+        daemon_state = "Connected"
+    elif backend_configured:
+        daemon_state = "Configured, not connected"
+    elif local_bridge_enabled:
+        daemon_state = "Local bridge token configured"
+    else:
+        daemon_state = "Not configured"
+
+    execution_mode = "Confirmation required" if Config.CONFIRM_SENSITIVE_ACTIONS else "Policy gated"
+    if not allow_prefixes:
+        execution_mode = "Read-only"
+
+    can_access = ["deployed runtime" if railway_runtime or backend_configured else "local CLI runtime"]
+    if sandbox_root != "unknown":
+        can_access.append(f"{sandbox_root} workspace")
+    can_access.extend(_capability_labels(allow_prefixes))
+
+    cannot_access = [
+        "your personal desktop" if railway_runtime else "paths outside the configured sandbox",
+        "unrestricted shell",
+        "raw secrets or environment variables",
+        "patches touching secret files",
+    ]
+    if not Config.RUN_ELEVATED:
+        cannot_access.append("elevated shell")
+
+    return {
+        "mode": mode,
+        "daemon": daemon_state,
+        "sandbox": sandbox_root,
+        "execution": execution_mode,
+        "canAccess": can_access,
+        "cannotAccess": cannot_access,
+        "environmentWarning": (
+            "Railway production runtime: this can operate only inside the deployed container sandbox."
+            if railway_runtime
+            else None
+        ),
+        "canAccessPersonalDesktop": bool(local_bridge_enabled and not railway_runtime),
+        "localDesktopDaemonReady": local_bridge_enabled,
+    }
+
+
+def render_execution_context_summary(cli: "ArcanosCLI", summary: Mapping[str, Any] | None = None) -> None:
+    """
+    Purpose: Render execution context in a compact, human-readable form.
+    Inputs/Outputs: CLI instance and optional summary; prints text to console.
+    Edge cases: Missing fields render as unknown/empty without secret-bearing fallbacks.
+    """
+    context = dict(summary or build_execution_context_summary(cli))
+    lines = [
+        "Execution Context",
+        "-----------------",
+        f"Mode: {context.get('mode', 'Unknown')}",
+        f"Daemon: {context.get('daemon', 'Unknown')}",
+        f"Sandbox: {context.get('sandbox', 'unknown')}",
+        f"Execution: {context.get('execution', 'Unknown')}",
+    ]
+    warning = context.get("environmentWarning")
+    if isinstance(warning, str) and warning:
+        lines.append(f"Warning: {warning}")
+
+    desktop_access = "Yes" if context.get("canAccessPersonalDesktop") else "No"
+    lines.append(f"Can access your personal desktop: {desktop_access}")
+    lines.append("Can access:")
+    for item in context.get("canAccess") or []:
+        lines.append(f"+ {item}")
+    lines.append("Cannot access:")
+    for item in context.get("cannotAccess") or []:
+        lines.append(f"- {item}")
+
+    cli.console.print("\n".join(lines))
+
+
+def _is_railway_runtime() -> bool:
+    railway_markers = (
+        "RAILWAY_ENVIRONMENT",
+        "RAILWAY_ENVIRONMENT_ID",
+        "RAILWAY_PROJECT_ID",
+        "RAILWAY_SERVICE_ID",
+        "RAILWAY_DEPLOYMENT_ID",
+    )
+    return any(bool(os.environ.get(marker)) for marker in railway_markers)
+
+
+def _capability_labels(allow_prefixes: list[str]) -> list[str]:
+    labels: list[str] = []
+    normalized = {prefix.lower() for prefix in allow_prefixes}
+    git_inspection_commands = ("git status", "git diff", "git log", "git show")
+    if any(
+        any(prefix.startswith(command) or command.startswith(prefix) for command in git_inspection_commands)
+        for prefix in normalized
+    ):
+        labels.append("read-only git inspection")
+    if any(prefix.startswith("npm run") or prefix.startswith("python ") for prefix in normalized):
+        labels.append("approved validation commands")
+    if allow_prefixes:
+        labels.append("allowlisted command proposals")
+    labels.append("redacted audit/history summaries")
+    return labels
+
+
 def handle_speak(cli: "ArcanosCLI") -> None:
     """
     Purpose: Replay last user-visible response through TTS.
@@ -130,6 +271,15 @@ def handle_stats(cli: "ArcanosCLI") -> None:
     cli.console.print(table)
 
 
+def handle_context(cli: "ArcanosCLI") -> None:
+    """
+    Purpose: Display the current daemon execution context and safety boundaries.
+    Inputs/Outputs: CLI instance; prints summary.
+    Edge cases: Summary builder degrades missing policy fields safely.
+    """
+    render_execution_context_summary(cli)
+
+
 def handle_help(cli: "ArcanosCLI") -> None:
     """
     Purpose: Display CLI help text panel.
@@ -163,11 +313,14 @@ def handle_reset(cli: "ArcanosCLI") -> None:
 
 
 __all__ = [
+    "build_execution_context_summary",
     "handle_clear",
+    "handle_context",
     "handle_help",
     "handle_reset",
     "handle_speak",
     "handle_stats",
+    "render_execution_context_summary",
     "render_system_state_table",
     "speak_to_user",
 ]

--- a/daemon-python/arcanos/cli_runner.py
+++ b/daemon-python/arcanos/cli_runner.py
@@ -186,6 +186,7 @@ def _build_command_handlers(cli: "ArcanosCLI", args: str) -> dict[str, Callable[
         "safemode": lambda: cli.handle_safemode(args),
         "feedback": lambda: cli.handle_feedback(args),
         "speak": cli.handle_speak,
+        "context": cli.handle_context,
         "status": cli.handle_status,
         "stats": cli.handle_stats,
         "clear": cli.handle_clear,

--- a/daemon-python/arcanos/cli_ui.py
+++ b/daemon-python/arcanos/cli_ui.py
@@ -96,6 +96,7 @@ Just type naturally — ask me anything, and I'll do my best to help.
   Example: `/run Get-Process` or `/run ls -la`
 
 ### Housekeeping
+- **/context** — Show where daemon actions run and what they can access
 - **/status** — Show backend-governed system state
 - **/stats** — See usage stats
 - **/clear** — Clear conversation history

--- a/daemon-python/arcanos/debug/logging.py
+++ b/daemon-python/arcanos/debug/logging.py
@@ -71,6 +71,7 @@ def get_debug_logger() -> logging.Logger:
         log_path = log_dir / "debug_server.log"
 
         logger = logging.getLogger("arcanos.debug_server")
+        logger.propagate = False
 
         # Avoid configuring multiple times if something else already did.
         if not logger.handlers:

--- a/daemon-python/tests/test_cli_execution_context_ux.py
+++ b/daemon-python/tests/test_cli_execution_context_ux.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from arcanos.cli import ui_ops
+from arcanos.config import Config
+
+
+def test_execution_context_summary_warns_for_railway_runtime(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("RAILWAY_ENVIRONMENT_ID", "env-test")
+    monkeypatch.setenv("ARCANOS_CLI_SANDBOX_ROOT", str(tmp_path))
+    monkeypatch.setattr(Config, "BACKEND_URL", "https://example.invalid")
+    monkeypatch.setattr(Config, "CONFIRM_SENSITIVE_ACTIONS", True)
+    monkeypatch.setattr(Config, "RUN_ELEVATED", False)
+    cli = SimpleNamespace(_daemon_running=True)
+
+    summary = ui_ops.build_execution_context_summary(cli)
+
+    assert summary["mode"] == "Production Runtime"
+    assert summary["daemon"] == "Connected"
+    assert summary["sandbox"] == str(tmp_path.resolve())
+    assert summary["execution"] == "Confirmation required"
+    assert summary["canAccessPersonalDesktop"] is False
+    assert "your personal desktop" in summary["cannotAccess"]
+    assert "Railway production runtime" in summary["environmentWarning"]
+
+
+def test_execution_context_rendering_is_human_readable(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("RAILWAY_ENVIRONMENT_ID", raising=False)
+    monkeypatch.setenv("ARCANOS_CLI_BRIDGE_TOKEN", "test-token")
+    monkeypatch.setenv("ARCANOS_CLI_SANDBOX_ROOT", str(tmp_path))
+    monkeypatch.setattr(Config, "BACKEND_URL", None)
+    monkeypatch.setattr(Config, "CONFIRM_SENSITIVE_ACTIONS", True)
+    cli = SimpleNamespace(_daemon_running=False)
+
+    summary = ui_ops.build_execution_context_summary(cli)
+
+    assert summary["mode"] == "Local Desktop Daemon"
+    assert summary["canAccessPersonalDesktop"] is True
+    assert "raw secrets or environment variables" in summary["cannotAccess"]
+
+
+def test_execution_context_detects_broad_git_allow_prefix() -> None:
+    labels = ui_ops._capability_labels(["git"])
+
+    assert "read-only git inspection" in labels
+
+
+def test_execution_context_logs_policy_resolution_failure(monkeypatch, caplog) -> None:
+    def _raise_policy_error() -> dict:
+        raise RuntimeError("broken policy")
+
+    monkeypatch.setattr(ui_ops, "load_cli_policy", _raise_policy_error)
+    monkeypatch.setattr(Config, "BACKEND_URL", None)
+    cli = SimpleNamespace(_daemon_running=False)
+
+    with caplog.at_level(logging.WARNING, logger="arcanos"):
+        summary = ui_ops.build_execution_context_summary(cli)
+
+    assert summary["sandbox"] == "unknown"
+    assert "Execution context policy resolution failed" in caplog.text

--- a/daemon-python/tests/test_cli_execution_context_ux.py
+++ b/daemon-python/tests/test_cli_execution_context_ux.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
 import logging
+import sys
 from types import SimpleNamespace
 
+from arcanos.cli import cli as cli_module
 from arcanos.cli import ui_ops
 from arcanos.config import Config
 
@@ -29,16 +32,48 @@ def test_execution_context_summary_warns_for_railway_runtime(monkeypatch, tmp_pa
 def test_execution_context_rendering_is_human_readable(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("RAILWAY_ENVIRONMENT_ID", raising=False)
     monkeypatch.setenv("ARCANOS_CLI_BRIDGE_TOKEN", "test-token")
+    monkeypatch.setenv("ARCANOS_CLI_BRIDGE_ENABLED", "true")
     monkeypatch.setenv("ARCANOS_CLI_SANDBOX_ROOT", str(tmp_path))
     monkeypatch.setattr(Config, "BACKEND_URL", None)
     monkeypatch.setattr(Config, "CONFIRM_SENSITIVE_ACTIONS", True)
-    cli = SimpleNamespace(_daemon_running=False)
+    cli = SimpleNamespace(_daemon_running=True)
 
     summary = ui_ops.build_execution_context_summary(cli)
 
     assert summary["mode"] == "Local Desktop Daemon"
     assert summary["canAccessPersonalDesktop"] is True
+    assert summary["localDesktopDaemonReady"] is True
     assert "raw secrets or environment variables" in summary["cannotAccess"]
+
+
+def test_execution_context_does_not_infer_desktop_access_from_token_only(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("RAILWAY_ENVIRONMENT_ID", raising=False)
+    monkeypatch.setenv("ARCANOS_CLI_BRIDGE_TOKEN", "test-token")
+    monkeypatch.delenv("ARCANOS_CLI_BRIDGE_ENABLED", raising=False)
+    monkeypatch.setenv("ARCANOS_CLI_SANDBOX_ROOT", str(tmp_path))
+    monkeypatch.setattr(Config, "BACKEND_URL", None)
+    cli = SimpleNamespace(_daemon_running=False)
+
+    summary = ui_ops.build_execution_context_summary(cli)
+
+    assert summary["mode"] == "Disabled"
+    assert summary["canAccessPersonalDesktop"] is False
+    assert summary["localDesktopDaemonReady"] is False
+
+
+def test_execution_context_uses_local_runtime_label_for_local_daemon(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("RAILWAY_ENVIRONMENT_ID", raising=False)
+    monkeypatch.delenv("ARCANOS_CLI_BRIDGE_ENABLED", raising=False)
+    monkeypatch.delenv("ARCANOS_CLI_BRIDGE_TOKEN", raising=False)
+    monkeypatch.setenv("ARCANOS_CLI_SANDBOX_ROOT", str(tmp_path))
+    monkeypatch.setattr(Config, "BACKEND_URL", "http://127.0.0.1:3000")
+    cli = SimpleNamespace(_daemon_running=True)
+
+    summary = ui_ops.build_execution_context_summary(cli)
+
+    assert summary["mode"] == "Local CLI Runtime"
+    assert "local CLI runtime" in summary["canAccess"]
+    assert "deployed runtime" not in summary["canAccess"]
 
 
 def test_execution_context_detects_broad_git_allow_prefix() -> None:
@@ -60,3 +95,22 @@ def test_execution_context_logs_policy_resolution_failure(monkeypatch, caplog) -
 
     assert summary["sandbox"] == "unknown"
     assert "Execution context policy resolution failed" in caplog.text
+
+
+def test_context_json_does_not_start_full_cli(monkeypatch, capsys) -> None:
+    def _raise_if_started() -> None:
+        raise AssertionError("context --json must not start the full CLI runtime")
+
+    monkeypatch.setattr(sys, "argv", ["arcanos", "context", "--json"])
+    monkeypatch.setattr(cli_module, "ArcanosCLI", _raise_if_started)
+    monkeypatch.setattr(Config, "BACKEND_URL", None)
+    monkeypatch.setattr(Config, "CONFIRM_SENSITIVE_ACTIONS", True)
+    monkeypatch.delenv("RAILWAY_ENVIRONMENT_ID", raising=False)
+    monkeypatch.delenv("ARCANOS_CLI_BRIDGE_TOKEN", raising=False)
+
+    cli_module.main()
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert captured.err == ""
+    assert payload["mode"] == "Disabled"

--- a/daemon-python/tests/test_cli_method_contracts.py
+++ b/daemon-python/tests/test_cli_method_contracts.py
@@ -14,6 +14,7 @@ def test_arcanos_cli_exposes_expected_command_methods() -> None:
         "handle_dryrun",
         "handle_feedback",
         "handle_safemode",
+        "handle_context",
         "handle_speak",
         "handle_stats",
         "handle_help",

--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -273,9 +273,100 @@ describe("Arcanos CLI", () => {
     expect(stderr.read()).toBe("");
     expect(output).toContain("Execution Context");
     expect(output).toContain("Daemon: Connected");
-    expect(output).toContain("Execution: Confirmation required for CLI daemon actions");
+    expect(output.split(/\r?\n/).find((line) => line.startsWith("Execution: "))).toBeTruthy();
+    expect(output).not.toContain("Execution: Confirmation required for CLI daemon actions");
     expect(output).toContain("Can access your personal desktop: No");
     expect(output).toContain("Cannot access:");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not infer desktop access from a bridge token alone", async () => {
+    const previousToken = process.env.ARCANOS_CLI_BRIDGE_TOKEN;
+    const previousEnabled = process.env.ARCANOS_CLI_BRIDGE_ENABLED;
+    process.env.ARCANOS_CLI_BRIDGE_TOKEN = "test-token";
+    delete process.env.ARCANOS_CLI_BRIDGE_ENABLED;
+    const fetchMock = jest.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      const pathname = url instanceof URL ? url.pathname : String(url);
+      if (pathname.endsWith("/status")) {
+        return createJsonResponse({ ok: true });
+      }
+      if (pathname.endsWith("/health")) {
+        return createJsonResponse({ status: "healthy" });
+      }
+      throw new Error(`Unexpected URL: ${pathname}`);
+    });
+    const stdout = createWritableCapture();
+    const stderr = createWritableCapture();
+
+    try {
+      const exitCode = await runCli(
+        ["status", "--transport", "local", "--cwd", path.resolve("tmp", "arcanos-status-test")],
+        stdout.stream,
+        stderr.stream
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stderr.read()).toBe("");
+      const output = stdout.read();
+      expect(output).toContain("Mode: Local CLI Runtime");
+      expect(output).toContain("Can access your personal desktop: No");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.ARCANOS_CLI_BRIDGE_TOKEN;
+      } else {
+        process.env.ARCANOS_CLI_BRIDGE_TOKEN = previousToken;
+      }
+      if (previousEnabled === undefined) {
+        delete process.env.ARCANOS_CLI_BRIDGE_ENABLED;
+      } else {
+        process.env.ARCANOS_CLI_BRIDGE_ENABLED = previousEnabled;
+      }
+    }
+  });
+
+  it("prints runtime-provided execution context details for status when available", async () => {
+    const fetchMock = jest.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      const pathname = url instanceof URL ? url.pathname : String(url);
+      if (pathname.endsWith("/status")) {
+        return createJsonResponse({
+          ok: true,
+          executionContext: {
+            mode: "Production Runtime",
+            daemon: "Connected",
+            sandbox: "/app",
+            execution: "Confirmation required",
+            canAccess: ["deployed runtime", "/app workspace"],
+            cannotAccess: ["your personal desktop", "unrestricted shell"],
+            environmentWarning: "Railway production runtime: this can operate only inside the deployed container sandbox.",
+            canAccessPersonalDesktop: false,
+            localDesktopDaemonReady: false
+          }
+        });
+      }
+      if (pathname.endsWith("/health")) {
+        return createJsonResponse({ status: "healthy" });
+      }
+      throw new Error(`Unexpected URL: ${pathname}`);
+    });
+    const stdout = createWritableCapture();
+    const stderr = createWritableCapture();
+
+    const exitCode = await runCli(
+      ["status", "--transport", "local", "--cwd", path.resolve("tmp", "arcanos-status-test")],
+      stdout.stream,
+      stderr.stream
+    );
+
+    const output = stdout.read();
+    expect(exitCode).toBe(0);
+    expect(stderr.read()).toBe("");
+    expect(output).toContain("Mode: Production Runtime");
+    expect(output).toContain("Sandbox: /app");
+    expect(output.split(/\r?\n/)).toContain("Execution: Confirmation required");
+    expect(output).toContain("Warning: Railway production runtime");
+    expect(output).toContain("+ deployed runtime");
+    expect(output).not.toContain("Execution: Confirmation required for CLI daemon actions");
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -248,6 +248,37 @@ describe("Arcanos CLI", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("prints execution context details for status", async () => {
+    const fetchMock = jest.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      const pathname = url instanceof URL ? url.pathname : String(url);
+      if (pathname.endsWith("/status")) {
+        return createJsonResponse({ ok: true });
+      }
+      if (pathname.endsWith("/health")) {
+        return createJsonResponse({ status: "healthy" });
+      }
+      throw new Error(`Unexpected URL: ${pathname}`);
+    });
+    const stdout = createWritableCapture();
+    const stderr = createWritableCapture();
+
+    const exitCode = await runCli(
+      ["status", "--transport", "local", "--cwd", path.resolve("tmp", "arcanos-status-test")],
+      stdout.stream,
+      stderr.stream
+    );
+
+    const output = stdout.read();
+    expect(exitCode).toBe(0);
+    expect(stderr.read()).toBe("");
+    expect(output).toContain("Execution Context");
+    expect(output).toContain("Daemon: Connected");
+    expect(output).toContain("Execution: Confirmation required for CLI daemon actions");
+    expect(output).toContain("Can access your personal desktop: No");
+    expect(output).toContain("Cannot access:");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("sends ask requests to the canonical backend GPT route", async () => {
     const fetchMock = jest.spyOn(globalThis, "fetch").mockResolvedValue(
       createJsonResponse({ result: "backend ok" })

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -29,13 +29,18 @@ export async function runStatusCommand(
     ? backendStatus.health.status
     : "unknown";
   const cwd = validatedResponse.data?.environment.cwd ?? invocation.options.cwd ?? "unknown";
-  const executionContext = buildExecutionContextSummary({
+  const fallbackExecutionContext = buildExecutionContextSummary({
     cwd,
     environmentType: validatedResponse.data?.environment.type ?? invocation.options.environment,
     environmentCapabilities: validatedResponse.data?.environment.capabilities ?? [],
     healthStatus,
-    supportedCommandCount: validatedCapabilitiesResponse.data?.supportedCommands.length ?? 0
+    supportedCommandCount: validatedCapabilitiesResponse.data?.supportedCommands.length ?? 0,
+    supportedCommands: validatedCapabilitiesResponse.data?.supportedCommands ?? []
   });
+  const executionContext = resolveExecutionContextSummary(
+    backendStatus.state.executionContext,
+    fallbackExecutionContext
+  );
 
   return {
     command: request.command,
@@ -57,6 +62,7 @@ interface ExecutionContextSummaryInput {
   environmentCapabilities: string[];
   healthStatus: string;
   supportedCommandCount: number;
+  supportedCommands?: string[];
 }
 
 interface ExecutionContextSummary {
@@ -68,24 +74,38 @@ interface ExecutionContextSummary {
   cannotAccess: string[];
   environmentWarning?: string;
   canAccessPersonalDesktop: boolean;
+  localDesktopDaemonReady: boolean;
   supportedCommandCount: number;
 }
 
 function buildExecutionContextSummary(input: ExecutionContextSummaryInput): ExecutionContextSummary {
   const isRailwayRuntime = hasRailwayRuntimeMarker();
   const isRemoteEnvironment = input.environmentType === "remote";
+  const isProductionRuntime = isRailwayRuntime || isRemoteEnvironment;
+  const bridgeEnabled = process.env.ARCANOS_CLI_BRIDGE_ENABLED?.trim().toLowerCase() === "true";
   const bridgeTokenConfigured = Boolean(process.env.ARCANOS_CLI_BRIDGE_TOKEN?.trim());
   const healthConnected = ["ok", "healthy", "ready", "live"].includes(input.healthStatus.toLowerCase());
-  const mode = isRailwayRuntime || isRemoteEnvironment
+  const localDesktopDaemonReady = bridgeEnabled
+    && bridgeTokenConfigured
+    && healthConnected
+    && !isProductionRuntime;
+  const mode = isProductionRuntime
     ? "Production Runtime"
-    : bridgeTokenConfigured
+    : localDesktopDaemonReady
     ? "Local Desktop Daemon"
     : healthConnected
     ? "Local CLI Runtime"
     : "Unavailable";
 
+  const runtimeLabel = isProductionRuntime
+    ? "deployed runtime"
+    : localDesktopDaemonReady
+    ? "local desktop daemon"
+    : healthConnected
+    ? "local CLI runtime"
+    : undefined;
   const canAccess = [
-    isRailwayRuntime || isRemoteEnvironment ? "deployed runtime" : "local CLI runtime",
+    ...(runtimeLabel ? [runtimeLabel] : []),
     `${input.cwd} workspace`,
     ...formatCapabilityLabels(input.environmentCapabilities)
   ];
@@ -94,20 +114,80 @@ function buildExecutionContextSummary(input: ExecutionContextSummaryInput): Exec
     mode,
     daemon: healthConnected ? "Connected" : `Health ${input.healthStatus}`,
     sandbox: input.cwd,
-    execution: "Confirmation required for CLI daemon actions",
+    execution: formatExecutionMode(input.supportedCommands, input.supportedCommandCount),
     canAccess,
     cannotAccess: [
-      isRailwayRuntime || isRemoteEnvironment ? "your personal desktop" : "paths outside the configured sandbox",
+      isProductionRuntime
+        ? "your personal desktop"
+        : localDesktopDaemonReady
+        ? "paths outside the configured sandbox"
+        : "your personal desktop through the local desktop daemon",
       "unrestricted shell",
       "raw secrets or environment variables",
       "patches touching secret files"
     ],
-    environmentWarning: isRailwayRuntime || isRemoteEnvironment
+    environmentWarning: isProductionRuntime
       ? "Production runtime: actions are limited to the deployed container sandbox."
       : undefined,
-    canAccessPersonalDesktop: bridgeTokenConfigured && !isRailwayRuntime && !isRemoteEnvironment,
+    canAccessPersonalDesktop: localDesktopDaemonReady,
+    localDesktopDaemonReady,
     supportedCommandCount: input.supportedCommandCount
   };
+}
+
+function formatExecutionMode(supportedCommands: string[] | undefined, supportedCommandCount: number): string {
+  const normalized = new Set((supportedCommands ?? []).map((command) => command.toLowerCase()));
+  if (normalized.has("tool.invoke") || normalized.has("exec.start")) {
+    return "Confirmation required";
+  }
+  if (supportedCommandCount > 0) {
+    return "Read-only protocol inspection";
+  }
+  return "Protocol commands unavailable";
+}
+
+function resolveExecutionContextSummary(raw: unknown, fallback: ExecutionContextSummary): ExecutionContextSummary {
+  if (!isRecord(raw)) {
+    return fallback;
+  }
+
+  const environmentWarning = readString(raw.environmentWarning);
+  return {
+    mode: readString(raw.mode) ?? fallback.mode,
+    daemon: readString(raw.daemon) ?? fallback.daemon,
+    sandbox: readString(raw.sandbox) ?? fallback.sandbox,
+    execution: readString(raw.execution) ?? fallback.execution,
+    canAccess: readStringArray(raw.canAccess) ?? fallback.canAccess,
+    cannotAccess: readStringArray(raw.cannotAccess) ?? fallback.cannotAccess,
+    ...(environmentWarning ? { environmentWarning } : {}),
+    canAccessPersonalDesktop: typeof raw.canAccessPersonalDesktop === "boolean"
+      ? raw.canAccessPersonalDesktop
+      : fallback.canAccessPersonalDesktop,
+    localDesktopDaemonReady: typeof raw.localDesktopDaemonReady === "boolean"
+      ? raw.localDesktopDaemonReady
+      : fallback.localDesktopDaemonReady,
+    supportedCommandCount: readNumber(raw.supportedCommandCount) ?? fallback.supportedCommandCount
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function readStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const strings = value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+  return strings.length > 0 ? strings : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function renderExecutionContextSummary(summary: ExecutionContextSummary): string {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -29,16 +29,135 @@ export async function runStatusCommand(
     ? backendStatus.health.status
     : "unknown";
   const cwd = validatedResponse.data?.environment.cwd ?? invocation.options.cwd ?? "unknown";
+  const executionContext = buildExecutionContextSummary({
+    cwd,
+    environmentType: validatedResponse.data?.environment.type ?? invocation.options.environment,
+    environmentCapabilities: validatedResponse.data?.environment.capabilities ?? [],
+    healthStatus,
+    supportedCommandCount: validatedCapabilitiesResponse.data?.supportedCommands.length ?? 0
+  });
 
   return {
     command: request.command,
     request,
     response: validatedResponse,
-    humanOutput: `Status: ${healthStatus} | cwd=${cwd} | supportedCommands=${validatedCapabilitiesResponse.data?.supportedCommands.length ?? 0}`,
+    humanOutput: renderExecutionContextSummary(executionContext),
     extraJson: {
+      executionContext,
       capabilitiesRequest,
       capabilitiesResponse: validatedCapabilitiesResponse,
       backendStatus
     }
   };
+}
+
+interface ExecutionContextSummaryInput {
+  cwd: string;
+  environmentType?: string;
+  environmentCapabilities: string[];
+  healthStatus: string;
+  supportedCommandCount: number;
+}
+
+interface ExecutionContextSummary {
+  mode: string;
+  daemon: string;
+  sandbox: string;
+  execution: string;
+  canAccess: string[];
+  cannotAccess: string[];
+  environmentWarning?: string;
+  canAccessPersonalDesktop: boolean;
+  supportedCommandCount: number;
+}
+
+function buildExecutionContextSummary(input: ExecutionContextSummaryInput): ExecutionContextSummary {
+  const isRailwayRuntime = hasRailwayRuntimeMarker();
+  const isRemoteEnvironment = input.environmentType === "remote";
+  const bridgeTokenConfigured = Boolean(process.env.ARCANOS_CLI_BRIDGE_TOKEN?.trim());
+  const healthConnected = ["ok", "healthy", "ready", "live"].includes(input.healthStatus.toLowerCase());
+  const mode = isRailwayRuntime || isRemoteEnvironment
+    ? "Production Runtime"
+    : bridgeTokenConfigured
+    ? "Local Desktop Daemon"
+    : healthConnected
+    ? "Local CLI Runtime"
+    : "Unavailable";
+
+  const canAccess = [
+    isRailwayRuntime || isRemoteEnvironment ? "deployed runtime" : "local CLI runtime",
+    `${input.cwd} workspace`,
+    ...formatCapabilityLabels(input.environmentCapabilities)
+  ];
+
+  return {
+    mode,
+    daemon: healthConnected ? "Connected" : `Health ${input.healthStatus}`,
+    sandbox: input.cwd,
+    execution: "Confirmation required for CLI daemon actions",
+    canAccess,
+    cannotAccess: [
+      isRailwayRuntime || isRemoteEnvironment ? "your personal desktop" : "paths outside the configured sandbox",
+      "unrestricted shell",
+      "raw secrets or environment variables",
+      "patches touching secret files"
+    ],
+    environmentWarning: isRailwayRuntime || isRemoteEnvironment
+      ? "Production runtime: actions are limited to the deployed container sandbox."
+      : undefined,
+    canAccessPersonalDesktop: bridgeTokenConfigured && !isRailwayRuntime && !isRemoteEnvironment,
+    supportedCommandCount: input.supportedCommandCount
+  };
+}
+
+function renderExecutionContextSummary(summary: ExecutionContextSummary): string {
+  const lines = [
+    "Execution Context",
+    "-----------------",
+    `Mode: ${summary.mode}`,
+    `Daemon: ${summary.daemon}`,
+    `Sandbox: ${summary.sandbox}`,
+    `Execution: ${summary.execution}`
+  ];
+
+  if (summary.environmentWarning) {
+    lines.push(`Warning: ${summary.environmentWarning}`);
+  }
+
+  lines.push(`Can access your personal desktop: ${summary.canAccessPersonalDesktop ? "Yes" : "No"}`);
+  lines.push("Can access:");
+  for (const item of summary.canAccess) {
+    lines.push(`+ ${item}`);
+  }
+  lines.push("Cannot access:");
+  for (const item of summary.cannotAccess) {
+    lines.push(`- ${item}`);
+  }
+  lines.push(`Supported protocol commands: ${summary.supportedCommandCount}`);
+  return lines.join("\n");
+}
+
+function hasRailwayRuntimeMarker(): boolean {
+  return [
+    "RAILWAY_ENVIRONMENT",
+    "RAILWAY_ENVIRONMENT_ID",
+    "RAILWAY_PROJECT_ID",
+    "RAILWAY_SERVICE_ID",
+    "RAILWAY_DEPLOYMENT_ID"
+  ].some((name) => Boolean(process.env[name]?.trim()));
+}
+
+function formatCapabilityLabels(capabilities: string[]): string[] {
+  const normalized = new Set(capabilities.map((capability) => capability.toLowerCase()));
+  const labels: string[] = [];
+  if (normalized.has("repo-read") || normalized.has("git-read") || normalized.has("fs-read")) {
+    labels.push("read-only repository inspection");
+  }
+  if (normalized.has("protocol-validation")) {
+    labels.push("protocol validation");
+  }
+  if (normalized.has("in-memory-execution")) {
+    labels.push("queued protocol execution state");
+  }
+  return labels;
 }


### PR DESCRIPTION
## Summary

Adds a user-facing execution context UX for the ARCANOS CLI daemon across the public TypeScript CLI and Python daemon shell.

## Changes

- Render an `Execution Context` summary from `arcanos status` with mode, daemon state, sandbox, safety boundaries, and supported protocol command count.
- Add Python daemon `/context` and one-shot `arcanos context` output, including JSON support.
- Improve command and patch proposal review text with redacted command/output handling, patch counts, hash confirmation, and rollback safety indicators.
- Add focused Python and TypeScript coverage for the new UX surfaces.

## Impact

Users can more clearly tell whether actions run in production, a local daemon, or a constrained sandbox, and can see what the daemon can and cannot access before approving CLI/daemon work.

## Validation

- `python -m pytest tests/test_cli_execution_context_ux.py tests/test_cli_method_contracts.py tests/test_cli_policy_security.py tests/test_patch_orchestrator_non_interactive.py`
- `node scripts/run-jest.mjs --testPathPatterns=packages/cli/__tests__/cli.test.ts --coverage=false`
- `npm run build:packages`
- `npm run validate:backend-cli:contract`
- `npm run validate:backend-cli:offline`

No Railway mutating commands were run.