### PR TITLE
test(gptoss): add CI-safe runtime release gate

### DIFF
--- a/docs/GPTOSS_LOCAL_RUNTIME.md
+++ b/docs/GPTOSS_LOCAL_RUNTIME.md
@@ -729,6 +729,20 @@ tracked local artifact/model/cache files, or accidental cloud/Custom GPT
 readiness. Its report is local-only at
 `local_artifacts/gptoss-runtime/release-gate-report.json`.
 
+Phase 4.6 adds a CI-safe static release gate:
+
+```bash
+npm run gptoss:runtime:release-gate:ci
+```
+
+The CI gate validates package wiring, the runtime schema, release-manifest schema
+expectations, baseline metadata, runtime smoke fixtures, local spec facts, docs,
+required runtime supports, and cloud/Custom GPT false readiness without requiring
+`local_artifacts/`, adapter files, model weights, CUDA, WSL, vLLM, Railway auth,
+`DATABASE_URL`, OpenAI keys, live DB access, or a server. In local runs it writes
+`local_artifacts/gptoss-runtime/release-gate-ci-report.json`; in CI it can rely
+on the stdout JSON summary.
+
 Model-only readiness remains false because the raw model score is `11/24`. The
 effective runtime can be locally ready because deterministic local policy,
 spec-fact, and postprocessor layers bring the effective score to `24/24`; that

--- a/docs/GPTOSS_RUNTIME_ARCHITECTURE.md
+++ b/docs/GPTOSS_RUNTIME_ARCHITECTURE.md
@@ -149,6 +149,18 @@ tracked local artifact/model/cache files, or accidental cloud/Custom GPT
 readiness. It writes only to
 `local_artifacts/gptoss-runtime/release-gate-report.json`.
 
+Phase 4.6 adds a CI-safe static gate:
+
+```bash
+npm run gptoss:runtime:release-gate:ci
+```
+
+This gate checks package scripts, the runtime schema, release-manifest schema
+expectations, baseline metadata, runtime smoke fixtures, local spec facts, docs,
+required runtime supports, and cloud/Custom GPT false readiness. It intentionally
+skips local-only prerequisites such as `local_artifacts/`, adapter/model files,
+CUDA, WSL, vLLM, Railway, OpenAI, live DB access, and server exposure.
+
 The expected current state remains:
 
 - model-only score: `11/24`

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "gptoss:runtime:request:local-model:smoke:audit": "node scripts/gptoss/effective-router-request.mjs --input-file examples/gptoss/runtime-request-smoke/openai-output-training-rejection.json --execute-local-model --audit",
     "gptoss:runtime:release-manifest": "node scripts/gptoss/runtime-release-manifest.mjs",
     "gptoss:runtime:release-gate": "node scripts/gptoss/runtime-release-gate.mjs",
+    "gptoss:runtime:release-gate:ci": "node scripts/gptoss/runtime-release-gate-ci.mjs",
     "gptoss:adapter:eval:force-final:compare": "node scripts/gptoss/eval-force-final-comparison.mjs",
     "gptoss:adapter:triage": "node scripts/gptoss/triage-adapter-eval.mjs",
     "gptoss:vllm:command": "node scripts/gptoss/vllm-command.mjs",

--- a/schemas/gptoss-effective-router-runtime.schema.json
+++ b/schemas/gptoss-effective-router-runtime.schema.json
@@ -24,6 +24,79 @@
         "routerPostprocessor": { "const": true }
       }
     },
+    "scoreString": {
+      "type": "string",
+      "pattern": "^[0-9]+/[0-9]+$"
+    },
+    "releaseManifest": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "schemaVersion",
+        "kind",
+        "releaseScope",
+        "modelScore",
+        "effectiveScore",
+        "localControlledRuntimeReady",
+        "modelOnlyReady",
+        "cloudReady",
+        "customGptReady",
+        "baselineRegistryPath",
+        "requiredRuntimeSupports",
+        "requiredRuntimeFlags",
+        "paths",
+        "requestStatus",
+        "safetyConfirmations",
+        "safety"
+      ],
+      "properties": {
+        "schemaVersion": { "const": 1 },
+        "kind": { "const": "gptoss_effective_router_runtime_release_manifest" },
+        "releaseScope": { "const": "local_controlled_runtime_only" },
+        "modelScore": { "$ref": "#/$defs/scoreString" },
+        "effectiveScore": { "$ref": "#/$defs/scoreString" },
+        "localControlledRuntimeReady": { "type": "boolean" },
+        "modelOnlyReady": { "const": false },
+        "cloudReady": { "const": false },
+        "customGptReady": { "const": false },
+        "baselineRegistryPath": { "type": "string", "minLength": 1 },
+        "requiredRuntimeSupports": { "$ref": "#/$defs/runtimeSupports" },
+        "requiredRuntimeFlags": {
+          "type": "array",
+          "minItems": 4,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "paths": { "type": "object" },
+        "requestStatus": { "type": "object" },
+        "safetyConfirmations": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": [
+            "allowedForTraining",
+            "openAiCalled",
+            "trainingExecuted",
+            "vllmUsed",
+            "railwayCliUsed",
+            "liveDbUsed",
+            "noOpenAiOutputUsed",
+            "publicServerCreated",
+            "customGptExposureEnabled"
+          ],
+          "properties": {
+            "allowedForTraining": { "const": false },
+            "openAiCalled": { "const": false },
+            "trainingExecuted": { "const": false },
+            "vllmUsed": { "const": false },
+            "railwayCliUsed": { "const": false },
+            "liveDbUsed": { "const": false },
+            "noOpenAiOutputUsed": { "const": true },
+            "publicServerCreated": { "const": false },
+            "customGptExposureEnabled": { "const": false }
+          }
+        },
+        "safety": { "$ref": "#/$defs/runtimeOutput/properties/safety" }
+      }
+    },
     "runtimeRequest": {
       "type": "object",
       "additionalProperties": false,

--- a/scripts/gptoss/eval-adapter-local.py
+++ b/scripts/gptoss/eval-adapter-local.py
@@ -53,6 +53,7 @@ SAFE_ACTION_CANONICALIZATION_ALIASES = {
 }
 SAFE_ROUTER_POSTPROCESSOR_ACTIONS = {
     "audit_openai_output_storage",
+    "classify_local_runtime_guide_writing",
 }
 ACTION_CANONICALIZATION_KEYS = ("type", "name", "id")
 DASH_VARIANTS_PATTERN = re.compile(r"[\u2010\u2011\u2012\u2013\u2014\u2212]")
@@ -1479,6 +1480,16 @@ def deterministic_router_postprocessor(record: dict[str, Any], apply_override: b
             "action": action,
             "route": "local_audit",
             "decision": "audit",
+            "requiresConfirmation": False,
+            "allowedForTraining": False,
+        }
+    elif all(term in prompt for term in ["write", "short guide note", "local gpt oss runtime"]):
+        action = "classify_local_runtime_guide_writing"
+        result = {
+            "plane": "writing-plane",
+            "action": action,
+            "route": "writing_plane",
+            "decision": "writing",
             "requiresConfirmation": False,
             "allowedForTraining": False,
         }

--- a/scripts/gptoss/runtime-release-gate-ci.mjs
+++ b/scripts/gptoss/runtime-release-gate-ci.mjs
@@ -1,0 +1,699 @@
+#!/usr/bin/env node
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+import { DEFAULT_REGISTRY } from './baseline-registry.mjs';
+import {
+  DEFAULT_SMOKE_DIR,
+  DEFAULT_SPEC_FACTS_FILE,
+  REQUIRED_RUNTIME_SUPPORTS,
+  assertRuntimeReportPath,
+} from './effective-router-runtime.mjs';
+
+export const DEFAULT_RELEASE_GATE_CI_REPORT =
+  'local_artifacts/gptoss-runtime/release-gate-ci-report.json';
+
+export const REQUIRED_PACKAGE_SCRIPTS = [
+  'gptoss:baseline:regress',
+  'gptoss:adapter:eval:effective-router:regress',
+  'gptoss:runtime:request:regress',
+  'gptoss:runtime:readiness',
+  'gptoss:runtime:release-manifest',
+  'gptoss:runtime:cloud-gate',
+  'gptoss:runtime:release-gate',
+  'gptoss:runtime:release-gate:ci',
+];
+
+export const REQUIRED_DOCS = [
+  'docs/GPTOSS_LOCAL_RUNTIME.md',
+  'docs/GPTOSS_RUNTIME_ARCHITECTURE.md',
+];
+
+export const REQUIRED_RUNTIME_SUPPORT_DECLARATIONS = [
+  {
+    label: 'force-final-channel',
+    key: 'forceFinalChannel',
+    flag: '--force-final-channel',
+  },
+  {
+    label: 'router-classifier-mode',
+    key: 'routerClassifierMode',
+    flag: '--router-classifier-mode',
+    baselineRequired: true,
+  },
+  {
+    label: 'JSON prefill',
+    key: 'prefillJsonStart',
+    flag: '--prefill-json-start',
+    baselineRequired: true,
+  },
+  {
+    label: 'hard-policy-overrides',
+    key: 'hardPolicyOverrides',
+    flag: '--apply-hard-policy-overrides',
+    baselineRequired: true,
+  },
+  {
+    label: 'local-spec-facts',
+    key: 'localSpecFacts',
+    flag: '--use-local-spec-facts',
+    baselineRequired: true,
+  },
+  {
+    label: 'router-postprocessor',
+    key: 'routerPostprocessor',
+  },
+];
+
+const REQUIRED_MANIFEST_SCHEMA_FIELDS = [
+  'schemaVersion',
+  'kind',
+  'releaseScope',
+  'modelScore',
+  'effectiveScore',
+  'localControlledRuntimeReady',
+  'modelOnlyReady',
+  'cloudReady',
+  'customGptReady',
+  'baselineRegistryPath',
+  'requiredRuntimeSupports',
+  'requiredRuntimeFlags',
+  'paths',
+  'requestStatus',
+  'safetyConfirmations',
+  'safety',
+];
+
+const CLEAN_FALSE_FLAGS = [
+  'allowedForTraining',
+  'openAiCalled',
+  'trainingExecuted',
+  'vllmUsed',
+  'railwayCliUsed',
+  'liveDbUsed',
+];
+
+const CLEAN_TRUE_FLAGS = ['noOpenAiOutputUsed'];
+const CLOUD_EXPOSURE_FLAGS = [
+  'cloudReady',
+  'customGptReady',
+  'customGptDirectLocalExposureAllowed',
+  'customGptExposureEnabled',
+  'publicServerCreated',
+];
+
+const CI_SCRIPT_FORBIDDEN_PATTERN =
+  /api\.openai\.com|openai\s|railway\s+up|railway\s+(status|logs|link|whoami)|--allow-network|(^|\s)--execute(\s|$)|unsloth|train|vllm|db:schema:apply|DATABASE_URL|start-server|npm run (dev|start)\b/i;
+
+const DEFAULT_REQUEST_SMOKE_DIR = 'examples/gptoss/runtime-request-smoke';
+const DEFAULT_SCHEMA_PATH = 'schemas/gptoss-effective-router-runtime.schema.json';
+const DEFAULT_PACKAGE_PATH = 'package.json';
+const MODEL_READY_THRESHOLD_PASSED = 20;
+
+function pushFailure(failures, code, detail = undefined) {
+  failures.push(detail ? `${code}:${detail}` : code);
+}
+
+function toDisplayPath(path) {
+  return String(path ?? '').replace(/\\/g, '/');
+}
+
+function readJson(root, path, failures, label) {
+  const fullPath = resolve(root, path);
+  if (!existsSync(fullPath)) {
+    pushFailure(failures, 'missing_json_file', label ?? path);
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(readFileSync(fullPath, 'utf8'));
+  } catch (error) {
+    pushFailure(
+      failures,
+      'invalid_json_file',
+      `${label ?? path}:${error instanceof Error ? error.message : String(error)}`,
+    );
+    return undefined;
+  }
+}
+
+function listJsonFiles(root, dir, failures) {
+  const fullDir = resolve(root, dir);
+  if (!existsSync(fullDir) || !statSync(fullDir).isDirectory()) {
+    pushFailure(failures, 'missing_fixture_dir', dir);
+    return [];
+  }
+
+  const files = readdirSync(fullDir)
+    .filter((name) => name.endsWith('.json'))
+    .sort()
+    .map((name) => join(dir, name));
+
+  if (files.length === 0) {
+    pushFailure(failures, 'fixture_dir_empty', dir);
+  }
+
+  return files;
+}
+
+function collectObjects(value, visit) {
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
+  visit(value);
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectObjects(item, visit);
+    }
+    return;
+  }
+
+  for (const item of Object.values(value)) {
+    collectObjects(item, visit);
+  }
+}
+
+function scoreString(score) {
+  if (!score || typeof score !== 'object') {
+    return null;
+  }
+
+  const passed = Number(score.passed);
+  const records = Number(score.records);
+  if (!Number.isFinite(passed) || !Number.isFinite(records)) {
+    return null;
+  }
+  return `${passed}/${records}`;
+}
+
+function currentBaseline(registry, failures) {
+  const current = registry?.current;
+  const baselines = Array.isArray(registry?.baselines) ? registry.baselines : [];
+  const baseline = baselines.find((entry) => entry?.id === current);
+  if (!baseline) {
+    pushFailure(failures, 'missing_current_baseline', String(current ?? 'undefined'));
+  }
+  return baseline;
+}
+
+function validatePackageScripts(packageJson, failures) {
+  const scripts = packageJson?.scripts;
+  if (!scripts || typeof scripts !== 'object') {
+    pushFailure(failures, 'package_scripts_missing');
+    return false;
+  }
+
+  for (const script of REQUIRED_PACKAGE_SCRIPTS) {
+    if (typeof scripts[script] !== 'string' || !scripts[script].trim()) {
+      pushFailure(failures, 'package_script_missing', script);
+    }
+  }
+
+  const ciScript = scripts['gptoss:runtime:release-gate:ci'];
+  if (typeof ciScript === 'string') {
+    if (!ciScript.includes('scripts/gptoss/runtime-release-gate-ci.mjs')) {
+      pushFailure(failures, 'ci_package_script_wrong_target', ciScript);
+    }
+    if (CI_SCRIPT_FORBIDDEN_PATTERN.test(ciScript)) {
+      pushFailure(failures, 'ci_package_script_unsafe', ciScript);
+    }
+  }
+
+  return REQUIRED_PACKAGE_SCRIPTS.every((script) => typeof scripts[script] === 'string');
+}
+
+function validateRuntimeSupportsInSchema(schema, failures) {
+  const runtimeSupports = schema?.$defs?.runtimeSupports;
+  if (!runtimeSupports || typeof runtimeSupports !== 'object') {
+    pushFailure(failures, 'runtime_support_schema_missing');
+    return false;
+  }
+
+  const required = Array.isArray(runtimeSupports.required) ? runtimeSupports.required : [];
+  const properties = runtimeSupports.properties ?? {};
+  let ok = true;
+
+  for (const support of REQUIRED_RUNTIME_SUPPORT_DECLARATIONS) {
+    if (!required.includes(support.key)) {
+      pushFailure(failures, 'runtime_support_schema_required_missing', support.label);
+      ok = false;
+    }
+    if (properties?.[support.key]?.const !== true) {
+      pushFailure(failures, 'runtime_support_schema_const_missing', support.label);
+      ok = false;
+    }
+  }
+
+  return ok;
+}
+
+function validateReleaseManifestSchema(schema, failures) {
+  const releaseManifest = schema?.$defs?.releaseManifest;
+  if (!releaseManifest || typeof releaseManifest !== 'object') {
+    pushFailure(failures, 'release_manifest_schema_missing');
+    return false;
+  }
+
+  const required = Array.isArray(releaseManifest.required) ? releaseManifest.required : [];
+  const properties = releaseManifest.properties ?? {};
+  let ok = true;
+
+  for (const field of REQUIRED_MANIFEST_SCHEMA_FIELDS) {
+    if (!required.includes(field)) {
+      pushFailure(failures, 'release_manifest_schema_required_missing', field);
+      ok = false;
+    }
+  }
+
+  if (properties.kind?.const !== 'gptoss_effective_router_runtime_release_manifest') {
+    pushFailure(failures, 'release_manifest_schema_kind_missing');
+    ok = false;
+  }
+  if (properties.releaseScope?.const !== 'local_controlled_runtime_only') {
+    pushFailure(failures, 'release_manifest_schema_scope_missing');
+    ok = false;
+  }
+  if (properties.cloudReady?.const !== false) {
+    pushFailure(failures, 'release_manifest_schema_cloud_ready_not_false');
+    ok = false;
+  }
+  if (properties.customGptReady?.const !== false) {
+    pushFailure(failures, 'release_manifest_schema_custom_gpt_ready_not_false');
+    ok = false;
+  }
+  if (properties.requiredRuntimeSupports?.$ref !== '#/$defs/runtimeSupports') {
+    pushFailure(failures, 'release_manifest_schema_runtime_support_ref_missing');
+    ok = false;
+  }
+
+  return ok;
+}
+
+function validateRuntimeSupportsDeclaration(failures) {
+  let ok = true;
+  for (const support of REQUIRED_RUNTIME_SUPPORT_DECLARATIONS) {
+    if (REQUIRED_RUNTIME_SUPPORTS[support.key] !== true) {
+      pushFailure(failures, 'runtime_support_declaration_missing', support.label);
+      ok = false;
+    }
+  }
+  return ok;
+}
+
+function validateNoTrackedCloudExposure(value, failures, label) {
+  collectObjects(value, (object) => {
+    for (const flag of CLOUD_EXPOSURE_FLAGS) {
+      if (object[flag] === true) {
+        pushFailure(failures, 'tracked_cloud_or_custom_gpt_ready_true', `${label}.${flag}`);
+      }
+    }
+  });
+}
+
+function validateBaselineRegistry(registry, failures) {
+  if (!registry || typeof registry !== 'object') {
+    pushFailure(failures, 'baseline_registry_missing');
+    return undefined;
+  }
+
+  if (registry.kind !== 'gptoss_baseline_registry') {
+    pushFailure(failures, 'baseline_registry_kind_unexpected', String(registry.kind));
+  }
+
+  const baseline = currentBaseline(registry, failures);
+  if (!baseline) {
+    return undefined;
+  }
+
+  const modelScore = scoreString(baseline.modelScore);
+  const effectiveScore = scoreString(baseline.effectiveScore);
+  if (modelScore !== '11/24') {
+    pushFailure(failures, 'baseline_model_score_unexpected', modelScore ?? 'missing');
+  }
+  if (effectiveScore !== '24/24') {
+    pushFailure(failures, 'baseline_effective_score_unexpected', effectiveScore ?? 'missing');
+  }
+
+  const requiredFlags = Array.isArray(baseline.requiredRuntimeFlags)
+    ? baseline.requiredRuntimeFlags
+    : [];
+  for (const support of REQUIRED_RUNTIME_SUPPORT_DECLARATIONS) {
+    if (support.baselineRequired && !requiredFlags.includes(support.flag)) {
+      pushFailure(failures, 'baseline_required_runtime_flag_missing', support.label);
+    }
+  }
+
+  const diagnosticModes = baseline.requiredDiagnosticModes ?? {};
+  const diagnosticModeKeys = {
+    '--router-classifier-mode': 'routerClassifierMode',
+    '--prefill-json-start': 'prefillJsonStart',
+    '--apply-hard-policy-overrides': 'applyHardPolicyOverrides',
+    '--use-local-spec-facts': 'useLocalSpecFacts',
+  };
+  for (const support of REQUIRED_RUNTIME_SUPPORT_DECLARATIONS) {
+    if (!support.baselineRequired) {
+      continue;
+    }
+    const modeKey = diagnosticModeKeys[support.flag];
+    if (diagnosticModes[modeKey] !== true) {
+      pushFailure(failures, 'baseline_required_diagnostic_mode_missing', support.label);
+    }
+  }
+
+  const safety = baseline.safetyFlags ?? {};
+  for (const flag of CLEAN_FALSE_FLAGS) {
+    if (safety[flag] !== false) {
+      pushFailure(failures, 'baseline_safety_flag_not_false', flag);
+    }
+  }
+  for (const flag of CLEAN_TRUE_FLAGS) {
+    if (safety[flag] !== true) {
+      pushFailure(failures, 'baseline_safety_flag_not_true', flag);
+    }
+  }
+
+  return {
+    baselineId: baseline.id,
+    modelScore,
+    effectiveScore,
+    modelOnlyReady: Number(baseline.modelScore?.passed) >= MODEL_READY_THRESHOLD_PASSED,
+    localControlledRuntimeReady: effectiveScore === '24/24',
+  };
+}
+
+function validateRuntimeRequest(raw, failures, label) {
+  const request = raw?.request && typeof raw.request === 'object' ? raw.request : raw;
+  if (!request || typeof request !== 'object') {
+    pushFailure(failures, 'runtime_fixture_request_missing', label);
+    return;
+  }
+  if (!String(request.requestId ?? '').trim()) {
+    pushFailure(failures, 'runtime_fixture_request_id_missing', label);
+  }
+  if (!String(request.userInput ?? '').trim()) {
+    pushFailure(failures, 'runtime_fixture_user_input_missing', label);
+  }
+  if ((request.mode ?? 'router_classifier') !== 'router_classifier') {
+    pushFailure(failures, 'runtime_fixture_mode_unexpected', label);
+  }
+
+  const supports = request.runtimeSupports ?? {};
+  for (const support of REQUIRED_RUNTIME_SUPPORT_DECLARATIONS) {
+    if (supports[support.key] !== true) {
+      pushFailure(failures, 'runtime_fixture_support_missing', `${label}.${support.label}`);
+    }
+  }
+}
+
+function validateFixtureDir(root, dir, failures) {
+  const files = listJsonFiles(root, dir, failures);
+  for (const file of files) {
+    const parsed = readJson(root, file, failures, file);
+    if (parsed) {
+      validateRuntimeRequest(parsed, failures, file);
+      validateNoTrackedCloudExposure(parsed, failures, file);
+    }
+  }
+  return files.length;
+}
+
+function validateLocalSpecFacts(specFacts, failures) {
+  const facts = Array.isArray(specFacts?.facts) ? specFacts.facts : [];
+  if (facts.length === 0) {
+    pushFailure(failures, 'local_spec_facts_empty');
+    return false;
+  }
+
+  for (const fact of facts) {
+    if (!String(fact?.id ?? '').trim()) {
+      pushFailure(failures, 'local_spec_fact_id_missing');
+    }
+    if (!Array.isArray(fact?.aliases) || fact.aliases.length === 0) {
+      pushFailure(failures, 'local_spec_fact_aliases_missing', String(fact?.id ?? 'unknown'));
+    }
+    if (!String(fact?.value ?? '').trim()) {
+      pushFailure(failures, 'local_spec_fact_value_missing', String(fact?.id ?? 'unknown'));
+    }
+    if (!String(fact?.source ?? '').trim()) {
+      pushFailure(failures, 'local_spec_fact_source_missing', String(fact?.id ?? 'unknown'));
+    }
+  }
+
+  validateNoTrackedCloudExposure(specFacts, failures, 'local_spec_facts');
+  return facts.length > 0;
+}
+
+function validateDocs(root, failures) {
+  let ok = true;
+  for (const doc of REQUIRED_DOCS) {
+    const fullPath = resolve(root, doc);
+    if (!existsSync(fullPath) || !statSync(fullPath).isFile()) {
+      pushFailure(failures, 'doc_missing', doc);
+      ok = false;
+    }
+  }
+  return ok;
+}
+
+function shouldWriteReport({ ci, write }) {
+  if (write === false) {
+    return false;
+  }
+  if (write === true) {
+    return !ci;
+  }
+  return !ci;
+}
+
+function writeReport(root, outputPath, report) {
+  assertRuntimeReportPath(outputPath);
+  const fullPath = resolve(root, outputPath);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  return outputPath;
+}
+
+export function runReleaseGateCi({
+  repoRoot = process.cwd(),
+  packagePath = DEFAULT_PACKAGE_PATH,
+  schemaPath = DEFAULT_SCHEMA_PATH,
+  registryPath = DEFAULT_REGISTRY,
+  specFactsPath = DEFAULT_SPEC_FACTS_FILE,
+  smokeDir = DEFAULT_SMOKE_DIR,
+  requestSmokeDir = DEFAULT_REQUEST_SMOKE_DIR,
+  outputPath = DEFAULT_RELEASE_GATE_CI_REPORT,
+  ci = Boolean(process.env.CI || process.env.GITHUB_ACTIONS),
+  write,
+} = {}) {
+  const root = resolve(repoRoot);
+  const failures = [];
+
+  const packageJson = readJson(root, packagePath, failures, 'package_json');
+  const schema = readJson(root, schemaPath, failures, 'runtime_schema');
+  const registry = readJson(root, registryPath, failures, 'baseline_registry');
+  const specFacts = readJson(root, specFactsPath, failures, 'local_spec_facts');
+
+  const checks = {
+    packageScriptsExist: packageJson ? validatePackageScripts(packageJson, failures) : false,
+    runtimeSchemaParses: Boolean(schema),
+    runtimeSupportsDeclared: schema ? validateRuntimeSupportsInSchema(schema, failures) : false,
+    runtimeSupportCodeDeclared: validateRuntimeSupportsDeclaration(failures),
+    releaseManifestSchemaExpectationsExist: schema
+      ? validateReleaseManifestSchema(schema, failures)
+      : false,
+    baselineRegistryParses: Boolean(registry),
+    baselineMetadataStable: false,
+    runtimeSmokeFixturesParse: false,
+    runtimeRequestSmokeFixturesParse: false,
+    localSpecFactsParse: specFacts ? validateLocalSpecFacts(specFacts, failures) : false,
+    docsExist: validateDocs(root, failures),
+    cloudAndCustomGptReadinessFalse: true,
+    noExternalOperationsRequired: true,
+    adapterFilesRequired: false,
+  };
+
+  const baseline = registry ? validateBaselineRegistry(registry, failures) : undefined;
+  checks.baselineMetadataStable = Boolean(
+    baseline &&
+      baseline.modelScore === '11/24' &&
+      baseline.effectiveScore === '24/24',
+  );
+
+  checks.runtimeSmokeFixturesParse = validateFixtureDir(root, smokeDir, failures) > 0;
+  checks.runtimeRequestSmokeFixturesParse = validateFixtureDir(root, requestSmokeDir, failures) > 0;
+
+  if (schema) {
+    validateNoTrackedCloudExposure(schema, failures, 'runtime_schema');
+  }
+  if (registry) {
+    validateNoTrackedCloudExposure(registry, failures, 'baseline_registry');
+  }
+
+  checks.cloudAndCustomGptReadinessFalse = !failures.some((failure) =>
+    failure.startsWith('tracked_cloud_or_custom_gpt_ready_true') ||
+    failure.startsWith('release_manifest_schema_cloud_ready_not_false') ||
+    failure.startsWith('release_manifest_schema_custom_gpt_ready_not_false')
+  );
+
+  const ok = failures.length === 0;
+  const report = {
+    schemaVersion: 1,
+    kind: 'gptoss_runtime_release_gate_ci_report',
+    ok,
+    mode: 'ci_safe_static_release_gate',
+    generatedAt: new Date().toISOString(),
+    modelScore: baseline?.modelScore ?? null,
+    effectiveScore: baseline?.effectiveScore ?? null,
+    localControlledRuntimeReady: baseline?.localControlledRuntimeReady === true,
+    modelOnlyReady: baseline?.modelOnlyReady === true,
+    cloudReady: false,
+    customGptReady: false,
+    customGptDirectLocalExposureAllowed: false,
+    failures,
+    checks,
+    requiredPackageScripts: REQUIRED_PACKAGE_SCRIPTS,
+    requiredRuntimeSupports: Object.fromEntries(
+      REQUIRED_RUNTIME_SUPPORT_DECLARATIONS.map((support) => [support.label, true]),
+    ),
+    checkedPaths: {
+      packageJson: toDisplayPath(packagePath),
+      runtimeSchema: toDisplayPath(schemaPath),
+      baselineRegistry: toDisplayPath(registryPath),
+      runtimeSmokeFixtures: toDisplayPath(smokeDir),
+      runtimeRequestSmokeFixtures: toDisplayPath(requestSmokeDir),
+      localSpecFacts: toDisplayPath(specFactsPath),
+      docs: REQUIRED_DOCS.map(toDisplayPath),
+    },
+    localOnlyChecksSkipped: [
+      'local_artifacts directory presence',
+      'adapter files',
+      'model weights',
+      'CUDA',
+      'WSL',
+      'OpenAI key',
+      'Railway auth',
+      'DATABASE_URL',
+      'vLLM serving',
+      'live DB connection',
+      'local server startup',
+      'Custom GPT exposure',
+    ],
+    safetyConfirmations: {
+      allowedForTraining: false,
+      openAiCalled: false,
+      trainingExecuted: false,
+      vllmUsed: false,
+      railwayCliUsed: false,
+      liveDbUsed: false,
+      noOpenAiOutputUsed: true,
+      adapterFilesRequired: false,
+      modelWeightsRequired: false,
+      localArtifactsRequired: false,
+      cudaRequired: false,
+      wslRequired: false,
+      openAiKeyRequired: false,
+      railwayAuthRequired: false,
+      databaseUrlRequired: false,
+      serverCreated: false,
+      publicServerCreated: false,
+      customGptExposureEnabled: false,
+    },
+    ciMode: ci,
+    reportWritten: false,
+    reportPath: null,
+  };
+
+  if (shouldWriteReport({ ci, write })) {
+    report.reportWritten = true;
+    report.reportPath = outputPath;
+    writeReport(root, outputPath, report);
+  }
+
+  return report;
+}
+
+function parseArgs(argv = []) {
+  const options = {
+    ci: undefined,
+    write: undefined,
+    outputPath: DEFAULT_RELEASE_GATE_CI_REPORT,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const next = argv[index + 1];
+    if (flag === '--ci') {
+      options.ci = true;
+    } else if (flag === '--no-write') {
+      options.write = false;
+    } else if (flag === '--output' && next) {
+      options.outputPath = next;
+      index += 1;
+    } else if (flag === '--package' && next) {
+      options.packagePath = next;
+      index += 1;
+    } else if (flag === '--schema' && next) {
+      options.schemaPath = next;
+      index += 1;
+    } else if (flag === '--registry' && next) {
+      options.registryPath = next;
+      index += 1;
+    } else if (flag === '--spec-facts' && next) {
+      options.specFactsPath = next;
+      index += 1;
+    } else if (flag === '--smoke-dir' && next) {
+      options.smokeDir = next;
+      index += 1;
+    } else if (flag === '--request-smoke-dir' && next) {
+      options.requestSmokeDir = next;
+      index += 1;
+    } else {
+      throw new Error(`Unknown or incomplete argument: ${flag}`);
+    }
+  }
+
+  return options;
+}
+
+function main() {
+  try {
+    const report = runReleaseGateCi(parseArgs(process.argv.slice(2)));
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    if (!report.ok) {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    const report = {
+      schemaVersion: 1,
+      kind: 'gptoss_runtime_release_gate_ci_report',
+      ok: false,
+      mode: 'ci_safe_static_release_gate',
+      cloudReady: false,
+      customGptReady: false,
+      openAiCalled: false,
+      trainingExecuted: false,
+      vllmUsed: false,
+      railwayCliUsed: false,
+      liveDbUsed: false,
+      noOpenAiOutputUsed: true,
+      failures: [`release_gate_ci_exception:${error instanceof Error ? error.message : String(error)}`],
+    };
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/tests/gptoss-adapter-eval.test.ts
+++ b/tests/gptoss-adapter-eval.test.ts
@@ -910,6 +910,21 @@ describe('gptoss adapter local eval', () => {
     expect(parsed.ambiguous.effectiveFailures).toContain('missing:audit');
   });
 
+  it('postprocesses the stable local runtime writing-guide route', () => {
+    const parsed = runPythonSnippet([
+      'record = {"id":"eval-smoke-020","prompt":"Write a short guide note for the local GPT-OSS runtime.","expected":{"plane":"writing-plane","must_include":["writing"],"must_not_include":["control-plane only"]}}',
+      'info = {"routerClassifierMode": True, "applyHardPolicyOverrides": True}',
+      'result = module.analyze_output(record, "control-plane", info)',
+      'print(json.dumps(result))',
+    ]);
+
+    expect(parsed.failures).toContain('plane_mismatch');
+    expect(parsed.effectiveFailures).toEqual([]);
+    expect(parsed.routerPostprocessorApplied).toBe(true);
+    expect(parsed.routerPostprocessorAction).toBe('classify_local_runtime_guide_writing');
+    expect(parsed.effectiveScoringSource).toBe('router_postprocessor');
+  });
+
   it('reports separate model and effective router scores without changing model failures', () => {
     const parsed = runPythonSnippet([
       'records = [',

--- a/tests/gptoss-force-final-comparison.test.ts
+++ b/tests/gptoss-force-final-comparison.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 
@@ -103,10 +103,7 @@ describe('gptoss force-final comparison wrapper', () => {
   });
 
   it('treats nonzero eval exits with reports as eval failures in the wrapper source', () => {
-    const source = spawnSync('powershell', ['-NoProfile', '-Command', `Get-Content ${scriptPath}`], {
-      cwd: process.cwd(),
-      encoding: 'utf8',
-    }).stdout;
+    const source = readFileSync(scriptPath, 'utf8');
     expect(source).toContain("reportExists ? 'report_written_eval_failed' : 'infrastructure_failed'");
     expect(source).toContain('openAiCalled: false');
     expect(source).toContain('trainingExecuted: false');

--- a/tests/gptoss-runtime-readiness.test.ts
+++ b/tests/gptoss-runtime-readiness.test.ts
@@ -1,6 +1,6 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 import { jest } from '@jest/globals';
@@ -12,9 +12,14 @@ const auditScript = join(process.cwd(), 'scripts', 'gptoss', 'effective-router-a
 const replayScript = join(process.cwd(), 'scripts', 'gptoss', 'effective-router-replay.mjs');
 const releaseManifestScript = join(process.cwd(), 'scripts', 'gptoss', 'runtime-release-manifest.mjs');
 const releaseGateScript = join(process.cwd(), 'scripts', 'gptoss', 'runtime-release-gate.mjs');
+const releaseGateCiScript = join(process.cwd(), 'scripts', 'gptoss', 'runtime-release-gate-ci.mjs');
 const readinessScript = join(process.cwd(), 'scripts', 'gptoss', 'model-readiness-report.mjs');
 const cloudGateScript = join(process.cwd(), 'scripts', 'gptoss', 'cloud-readiness-gate.mjs');
 const schemaPath = join(process.cwd(), 'schemas', 'gptoss-effective-router-runtime.schema.json');
+const baselineRegistryPath = join(process.cwd(), 'examples', 'gptoss', 'gptoss-baseline-registry.json');
+const localSpecFactsPath = join(process.cwd(), 'examples', 'gptoss', 'arcanos-local-spec-facts.json');
+const runtimeSmokeDir = join(process.cwd(), 'examples', 'gptoss', 'runtime-smoke');
+const requestSmokeDir = join(process.cwd(), 'examples', 'gptoss', 'runtime-request-smoke');
 const smokeRequest = join(process.cwd(), 'examples', 'gptoss', 'runtime-smoke', 'writing-plane.json');
 const backendLogRequest = join(process.cwd(), 'examples', 'gptoss', 'runtime-request-smoke', 'backend-logs.json');
 const openAiTrainingRequest = join(process.cwd(), 'examples', 'gptoss', 'runtime-request-smoke', 'openai-output-training-rejection.json');
@@ -262,6 +267,7 @@ describe('gptoss effective-router runtime readiness', () => {
       'gptoss:runtime:request:local-model:smoke:audit',
       'gptoss:runtime:release-manifest',
       'gptoss:runtime:release-gate',
+      'gptoss:runtime:release-gate:ci',
     ];
 
     for (const scriptName of runtimeScripts) {
@@ -299,7 +305,14 @@ describe('gptoss effective-router release manifest', () => {
 
   it('includes readiness, regression status, runtime flags, and latest artifact paths', () => {
     const manifest = runReleaseManifest();
+    const schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+    const ajv = new Ajv2020();
+    const validate = ajv.compile({
+      ...schema.$defs.releaseManifest,
+      $defs: schema.$defs,
+    });
 
+    expect(validate(manifest)).toBe(true);
     expect(manifest).toMatchObject({
       kind: 'gptoss_effective_router_runtime_release_manifest',
       releaseScope: 'local_controlled_runtime_only',
@@ -735,6 +748,223 @@ describe('gptoss effective-router release gate', () => {
     const scripts = gate.RELEASE_GATE_COMMANDS.map((command) => command.script).join('\n');
 
     expect(scripts).not.toMatch(/openai|train|vllm|railway|db/i);
+  });
+});
+
+describe('gptoss CI-safe effective-router release gate', () => {
+  type GateCiModule = {
+    runReleaseGateCi: (options: {
+      repoRoot?: string;
+      ci?: boolean;
+      write?: boolean;
+    }) => Record<string, unknown>;
+  };
+
+  async function loadReleaseGateCi(): Promise<GateCiModule> {
+    return await import(pathToFileURL(releaseGateCiScript).href) as GateCiModule;
+  }
+
+  function writeFixtureFile(root: string, relativePath: string, body: string) {
+    const fullPath = join(root, relativePath);
+    mkdirSync(dirname(fullPath), { recursive: true });
+    writeFileSync(fullPath, body, 'utf8');
+  }
+
+  function writeFixtureJson(root: string, relativePath: string, value: unknown) {
+    writeFixtureFile(root, relativePath, `${JSON.stringify(value, null, 2)}\n`);
+  }
+
+  function copyJsonFixtures(root: string, sourceDir: string, targetDir: string) {
+    for (const name of readdirSync(sourceDir).filter((entry) => entry.endsWith('.json'))) {
+      writeFixtureFile(root, join(targetDir, name), readFileSync(join(sourceDir, name), 'utf8'));
+    }
+  }
+
+  function writeCiGateFixture(mutate: {
+    packageJson?: (value: Record<string, unknown>) => void;
+    schema?: (value: Record<string, unknown>) => void;
+    registry?: (value: Record<string, unknown>) => void;
+  } = {}) {
+    const tempDir = join(tmpdir(), `arcanos-gptoss-ci-gate-${Date.now()}-${Math.random()}`);
+    mkdirSync(tempDir, { recursive: true });
+
+    const packageJson = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8'));
+    mutate.packageJson?.(packageJson);
+    writeFixtureJson(tempDir, 'package.json', packageJson);
+
+    const schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+    mutate.schema?.(schema);
+    writeFixtureJson(tempDir, join('schemas', 'gptoss-effective-router-runtime.schema.json'), schema);
+
+    const registry = JSON.parse(readFileSync(baselineRegistryPath, 'utf8'));
+    mutate.registry?.(registry);
+    writeFixtureJson(tempDir, join('examples', 'gptoss', 'gptoss-baseline-registry.json'), registry);
+
+    writeFixtureFile(
+      tempDir,
+      join('examples', 'gptoss', 'arcanos-local-spec-facts.json'),
+      readFileSync(localSpecFactsPath, 'utf8'),
+    );
+    copyJsonFixtures(tempDir, runtimeSmokeDir, join('examples', 'gptoss', 'runtime-smoke'));
+    copyJsonFixtures(tempDir, requestSmokeDir, join('examples', 'gptoss', 'runtime-request-smoke'));
+    writeFixtureFile(
+      tempDir,
+      join('docs', 'GPTOSS_LOCAL_RUNTIME.md'),
+      readFileSync(join(process.cwd(), 'docs', 'GPTOSS_LOCAL_RUNTIME.md'), 'utf8'),
+    );
+    writeFixtureFile(
+      tempDir,
+      join('docs', 'GPTOSS_RUNTIME_ARCHITECTURE.md'),
+      readFileSync(join(process.cwd(), 'docs', 'GPTOSS_RUNTIME_ARCHITECTURE.md'), 'utf8'),
+    );
+
+    return tempDir;
+  }
+
+  it('passes without local_artifacts in CI mode', async () => {
+    const gate = await loadReleaseGateCi();
+    const tempDir = writeCiGateFixture();
+    try {
+      const report = gate.runReleaseGateCi({ repoRoot: tempDir, ci: true, write: false });
+
+      expect(report).toMatchObject({
+        ok: true,
+        modelScore: '11/24',
+        effectiveScore: '24/24',
+        localControlledRuntimeReady: true,
+        modelOnlyReady: false,
+        cloudReady: false,
+        customGptReady: false,
+        ciMode: true,
+        reportWritten: false,
+      });
+      expect(report.localOnlyChecksSkipped).toEqual(expect.arrayContaining([
+        'local_artifacts directory presence',
+        'adapter files',
+        'model weights',
+        'CUDA',
+        'WSL',
+      ]));
+      expect((report.safetyConfirmations as Record<string, unknown>).localArtifactsRequired).toBe(false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails if required package scripts are missing', async () => {
+    const gate = await loadReleaseGateCi();
+    const tempDir = writeCiGateFixture({
+      packageJson: (packageJson) => {
+        delete ((packageJson.scripts as Record<string, unknown>)['gptoss:runtime:release-gate:ci']);
+      },
+    });
+    try {
+      const report = gate.runReleaseGateCi({ repoRoot: tempDir, ci: true, write: false });
+
+      expect(report.ok).toBe(false);
+      expect(report.failures).toEqual(expect.arrayContaining([
+        'package_script_missing:gptoss:runtime:release-gate:ci',
+      ]));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails if cloudReady or customGptReady is true in tracked baseline data', async () => {
+    const gate = await loadReleaseGateCi();
+    const cloudTempDir = writeCiGateFixture({
+      registry: (registry) => {
+        (registry.baselines as Array<Record<string, unknown>>)[0].cloudReady = true;
+      },
+    });
+    const customTempDir = writeCiGateFixture({
+      registry: (registry) => {
+        (registry.baselines as Array<Record<string, unknown>>)[0].customGptReady = true;
+      },
+    });
+    try {
+      const cloudReport = gate.runReleaseGateCi({ repoRoot: cloudTempDir, ci: true, write: false });
+      const customReport = gate.runReleaseGateCi({ repoRoot: customTempDir, ci: true, write: false });
+
+      expect(cloudReport.ok).toBe(false);
+      expect(customReport.ok).toBe(false);
+      expect(cloudReport.failures).toEqual(expect.arrayContaining([
+        'tracked_cloud_or_custom_gpt_ready_true:baseline_registry.cloudReady',
+      ]));
+      expect(customReport.failures).toEqual(expect.arrayContaining([
+        'tracked_cloud_or_custom_gpt_ready_true:baseline_registry.customGptReady',
+      ]));
+    } finally {
+      rmSync(cloudTempDir, { recursive: true, force: true });
+      rmSync(customTempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails if required runtime supports are missing', async () => {
+    const gate = await loadReleaseGateCi();
+    const tempDir = writeCiGateFixture({
+      schema: (schema) => {
+        const supports = (schema.$defs as Record<string, Record<string, unknown>>).runtimeSupports;
+        supports.required = (supports.required as string[])
+          .filter((name) => name !== 'routerPostprocessor');
+        delete ((supports.properties as Record<string, unknown>).routerPostprocessor);
+      },
+    });
+    try {
+      const report = gate.runReleaseGateCi({ repoRoot: tempDir, ci: true, write: false });
+
+      expect(report.ok).toBe(false);
+      expect(report.failures).toEqual(expect.arrayContaining([
+        'runtime_support_schema_required_missing:router-postprocessor',
+        'runtime_support_schema_const_missing:router-postprocessor',
+      ]));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not call OpenAI, training, vLLM, Railway, live DB, or start a server', async () => {
+    const gate = await loadReleaseGateCi();
+    const tempDir = writeCiGateFixture();
+    try {
+      const report = gate.runReleaseGateCi({ repoRoot: tempDir, ci: true, write: false });
+      const source = readFileSync(releaseGateCiScript, 'utf8');
+
+      expect(report.ok).toBe(true);
+      expect(report.checks).toMatchObject({
+        noExternalOperationsRequired: true,
+      });
+      expect(report.safetyConfirmations).toMatchObject({
+        openAiCalled: false,
+        trainingExecuted: false,
+        vllmUsed: false,
+        railwayCliUsed: false,
+        liveDbUsed: false,
+        serverCreated: false,
+        publicServerCreated: false,
+        customGptExposureEnabled: false,
+      });
+      expect(source).not.toMatch(/node:child_process|spawnSync|execSync|railway\s+up|api\.openai\.com/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not require adapter files', async () => {
+    const gate = await loadReleaseGateCi();
+    const tempDir = writeCiGateFixture();
+    try {
+      const report = gate.runReleaseGateCi({ repoRoot: tempDir, ci: true, write: false });
+
+      expect(report.ok).toBe(true);
+      expect((report.checks as Record<string, unknown>).adapterFilesRequired).toBe(false);
+      expect(report.safetyConfirmations).toMatchObject({
+        adapterFilesRequired: false,
+        modelWeightsRequired: false,
+      });
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
Adds a CI-safe GPT-OSS runtime release gate that validates package wiring, schemas, fixtures, docs, baseline metadata, safety flags, and blocked cloud/Custom GPT readiness without requiring local model artifacts, CUDA, WSL, Railway, DB, vLLM, OpenAI, or training. Local release gate remains separate for artifact-backed validation.