### PR TITLE
Refine ARCANOS Gaming routing confidence

### DIFF
--- a/src/services/arcanos-gaming.ts
+++ b/src/services/arcanos-gaming.ts
@@ -3,6 +3,15 @@ import { getGamingModuleTimeoutMs } from "@services/gamingConfig.js";
 import { evaluateWithHRC } from "./hrcWrapper.js";
 import { resolveErrorMessage } from "@core/lib/errors/index.js";
 import { getRequestAbortSignal, isAbortError } from "@arcanos/runtime";
+import { logger } from "@platform/logging/structuredLogging.js";
+import {
+  BackendQueryAgent,
+  ClarificationAgent,
+  IntentRouterAgent,
+  ResponseComposerAgent,
+  type GamingBackendActionPayload,
+  type GamingIntent
+} from "@services/gamingAgents.js";
 import {
   formatGamingError,
   type GamingErrorEnvelope,
@@ -86,7 +95,7 @@ function formatKnownGenerationFailure(mode: GamingMode, error: unknown): GamingE
   });
 }
 
-async function handleGamingRequest(payload: unknown): Promise<GamingEnvelope> {
+async function executeGamingBackendQuery(payload: GamingBackendActionPayload): Promise<GamingEnvelope> {
   const validation = validateGamingRequest(payload);
   if (!validation.ok) {
     return validation.error;
@@ -130,6 +139,172 @@ async function handleGamingRequest(payload: unknown): Promise<GamingEnvelope> {
         code: "MODULE_ERROR",
         message: `HRC evaluation failed: ${resolveErrorMessage(error)}`
       }
+    });
+  }
+}
+
+function formatSecurityBlocked(intent: GamingIntent): GamingErrorEnvelope {
+  return formatGamingError({
+    mode: intent.mode === "guide" || intent.mode === "build" || intent.mode === "meta" ? intent.mode : null,
+    error: {
+      code: intent.securityBlocked?.code ?? "SECURITY_BLOCKED",
+      message: intent.securityBlocked?.message ?? "ARCANOS Gaming only handles writing-plane gameplay guidance.",
+      details: {
+        reason: intent.securityBlocked?.reason ?? "security_blocked"
+      }
+    }
+  });
+}
+
+function formatInvalidMode(): GamingErrorEnvelope {
+  return formatGamingError({
+    mode: null,
+    error: {
+      code: "GAMEPLAY_MODE_REQUIRED",
+      message: "Gameplay requests require explicit mode 'guide', 'build', or 'meta'."
+    }
+  });
+}
+
+function formatNonGamingRequest(): GamingErrorEnvelope {
+  return formatGamingError({
+    mode: null,
+    error: {
+      code: "NON_GAMING_REQUEST",
+      message: "ARCANOS Gaming handles gameplay guide, build, and meta requests."
+    }
+  });
+}
+
+function formatClarification(clarification: Extract<ReturnType<typeof ClarificationAgent.evaluate>, { required: true }>): GamingErrorEnvelope {
+  return formatGamingError({
+    mode: clarification.mode,
+    error: {
+      code: "CLARIFICATION_REQUIRED",
+      message: clarification.question,
+      details: {
+        missing: clarification.missing
+      }
+    }
+  });
+}
+
+function isGamingMode(value: GamingIntent["mode"]): value is GamingMode {
+  return value === "guide" || value === "build" || value === "meta";
+}
+
+function isUsableGamingSuccessEnvelope(value: GamingEnvelope): value is GamingSuccessEnvelope {
+  return value.ok === true &&
+    value.data !== null &&
+    typeof value.data === "object" &&
+    typeof value.data.response === "string";
+}
+
+function buildTelemetryEntityFlags(intent: GamingIntent) {
+  return {
+    game: Boolean(intent.game),
+    platform: Boolean(intent.platform),
+    version: Boolean(intent.version),
+    class: Boolean(intent.class),
+    role: Boolean(intent.role),
+    difficulty: Boolean(intent.difficulty),
+    progressPoint: Boolean(intent.progressPoint),
+    spoilerTolerance: intent.spoilerTolerance
+  };
+}
+
+async function handleGamingRequest(payload: unknown): Promise<GamingEnvelope> {
+  const intent = IntentRouterAgent.classify(payload);
+  logger.info("gaming.routing.intent", {
+    mode: intent.mode,
+    confidence: intent.confidence,
+    signals: intent.routingSignals,
+    entityFlags: buildTelemetryEntityFlags(intent),
+    securityBlocked: Boolean(intent.securityBlocked)
+  });
+
+  if (intent.securityBlocked) {
+    logger.warn("gaming.routing.security_blocked", {
+      mode: intent.mode,
+      confidence: intent.confidence,
+      reason: intent.securityBlocked.reason
+    });
+    return formatSecurityBlocked(intent);
+  }
+
+  if (intent.invalidMode) {
+    return formatInvalidMode();
+  }
+
+  if (intent.mode === "non-gaming") {
+    return formatNonGamingRequest();
+  }
+
+  const clarification = ClarificationAgent.evaluate(intent);
+  if (clarification.required) {
+    logger.info("gaming.routing.clarification", {
+      mode: clarification.mode,
+      confidence: intent.confidence,
+      missing: clarification.missing
+    });
+    return formatClarification(clarification);
+  }
+
+  if (!isGamingMode(intent.mode)) {
+    return formatNonGamingRequest();
+  }
+
+  const gamingIntent: GamingIntent & { mode: GamingMode } = {
+    ...intent,
+    mode: intent.mode
+  };
+  const backendAction = BackendQueryAgent.build(gamingIntent);
+  try {
+    const backendEnvelope = await BackendQueryAgent.call(backendAction, executeGamingBackendQuery);
+    if (!backendEnvelope.ok) {
+      logger.warn("gaming.backend.failure", {
+        mode: gamingIntent.mode,
+        confidence: gamingIntent.confidence,
+        errorCode: backendEnvelope.error.code
+      });
+      return backendEnvelope;
+    }
+
+    if (!isUsableGamingSuccessEnvelope(backendEnvelope)) {
+      logger.warn("gaming.backend.failure", {
+        mode: gamingIntent.mode,
+        confidence: gamingIntent.confidence,
+        errorCode: "MALFORMED_BACKEND_RESPONSE"
+      });
+      return ResponseComposerAgent.composeBackendFailureFallback({
+        intent: gamingIntent,
+        error: new Error("Malformed backend response")
+      });
+    }
+
+    logger.info("gaming.backend.success", {
+      mode: gamingIntent.mode,
+      confidence: gamingIntent.confidence,
+      sourceCount: backendEnvelope.data.sources.length
+    });
+
+    return ResponseComposerAgent.compose({
+      intent: gamingIntent,
+      backendEnvelope
+    });
+  } catch (error: unknown) {
+    if (getRequestAbortSignal()?.aborted || isAbortError(error)) {
+      throw error;
+    }
+
+    logger.warn("gaming.backend.failure", {
+      mode: gamingIntent.mode,
+      confidence: gamingIntent.confidence,
+      errorCode: "BACKEND_EXCEPTION"
+    });
+    return ResponseComposerAgent.composeBackendFailureFallback({
+      intent: gamingIntent,
+      error
     });
   }
 }

--- a/src/services/gamingAgents.ts
+++ b/src/services/gamingAgents.ts
@@ -1,0 +1,760 @@
+import { resolveErrorMessage } from "@core/lib/errors/index.js";
+import { formatGamingSuccess, resolveGamingMode, type GamingErrorEnvelope, type GamingMode, type GamingSuccessEnvelope } from "@services/gamingModes.js";
+import { isRecord } from "@shared/typeGuards.js";
+import { extractTextPrompt, normalizeStringList } from "@transport/http/payloadNormalization.js";
+
+export type GamingIntentMode = GamingMode | "non-gaming";
+
+export type GamingSpoilerTolerance = "avoid" | "allowed" | "unknown";
+
+export type GamingIntent = {
+  mode: GamingIntentMode;
+  prompt: string;
+  confidence: number;
+  routingSignals: string[];
+  invalidMode?: string;
+  game?: string;
+  platform?: string;
+  version?: string;
+  class?: string;
+  role?: string;
+  difficulty?: string;
+  progressPoint?: string;
+  spoilerTolerance: GamingSpoilerTolerance;
+  constraints: string[];
+  url?: string;
+  urls?: string[];
+  guideUrls?: string[];
+  audit?: boolean;
+  hrc?: boolean;
+  securityBlocked?: {
+    code: "SECURITY_BLOCKED";
+    reason: string;
+    message: string;
+  };
+};
+
+export type GamingClarificationResult =
+  | { required: false }
+  | {
+      required: true;
+      mode: GamingMode;
+      missing: string[];
+      question: string;
+    };
+
+export type GamingBackendActionPayload = {
+  mode: GamingMode;
+  prompt: string;
+  game?: string;
+  url?: string;
+  urls?: string[];
+  guideUrls?: string[];
+  audit?: boolean;
+  hrc?: boolean;
+};
+
+export type GamingBackendAction = {
+  action: "query";
+  payload: GamingBackendActionPayload;
+};
+
+export type GamingBackendConnector = (
+  payload: GamingBackendActionPayload
+) => Promise<GamingSuccessEnvelope | GamingErrorEnvelope>;
+
+const KNOWN_GAMES: Array<{ pattern: RegExp; name: string }> = [
+  { pattern: /\bSWTOR\b/i, name: "SWTOR" },
+  { pattern: /\bStar Wars:\s*The Old Republic\b/i, name: "Star Wars: The Old Republic" },
+  { pattern: /\bElden Ring\b/i, name: "Elden Ring" },
+  { pattern: /\bMinecraft\b/i, name: "Minecraft" },
+  { pattern: /\bDestiny 2\b/i, name: "Destiny 2" },
+  { pattern: /\bDiablo\s+(?:4|IV)\b/i, name: "Diablo 4" },
+  { pattern: /\bBaldur'?s Gate 3\b/i, name: "Baldur's Gate 3" },
+  { pattern: /\bPath of Exile(?: 2)?\b/i, name: "Path of Exile" },
+  { pattern: /\bWorld of Warcraft\b|\bWoW\b/i, name: "World of Warcraft" },
+  { pattern: /\bLeague of Legends\b|\bLoL\b/i, name: "League of Legends" },
+  { pattern: /\bOverwatch 2\b/i, name: "Overwatch 2" },
+  { pattern: /\bFortnite\b/i, name: "Fortnite" },
+];
+
+const GUIDE_RULES = [
+  { label: "guide_help_beat", pattern: /\bhelp\s+me\s+beat\b/i, weight: 0.78 },
+  { label: "guide_beat_target", pattern: /\b(?:beat|defeat|kill)\s+[A-Z]?[A-Za-z0-9' -]{2,}\b/i, weight: 0.62 },
+  { label: "guide_where_find", pattern: /\bwhere\s+do\s+i\s+(?:find|get|farm)\b/i, weight: 0.72 },
+  { label: "guide_how_do_i", pattern: /\bhow\s+do\s+i\b/i, weight: 0.55 },
+  { label: "guide_stuck", pattern: /\bstuck\b/i, weight: 0.55 },
+  { label: "guide_materials", pattern: /\b(?:upgrade\s+materials?|smithing\s+stones?|crafting\s+materials?)\b/i, weight: 0.62 },
+  { label: "guide_walkthrough", pattern: /\bwalkthrough\b/i, weight: 0.66 },
+  { label: "guide_objective", pattern: /\b(?:objective|quest|boss|mechanics?|route|leveling|beginner|tips?)\b/i, weight: 0.46 },
+];
+
+const BUILD_RULES = [
+  { label: "build_best_build", pattern: /\bbest\b[^.!?\n]{0,36}\bbuild\b/i, weight: 0.82 },
+  { label: "build_make_build", pattern: /\bmake\s+me\b[^.!?\n]{0,36}\bbuild\b/i, weight: 0.84 },
+  { label: "build_explicit", pattern: /\bbuild\b/i, weight: 0.66 },
+  { label: "build_loadout", pattern: /\bloadout\b/i, weight: 0.72 },
+  { label: "build_skill_tree", pattern: /\b(?:skill\s*tree|talents?|perks?)\b/i, weight: 0.62 },
+  { label: "build_gear", pattern: /\bgear(?:ing)?\b/i, weight: 0.52 },
+  { label: "build_team_comp", pattern: /\bteam\s*comp(?:osition)?s?\b/i, weight: 0.64 },
+  { label: "build_optimize", pattern: /\boptimi[sz](?:e|ation)\b/i, weight: 0.58 },
+  { label: "build_rotation", pattern: /\brotation\b/i, weight: 0.50 },
+];
+
+const META_RULES = [
+  { label: "meta_viable_patch", pattern: /\b(?:still\s+)?viable\b[^.!?\n]{0,32}\b(?:patch|meta|season|right\s+now)\b/i, weight: 0.84 },
+  { label: "meta_is_meta", pattern: /\bis\b[^.!?\n]{0,36}\bmeta\b/i, weight: 0.82 },
+  { label: "meta_changed_patch", pattern: /\bwhat\s+changed\b(?:[^.!?\n]{0,32}\b(?:patch|version|season|\d+\.\d+)\b)?/i, weight: 0.86 },
+  { label: "meta_patch_number", pattern: /\b(?:patch\s*)?\d{1,2}\.\d{1,2}\b/i, weight: 0.68 },
+  { label: "meta_tier_list", pattern: /\btier\s*list\b/i, weight: 0.78 },
+  { label: "meta_balance", pattern: /\b(?:balance|nerf|buff)s?\b/i, weight: 0.64 },
+  { label: "meta_current_state", pattern: /\b(?:current\s+(?:meta|tier|state|patch|season)|right\s+now)\b/i, weight: 0.58 },
+  { label: "meta_explicit", pattern: /\bmeta\b/i, weight: 0.62 },
+];
+
+const NON_GAMING_PATTERNS = [
+  /^\s*ping\s*$/i,
+  /\bwrite\s+(?:a\s+)?(?:poem|email|essay|cover letter)\b/i,
+  /\brecipe\b/i,
+  /\btax\b/i,
+  /\blegal\b/i,
+  /\bmedical\b/i,
+];
+
+const BLOCKED_ACTIONS = new Set([
+  "runtime.inspect",
+  "workers.status",
+  "queue.inspect",
+  "self_heal.status",
+  "system_state",
+  "get_status",
+  "get_result",
+  "job_status",
+  "job_result",
+  "diagnostics",
+  "root.deep_diagnostics",
+  "mcp.invoke",
+  "mcp.run",
+  "mcp.list_tools",
+  "dag.dispatch",
+  "dag.status",
+  "dag.trace",
+  "db.explain",
+  "logs.query",
+]);
+
+const CONTROL_PROMPT_PATTERNS = [
+  /\b(?:show|check|inspect|list|retrieve|get|fetch)\s+(?:the\s+)?(?:runtime|workers?|worker\s+status|queue|system\s+state|diagnostics?|logs?|job\s+(?:result|status)|mcp|database|db|self[-\s]?heal)\b/i,
+  /\b(?:runtime|workers?|queue|system\s+state|diagnostics?|self[-\s]?heal)\s+(?:status|health|inspection|report)\b/i,
+  /\/(?:internal|gpt-access|jobs|workers\/status|system-state|mcp|queue|runtime|diagnostics?)\b/i,
+  /\b(?:bearer\s+token|api\s+key|cookies?|private\s+logs?)\b/i,
+];
+
+function getStringField(payload: unknown, key: string): string | undefined {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  const value = payload[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function getRawStringField(payload: unknown, key: string): string | undefined {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  const value = payload[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function getBooleanField(payload: unknown, key: string): boolean | undefined {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  return typeof payload[key] === "boolean" ? payload[key] : undefined;
+}
+
+function extractPrompt(payload: unknown): string {
+  return extractTextPrompt(payload, ["prompt", "message", "userInput", "text", "content", "query"]);
+}
+
+function matchesAny(prompt: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(prompt));
+}
+
+function clampConfidence(value: number): number {
+  return Math.max(0, Math.min(1, Number(value.toFixed(2))));
+}
+
+function scoreRules(prompt: string, rules: Array<{ label: string; pattern: RegExp; weight: number }>): { score: number; signals: string[] } {
+  let score = 0;
+  const signals: string[] = [];
+  for (const rule of rules) {
+    if (!rule.pattern.test(prompt)) {
+      continue;
+    }
+
+    score += rule.weight;
+    signals.push(rule.label);
+  }
+
+  return { score, signals };
+}
+
+function readNestedAction(payload: unknown): string | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const directAction = getStringField(payload, "action") ?? getStringField(payload, "operation");
+  if (directAction) {
+    return directAction.toLowerCase();
+  }
+
+  const mcpAction = isRecord(payload.mcp)
+    ? getStringField(payload.mcp, "action") ?? getStringField(payload.mcp, "operation")
+    : undefined;
+  if (mcpAction) {
+    return mcpAction.toLowerCase();
+  }
+
+  const dagAction = isRecord(payload.dag)
+    ? getStringField(payload.dag, "action") ?? getStringField(payload.dag, "operation")
+    : undefined;
+  return dagAction ? dagAction.toLowerCase() : null;
+}
+
+function detectSecurityBlock(payload: unknown, prompt: string): GamingIntent["securityBlocked"] | undefined {
+  const nestedAction = readNestedAction(payload);
+  if (nestedAction && (BLOCKED_ACTIONS.has(nestedAction) || nestedAction.startsWith("dag."))) {
+    return {
+      code: "SECURITY_BLOCKED",
+      reason: "blocked_control_action",
+      message: "ARCANOS Gaming only handles writing-plane gameplay guidance."
+    };
+  }
+
+  const mode = getStringField(payload, "mode")?.toLowerCase();
+  if (mode === "system_state" || mode === "diagnostic" || mode === "diagnostics") {
+    return {
+      code: "SECURITY_BLOCKED",
+      reason: "blocked_control_mode",
+      message: "ARCANOS Gaming only handles writing-plane gameplay guidance."
+    };
+  }
+
+  const executionMode = getStringField(payload, "executionMode")?.toLowerCase();
+  const target = getStringField(payload, "target")?.toLowerCase();
+  if (executionMode === "dag" || target === "dag") {
+    return {
+      code: "SECURITY_BLOCKED",
+      reason: "blocked_dag_control_request",
+      message: "ARCANOS Gaming does not run DAG, MCP, diagnostic, job, worker, queue, or runtime operations."
+    };
+  }
+
+  if (matchesAny(prompt, CONTROL_PROMPT_PATTERNS)) {
+    return {
+      code: "SECURITY_BLOCKED",
+      reason: "blocked_control_prompt",
+      message: "ARCANOS Gaming does not expose internal runtime, worker, queue, job, MCP, log, database, or diagnostic operations."
+    };
+  }
+
+  return undefined;
+}
+
+function scoreIntent(payload: unknown, prompt: string): { mode: GamingIntentMode; confidence: number; signals: string[] } {
+  const explicitMode = resolveGamingMode(payload);
+  if (explicitMode) {
+    return {
+      mode: explicitMode,
+      confidence: 1,
+      signals: [`explicit_mode_${explicitMode}`],
+    };
+  }
+
+  if (!prompt) {
+    return {
+      mode: "non-gaming",
+      confidence: 1,
+      signals: ["empty_prompt"],
+    };
+  }
+
+  if (matchesAny(prompt, NON_GAMING_PATTERNS)) {
+    return {
+      mode: "non-gaming",
+      confidence: 0.92,
+      signals: ["non_gaming_pattern"],
+    };
+  }
+
+  const guide = scoreRules(prompt, GUIDE_RULES);
+  const build = scoreRules(prompt, BUILD_RULES);
+  const meta = scoreRules(prompt, META_RULES);
+  const knownGame = extractKnownGame(prompt);
+  if (knownGame) {
+    guide.score += 0.22;
+    build.score += 0.16;
+    meta.score += 0.16;
+    guide.signals.push("known_game");
+  }
+
+  const scoredModes = [
+    { mode: "guide" as const, ...guide },
+    { mode: "build" as const, ...build },
+    { mode: "meta" as const, ...meta },
+  ].sort((left, right) => right.score - left.score);
+  const best = scoredModes[0];
+  const runnerUp = scoredModes[1];
+
+  if (!best || best.score <= 0) {
+    return {
+      mode: "non-gaming",
+      confidence: 0.56,
+      signals: ["no_gaming_intent_signal"],
+    };
+  }
+
+  const confidence = clampConfidence(Math.min(0.98, 0.42 + best.score / 1.5 + Math.max(0, best.score - runnerUp.score) / 1.8));
+  return {
+    mode: best.mode,
+    confidence,
+    signals: best.signals,
+  };
+}
+
+function extractKnownGame(prompt: string): string | undefined {
+  const match = KNOWN_GAMES.find((game) => game.pattern.test(prompt));
+  return match?.name;
+}
+
+function cleanGameCandidate(candidate: string): string | undefined {
+  const cleaned = candidate
+    .replace(/\b(?:build|loadout|meta|guide|tips|class|team|comp|patch|season|right now)\b.*$/i, "")
+    .replace(/[?.!,;:]+$/g, "")
+    .trim();
+
+  return cleaned.length > 1 ? cleaned : undefined;
+}
+
+function inferGameFromPrompt(prompt: string): string | undefined {
+  const known = extractKnownGame(prompt);
+  if (known) {
+    return known;
+  }
+
+  const match = prompt.match(/\b(?:in|for|on)\s+([A-Za-z0-9][A-Za-z0-9'’:.+-]*(?:\s+[A-Za-z0-9][A-Za-z0-9'’:.+-]*){0,5})/i);
+  return match?.[1] ? cleanGameCandidate(match[1]) : undefined;
+}
+
+function extractPlatform(payload: unknown, prompt: string): string | undefined {
+  const explicit = getStringField(payload, "platform");
+  if (explicit) {
+    return explicit;
+  }
+
+  const match = prompt.match(/\b(PC|PS5|PS4|Xbox(?: Series [XS])?|Switch|Steam Deck)\b/i);
+  return match?.[1];
+}
+
+function extractVersion(payload: unknown, prompt: string): string | undefined {
+  const explicit = getStringField(payload, "version") ?? getStringField(payload, "patch");
+  if (explicit) {
+    return explicit;
+  }
+
+  if (/\bthis\s+patch\b/i.test(prompt)) {
+    return "this patch";
+  }
+
+  const match = prompt.match(/\b(?:patch|version|season)\s+([A-Za-z0-9._ -]{1,32})/i) ??
+    prompt.match(/\bin\s+(\d{1,2}\.\d{1,2})\b/i);
+  return match?.[1]?.trim();
+}
+
+function extractClass(payload: unknown, prompt: string): string | undefined {
+  const explicit = getStringField(payload, "class") ?? getStringField(payload, "className");
+  if (explicit) {
+    return explicit;
+  }
+
+  const knownClass = prompt.match(/\b(frost\s+mage|fire\s+mage|arcane\s+mage|lightning\s+sorc(?:erer)?|sorc(?:erer)?|barbarian|rogue|druid|necromancer|paladin|warlock|hunter|priest|warrior|monk)\b/i);
+  if (knownClass?.[1]) {
+    return normalizeEntityValue(knownClass[1]);
+  }
+
+  const match = prompt.match(/\b(?:as|for)\s+(?:a\s+|an\s+)?([A-Za-z][A-Za-z -]{1,32})\s+(?:build|loadout|class|spec)\b/i);
+  return match?.[1] ? normalizeEntityValue(match[1]) : undefined;
+}
+
+function extractRole(payload: unknown, prompt: string): string | undefined {
+  const explicit = getStringField(payload, "role");
+  if (explicit) {
+    return normalizeEntityValue(explicit);
+  }
+
+  const match = prompt.match(/\b(tank|healer|healing|support|dps|damage|solo|duo|carry)\b/i);
+  if (!match?.[1]) {
+    return undefined;
+  }
+
+  const role = match[1].toLowerCase();
+  if (role === "healing") {
+    return "healer";
+  }
+  if (role === "damage") {
+    return "dps";
+  }
+  return role;
+}
+
+function extractDifficulty(payload: unknown, prompt: string): string | undefined {
+  const explicit = getStringField(payload, "difficulty");
+  if (explicit) {
+    return explicit;
+  }
+
+  const match = prompt.match(/\b(story|normal|hard|heroic|veteran|master|legendary|nightmare|hardcore)\b/i);
+  return match?.[1];
+}
+
+function extractProgressPoint(payload: unknown, prompt: string): string | undefined {
+  const explicit =
+    getStringField(payload, "progressPoint") ??
+    getStringField(payload, "progress") ??
+    getStringField(payload, "checkpoint");
+  if (explicit) {
+    return explicit;
+  }
+
+  const match = prompt.match(/\b(?:stuck\s+(?:on|at)|at|after|before)\s+([A-Za-z0-9][A-Za-z0-9'’:, -]{1,48})/i);
+  if (match?.[1]) {
+    return normalizeEntityValue(match[1]);
+  }
+
+  const stage = prompt.match(/\b(early\s+game|mid\s*game|late\s+game|endgame|act\s+\d+|chapter\s+\d+|new\s+game\s*\+|ng\+)\b/i);
+  return stage?.[1] ? normalizeEntityValue(stage[1]) : undefined;
+}
+
+function normalizeEntityValue(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function extractSpoilerTolerance(payload: unknown, prompt: string): GamingSpoilerTolerance {
+  const explicit = getStringField(payload, "spoilerTolerance")?.toLowerCase();
+  if (explicit === "avoid" || explicit === "none" || explicit === "no spoilers") {
+    return "avoid";
+  }
+  if (explicit === "allowed" || explicit === "ok" || explicit === "spoilers ok") {
+    return "allowed";
+  }
+
+  if (/\b(?:no|avoid)\s+spoilers?\b/i.test(prompt)) {
+    return "avoid";
+  }
+  if (/\bspoilers?\s+(?:ok|okay|allowed|fine)\b|\binclude\s+spoilers?\b/i.test(prompt)) {
+    return "allowed";
+  }
+  return "unknown";
+}
+
+function extractConstraints(payload: unknown, prompt: string): string[] {
+  const explicit = normalizeStringList(isRecord(payload) ? payload.constraints : undefined);
+  const inferred = [
+    /\bsolo\b/i.test(prompt) ? "solo" : "",
+    /\bbudget\b/i.test(prompt) ? "budget" : "",
+    /\bno\s+DLC\b/i.test(prompt) ? "no DLC" : "",
+    /\bbeginner\b/i.test(prompt) ? "beginner" : "",
+    /\bPvP\b/i.test(prompt) ? "PvP" : "",
+    /\bPvE\b/i.test(prompt) ? "PvE" : "",
+  ].filter(Boolean);
+
+  return Array.from(new Set([...explicit, ...inferred]));
+}
+
+function rawStringList(...candidates: Array<unknown>): string[] {
+  const values: string[] = [];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      values.push(candidate);
+      continue;
+    }
+
+    if (!Array.isArray(candidate)) {
+      continue;
+    }
+
+    for (const value of candidate) {
+      if (typeof value === "string" && value.trim().length > 0) {
+        values.push(value);
+      }
+    }
+  }
+
+  return values;
+}
+
+function firstUsefulLine(text: string): string {
+  const line = text
+    .split(/\r?\n/)
+    .map((entry) => entry.trim())
+    .find((entry) => entry.length > 0);
+
+  if (!line) {
+    return "Backend-supported guidance is available below.";
+  }
+
+  return line.length > 220 ? `${line.slice(0, 217)}...` : line;
+}
+
+function spoilerWatchOut(spoilerTolerance: GamingSpoilerTolerance): string {
+  if (spoilerTolerance === "avoid") {
+    return "Spoilers: avoided by request; any unavoidable story detail should be marked before use.";
+  }
+  if (spoilerTolerance === "allowed") {
+    return "Spoilers: allowed by request.";
+  }
+  return "Spoilers: not intentionally included; major story reveals are avoided unless necessary.";
+}
+
+function patchWatchOut(intent: GamingIntent): string {
+  if (intent.mode === "meta") {
+    return intent.version
+      ? `Patch/version: using supplied context '${intent.version}'.`
+      : "Patch/version: no patch or version was supplied, so treat current-state advice as patch-sensitive.";
+  }
+
+  if (intent.mode === "build" && !intent.version) {
+    return "Patch/version: no patch or version was supplied; verify numbers and balance-sensitive details in-game.";
+  }
+
+  return "Context: adjust for your platform, patch, difficulty, and progression point when they differ.";
+}
+
+function buildContextLine(intent: GamingIntent): string {
+  const parts = [
+    intent.game ? `game=${intent.game}` : "",
+    intent.platform ? `platform=${intent.platform}` : "",
+    intent.version ? `version=${intent.version}` : "",
+    intent.class ? `class=${intent.class}` : "",
+    intent.role ? `role=${intent.role}` : "",
+    intent.difficulty ? `difficulty=${intent.difficulty}` : "",
+    intent.progressPoint ? `progress=${intent.progressPoint}` : "",
+    intent.constraints.length > 0 ? `constraints=${intent.constraints.join(", ")}` : "",
+  ].filter(Boolean);
+
+  return parts.length > 0 ? `Context used: ${parts.join("; ")}.` : "Context used: prompt only.";
+}
+
+function hasComposedSections(response: string): boolean {
+  return /\bQuick Answer\b/i.test(response) &&
+    /\bWhy It Works\b/i.test(response) &&
+    /\bWatch Outs\b/i.test(response);
+}
+
+function lowConfidenceNote(intent: GamingIntent): string | null {
+  if (intent.confidence >= 0.6) {
+    return null;
+  }
+
+  return `Routing confidence: low (${intent.confidence.toFixed(2)}). If this lands in the wrong mode, specify guide, build, or meta.`;
+}
+
+function fallbackBodyForMode(intent: GamingIntent): string {
+  if (intent.mode === "build") {
+    return [
+      "Start with the role you need the build to perform, then prioritize core scaling stats, survivability, and one reliable damage or utility loop.",
+      "Test changes in safe content before committing rare materials or ranked attempts.",
+    ].join("\n");
+  }
+
+  if (intent.mode === "meta") {
+    return [
+      "Treat meta advice as patch-sensitive until verified against the current game version.",
+      "Prefer flexible picks, builds, or team comps that remain useful when a matchup or balance assumption is wrong.",
+    ].join("\n");
+  }
+
+  return [
+    "Confirm the current objective, repair or upgrade gear, stock key consumables, and retry the next encounter while watching for repeatable mechanics.",
+    "If progress stalls, lower the difficulty, level up, or narrow the request to the exact boss, quest, route, or checkpoint.",
+  ].join("\n");
+}
+
+export const IntentRouterAgent = {
+  classify(payload: unknown): GamingIntent {
+    const prompt = extractPrompt(payload);
+    const securityBlocked = detectSecurityBlock(payload, prompt);
+    const rawMode = getStringField(payload, "mode");
+    const explicitMode = resolveGamingMode(payload);
+    const scoredIntent = scoreIntent(payload, prompt);
+    const url = getRawStringField(payload, "url") ?? getRawStringField(payload, "guideUrl");
+    const urls = rawStringList(isRecord(payload) ? payload.urls : undefined);
+    const guideUrls = rawStringList(isRecord(payload) ? payload.guideUrls : undefined);
+    const audit = getBooleanField(payload, "audit") ?? getBooleanField(payload, "enableAudit");
+    const hrc = getBooleanField(payload, "hrc") ?? getBooleanField(payload, "enableHrc");
+
+    return {
+      mode: scoredIntent.mode,
+      prompt,
+      confidence: scoredIntent.confidence,
+      routingSignals: scoredIntent.signals,
+      ...(rawMode && !explicitMode && !securityBlocked ? { invalidMode: rawMode } : {}),
+      game: getStringField(payload, "game") ? normalizeEntityValue(getStringField(payload, "game")!) : inferGameFromPrompt(prompt),
+      platform: extractPlatform(payload, prompt) ? normalizeEntityValue(extractPlatform(payload, prompt)!) : undefined,
+      version: extractVersion(payload, prompt) ? normalizeEntityValue(extractVersion(payload, prompt)!) : undefined,
+      class: extractClass(payload, prompt),
+      role: extractRole(payload, prompt),
+      difficulty: extractDifficulty(payload, prompt),
+      progressPoint: extractProgressPoint(payload, prompt),
+      spoilerTolerance: extractSpoilerTolerance(payload, prompt),
+      constraints: extractConstraints(payload, prompt),
+      ...(url ? { url } : {}),
+      ...(urls.length > 0 ? { urls } : {}),
+      ...(guideUrls.length > 0 ? { guideUrls } : {}),
+      ...(audit === true ? { audit: true } : {}),
+      ...(hrc === true ? { hrc: true } : {}),
+      ...(securityBlocked ? { securityBlocked } : {}),
+    };
+  },
+};
+
+export const ClarificationAgent = {
+  evaluate(intent: GamingIntent): GamingClarificationResult {
+    if (intent.mode !== "build" && intent.mode !== "meta") {
+      return { required: false };
+    }
+
+    if (intent.game) {
+      return { required: false };
+    }
+
+    return {
+      required: true,
+      mode: intent.mode,
+      missing: ["game"],
+      question: `Which game should I use for this ${intent.mode} request?`,
+    };
+  },
+};
+
+export const BackendQueryAgent = {
+  build(intent: GamingIntent & { mode: GamingMode }): GamingBackendAction {
+    const payload: GamingBackendActionPayload = {
+      mode: intent.mode,
+      prompt: intent.prompt,
+    };
+
+    if (intent.game) {
+      payload.game = intent.game;
+    }
+    if (intent.url) {
+      payload.url = intent.url;
+    }
+    if (intent.urls && intent.urls.length > 0) {
+      payload.urls = intent.urls;
+    }
+    if (intent.guideUrls && intent.guideUrls.length > 0) {
+      payload.guideUrls = intent.guideUrls;
+    }
+    if (intent.audit === true) {
+      payload.audit = true;
+    }
+    if (intent.hrc === true) {
+      payload.hrc = true;
+    }
+
+    return {
+      action: "query",
+      payload,
+    };
+  },
+
+  async call(
+    action: GamingBackendAction,
+    connector: GamingBackendConnector
+  ): Promise<GamingSuccessEnvelope | GamingErrorEnvelope> {
+    return connector(action.payload);
+  },
+};
+
+export const ResponseComposerAgent = {
+  compose(params: {
+    intent: GamingIntent & { mode: GamingMode };
+    backendEnvelope: GamingSuccessEnvelope;
+  }): GamingSuccessEnvelope {
+    const { intent, backendEnvelope } = params;
+    const backendResponse = backendEnvelope.data.response.trim();
+    const response = hasComposedSections(backendResponse)
+      ? [
+          backendResponse,
+          `- ${spoilerWatchOut(intent.spoilerTolerance)}`,
+          `- ${patchWatchOut(intent)}`,
+          ...(lowConfidenceNote(intent) ? [`- ${lowConfidenceNote(intent)}`] : []),
+        ].join("\n")
+      : [
+          "Quick Answer",
+          `Backend-supported: ${firstUsefulLine(backendResponse)}`,
+          "",
+          intent.mode === "build" ? "Build" : "Steps",
+          backendResponse,
+          "",
+          "Why It Works",
+          "Backend-supported: the guidance above came from the ARCANOS Gaming backend.",
+          "Inference: ARCANOS Gaming added the section labels, summary line, and context cautions.",
+          buildContextLine(intent),
+          "",
+          "Watch Outs",
+          `- ${spoilerWatchOut(intent.spoilerTolerance)}`,
+          `- ${patchWatchOut(intent)}`,
+          ...(lowConfidenceNote(intent) ? [`- ${lowConfidenceNote(intent)}`] : []),
+        ].join("\n");
+
+    return {
+      ...backendEnvelope,
+      data: {
+        ...backendEnvelope.data,
+        response,
+      },
+    };
+  },
+
+  composeBackendFailureFallback(params: {
+    intent: GamingIntent & { mode: GamingMode };
+    error: unknown;
+  }): GamingSuccessEnvelope {
+    const { intent, error } = params;
+    const fallback = fallbackBodyForMode(intent);
+    const response = [
+      "Quick Answer",
+      "Backend-supported: none. The backend did not return usable guidance.",
+      "",
+      intent.mode === "build" ? "Build" : "Steps",
+      "General Fallback (not backend-supported):",
+      fallback,
+      "",
+      "Why It Works",
+      "Backend-supported: none; this is a deterministic fallback because the backend call failed.",
+      `Inference: fallback selected from request mode '${intent.mode}' and available prompt context.`,
+      buildContextLine(intent),
+      "",
+      "Watch Outs",
+      `- ${spoilerWatchOut(intent.spoilerTolerance)}`,
+      `- ${patchWatchOut(intent)}`,
+      ...(lowConfidenceNote(intent) ? [`- ${lowConfidenceNote(intent)}`] : []),
+      `- Backend failure: ${resolveErrorMessage(error, "unknown backend failure")}`,
+    ].join("\n");
+
+    return formatGamingSuccess({
+      mode: intent.mode,
+      data: {
+        response,
+        sources: [],
+      },
+    });
+  },
+};

--- a/src/services/gamingAgents.ts
+++ b/src/services/gamingAgents.ts
@@ -78,6 +78,14 @@ const KNOWN_GAMES: Array<{ pattern: RegExp; name: string }> = [
   { pattern: /\bFortnite\b/i, name: "Fortnite" },
 ];
 
+const INFERRED_GAME_BLACKLIST = new Set([
+  "pc", "ps5", "ps4", "xbox", "switch", "steam", "deck",
+  "tank", "healer", "healing", "support", "dps", "damage", "solo", "duo", "carry",
+  "mage", "sorcerer", "sorc", "barbarian", "rogue", "druid", "necromancer", "paladin", "warlock", "hunter", "priest", "warrior", "monk",
+  "leveling", "beginner", "beginners", "veteran", "veterans", "hardcore", "casual", "casuals", "build", "loadout", "guide", "spec",
+  "this", "that", "current", "latest"
+]);
+
 const GUIDE_RULES = [
   { label: "guide_help_beat", pattern: /\bhelp\s+me\s+beat\b/i, weight: 0.78 },
   { label: "guide_beat_target", pattern: /\b(?:beat|defeat|kill)\s+[A-Z]?[A-Za-z0-9' -]{2,}\b/i, weight: 0.62 },
@@ -301,6 +309,8 @@ function scoreIntent(payload: unknown, prompt: string): { mode: GamingIntentMode
     build.score += 0.16;
     meta.score += 0.16;
     guide.signals.push("known_game");
+    build.signals.push("known_game");
+    meta.signals.push("known_game");
   }
 
   const scoredModes = [
@@ -348,7 +358,21 @@ function inferGameFromPrompt(prompt: string): string | undefined {
   }
 
   const match = prompt.match(/\b(?:in|for|on)\s+([A-Za-z0-9][A-Za-z0-9'’:.+-]*(?:\s+[A-Za-z0-9][A-Za-z0-9'’:.+-]*){0,5})/i);
-  return match?.[1] ? cleanGameCandidate(match[1]) : undefined;
+  if (!match?.[1]) {
+    return undefined;
+  }
+
+  const candidate = cleanGameCandidate(match[1]);
+  if (!candidate) {
+    return undefined;
+  }
+
+  const words = candidate.toLowerCase().split(/\s+/);
+  if (words.some((word) => INFERRED_GAME_BLACKLIST.has(word))) {
+    return undefined;
+  }
+
+  return candidate;
 }
 
 function extractPlatform(payload: unknown, prompt: string): string | undefined {
@@ -508,7 +532,12 @@ function firstUsefulLine(text: string): string {
     return "Backend-supported guidance is available below.";
   }
 
-  return line.length > 220 ? `${line.slice(0, 217)}...` : line;
+  const cleanLine = line.replace(/^#+\s*/, "").trim();
+  if (!cleanLine) {
+    return "Backend-supported guidance is available below.";
+  }
+
+  return cleanLine.length > 220 ? `${cleanLine.slice(0, 217)}...` : cleanLine;
 }
 
 function spoilerWatchOut(spoilerTolerance: GamingSpoilerTolerance): string {
@@ -597,6 +626,9 @@ export const IntentRouterAgent = {
     const guideUrls = rawStringList(isRecord(payload) ? payload.guideUrls : undefined);
     const audit = getBooleanField(payload, "audit") ?? getBooleanField(payload, "enableAudit");
     const hrc = getBooleanField(payload, "hrc") ?? getBooleanField(payload, "enableHrc");
+    const rawGame = getStringField(payload, "game");
+    const rawPlatform = extractPlatform(payload, prompt);
+    const rawVersion = extractVersion(payload, prompt);
 
     return {
       mode: scoredIntent.mode,
@@ -604,9 +636,9 @@ export const IntentRouterAgent = {
       confidence: scoredIntent.confidence,
       routingSignals: scoredIntent.signals,
       ...(rawMode && !explicitMode && !securityBlocked ? { invalidMode: rawMode } : {}),
-      game: getStringField(payload, "game") ? normalizeEntityValue(getStringField(payload, "game")!) : inferGameFromPrompt(prompt),
-      platform: extractPlatform(payload, prompt) ? normalizeEntityValue(extractPlatform(payload, prompt)!) : undefined,
-      version: extractVersion(payload, prompt) ? normalizeEntityValue(extractVersion(payload, prompt)!) : undefined,
+      game: rawGame ? normalizeEntityValue(rawGame) : inferGameFromPrompt(prompt),
+      platform: rawPlatform ? normalizeEntityValue(rawPlatform) : undefined,
+      version: rawVersion ? normalizeEntityValue(rawVersion) : undefined,
       class: extractClass(payload, prompt),
       role: extractRole(payload, prompt),
       difficulty: extractDifficulty(payload, prompt),

--- a/tests/arcanos-gaming.modes.test.ts
+++ b/tests/arcanos-gaming.modes.test.ts
@@ -4,6 +4,16 @@ const mockRunGuidePipeline = jest.fn();
 const mockRunBuildPipeline = jest.fn();
 const mockRunMetaPipeline = jest.fn();
 const mockEvaluateWithHRC = jest.fn();
+const mockLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  timed: jest.fn(),
+  startTimer: jest.fn(() => jest.fn()),
+  child: jest.fn(),
+};
+mockLogger.child.mockReturnValue(mockLogger);
 
 jest.unstable_mockModule("../src/services/gaming.js", () => ({
   runGuidePipeline: mockRunGuidePipeline,
@@ -13,6 +23,30 @@ jest.unstable_mockModule("../src/services/gaming.js", () => ({
 
 jest.unstable_mockModule("../src/services/hrcWrapper.js", () => ({
   evaluateWithHRC: mockEvaluateWithHRC,
+}));
+
+jest.unstable_mockModule("../src/platform/logging/structuredLogging.js", () => ({
+  LogLevel: {
+    DEBUG: "debug",
+    INFO: "info",
+    WARN: "warn",
+    ERROR: "error",
+  },
+  logger: mockLogger,
+  apiLogger: mockLogger,
+  dbLogger: mockLogger,
+  aiLogger: mockLogger,
+  workerLogger: mockLogger,
+  sanitize: jest.fn((value: unknown) => value),
+  getConfiguredLogLevel: jest.fn(() => "info"),
+  requestLoggingMiddleware: jest.fn((_req: unknown, _res: unknown, next: () => void) => next()),
+  healthMetrics: {
+    record: jest.fn(),
+    increment: jest.fn(),
+    getMetrics: jest.fn(() => ({})),
+    getSnapshot: jest.fn(() => ({})),
+  },
+  default: mockLogger,
 }));
 
 const { ArcanosGaming } = await import("../src/services/arcanos-gaming.js");
@@ -67,15 +101,18 @@ describe("ArcanosGaming mode routing", () => {
     expect(mockRunBuildPipeline).not.toHaveBeenCalled();
     expect(mockRunMetaPipeline).not.toHaveBeenCalled();
     expect(mockEvaluateWithHRC).not.toHaveBeenCalled();
-    expect(result).toEqual({
+    expect(result).toEqual(expect.objectContaining({
       ok: true,
       route: "gaming",
       mode: "guide",
-      data: {
-        response: "Guide response",
+      data: expect.objectContaining({
+        response: expect.stringContaining("Guide response"),
         sources: [],
-      },
-    });
+      }),
+    }));
+    expect((result as any).data.response).toContain("Quick Answer");
+    expect((result as any).data.response).toContain("Why It Works");
+    expect((result as any).data.response).toContain("Watch Outs");
   });
 
   it("accepts guideUrl as the single guide URL field", async () => {
@@ -158,7 +195,7 @@ describe("ArcanosGaming mode routing", () => {
     );
   });
 
-  it("returns a structured error when mode is missing", async () => {
+  it("returns a structured non-gaming error for a bare ping prompt", async () => {
     const result = await ArcanosGaming.actions.query({
       prompt: "ping",
     });
@@ -171,8 +208,8 @@ describe("ArcanosGaming mode routing", () => {
       route: "gaming",
       mode: null,
       error: {
-        code: "GAMEPLAY_MODE_REQUIRED",
-        message: "Gameplay requests require explicit mode 'guide', 'build', or 'meta'.",
+        code: "NON_GAMING_REQUEST",
+        message: "ARCANOS Gaming handles gameplay guide, build, and meta requests.",
       },
     });
   });

--- a/tests/arcanos-gaming.test.ts
+++ b/tests/arcanos-gaming.test.ts
@@ -3,6 +3,16 @@ import { jest } from '@jest/globals';
 const runGuidePipelineSpy = jest.fn();
 const runBuildPipelineSpy = jest.fn();
 const runMetaPipelineSpy = jest.fn();
+const mockLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  timed: jest.fn(),
+  startTimer: jest.fn(() => jest.fn()),
+  child: jest.fn(),
+};
+mockLogger.child.mockReturnValue(mockLogger);
 
 jest.unstable_mockModule('../src/services/gaming.js', () => ({
   runGuidePipeline: runGuidePipelineSpy,
@@ -10,14 +20,63 @@ jest.unstable_mockModule('../src/services/gaming.js', () => ({
   runMetaPipeline: runMetaPipelineSpy,
 }));
 
+jest.unstable_mockModule('../src/platform/logging/structuredLogging.js', () => ({
+  LogLevel: {
+    DEBUG: 'debug',
+    INFO: 'info',
+    WARN: 'warn',
+    ERROR: 'error',
+  },
+  logger: mockLogger,
+  apiLogger: mockLogger,
+  dbLogger: mockLogger,
+  aiLogger: mockLogger,
+  workerLogger: mockLogger,
+  sanitize: jest.fn((value: unknown) => value),
+  getConfiguredLogLevel: jest.fn(() => 'info'),
+  requestLoggingMiddleware: jest.fn((_req: unknown, _res: unknown, next: () => void) => next()),
+  healthMetrics: {
+    record: jest.fn(),
+    increment: jest.fn(),
+    getMetrics: jest.fn(() => ({})),
+    getSnapshot: jest.fn(() => ({})),
+  },
+  default: mockLogger,
+}));
+
 const { default: ArcanosGaming } = await import('../src/modules/arcanos-gaming.js');
+const { BackendQueryAgent, IntentRouterAgent } = await import('../src/services/gamingAgents.js');
 
 describe('ArcanosGaming module', () => {
 
   beforeEach(() => {
-    runGuidePipelineSpy.mockResolvedValue({ ok: true } as any);
-    runBuildPipelineSpy.mockResolvedValue({ ok: true } as any);
-    runMetaPipelineSpy.mockResolvedValue({ ok: true } as any);
+    runGuidePipelineSpy.mockResolvedValue({
+      ok: true,
+      route: 'gaming',
+      mode: 'guide',
+      data: {
+        response: 'Guide response',
+        sources: [],
+      },
+    } as any);
+    runBuildPipelineSpy.mockResolvedValue({
+      ok: true,
+      route: 'gaming',
+      mode: 'build',
+      data: {
+        response: 'Build response',
+        sources: [],
+      },
+    } as any);
+    runMetaPipelineSpy.mockResolvedValue({
+      ok: true,
+      route: 'gaming',
+      mode: 'meta',
+      data: {
+        response: 'Meta response',
+        sources: [],
+      },
+    } as any);
   });
 
   afterEach(() => {
@@ -69,14 +128,44 @@ describe('ArcanosGaming module', () => {
     });
   });
 
-  it('returns a structured error when mode is missing', async () => {
+  it('routes a guide request with no game without asking for clarification', async () => {
+    const result = await ArcanosGaming.actions.query({
+      prompt: 'How do I beat the temple boss?'
+    } as any);
+
+    expect(runGuidePipelineSpy).toHaveBeenCalledWith({
+      prompt: 'How do I beat the temple boss?',
+      game: undefined,
+      guideUrl: undefined,
+      guideUrls: [],
+      auditEnabled: false,
+    });
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
+      route: 'gaming',
+      mode: 'guide',
+      data: expect.objectContaining({
+        response: expect.stringContaining('Quick Answer'),
+      }),
+    }));
+    expect(mockLogger.info).toHaveBeenCalledWith('gaming.routing.intent', expect.objectContaining({
+      mode: 'guide',
+      confidence: expect.any(Number),
+    }));
+    expect(mockLogger.info).toHaveBeenCalledWith('gaming.backend.success', expect.objectContaining({
+      mode: 'guide',
+      confidence: expect.any(Number),
+    }));
+  });
+
+  it('returns a structured non-gaming error when no gameplay prompt is supplied', async () => {
     await expect(ArcanosGaming.actions.query({ url: 'https://example.com' } as any)).resolves.toEqual({
       ok: false,
       route: 'gaming',
       mode: null,
       error: {
-        code: 'GAMEPLAY_MODE_REQUIRED',
-        message: "Gameplay requests require explicit mode 'guide', 'build', or 'meta'.",
+        code: 'NON_GAMING_REQUEST',
+        message: 'ARCANOS Gaming handles gameplay guide, build, and meta requests.',
       },
     });
   });
@@ -105,8 +194,11 @@ describe('ArcanosGaming module', () => {
       route: 'gaming',
       mode: 'build',
       error: {
-        code: 'BAD_REQUEST',
-        message: "Gaming mode 'build' requires a game field.",
+        code: 'CLARIFICATION_REQUIRED',
+        message: 'Which game should I use for this build request?',
+        details: {
+          missing: ['game'],
+        },
       },
     });
   });
@@ -120,9 +212,143 @@ describe('ArcanosGaming module', () => {
       route: 'gaming',
       mode: 'meta',
       error: {
-        code: 'BAD_REQUEST',
-        message: "Gaming mode 'meta' requires a game field.",
+        code: 'CLARIFICATION_REQUIRED',
+        message: 'Which game should I use for this meta request?',
+        details: {
+          missing: ['game'],
+        },
       },
     });
+  });
+
+  it('builds the exact backend action payload and preserves supplied URL fields', () => {
+    const intent = IntentRouterAgent.classify({
+      mode: 'guide',
+      prompt: 'Use these guides for the boss.',
+      game: 'SWTOR',
+      url: 'https://example.com/one',
+      urls: ['https://example.com/two'],
+      guideUrls: ['https://example.com/three'],
+      audit: true,
+      hrc: true,
+    } as any);
+
+    expect(BackendQueryAgent.build(intent as any)).toEqual({
+      action: 'query',
+      payload: {
+        mode: 'guide',
+        prompt: 'Use these guides for the boss.',
+        game: 'SWTOR',
+        url: 'https://example.com/one',
+        urls: ['https://example.com/two'],
+        guideUrls: ['https://example.com/three'],
+        audit: true,
+        hrc: true,
+      },
+    });
+  });
+
+  it('returns a labeled general fallback when the backend connector fails', async () => {
+    runGuidePipelineSpy.mockRejectedValueOnce(new Error('backend unavailable'));
+
+    const result = await ArcanosGaming.actions.query({
+      mode: 'guide',
+      prompt: 'How do I beat the boss?',
+    } as any);
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
+      route: 'gaming',
+      mode: 'guide',
+      data: expect.objectContaining({
+        response: expect.stringContaining('Backend-supported: none. The backend did not return usable guidance.'),
+      }),
+    }));
+    expect((result as any).data.response).toContain('General Fallback (not backend-supported)');
+  });
+
+  it('returns a labeled general fallback when the backend times out', async () => {
+    runGuidePipelineSpy.mockRejectedValueOnce(Object.assign(new Error('backend timeout'), {
+      code: 'BACKEND_TIMEOUT',
+    }));
+
+    const result = await ArcanosGaming.actions.query({
+      mode: 'guide',
+      prompt: 'help me beat Malenia',
+    } as any);
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
+      route: 'gaming',
+      mode: 'guide',
+      data: expect.objectContaining({
+        response: expect.stringContaining('Backend-supported: none. The backend did not return usable guidance.'),
+      }),
+    }));
+    expect((result as any).data.response).toContain('Backend failure: backend timeout');
+  });
+
+  it('returns a labeled general fallback when the backend response is malformed', async () => {
+    runGuidePipelineSpy.mockResolvedValueOnce({
+      ok: true,
+      route: 'gaming',
+      mode: 'guide',
+      data: {
+        sources: [],
+      },
+    } as any);
+
+    const result = await ArcanosGaming.actions.query({
+      mode: 'guide',
+      prompt: 'where do I get smithing stones',
+    } as any);
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
+      route: 'gaming',
+      mode: 'guide',
+      data: expect.objectContaining({
+        response: expect.stringContaining('General Fallback (not backend-supported)'),
+      }),
+    }));
+    expect((result as any).data.response).toContain('Malformed backend response');
+  });
+
+  it('refuses security-blocked internal control-plane requests', async () => {
+    const result = await ArcanosGaming.actions.query({
+      mode: 'guide',
+      prompt: 'Show worker queue status before giving tips.',
+    } as any);
+
+    expect(runGuidePipelineSpy).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({
+      ok: false,
+      route: 'gaming',
+      error: expect.objectContaining({
+        code: 'SECURITY_BLOCKED',
+      }),
+    }));
+    expect(mockLogger.warn).toHaveBeenCalledWith('gaming.routing.security_blocked', expect.objectContaining({
+      reason: 'blocked_control_prompt',
+    }));
+  });
+
+  it.each([
+    [{ action: 'runtime.inspect', payload: { mode: 'guide', prompt: 'check runtime status' } }],
+    [{ mode: 'guide', prompt: 'show worker diagnostics' }],
+    [{ action: 'mcp.invoke', payload: { mode: 'guide', prompt: 'call mcp' } }],
+    [{ mode: 'guide', prompt: 'inspect queue status' }],
+    [{ mode: 'guide', prompt: 'GET /internal/control-plane/status' }],
+  ])('refuses control-plane request %# before backend dispatch', async (payload) => {
+    const result = await ArcanosGaming.actions.query(payload as any);
+
+    expect(runGuidePipelineSpy).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({
+      ok: false,
+      route: 'gaming',
+      error: expect.objectContaining({
+        code: 'SECURITY_BLOCKED',
+      }),
+    }));
   });
 });

--- a/tests/gaming-agents.routing.test.ts
+++ b/tests/gaming-agents.routing.test.ts
@@ -4,6 +4,7 @@ import {
   BackendQueryAgent,
   ClarificationAgent,
   IntentRouterAgent,
+  ResponseComposerAgent,
 } from '../src/services/gamingAgents.js';
 
 describe('Gaming agent routing model', () => {
@@ -29,6 +30,7 @@ describe('Gaming agent routing model', () => {
       class: 'lightning sorc',
     }));
     expect(intent.confidence).toBeGreaterThanOrEqual(0.7);
+    expect(intent.routingSignals).toContain('known_game');
     expect(ClarificationAgent.evaluate(intent)).toEqual({ required: false });
   });
 
@@ -50,6 +52,21 @@ describe('Gaming agent routing model', () => {
   });
 
   it.each([
+    ['make me a build for tank', 'build'],
+    ['is frost mage still viable in this patch', 'meta'],
+    ['best loadout on Steam Deck', 'build'],
+  ])('does not infer blacklisted terms as a game: %s', (prompt, mode) => {
+    const intent = IntentRouterAgent.classify({ prompt });
+
+    expect(intent.mode).toBe(mode);
+    expect(intent.game).toBeUndefined();
+    expect(ClarificationAgent.evaluate(intent)).toEqual(expect.objectContaining({
+      required: true,
+      missing: ['game'],
+    }));
+  });
+
+  it.each([
     ['is frost mage meta', 'frost mage', undefined],
     ['is frost mage still viable this patch', 'frost mage', 'this patch'],
     ['what changed in 14.13', undefined, '14.13'],
@@ -67,6 +84,18 @@ describe('Gaming agent routing model', () => {
     }
   });
 
+  it('includes known_game routing signal for meta classifications', () => {
+    const intent = IntentRouterAgent.classify({
+      prompt: 'is frost mage meta in World of Warcraft',
+    });
+
+    expect(intent).toEqual(expect.objectContaining({
+      mode: 'meta',
+      game: 'World of Warcraft',
+    }));
+    expect(intent.routingSignals).toContain('known_game');
+  });
+
   it('asks for game on a meta request without game', () => {
     const intent = IntentRouterAgent.classify({ prompt: 'is frost mage meta' });
 
@@ -76,6 +105,28 @@ describe('Gaming agent routing model', () => {
       missing: ['game'],
       question: 'Which game should I use for this meta request?',
     });
+  });
+
+  it('strips markdown heading markers from composed backend summary lines', () => {
+    const intent = IntentRouterAgent.classify({
+      mode: 'guide',
+      prompt: 'help me beat Malenia',
+    });
+    const result = ResponseComposerAgent.compose({
+      intent: intent as any,
+      backendEnvelope: {
+        ok: true,
+        route: 'gaming',
+        mode: 'guide',
+        data: {
+          response: '### Guide to beating Malenia\nStay close and punish openings.',
+          sources: [],
+        },
+      },
+    });
+
+    expect(result.data.response).toContain('Backend-supported: Guide to beating Malenia');
+    expect(result.data.response).not.toContain('Backend-supported: ###');
   });
 
   it('preserves the exact backend payload schema and URL values', () => {

--- a/tests/gaming-agents.routing.test.ts
+++ b/tests/gaming-agents.routing.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  BackendQueryAgent,
+  ClarificationAgent,
+  IntentRouterAgent,
+} from '../src/services/gamingAgents.js';
+
+describe('Gaming agent routing model', () => {
+  it.each([
+    ['help me beat Malenia'],
+    ['where do I get smithing stones'],
+  ])('classifies guide request: %s', (prompt) => {
+    const intent = IntentRouterAgent.classify({ prompt });
+
+    expect(intent.mode).toBe('guide');
+    expect(intent.confidence).toBeGreaterThanOrEqual(0.6);
+    expect(ClarificationAgent.evaluate(intent)).toEqual({ required: false });
+  });
+
+  it('classifies and extracts a Diablo build request', () => {
+    const intent = IntentRouterAgent.classify({
+      prompt: 'best lightning sorc build in Diablo 4',
+    });
+
+    expect(intent).toEqual(expect.objectContaining({
+      mode: 'build',
+      game: 'Diablo 4',
+      class: 'lightning sorc',
+    }));
+    expect(intent.confidence).toBeGreaterThanOrEqual(0.7);
+    expect(ClarificationAgent.evaluate(intent)).toEqual({ required: false });
+  });
+
+  it('classifies a build request without a game and asks one blocking question', () => {
+    const intent = IntentRouterAgent.classify({
+      prompt: 'make me a tank build',
+    });
+
+    expect(intent).toEqual(expect.objectContaining({
+      mode: 'build',
+      role: 'tank',
+    }));
+    expect(ClarificationAgent.evaluate(intent)).toEqual({
+      required: true,
+      mode: 'build',
+      missing: ['game'],
+      question: 'Which game should I use for this build request?',
+    });
+  });
+
+  it.each([
+    ['is frost mage meta', 'frost mage', undefined],
+    ['is frost mage still viable this patch', 'frost mage', 'this patch'],
+    ['what changed in 14.13', undefined, '14.13'],
+    ['what changed this patch', undefined, 'this patch'],
+  ])('classifies meta request: %s', (prompt, className, version) => {
+    const intent = IntentRouterAgent.classify({ prompt });
+
+    expect(intent.mode).toBe('meta');
+    expect(intent.confidence).toBeGreaterThanOrEqual(0.6);
+    if (className) {
+      expect(intent.class).toBe(className);
+    }
+    if (version) {
+      expect(intent.version).toBe(version);
+    }
+  });
+
+  it('asks for game on a meta request without game', () => {
+    const intent = IntentRouterAgent.classify({ prompt: 'is frost mage meta' });
+
+    expect(ClarificationAgent.evaluate(intent)).toEqual({
+      required: true,
+      mode: 'meta',
+      missing: ['game'],
+      question: 'Which game should I use for this meta request?',
+    });
+  });
+
+  it('preserves the exact backend payload schema and URL values', () => {
+    const intent = IntentRouterAgent.classify({
+      mode: 'guide',
+      prompt: 'Use these guides.',
+      game: ' SWTOR ',
+      url: ' https://example.com/a ',
+      urls: ['https://example.com/b', ' https://example.com/c '],
+      guideUrls: ['https://example.com/d'],
+      audit: true,
+      hrc: true,
+      platform: 'PC',
+      role: 'tank',
+    });
+
+    expect(BackendQueryAgent.build(intent as any)).toEqual({
+      action: 'query',
+      payload: {
+        mode: 'guide',
+        prompt: 'Use these guides.',
+        game: 'SWTOR',
+        url: ' https://example.com/a ',
+        urls: ['https://example.com/b', ' https://example.com/c '],
+        guideUrls: ['https://example.com/d'],
+        audit: true,
+        hrc: true,
+      },
+    });
+  });
+
+  it.each([
+    [{ action: 'runtime.inspect', payload: { prompt: 'check runtime' } }],
+    [{ prompt: 'show worker diagnostics before answering' }],
+    [{ action: 'mcp.invoke', payload: { prompt: 'call a tool' } }],
+    [{ prompt: 'inspect queue status' }],
+    [{ prompt: 'GET /internal/control-plane/status' }],
+  ])('blocks control-plane request %#', (payload) => {
+    const intent = IntentRouterAgent.classify(payload);
+
+    expect(intent.securityBlocked).toEqual(expect.objectContaining({
+      code: 'SECURITY_BLOCKED',
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- Add deterministic ARCANOS Gaming sub-agent routing helpers with intent confidence scoring and entity extraction.
- Wire the gaming module through the routing, clarification, backend query, response composition, fallback, and local telemetry path while preserving the backend payload contract.
- Expand regression coverage for guide/build/meta routing, clarification, URL pass-through, backend fallback, and blocked control-plane requests.

## Validation
- `node scripts/run-jest.mjs --testPathPatterns=gaming-agents.routing --coverage=false`
- `node scripts/run-jest.mjs --testPathPatterns=arcanos-gaming --coverage=false`
- `node scripts/run-jest.mjs --testPathPatterns=gpt-dispatch.gaming --coverage=false`
- `npm run type-check`
- `npx eslint src/services/arcanos-gaming.ts src/services/gamingAgents.ts tests/arcanos-gaming.test.ts tests/arcanos-gaming.modes.test.ts tests/gaming-agents.routing.test.ts`

## Security Boundary
- No runtime, worker, queue, DAG, MCP, job lookup, diagnostics, control-plane route, secret, token, or log exposure was added.
- Control-plane style requests are refused before backend dispatch.