### PR TITLE
Handle gaming guide timeout fallback

### DIFF
--- a/src/services/arcanos-gaming.ts
+++ b/src/services/arcanos-gaming.ts
@@ -47,8 +47,8 @@ function logGamingIntakeStep(
   logger.info("gaming.intake.step", {
     ...logContext,
     step,
-    timeoutPhase,
     ...details,
+    timeoutPhase,
     elapsedMs: Date.now() - startedAt
   });
 }

--- a/src/services/arcanos-gaming.ts
+++ b/src/services/arcanos-gaming.ts
@@ -103,14 +103,18 @@ function formatKnownGenerationFailure(mode: GamingMode, error: unknown): GamingE
     return formatGenerationTimeout(mode, error);
   }
 
-  if (code !== "OPENAI_COMPLETION_INCOMPLETE" && code !== "TRINITY_OUTPUT_INTEGRITY_FAILED") {
+  if (code === "OPENAI_COMPLETION_INCOMPLETE") {
+    return null;
+  }
+
+  if (code !== "TRINITY_OUTPUT_INTEGRITY_FAILED") {
     return null;
   }
 
   return formatGamingError({
     mode,
     error: {
-      code: code === "OPENAI_COMPLETION_INCOMPLETE" ? "GENERATION_INCOMPLETE" : "GENERATION_INTEGRITY_FAILED",
+      code: "GENERATION_INTEGRITY_FAILED",
       message: "Gaming generation did not complete cleanly; no partial answer was returned.",
       details: {
         finishReason: readSafeErrorString(error, "finishReason"),

--- a/src/services/arcanos-gaming.ts
+++ b/src/services/arcanos-gaming.ts
@@ -2,7 +2,7 @@ import { runBuildPipeline, runGuidePipeline, runMetaPipeline } from "@services/g
 import { getGamingModuleTimeoutMs } from "@services/gamingConfig.js";
 import { evaluateWithHRC } from "./hrcWrapper.js";
 import { resolveErrorMessage } from "@core/lib/errors/index.js";
-import { getRequestAbortSignal, isAbortError } from "@arcanos/runtime";
+import { getRequestAbortContext, getRequestAbortSignal, isAbortError } from "@arcanos/runtime";
 import { logger } from "@platform/logging/structuredLogging.js";
 import {
   BackendQueryAgent,
@@ -21,6 +21,37 @@ import {
 } from "@services/gamingModes.js";
 
 type GamingEnvelope = GamingSuccessEnvelope | GamingErrorEnvelope;
+type GamingRequestLogContext = {
+  module: "ARCANOS:GAMING";
+  route: "gaming";
+  requestId?: string;
+  traceId?: string;
+};
+
+function buildGamingRequestLogContext(): GamingRequestLogContext {
+  const requestId = getRequestAbortContext()?.requestId;
+  return {
+    module: "ARCANOS:GAMING",
+    route: "gaming",
+    ...(requestId ? { requestId, traceId: requestId } : {})
+  };
+}
+
+function logGamingIntakeStep(
+  logContext: GamingRequestLogContext,
+  step: string,
+  startedAt: number,
+  details: Record<string, unknown> = {}
+): void {
+  const timeoutPhase = typeof details.timeoutPhase === "string" ? details.timeoutPhase : null;
+  logger.info("gaming.intake.step", {
+    ...logContext,
+    step,
+    timeoutPhase,
+    ...details,
+    elapsedMs: Date.now() - startedAt
+  });
+}
 
 function readSafeErrorString(error: unknown, key: string): string | undefined {
   if (!error || typeof error !== "object") {
@@ -93,6 +124,27 @@ function formatKnownGenerationFailure(mode: GamingMode, error: unknown): GamingE
       }
     }
   });
+}
+
+function describeGamingErrorEnvelope(error: GamingErrorEnvelope["error"]): string {
+  const detailParts: string[] = [];
+  if (error.details && typeof error.details === "object") {
+    const details = error.details as Record<string, unknown>;
+    const timeoutPhase = typeof details.timeoutPhase === "string" ? details.timeoutPhase : undefined;
+    const timeoutMs = typeof details.timeoutMs === "number" ? details.timeoutMs : undefined;
+    const stageTimeoutMs = typeof details.stageTimeoutMs === "number" ? details.stageTimeoutMs : undefined;
+    if (timeoutPhase) {
+      detailParts.push(`phase=${timeoutPhase}`);
+    }
+    if (timeoutMs) {
+      detailParts.push(`timeoutMs=${timeoutMs}`);
+    }
+    if (stageTimeoutMs) {
+      detailParts.push(`stageTimeoutMs=${stageTimeoutMs}`);
+    }
+  }
+
+  return `${error.code}: ${error.message}${detailParts.length > 0 ? ` (${detailParts.join(", ")})` : ""}`;
 }
 
 async function executeGamingBackendQuery(payload: GamingBackendActionPayload): Promise<GamingEnvelope> {
@@ -214,17 +266,30 @@ function buildTelemetryEntityFlags(intent: GamingIntent) {
 }
 
 async function handleGamingRequest(payload: unknown): Promise<GamingEnvelope> {
+  const requestLogContext = buildGamingRequestLogContext();
+  const classifyStartedAt = Date.now();
   const intent = IntentRouterAgent.classify(payload);
   logger.info("gaming.routing.intent", {
+    ...requestLogContext,
     mode: intent.mode,
     confidence: intent.confidence,
     signals: intent.routingSignals,
     entityFlags: buildTelemetryEntityFlags(intent),
+    securityBlocked: Boolean(intent.securityBlocked),
+    timeoutPhase: null,
+    elapsedMs: Date.now() - classifyStartedAt
+  });
+  logGamingIntakeStep(requestLogContext, "classify", classifyStartedAt, {
+    mode: intent.mode,
+    confidence: intent.confidence,
+    gameProvided: Boolean(intent.game),
+    signalCount: intent.routingSignals.length,
     securityBlocked: Boolean(intent.securityBlocked)
   });
 
   if (intent.securityBlocked) {
     logger.warn("gaming.routing.security_blocked", {
+      ...requestLogContext,
       mode: intent.mode,
       confidence: intent.confidence,
       reason: intent.securityBlocked.reason
@@ -243,6 +308,7 @@ async function handleGamingRequest(payload: unknown): Promise<GamingEnvelope> {
   const clarification = ClarificationAgent.evaluate(intent);
   if (clarification.required) {
     logger.info("gaming.routing.clarification", {
+      ...requestLogContext,
       mode: clarification.mode,
       confidence: intent.confidence,
       missing: clarification.missing
@@ -258,20 +324,41 @@ async function handleGamingRequest(payload: unknown): Promise<GamingEnvelope> {
     ...intent,
     mode: intent.mode
   };
+  const backendBuildStartedAt = Date.now();
   const backendAction = BackendQueryAgent.build(gamingIntent);
+  logGamingIntakeStep(requestLogContext, "backend-build", backendBuildStartedAt, {
+    mode: gamingIntent.mode,
+    action: backendAction.action,
+    gameProvided: Boolean(backendAction.payload.game),
+    guideSourceCount: (backendAction.payload.url ? 1 : 0) + (backendAction.payload.guideUrls?.length ?? 0) + (backendAction.payload.urls?.length ?? 0)
+  });
+  const backendCallStartedAt = Date.now();
   try {
     const backendEnvelope = await BackendQueryAgent.call(backendAction, executeGamingBackendQuery);
+    logGamingIntakeStep(requestLogContext, "backend-call", backendCallStartedAt, {
+      mode: gamingIntent.mode,
+      ok: backendEnvelope.ok,
+      ...(backendEnvelope.ok ? { sourceCount: backendEnvelope.data.sources.length } : { errorCode: backendEnvelope.error.code })
+    });
     if (!backendEnvelope.ok) {
       logger.warn("gaming.backend.failure", {
+        ...requestLogContext,
         mode: gamingIntent.mode,
         confidence: gamingIntent.confidence,
         errorCode: backendEnvelope.error.code
       });
+      if (backendEnvelope.error.code === "GENERATION_TIMEOUT") {
+        return ResponseComposerAgent.composeBackendFailureFallback({
+          intent: gamingIntent,
+          error: new Error(describeGamingErrorEnvelope(backendEnvelope.error))
+        });
+      }
       return backendEnvelope;
     }
 
     if (!isUsableGamingSuccessEnvelope(backendEnvelope)) {
       logger.warn("gaming.backend.failure", {
+        ...requestLogContext,
         mode: gamingIntent.mode,
         confidence: gamingIntent.confidence,
         errorCode: "MALFORMED_BACKEND_RESPONSE"
@@ -283,6 +370,7 @@ async function handleGamingRequest(payload: unknown): Promise<GamingEnvelope> {
     }
 
     logger.info("gaming.backend.success", {
+      ...requestLogContext,
       mode: gamingIntent.mode,
       confidence: gamingIntent.confidence,
       sourceCount: backendEnvelope.data.sources.length
@@ -297,7 +385,13 @@ async function handleGamingRequest(payload: unknown): Promise<GamingEnvelope> {
       throw error;
     }
 
+    logGamingIntakeStep(requestLogContext, "backend-call", backendCallStartedAt, {
+      mode: gamingIntent.mode,
+      ok: false,
+      errorCode: "BACKEND_EXCEPTION"
+    });
     logger.warn("gaming.backend.failure", {
+      ...requestLogContext,
       mode: gamingIntent.mode,
       confidence: gamingIntent.confidence,
       errorCode: "BACKEND_EXCEPTION"

--- a/src/services/gamingConfig.ts
+++ b/src/services/gamingConfig.ts
@@ -4,6 +4,7 @@ import type { GamingMode } from "@services/gamingModes.js";
 export const DEFAULT_GAMING_MODULE_TIMEOUT_MS = 60_000;
 export const DEFAULT_GAMING_WEB_CONTEXT_CHARS = 5_000;
 export const DEFAULT_GAMING_WEB_CONTEXT_MAX_URLS = 15;
+export const DEFAULT_GAMING_WEB_CONTEXT_FETCH_TIMEOUT_MS = 5_000;
 export const DEFAULT_GAMING_PIPELINE_TIMEOUT_MS = 35_000;
 export const DEFAULT_GAMING_GUIDE_PIPELINE_TIMEOUT_MS = 50_000;
 export const DEFAULT_GAMING_STAGE_TIMEOUT_MS = 12_000;
@@ -33,6 +34,14 @@ export function getGamingWebContextMaxUrls(): number {
     "ARCANOS_GAMING_WEB_CONTEXT_MAX_URLS",
     DEFAULT_GAMING_WEB_CONTEXT_MAX_URLS,
     0
+  );
+}
+
+export function getGamingWebContextFetchTimeoutMs(): number {
+  return getEnvIntegerAtLeast(
+    "ARCANOS_GAMING_WEB_CONTEXT_FETCH_TIMEOUT_MS",
+    DEFAULT_GAMING_WEB_CONTEXT_FETCH_TIMEOUT_MS,
+    1
   );
 }
 

--- a/src/services/gamingPipeline.ts
+++ b/src/services/gamingPipeline.ts
@@ -320,8 +320,16 @@ function stringifyMockResult(result: unknown): string {
   }
 }
 
-function buildGamingRunOptions(mode: GamingMode) {
+function buildGamingRunOptions(mode: GamingMode, hasGuideSources: boolean) {
   if (mode === "guide") {
+    if (hasGuideSources) {
+      return {
+        answerMode: "explained" as const,
+        requestedVerbosity: "normal" as const,
+        strictUserVisibleOutput: true
+      };
+    }
+
     return {
       answerMode: "direct" as const,
       requestedVerbosity: "normal" as const,
@@ -473,7 +481,7 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
               GAMING_RUNTIME_BUDGET_SAFETY_BUFFER_MS
             ),
             runOptions: {
-              ...buildGamingRunOptions(params.mode),
+              ...buildGamingRunOptions(params.mode, guideUrls.length > 0),
               watchdogModelTimeoutMs: stageTimeoutMs
             }
           }

--- a/src/services/gamingPipeline.ts
+++ b/src/services/gamingPipeline.ts
@@ -112,7 +112,9 @@ function classifyGamingProviderFallbackReason(timeoutPhase?: string): string {
     normalizedPhase === "intake" ||
     normalizedPhase === "reasoning" ||
     normalizedPhase === "final" ||
-    normalizedPhase === "provider"
+    normalizedPhase === "provider" ||
+    normalizedPhase?.includes("direct-answer") === true ||
+    normalizedPhase?.includes("direct_answer") === true
   ) {
     return "INTAKE_UPSTREAM_TIMEOUT";
   }
@@ -327,8 +329,15 @@ function buildGamingRunOptions(mode: GamingMode) {
     };
   }
 
+  if (mode === "build") {
+    return {
+      answerMode: "direct" as const,
+      strictUserVisibleOutput: true
+    };
+  }
+
   return {
-    answerMode: "direct" as const,
+    answerMode: "explained" as const,
     strictUserVisibleOutput: true
   };
 }

--- a/src/services/gamingPipeline.ts
+++ b/src/services/gamingPipeline.ts
@@ -143,8 +143,8 @@ function logGamingIntakeStep(
   logger.info("gaming.intake.step", {
     ...logContext,
     step,
-    timeoutPhase,
     ...details,
+    timeoutPhase,
     elapsedMs: Date.now() - startedAt
   });
 }

--- a/src/services/gamingPipeline.ts
+++ b/src/services/gamingPipeline.ts
@@ -321,14 +321,15 @@ function stringifyMockResult(result: unknown): string {
 function buildGamingRunOptions(mode: GamingMode) {
   if (mode === "guide") {
     return {
-      answerMode: "explained" as const,
-      requestedVerbosity: "detailed" as const,
+      answerMode: "direct" as const,
+      requestedVerbosity: "normal" as const,
       strictUserVisibleOutput: true
     };
   }
 
   return {
     answerMode: "direct" as const,
+    requestedVerbosity: "minimal" as const,
     strictUserVisibleOutput: true
   };
 }

--- a/src/services/gamingPipeline.ts
+++ b/src/services/gamingPipeline.ts
@@ -41,6 +41,7 @@ type GamingLogContext = {
   mode: GamingMode;
   sourceEndpoint: string;
   requestId?: string;
+  traceId?: string;
   promptLength: number;
   gameProvided: boolean;
   guideSourceCount: number;
@@ -99,21 +100,23 @@ function isGamingProviderTimeoutError(error: unknown): boolean {
   );
 }
 
-function createGamingProviderTimeoutError(
-  mode: GamingMode,
-  error: unknown,
-  timeoutMs: number,
-  stageTimeoutMs: number,
-  timeoutPhase = readTimeoutPhase(error) ?? "provider"
-): Error {
-  const timeoutError = new Error(`Gaming ${mode} generation timed out before a complete response was available.`);
-  Object.assign(timeoutError, {
-    code: "GAMING_PROVIDER_TIMEOUT",
-    timeoutMs,
-    stageTimeoutMs,
-    timeoutPhase
-  });
-  return timeoutError;
+function classifyGamingProviderFallbackReason(timeoutPhase?: string): string {
+  const normalizedPhase = timeoutPhase?.toLowerCase();
+  if (
+    normalizedPhase === "intake" ||
+    normalizedPhase === "reasoning" ||
+    normalizedPhase === "final" ||
+    normalizedPhase === "provider"
+  ) {
+    return "INTAKE_UPSTREAM_TIMEOUT";
+  }
+  if (normalizedPhase === "retrieval") {
+    return "INTAKE_RETRIEVAL_TIMEOUT";
+  }
+  if (normalizedPhase === "parse") {
+    return "INTAKE_PARSE_TIMEOUT";
+  }
+  return "INTAKE_UNKNOWN_TIMEOUT";
 }
 
 function estimateResponsePayloadChars(response: string, sources: GamingWebSource[]): number {
@@ -122,6 +125,22 @@ function estimateResponsePayloadChars(response: string, sources: GamingWebSource
       total + source.url.length + (source.snippet?.length ?? 0) + (source.error?.length ?? 0),
     response.length
   );
+}
+
+function logGamingIntakeStep(
+  logContext: GamingLogContext,
+  step: string,
+  startedAt: number,
+  details: Record<string, unknown> = {}
+): void {
+  const timeoutPhase = typeof details.timeoutPhase === "string" ? details.timeoutPhase : null;
+  logger.info("gaming.intake.step", {
+    ...logContext,
+    step,
+    timeoutPhase,
+    ...details,
+    elapsedMs: Date.now() - startedAt
+  });
 }
 
 function formatGameplaySuccessWithLogs(params: {
@@ -170,6 +189,104 @@ function formatGameplaySuccessWithLogs(params: {
   return envelope;
 }
 
+function hasEldenRingContext(params: GamingPipelineInput): boolean {
+  return /\belden\s+ring\b/i.test(`${params.game ?? ""} ${params.prompt}`);
+}
+
+function buildGuideFallbackSteps(params: GamingPipelineInput): string[] {
+  if (hasEldenRingContext(params)) {
+    if (/\b(after\s+leaving\s+the\s+tutorial|where\s+do\s+i\s+go\s+first|go\s+first)\b/i.test(params.prompt)) {
+      return [
+        "Rest at The First Step Site of Grace, then head to the Church of Elleh for the merchant and crafting kit.",
+        "Follow the guidance trail toward Gatefront Ruins, grab the map fragment, and rest at a grace to unlock Torrent.",
+        "Avoid fighting the Tree Sentinel early; clear nearby caves, ruins, and soldier camps for runes and upgrade materials.",
+        "Level Vigor early, upgrade one weapon you like, then try Margit and Stormveil only after Limgrave feels manageable."
+      ];
+    }
+
+    return [
+      "Start in Limgrave, unlock Sites of Grace, the Church of Elleh, Gatefront Ruins, the map fragment, and Torrent.",
+      "Prioritize survivability first: level Vigor, keep equipment load medium or lighter, and upgrade one main weapon.",
+      "Explore caves, ruins, and Weeping Peninsula before forcing Stormveil; skip enemies that are clearly overtuned.",
+      "Use spirit ashes, guard counters, jumping attacks, and status tools when bosses punish repeated light-attack trades."
+    ];
+  }
+
+  return [
+    "Confirm the next objective, nearest checkpoint, and any missing game/version details before committing rare resources.",
+    "Upgrade or repair core gear, stock healing and utility items, and retry the next encounter while watching repeatable mechanics.",
+    "If progress stalls, narrow the request to the exact boss, quest, route, build, or checkpoint for a more precise guide.",
+    "Treat patch-sensitive numbers as provisional until verified in game or against a provided guide URL."
+  ];
+}
+
+function buildBuildFallbackSteps(params: GamingPipelineInput): string[] {
+  return [
+    `For ${params.game ?? "the requested game"}, start from the role the build must perform and choose one reliable damage or utility loop.`,
+    "Prioritize core scaling stats, survivability, and resource sustain before niche optimization.",
+    "Test changes in safe content before spending rare materials, ranked attempts, or irreversible respec resources."
+  ];
+}
+
+function buildMetaFallbackSteps(params: GamingPipelineInput): string[] {
+  return [
+    `For ${params.game ?? "the requested game"}, treat current-state advice as patch-sensitive until verified against the latest in-game version.`,
+    "Prefer flexible picks, builds, routes, or team comps that stay useful when a matchup or balance assumption is wrong.",
+    "Avoid overcommitting to exact tier claims without a supplied patch, date, or guide source."
+  ];
+}
+
+function sourceAvailabilityLine(sources: GamingWebSource[]): string {
+  if (sources.length === 0) {
+    return "Sources unavailable: no guide URL content was available for this request.";
+  }
+
+  const usableSourceCount = sources.filter((source) => Boolean(source.snippet)).length;
+  if (usableSourceCount === 0) {
+    return "Sources unavailable: provided guide sources could not be retrieved before the fallback.";
+  }
+
+  if (usableSourceCount < sources.length) {
+    return `Sources partially available: ${usableSourceCount} of ${sources.length} provided guide sources were usable.`;
+  }
+
+  return `Sources available: ${usableSourceCount} provided guide source${usableSourceCount === 1 ? " was" : "s were"} retrieved.`;
+}
+
+function buildGamingProviderFallbackResponse(params: {
+  input: GamingPipelineInput;
+  sources: GamingWebSource[];
+  fallbackReason: string;
+  timeoutPhase?: string;
+}): string {
+  const steps =
+    params.input.mode === "build"
+      ? buildBuildFallbackSteps(params.input)
+      : params.input.mode === "meta"
+      ? buildMetaFallbackSteps(params.input)
+      : buildGuideFallbackSteps(params.input);
+  const sectionLabel = params.input.mode === "build" ? "Build" : "Steps";
+  const phaseLine = params.timeoutPhase
+    ? `Timeout phase: ${params.timeoutPhase}.`
+    : "Timeout phase: unknown.";
+
+  return [
+    "Quick Answer",
+    `${sourceAvailabilityLine(params.sources)} The full generation path hit ${params.fallbackReason}, so this is a bounded deterministic fallback.`,
+    "",
+    sectionLabel,
+    ...steps.map((step, index) => `${index + 1}. ${step}`),
+    "",
+    "Why It Works",
+    "Backend-supported: partial. ARCANOS Gaming returned stable gameplay guidance instead of waiting for the timed-out upstream stage.",
+    `Fallback reason: ${params.fallbackReason}. ${phaseLine}`,
+    "",
+    "Watch Outs",
+    "- Ask again with a narrower boss, quest, route, build, patch, or guide URL for a more specific answer.",
+    "- Verify patch-sensitive numbers and current meta details in game or with a provided source."
+  ].join("\n");
+}
+
 function stringifyMockResult(result: unknown): string {
   if (typeof result === "string") {
     return result;
@@ -204,7 +321,9 @@ function buildGamingRunOptions(mode: GamingMode) {
 export async function runGameplayPipeline(params: GamingPipelineInput): Promise<GamingSuccessEnvelope> {
   const requestStartedAt = Date.now();
   const sourceEndpoint = `arcanos-gaming.${params.mode}`;
-  const requestId = getRequestAbortContext()?.requestId;
+  const requestContext = getRequestAbortContext();
+  const requestId = requestContext?.requestId;
+  const traceId = requestId;
   const guideSourceCount = (params.guideUrl ? 1 : 0) + params.guideUrls.length;
   const baseLogContext: GamingLogContext = {
     module: "ARCANOS:GAMING",
@@ -212,6 +331,7 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
     mode: params.mode,
     sourceEndpoint,
     ...(requestId ? { requestId } : {}),
+    ...(traceId ? { traceId } : {}),
     promptLength: params.prompt.length,
     gameProvided: Boolean(params.game),
     guideSourceCount
@@ -219,7 +339,11 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
 
   logger.info("gaming.request.start", baseLogContext);
 
+  const shortcutStartedAt = Date.now();
   const exactLiteralShortcut = tryExtractExactLiteralPromptShortcut(params.prompt);
+  logGamingIntakeStep(baseLogContext, "shortcut", shortcutStartedAt, {
+    ok: Boolean(exactLiteralShortcut)
+  });
   if (exactLiteralShortcut) {
     return formatGameplaySuccessWithLogs({
       mode: params.mode,
@@ -231,7 +355,39 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
   }
 
   const guideUrls = collectGamingGuideUrls(params);
-  const { context: webContext, sources } = await buildGamingWebContext(guideUrls);
+  const retrievalStartedAt = Date.now();
+  let webContext = "";
+  let sources: GamingWebSource[] = [];
+  try {
+    const webContextResult = await buildGamingWebContext(guideUrls, baseLogContext);
+    webContext = webContextResult.context;
+    sources = webContextResult.sources;
+    logGamingIntakeStep(baseLogContext, "retrieval", retrievalStartedAt, {
+      ok: true,
+      retrievalLatencyMs: Date.now() - retrievalStartedAt,
+      sourceCount: sources.length,
+      usableSourceCount: sources.filter((source) => Boolean(source.snippet)).length,
+      failedSourceCount: sources.filter((source) => Boolean(source.error)).length
+    });
+  } catch (error) {
+    const timeoutPhase = readTimeoutPhase(error) ?? "retrieval";
+    const fallbackReason = readErrorString(error, "code") ?? classifyGamingProviderFallbackReason(timeoutPhase);
+    logger.warn("gaming.retrieval.failure", {
+      ...baseLogContext,
+      elapsedMs: Date.now() - retrievalStartedAt,
+      timeoutPhase,
+      fallbackReason,
+      errorName: error instanceof Error ? error.name : typeof error,
+      errorCode: readErrorString(error, "code")
+    });
+    logGamingIntakeStep(baseLogContext, "retrieval", retrievalStartedAt, {
+      ok: false,
+      timeoutPhase,
+      retrievalLatencyMs: Date.now() - retrievalStartedAt,
+      fallbackReason
+    });
+  }
+
   const { client } = getOpenAIClientOrAdapter();
 
   if (!client) {
@@ -305,7 +461,8 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
       provider: "trinity",
       streaming: false,
       ok: false,
-      elapsedMs
+      elapsedMs,
+      upstreamModelLatencyMs: elapsedMs
     });
 
     if (isGamingProviderTimeoutError(error)) {
@@ -320,25 +477,58 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
       }
 
       const timeoutPhase = readTimeoutPhase(error) ?? "provider";
+      const fallbackReason = classifyGamingProviderFallbackReason(timeoutPhase);
       logger.warn("gaming.provider.timeout", {
         ...baseLogContext,
         provider: "trinity",
         timeoutMs: pipelineTimeoutMs,
         stageTimeoutMs,
         elapsedMs,
+        upstreamModelLatencyMs: elapsedMs,
         timeoutPhase,
+        fallbackReason,
         errorName: error instanceof Error ? error.name : typeof error,
         errorCode: readErrorString(error, "code")
       });
-      logger.info("gaming.request.end", {
-        ...baseLogContext,
+      logGamingIntakeStep(baseLogContext, "provider", providerStartedAt, {
         ok: false,
-        totalElapsedMs: Date.now() - requestStartedAt,
-        errorCode: "GAMING_PROVIDER_TIMEOUT"
+        provider: "trinity",
+        timeoutMs: pipelineTimeoutMs,
+        stageTimeoutMs,
+        timeoutPhase,
+        upstreamModelLatencyMs: elapsedMs,
+        fallbackReason
       });
-      throw createGamingProviderTimeoutError(params.mode, error, pipelineTimeoutMs, stageTimeoutMs, timeoutPhase);
+      logger.warn("gaming.fallback.used", {
+        ...baseLogContext,
+        provider: "trinity",
+        fallbackReason,
+        timeoutPhase,
+        elapsedMs,
+        timeoutMs: pipelineTimeoutMs,
+        stageTimeoutMs
+      });
+      return formatGameplaySuccessWithLogs({
+        mode: params.mode,
+        response: buildGamingProviderFallbackResponse({
+          input: params,
+          sources,
+          fallbackReason,
+          timeoutPhase
+        }),
+        sources,
+        logContext: baseLogContext,
+        requestStartedAt
+      });
     }
 
+    logGamingIntakeStep(baseLogContext, "provider", providerStartedAt, {
+      ok: false,
+      provider: "trinity",
+      timeoutPhase: readTimeoutPhase(error) ?? "provider",
+      upstreamModelLatencyMs: elapsedMs,
+      errorCode: readErrorString(error, "code")
+    });
     logger.error("gaming.provider.error", {
       ...baseLogContext,
       provider: "trinity",
@@ -360,12 +550,21 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
     provider: "trinity",
     streaming: false,
     ok: true,
-    elapsedMs: Date.now() - providerStartedAt
+    elapsedMs: Date.now() - providerStartedAt,
+    upstreamModelLatencyMs: Date.now() - providerStartedAt
   });
   logger.info("gaming.provider.end", {
     ...baseLogContext,
     provider: "trinity",
     elapsedMs: Date.now() - providerStartedAt,
+    upstreamModelLatencyMs: Date.now() - providerStartedAt,
+    activeModel: trinityResult.activeModel,
+    finishReason: trinityResult.meta?.provider?.finishReason ?? "unknown"
+  });
+  logGamingIntakeStep(baseLogContext, "provider", providerStartedAt, {
+    ok: true,
+    provider: "trinity",
+    upstreamModelLatencyMs: Date.now() - providerStartedAt,
     activeModel: trinityResult.activeModel,
     finishReason: trinityResult.meta?.provider?.finishReason ?? "unknown"
   });

--- a/src/services/gamingPipeline.ts
+++ b/src/services/gamingPipeline.ts
@@ -81,6 +81,8 @@ const PROVIDER_TIMEOUT_ERROR_MARKERS = [
   "execution aborted by watchdog"
 ];
 
+const PROVIDER_COMPLETION_INCOMPLETE_FALLBACK_REASON = "PROVIDER_COMPLETION_INCOMPLETE";
+
 function isGamingProviderTimeoutError(error: unknown): boolean {
   if (isAbortError(error)) {
     return true;
@@ -98,6 +100,10 @@ function isGamingProviderTimeoutError(error: unknown): boolean {
   return values.some((value) =>
     PROVIDER_TIMEOUT_ERROR_MARKERS.some((marker) => value.includes(marker))
   );
+}
+
+function isGamingProviderCompletionIncompleteError(error: unknown): boolean {
+  return readErrorString(error, "code") === "OPENAI_COMPLETION_INCOMPLETE";
 }
 
 function classifyGamingProviderFallbackReason(timeoutPhase?: string): string {
@@ -266,19 +272,28 @@ function buildGamingProviderFallbackResponse(params: {
       ? buildMetaFallbackSteps(params.input)
       : buildGuideFallbackSteps(params.input);
   const sectionLabel = params.input.mode === "build" ? "Build" : "Steps";
-  const phaseLine = params.timeoutPhase
-    ? `Timeout phase: ${params.timeoutPhase}.`
-    : "Timeout phase: unknown.";
+  const providerIncomplete = params.fallbackReason === PROVIDER_COMPLETION_INCOMPLETE_FALLBACK_REASON;
+  const phaseLine = providerIncomplete
+    ? "Provider output: incomplete."
+    : params.timeoutPhase
+      ? `Timeout phase: ${params.timeoutPhase}.`
+      : "Timeout phase: unknown.";
+  const fallbackSummary = providerIncomplete
+    ? `${sourceAvailabilityLine(params.sources)} The upstream provider returned an incomplete answer, so this is a bounded deterministic fallback.`
+    : `${sourceAvailabilityLine(params.sources)} The full generation path hit ${params.fallbackReason}, so this is a bounded deterministic fallback.`;
+  const supportLine = providerIncomplete
+    ? "Backend-supported: partial. ARCANOS Gaming returned stable gameplay guidance instead of exposing incomplete upstream output."
+    : "Backend-supported: partial. ARCANOS Gaming returned stable gameplay guidance instead of waiting for the timed-out upstream stage.";
 
   return [
     "Quick Answer",
-    `${sourceAvailabilityLine(params.sources)} The full generation path hit ${params.fallbackReason}, so this is a bounded deterministic fallback.`,
+    fallbackSummary,
     "",
     sectionLabel,
     ...steps.map((step, index) => `${index + 1}. ${step}`),
     "",
     "Why It Works",
-    "Backend-supported: partial. ARCANOS Gaming returned stable gameplay guidance instead of waiting for the timed-out upstream stage.",
+    supportLine,
     `Fallback reason: ${params.fallbackReason}. ${phaseLine}`,
     "",
     "Watch Outs",
@@ -516,6 +531,48 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
           sources,
           fallbackReason,
           timeoutPhase
+        }),
+        sources,
+        logContext: baseLogContext,
+        requestStartedAt
+      });
+    }
+
+    if (isGamingProviderCompletionIncompleteError(error)) {
+      const fallbackReason = PROVIDER_COMPLETION_INCOMPLETE_FALLBACK_REASON;
+      const errorCode = readErrorString(error, "code");
+      logger.warn("gaming.provider.incomplete", {
+        ...baseLogContext,
+        ...(params.game ? { game: params.game } : {}),
+        provider: "trinity",
+        elapsedMs,
+        upstreamModelLatencyMs: elapsedMs,
+        errorCode,
+        finishReason: readErrorString(error, "finishReason"),
+        incompleteReason: readErrorString(error, "incompleteReason"),
+        fallbackReason
+      });
+      logGamingIntakeStep(baseLogContext, "provider", providerStartedAt, {
+        ok: false,
+        provider: "trinity",
+        upstreamModelLatencyMs: elapsedMs,
+        errorCode,
+        fallbackReason
+      });
+      logger.warn("gaming.fallback.used", {
+        ...baseLogContext,
+        ...(params.game ? { game: params.game } : {}),
+        provider: "trinity",
+        fallbackReason,
+        elapsedMs,
+        errorCode
+      });
+      return formatGameplaySuccessWithLogs({
+        mode: params.mode,
+        response: buildGamingProviderFallbackResponse({
+          input: params,
+          sources,
+          fallbackReason
         }),
         sources,
         logContext: baseLogContext,

--- a/src/services/gamingPipeline.ts
+++ b/src/services/gamingPipeline.ts
@@ -370,19 +370,20 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
       failedSourceCount: sources.filter((source) => Boolean(source.error)).length
     });
   } catch (error) {
-    const timeoutPhase = readTimeoutPhase(error) ?? "retrieval";
-    const fallbackReason = readErrorString(error, "code") ?? classifyGamingProviderFallbackReason(timeoutPhase);
+    const errorCode = readErrorString(error, "code");
+    const timeoutPhase = readTimeoutPhase(error) ?? (errorCode === "INTAKE_RETRIEVAL_TIMEOUT" ? "retrieval" : undefined);
+    const fallbackReason = errorCode ?? (timeoutPhase ? classifyGamingProviderFallbackReason(timeoutPhase) : "INTAKE_RETRIEVAL_FAILED");
     logger.warn("gaming.retrieval.failure", {
       ...baseLogContext,
       elapsedMs: Date.now() - retrievalStartedAt,
-      timeoutPhase,
+      ...(timeoutPhase ? { timeoutPhase } : {}),
       fallbackReason,
       errorName: error instanceof Error ? error.name : typeof error,
-      errorCode: readErrorString(error, "code")
+      ...(errorCode ? { errorCode } : {})
     });
     logGamingIntakeStep(baseLogContext, "retrieval", retrievalStartedAt, {
       ok: false,
-      timeoutPhase,
+      ...(timeoutPhase ? { timeoutPhase } : {}),
       retrievalLatencyMs: Date.now() - retrievalStartedAt,
       fallbackReason
     });

--- a/src/services/gamingPipeline.ts
+++ b/src/services/gamingPipeline.ts
@@ -329,7 +329,6 @@ function buildGamingRunOptions(mode: GamingMode) {
 
   return {
     answerMode: "direct" as const,
-    requestedVerbosity: "minimal" as const,
     strictUserVisibleOutput: true
   };
 }

--- a/src/services/gamingPromptBuilder.ts
+++ b/src/services/gamingPromptBuilder.ts
@@ -19,10 +19,9 @@ const modeInstructions: Record<GamingMode, string> = {
   meta: "Return a meta overview with current assumptions, tradeoffs, counters, and explicit uncertainty when patch/version context is missing."
 };
 
-const outputShapeInstructions: Record<GamingMode, string> = {
+const outputShapeInstructions: Partial<Record<GamingMode, string>> = {
   guide: "Return only 6 short numbered bullets. Cover route/order, preparation, key mechanics, danger checks, upgrades/resources, and one missing-info note when relevant.",
-  build: "Return only 5 short numbered bullets. Cover role, core stats, weapons/skills, gear/talismans, and play pattern. Keep each bullet compact.",
-  meta: "Return only 4 short numbered bullets. Cover viability, assumptions, strengths, counters/risks, and missing patch context when relevant."
+  build: "Return only 5 short numbered bullets. Cover role, core stats, weapons/skills, gear/talismans, and play pattern. Keep each bullet compact."
 };
 
 function rewriteGuideDirectAnswerCues(prompt: string): string {
@@ -72,7 +71,8 @@ export function buildGamingPrompt(
   const modeLabel = `[MODE]\n${params.mode}`;
   const gameLabel = params.game ? `\n\n[GAME]\n${params.game}` : "";
   const requestPrompt = params.mode === "guide" ? rewriteGuideDirectAnswerCues(params.prompt) : params.prompt;
-  const outputLabel = `\n\n[OUTPUT]\n${outputShapeInstructions[params.mode]}`;
+  const outputInstruction = outputShapeInstructions[params.mode];
+  const outputLabel = outputInstruction ? `\n\n[OUTPUT]\n${outputInstruction}` : "";
   const webLabel = webContext
     ? `\n\n[WEB CONTEXT]\n${webContext}\n\n${gamingPrompts.webContextInstruction}`
     : hadSources

--- a/src/services/gamingPromptBuilder.ts
+++ b/src/services/gamingPromptBuilder.ts
@@ -20,7 +20,7 @@ const modeInstructions: Record<GamingMode, string> = {
 };
 
 const outputShapeInstructions: Partial<Record<GamingMode, string>> = {
-  guide: "Return only 6 short numbered bullets. Cover route/order, preparation, key mechanics, danger checks, upgrades/resources, and one missing-info note when relevant.",
+  guide: "Return only a six-item checklist using hyphen bullets, not numbered bullets. Cover route/order, preparation, key mechanics, danger checks, upgrades/resources, and one missing-info note when relevant.",
   build: "Return only 5 short numbered bullets. Cover role, core stats, weapons/skills, gear/talismans, and play pattern. Keep each bullet compact."
 };
 

--- a/src/services/gamingPromptBuilder.ts
+++ b/src/services/gamingPromptBuilder.ts
@@ -50,6 +50,17 @@ export function buildGamingSystemPrompt(mode: GamingMode): string {
     ].join(" ");
   }
 
+  if (mode === "meta") {
+    return [
+      "You are ARCANOS:GAMING:META.",
+      modeInstructions.meta,
+      "Give practical meta guidance with enough context to compare viability, counters, and uncertainty.",
+      "Avoid gameplay reenactment, roleplay framing, invented live patch details, hotline banter, and theatrical framing.",
+      "If the user requests an exact literal response, return only that literal.",
+      "State missing platform, class, role, patch, or version details plainly instead of guessing."
+    ].join(" ");
+  }
+
   return buildDirectAnswerModeSystemInstruction({
     moduleLabel: `ARCANOS:GAMING:${mode.toUpperCase()}`,
     domainGuidance: modeInstructions[mode],

--- a/src/services/gamingPromptBuilder.ts
+++ b/src/services/gamingPromptBuilder.ts
@@ -19,6 +19,12 @@ const modeInstructions: Record<GamingMode, string> = {
   meta: "Return a meta overview with current assumptions, tradeoffs, counters, and explicit uncertainty when patch/version context is missing."
 };
 
+const outputShapeInstructions: Record<GamingMode, string> = {
+  guide: "Return only 6 short numbered bullets. Cover route/order, preparation, key mechanics, danger checks, upgrades/resources, and one missing-info note when relevant.",
+  build: "Return only 5 short numbered bullets. Cover role, core stats, weapons/skills, gear/talismans, and play pattern. Keep each bullet compact.",
+  meta: "Return only 4 short numbered bullets. Cover viability, assumptions, strengths, counters/risks, and missing patch context when relevant."
+};
+
 function rewriteGuideDirectAnswerCues(prompt: string): string {
   return prompt
     .replace(/\b(?:answer|respond|reply)\s+directly\b/gi, "give practical guidance")
@@ -66,13 +72,14 @@ export function buildGamingPrompt(
   const modeLabel = `[MODE]\n${params.mode}`;
   const gameLabel = params.game ? `\n\n[GAME]\n${params.game}` : "";
   const requestPrompt = params.mode === "guide" ? rewriteGuideDirectAnswerCues(params.prompt) : params.prompt;
+  const outputLabel = `\n\n[OUTPUT]\n${outputShapeInstructions[params.mode]}`;
   const webLabel = webContext
     ? `\n\n[WEB CONTEXT]\n${webContext}\n\n${gamingPrompts.webContextInstruction}`
     : hadSources
     ? `\n\n[WEB CONTEXT]\nGuides were provided but no usable snippets were retrieved.\n\n${gamingPrompts.webUncertaintyGuidance}`
     : "";
 
-  return `${modeLabel}${gameLabel}\n\n[REQUEST]\n${requestPrompt}${webLabel}`;
+  return `${modeLabel}${gameLabel}\n\n[REQUEST]\n${requestPrompt}${outputLabel}${webLabel}`;
 }
 
 export function buildGamingTrinityPrompt(

--- a/src/services/gamingWebContext.ts
+++ b/src/services/gamingWebContext.ts
@@ -1,7 +1,12 @@
 import { resolveErrorMessage } from "@core/lib/errors/index.js";
+import { logger } from "@platform/logging/structuredLogging.js";
 import { fetchAndClean } from "@shared/webFetcher.js";
-import { getGamingWebContextMaxChars, getGamingWebContextMaxUrls } from "@services/gamingConfig.js";
-import type { GamingSuccessEnvelope, ValidatedGamingRequest } from "@services/gamingModes.js";
+import {
+  getGamingWebContextFetchTimeoutMs,
+  getGamingWebContextMaxChars,
+  getGamingWebContextMaxUrls
+} from "@services/gamingConfig.js";
+import type { GamingMode, GamingSuccessEnvelope, ValidatedGamingRequest } from "@services/gamingModes.js";
 
 export type GamingWebSource = GamingSuccessEnvelope["data"]["sources"][number];
 
@@ -11,6 +16,15 @@ export type GamingWebContext = {
 };
 
 export type GamingGuideUrlInput = Pick<ValidatedGamingRequest, "guideUrl" | "guideUrls">;
+
+export type GamingWebContextLogContext = {
+  module: "ARCANOS:GAMING";
+  route: "gaming";
+  mode: GamingMode;
+  sourceEndpoint: string;
+  requestId?: string;
+  traceId?: string;
+};
 
 export function collectGamingGuideUrls(params: GamingGuideUrlInput): string[] {
   return [
@@ -33,29 +47,153 @@ function redactUrlCredentials(url: string): string {
   }
 }
 
-export async function buildGamingWebContext(urls: string[]): Promise<GamingWebContext> {
+function readErrorString(error: unknown, key: string): string | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+
+  const value = (error as Record<string, unknown>)[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function createGamingRetrievalTimeoutError(timeoutMs: number): Error {
+  const error = new Error(`Gaming guide source fetch timed out after ${timeoutMs}ms.`);
+  Object.assign(error, {
+    code: "INTAKE_RETRIEVAL_TIMEOUT",
+    timeoutMs,
+    timeoutPhase: "retrieval"
+  });
+  return error;
+}
+
+function runWithLocalTimeout<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  return Promise.race([
+    operation,
+    new Promise<T>((_resolve, reject) => {
+      timeoutHandle = setTimeout(() => reject(createGamingRetrievalTimeoutError(timeoutMs)), timeoutMs);
+    })
+  ]).finally(() => {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  });
+}
+
+function buildSafeSourceLogTarget(url: string): { sourceHost: string; sourcePathLength: number } {
+  try {
+    const parsedUrl = new URL(url);
+    return {
+      sourceHost: parsedUrl.host,
+      sourcePathLength: parsedUrl.pathname.length
+    };
+  } catch {
+    return {
+      sourceHost: "invalid-url",
+      sourcePathLength: 0
+    };
+  }
+}
+
+export async function buildGamingWebContext(
+  urls: string[],
+  logContext?: GamingWebContextLogContext
+): Promise<GamingWebContext> {
   if (urls.length === 0) {
     return { context: "", sources: [] };
   }
 
   const maxContextChars = getGamingWebContextMaxChars();
-  const uniqueUrls = Array.from(new Set(urls)).slice(0, getGamingWebContextMaxUrls());
+  const maxUrls = getGamingWebContextMaxUrls();
+  const fetchTimeoutMs = getGamingWebContextFetchTimeoutMs();
+  const uniqueUrls = Array.from(new Set(urls)).slice(0, maxUrls);
+  const retrievalStartedAt = Date.now();
+  if (logContext) {
+    logger.info("gaming.retrieval.start", {
+      ...logContext,
+      sourceCount: uniqueUrls.length,
+      requestedSourceCount: urls.length,
+      maxUrls,
+      maxContextChars,
+      fetchTimeoutMs
+    });
+  }
+
   const sources: GamingWebSource[] = await Promise.all(
-    uniqueUrls.map(async (url): Promise<GamingWebSource> => {
+    uniqueUrls.map(async (url, index): Promise<GamingWebSource> => {
       const sourceUrl = redactUrlCredentials(url);
+      const sourceStartedAt = Date.now();
+      const sourceLogTarget = buildSafeSourceLogTarget(sourceUrl);
+      if (logContext) {
+        logger.info("gaming.retrieval.source.start", {
+          ...logContext,
+          ...sourceLogTarget,
+          sourceIndex: index + 1,
+          sourceCount: uniqueUrls.length,
+          fetchTimeoutMs,
+          maxContextChars
+        });
+      }
+
       try {
-        const snippet = await fetchAndClean(sourceUrl, maxContextChars);
+        const snippet = await runWithLocalTimeout(fetchAndClean(sourceUrl, maxContextChars), fetchTimeoutMs);
+        if (logContext) {
+          logger.info("gaming.retrieval.source.end", {
+            ...logContext,
+            ...sourceLogTarget,
+            sourceIndex: index + 1,
+            sourceCount: uniqueUrls.length,
+            ok: true,
+            elapsedMs: Date.now() - sourceStartedAt,
+            fetchParseMs: Date.now() - sourceStartedAt,
+            snippetChars: snippet.length,
+            maxContextChars,
+            fetchTimeoutMs
+          });
+        }
         return { url: sourceUrl, snippet };
       } catch (error) {
+        const errorCode = readErrorString(error, "code") ?? "INTAKE_RETRIEVAL_FAILED";
+        const timeoutPhase = readErrorString(error, "timeoutPhase");
+        if (logContext) {
+          logger.warn("gaming.retrieval.source.end", {
+            ...logContext,
+            ...sourceLogTarget,
+            sourceIndex: index + 1,
+            sourceCount: uniqueUrls.length,
+            ok: false,
+            elapsedMs: Date.now() - sourceStartedAt,
+            fetchParseMs: Date.now() - sourceStartedAt,
+            errorCode,
+            ...(timeoutPhase ? { timeoutPhase } : {}),
+            fallbackReason: errorCode,
+            fetchTimeoutMs
+          });
+        }
         return { url: sourceUrl, error: resolveErrorMessage(error, "Unknown fetch error") };
       }
     })
   );
 
+  const contextStartedAt = Date.now();
   const context = sources
     .filter((source) => Boolean(source.snippet))
     .map((source, index) => `[Source ${index + 1}] ${source.url}\n${source.snippet}`)
     .join("\n\n");
+
+  if (logContext) {
+    logger.info("gaming.retrieval.end", {
+      ...logContext,
+      sourceCount: sources.length,
+      usableSourceCount: sources.filter((source) => Boolean(source.snippet)).length,
+      failedSourceCount: sources.filter((source) => Boolean(source.error)).length,
+      contextChars: context.length,
+      parseMs: Date.now() - contextStartedAt,
+      retrievalLatencyMs: Date.now() - retrievalStartedAt,
+      maxContextChars,
+      fetchTimeoutMs
+    });
+  }
 
   return { context, sources };
 }

--- a/src/services/gamingWebContext.ts
+++ b/src/services/gamingWebContext.ts
@@ -33,6 +33,20 @@ export function collectGamingGuideUrls(params: GamingGuideUrlInput): string[] {
   ];
 }
 
+function isFetchableGuideUrl(url: string): boolean {
+  const trimmedUrl = url.trim();
+  if (trimmedUrl.length === 0) {
+    return false;
+  }
+
+  try {
+    const parsedUrl = new URL(trimmedUrl);
+    return parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 function redactUrlCredentials(url: string): string {
   try {
     const parsedUrl = new URL(url);
@@ -106,7 +120,7 @@ export async function buildGamingWebContext(
   const maxContextChars = getGamingWebContextMaxChars();
   const maxUrls = getGamingWebContextMaxUrls();
   const fetchTimeoutMs = getGamingWebContextFetchTimeoutMs();
-  const uniqueUrls = Array.from(new Set(urls)).slice(0, maxUrls);
+  const uniqueUrls = Array.from(new Set(urls.map((url) => url.trim()).filter(isFetchableGuideUrl))).slice(0, maxUrls);
   const retrievalStartedAt = Date.now();
   if (logContext) {
     logger.info("gaming.retrieval.start", {

--- a/src/services/gamingWebContext.ts
+++ b/src/services/gamingWebContext.ts
@@ -80,12 +80,16 @@ function createGamingRetrievalTimeoutError(timeoutMs: number): Error {
   return error;
 }
 
-function runWithLocalTimeout<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
+function runWithLocalTimeout<T>(operation: (signal: AbortSignal) => Promise<T>, timeoutMs: number): Promise<T> {
+  const controller = new AbortController();
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   return Promise.race([
-    operation,
+    operation(controller.signal),
     new Promise<T>((_resolve, reject) => {
-      timeoutHandle = setTimeout(() => reject(createGamingRetrievalTimeoutError(timeoutMs)), timeoutMs);
+      timeoutHandle = setTimeout(() => {
+        controller.abort();
+        reject(createGamingRetrievalTimeoutError(timeoutMs));
+      }, timeoutMs);
     })
   ]).finally(() => {
     if (timeoutHandle) {
@@ -150,7 +154,10 @@ export async function buildGamingWebContext(
       }
 
       try {
-        const snippet = await runWithLocalTimeout(fetchAndClean(sourceUrl, maxContextChars), fetchTimeoutMs);
+        const snippet = await runWithLocalTimeout(
+          (signal) => fetchAndClean(sourceUrl, maxContextChars, { signal, timeoutMs: fetchTimeoutMs }),
+          fetchTimeoutMs
+        );
         if (logContext) {
           logger.info("gaming.retrieval.source.end", {
             ...logContext,

--- a/src/shared/webFetcher.ts
+++ b/src/shared/webFetcher.ts
@@ -52,6 +52,11 @@ export interface FetchAndCleanDocument {
   combined: string;
 }
 
+export interface FetchAndCleanOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+
 /**
  * Purpose: Parse and validate a user-provided URL for fetch usage.
  * Inputs/Outputs: raw URL string -> normalized URL object.
@@ -104,7 +109,8 @@ export function serializeFetchAndCleanDocument(
  */
 export async function fetchAndCleanDocument(
   url: string,
-  maxChars = getConfiguredMaxChars()
+  maxChars = getConfiguredMaxChars(),
+  options: FetchAndCleanOptions = {}
 ): Promise<FetchAndCleanDocument> {
   const target = await resolveFetchTarget(url);
   const maxFetchBytes = getConfiguredMaxFetchBytes();
@@ -117,7 +123,8 @@ export async function fetchAndCleanDocument(
       : undefined;
 
   const { data } = await axios.get<string>(target.requestUrl.toString(), {
-    timeout: getConfiguredFetchTimeoutMs(),
+    timeout: options.timeoutMs ?? getConfiguredFetchTimeoutMs(),
+    signal: options.signal,
     maxContentLength: maxFetchBytes,
     maxBodyLength: maxFetchBytes,
     // SSRF safety: redirects would bypass resolveFetchTarget IP pinning and Host/SNI controls.
@@ -177,8 +184,12 @@ export async function fetchAndCleanDocument(
  * Inputs/Outputs: URL + optional max chars -> cleaned page text string.
  * Edge cases: Preserves the historical compact string payload for existing callers.
  */
-export async function fetchAndClean(url: string, maxChars = getConfiguredMaxChars()): Promise<string> {
-  const document = await fetchAndCleanDocument(url, maxChars);
+export async function fetchAndClean(
+  url: string,
+  maxChars = getConfiguredMaxChars(),
+  options: FetchAndCleanOptions = {}
+): Promise<string> {
+  const document = await fetchAndCleanDocument(url, maxChars, options);
   return document.combined;
 }
 

--- a/tests/arcanos-gaming.modes.test.ts
+++ b/tests/arcanos-gaming.modes.test.ts
@@ -214,7 +214,7 @@ describe("ArcanosGaming mode routing", () => {
     });
   });
 
-  it("returns an incomplete generation error instead of a partial guide when the provider truncates", async () => {
+  it("returns a controlled fallback when the provider reports incomplete generation", async () => {
     const incompleteError = Object.assign(new Error("provider output incomplete"), {
       code: "OPENAI_COMPLETION_INCOMPLETE",
       finishReason: "length",
@@ -231,23 +231,38 @@ describe("ArcanosGaming mode routing", () => {
       prompt: "Beginner to intermediate guide for tanking in Star Wars The Old Republic including mechanics, threat management, mitigation, positioning, and group play tips."
     });
 
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
+      route: "gaming",
+      mode: "guide",
+      data: expect.objectContaining({
+        response: expect.stringContaining("General Fallback (not backend-supported)")
+      })
+    }));
+    expect((result as any).data.response).toContain("provider output incomplete");
+  });
+
+  it("returns build clarification without calling fallback or provider", async () => {
+    const result = await ArcanosGaming.actions.query({
+      mode: "build",
+      prompt: "Make me a tank build."
+    });
+
     expect(result).toEqual({
       ok: false,
       route: "gaming",
-      mode: "guide",
+      mode: "build",
       error: {
-        code: "GENERATION_INCOMPLETE",
-        message: "Gaming generation did not complete cleanly; no partial answer was returned.",
+        code: "CLARIFICATION_REQUIRED",
+        message: "Which game should I use for this build request?",
         details: {
-          finishReason: "length",
-          incompleteReason: "max_output_tokens",
-          truncated: true,
-          lengthTruncated: true,
-          contentFiltered: false,
-          integrityIssues: undefined
+          missing: ["game"]
         }
       }
     });
+    expect(mockRunBuildPipeline).not.toHaveBeenCalled();
+    expect(mockRunGuidePipeline).not.toHaveBeenCalled();
+    expect(mockRunMetaPipeline).not.toHaveBeenCalled();
   });
 
   it("returns a controlled fallback when the provider aborts before module dispatch expires", async () => {

--- a/tests/arcanos-gaming.modes.test.ts
+++ b/tests/arcanos-gaming.modes.test.ts
@@ -265,6 +265,61 @@ describe("ArcanosGaming mode routing", () => {
     expect(mockRunMetaPipeline).not.toHaveBeenCalled();
   });
 
+  it("returns meta clarification without calling fallback or provider", async () => {
+    const result = await ArcanosGaming.actions.query({
+      mode: "meta",
+      prompt: "Is frost mage still viable this patch?"
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      route: "gaming",
+      mode: "meta",
+      error: {
+        code: "CLARIFICATION_REQUIRED",
+        message: "Which game should I use for this meta request?",
+        details: {
+          missing: ["game"]
+        }
+      }
+    });
+    expect(mockRunMetaPipeline).not.toHaveBeenCalled();
+    expect(mockRunBuildPipeline).not.toHaveBeenCalled();
+    expect(mockRunGuidePipeline).not.toHaveBeenCalled();
+  });
+
+  it("surfaces genuine Trinity integrity failures as generation integrity errors", async () => {
+    const integrityError = Object.assign(new Error("Trinity direct-answer output failed integrity validation."), {
+      code: "TRINITY_OUTPUT_INTEGRITY_FAILED",
+      integrityIssues: ["broken_numbering"]
+    });
+    mockRunMetaPipeline.mockRejectedValueOnce(integrityError);
+
+    const result = await ArcanosGaming.actions.query({
+      mode: "meta",
+      game: "World of Warcraft",
+      prompt: "Is frost mage still viable this patch?"
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      route: "gaming",
+      mode: "meta",
+      error: {
+        code: "GENERATION_INTEGRITY_FAILED",
+        message: "Gaming generation did not complete cleanly; no partial answer was returned.",
+        details: {
+          finishReason: undefined,
+          incompleteReason: undefined,
+          truncated: undefined,
+          lengthTruncated: undefined,
+          contentFiltered: undefined,
+          integrityIssues: ["broken_numbering"]
+        }
+      }
+    });
+  });
+
   it("returns a controlled fallback when the provider aborts before module dispatch expires", async () => {
     const timeoutError = Object.assign(new Error("Request was aborted."), {
       name: "AbortError",

--- a/tests/arcanos-gaming.modes.test.ts
+++ b/tests/arcanos-gaming.modes.test.ts
@@ -250,7 +250,7 @@ describe("ArcanosGaming mode routing", () => {
     });
   });
 
-  it("returns a controlled generation timeout when the provider aborts before module dispatch expires", async () => {
+  it("returns a controlled fallback when the provider aborts before module dispatch expires", async () => {
     const timeoutError = Object.assign(new Error("Request was aborted."), {
       name: "AbortError",
       code: "GAMING_PROVIDER_TIMEOUT",
@@ -266,23 +266,19 @@ describe("ArcanosGaming mode routing", () => {
       prompt: "Regression check only: Beginner to intermediate guide for tanking in Star Wars The Old Republic including mechanics, threat management, mitigation, positioning, and group play tips. Return a complete coherent answer with valid numbering."
     });
 
-    expect(result).toEqual({
-      ok: false,
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
       route: "gaming",
       mode: "guide",
-      error: {
-        code: "GENERATION_TIMEOUT",
-        message: "Gaming generation timed out before a complete answer was available.",
-        details: {
-          timeoutMs: 50_000,
-          stageTimeoutMs: 15_000,
-          timeoutPhase: "intake"
-        }
-      }
-    });
+      data: expect.objectContaining({
+        response: expect.stringContaining("General Fallback (not backend-supported)")
+      })
+    }));
+    expect((result as any).data.response).toContain("GENERATION_TIMEOUT");
+    expect((result as any).data.response).toContain("phase=intake");
   });
 
-  it("returns a controlled generation timeout when the runtime budget expires before module dispatch", async () => {
+  it("returns a controlled fallback when the runtime budget expires before module dispatch", async () => {
     const timeoutError = Object.assign(new Error("Gaming guide generation timed out."), {
       code: "GAMING_PROVIDER_TIMEOUT",
       timeoutMs: 50_000,
@@ -298,18 +294,15 @@ describe("ArcanosGaming mode routing", () => {
     });
 
     expect(result).toEqual(expect.objectContaining({
-      ok: false,
+      ok: true,
       route: "gaming",
       mode: "guide",
-      error: expect.objectContaining({
-        code: "GENERATION_TIMEOUT",
-        details: {
-          timeoutMs: 50_000,
-          stageTimeoutMs: 15_000,
-          timeoutPhase: "reasoning"
-        }
+      data: expect.objectContaining({
+        response: expect.stringContaining("General Fallback (not backend-supported)")
       })
     }));
+    expect((result as any).data.response).toContain("GENERATION_TIMEOUT");
+    expect((result as any).data.response).toContain("phase=reasoning");
   });
 
   it("preserves parent request aborts instead of mapping them to generation timeouts", async () => {

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -56,6 +56,7 @@ describe('gaming guide output hardening', () => {
     delete process.env.ARCANOS_GAMING_GUIDE_STAGE_TIMEOUT_MS;
     delete process.env.ARCANOS_GAMING_MODULE_TIMEOUT_MS;
     delete process.env.ARCANOS_GAMING_WEB_CONTEXT_MAX_URLS;
+    delete process.env.ARCANOS_GAMING_WEB_CONTEXT_FETCH_TIMEOUT_MS;
 
     mockGetEnv.mockImplementation((key: string, defaultValue?: string) => process.env[key] ?? defaultValue);
     mockGetEnvNumber.mockReturnValue(512);
@@ -287,61 +288,108 @@ describe('gaming guide output hardening', () => {
     );
   });
 
-  it('converts a provider abort into a bounded gaming timeout error', async () => {
+  it('passes a broad Elden Ring guide lookup through the normal guide path', async () => {
+    mockRunTrinityWritingPipeline.mockResolvedValueOnce({
+      result: 'Follow the Limgrave route, upgrade one weapon, and delay Stormveil until you are prepared.',
+      activeModel: 'gpt-test',
+      meta: { provider: { finishReason: 'stop' } }
+    });
+
+    const result = await runGuidePipeline({
+      game: 'Elden Ring',
+      prompt: 'Look up a guide for Elden Ring.',
+      guideUrls: [],
+      auditEnabled: false
+    });
+
+    expect(result.data.response).toBe('Follow the Limgrave route, upgrade one weapon, and delay Stormveil until you are prepared.');
+    expect(result.data.response).not.toContain('bounded deterministic fallback');
+    const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
+    expect(trinityRequest.input.prompt).toContain('[GAME]\nElden Ring');
+    expect(trinityRequest.input.prompt).toContain('Look up a guide for Elden Ring.');
+  });
+
+  it('passes a narrow Elden Ring progression guide through the normal guide path', async () => {
+    mockRunTrinityWritingPipeline.mockResolvedValueOnce({
+      result: 'Go to the Church of Elleh, then Gatefront Ruins for the map and Torrent unlock.',
+      activeModel: 'gpt-test',
+      meta: { provider: { finishReason: 'stop' } }
+    });
+
+    const result = await runGuidePipeline({
+      game: 'Elden Ring',
+      prompt: 'Where do I go first in Elden Ring after leaving the tutorial?',
+      guideUrls: [],
+      auditEnabled: false
+    });
+
+    expect(result.data.response).toBe('Go to the Church of Elleh, then Gatefront Ruins for the map and Torrent unlock.');
+    expect(result.data.response).not.toContain('bounded deterministic fallback');
+    const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
+    expect(trinityRequest.input.prompt).toContain('Where do I go first in Elden Ring after leaving the tutorial?');
+  });
+
+  it('returns a controlled fallback when upstream intake slows down', async () => {
     const providerAbort = Object.assign(new Error('Request was aborted.'), {
       name: 'AbortError',
       timeoutPhase: 'intake'
     });
     mockRunTrinityWritingPipeline.mockRejectedValueOnce(providerAbort);
 
-    await expect(runGuidePipeline({
-      game: 'Star Wars: The Old Republic',
-      prompt: 'Regression check only: Beginner to intermediate guide for tanking in Star Wars The Old Republic including mechanics, threat management, mitigation, positioning, and group play tips. Return a complete coherent answer with valid numbering.',
+    const result = await runGuidePipeline({
+      game: 'Elden Ring',
+      prompt: 'Look up a guide for Elden Ring.',
       guideUrls: [],
       auditEnabled: false
-    })).rejects.toMatchObject({
-      code: 'GAMING_PROVIDER_TIMEOUT',
-      timeoutMs: 50_000,
-      stageTimeoutMs: 15_000,
-      timeoutPhase: 'intake'
     });
+
+    expect(result).toEqual(expect.objectContaining({
+      ok: true,
+      route: 'gaming',
+      mode: 'guide'
+    }));
+    expect(result.data.response).toContain('Sources unavailable');
+    expect(result.data.response).toContain('INTAKE_UPSTREAM_TIMEOUT');
+    expect(result.data.response).toContain('Timeout phase: intake.');
+    expect(result.data.response).toContain('Limgrave');
   });
 
-  it('converts runtime budget exhaustion into a bounded gaming timeout error', async () => {
+  it('returns a controlled fallback when runtime budget exhaustion reaches the guide pipeline', async () => {
     const budgetError = Object.assign(new Error('runtime_budget_exhausted'), {
       name: 'RuntimeBudgetExceededError',
       timeoutPhase: 'reasoning'
     });
     mockRunTrinityWritingPipeline.mockRejectedValueOnce(budgetError);
 
-    await expect(runGuidePipeline({
+    const result = await runGuidePipeline({
       game: 'Star Wars: The Old Republic',
       prompt: 'Regression check only: Beginner to intermediate guide for tanking in Star Wars The Old Republic including mechanics, threat management, mitigation, positioning, and group play tips. Return a complete coherent answer with valid numbering.',
       guideUrls: [],
       auditEnabled: false
-    })).rejects.toMatchObject({
-      code: 'GAMING_PROVIDER_TIMEOUT',
-      timeoutMs: 50_000,
-      stageTimeoutMs: 15_000,
-      timeoutPhase: 'reasoning'
     });
+
+    expect(result.ok).toBe(true);
+    expect(result.data.response).toContain('bounded deterministic fallback');
+    expect(result.data.response).toContain('INTAKE_UPSTREAM_TIMEOUT');
+    expect(result.data.response).toContain('Timeout phase: reasoning.');
   });
 
-  it('defaults missing provider timeout phase consistently', async () => {
+  it('defaults missing provider timeout phase consistently in the fallback response', async () => {
     const providerAbort = Object.assign(new Error('Request was aborted.'), {
       name: 'AbortError'
     });
     mockRunTrinityWritingPipeline.mockRejectedValueOnce(providerAbort);
 
-    await expect(runGuidePipeline({
+    const result = await runGuidePipeline({
       game: 'Star Wars: The Old Republic',
       prompt: 'Smoke test: give three short tanking tips with valid numbering.',
       guideUrls: [],
       auditEnabled: false
-    })).rejects.toMatchObject({
-      code: 'GAMING_PROVIDER_TIMEOUT',
-      timeoutPhase: 'provider'
     });
+
+    expect(result.ok).toBe(true);
+    expect(result.data.response).toContain('INTAKE_UPSTREAM_TIMEOUT');
+    expect(result.data.response).toContain('Timeout phase: provider.');
   });
 
   it('preserves parent request aborts instead of reporting provider timeouts', async () => {
@@ -555,6 +603,30 @@ describe('gaming guide output hardening', () => {
     );
     const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
     expect(trinityRequest.input.prompt).not.toContain('user:pass');
+  });
+
+  it('continues with sources unavailable when retrieval fails', async () => {
+    mockFetchAndClean.mockRejectedValueOnce(new Error('network unavailable'));
+    mockRunTrinityWritingPipeline.mockResolvedValueOnce({
+      result: 'Use the safe route and verify the linked guide later.',
+      activeModel: 'gpt-test',
+      meta: { provider: { finishReason: 'stop' } }
+    });
+
+    const result = await runGuidePipeline({
+      prompt: 'Use the linked guide for a direct boss strategy.',
+      guideUrl: 'https://example.com/guide',
+      guideUrls: [],
+      auditEnabled: false
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.data.response).toBe('Use the safe route and verify the linked guide later.');
+    expect(result.data.sources).toEqual([
+      { url: 'https://example.com/guide', error: 'network unavailable' }
+    ]);
+    const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
+    expect(trinityRequest.input.prompt).toContain('Guides were provided but no usable snippets were retrieved.');
   });
 
   it('short-circuits exact-literal prompts before any provider call', async () => {

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -423,6 +423,7 @@ describe('gaming guide output hardening', () => {
     expect(trinityRequest.input.prompt).toContain('[MODE]\nmeta');
     expect(trinityRequest.input.prompt).toContain('[GAME]\nWorld of Warcraft');
     expect(trinityRequest.input.prompt).not.toContain('[OUTPUT]');
+    expect(trinityRequest.input.prompt).not.toContain('Answer the request directly');
     expect(trinityRequest.context.runOptions).toEqual(expect.objectContaining({
       answerMode: 'explained',
       strictUserVisibleOutput: true
@@ -461,6 +462,7 @@ describe('gaming guide output hardening', () => {
         context: { runOptions: { answerMode?: string; strictUserVisibleOutput?: boolean } };
       };
       expect(trinityRequest.input.prompt).not.toContain('[OUTPUT]');
+      expect(trinityRequest.input.prompt).not.toContain('Answer the request directly');
       expect(trinityRequest.context.runOptions).toEqual(expect.objectContaining({
         answerMode: 'explained',
         strictUserVisibleOutput: true
@@ -494,6 +496,26 @@ describe('gaming guide output hardening', () => {
       context: { runOptions: { answerMode?: string } };
     };
     expect(trinityRequest.context.runOptions.answerMode).toBe('explained');
+  });
+
+  it('uses explained mode for source-backed guide requests to avoid direct-answer integrity false positives', async () => {
+    await runGuidePipeline({
+      prompt: 'Use this source for a simple guide summary.',
+      guideUrl: 'https://example.com/',
+      guideUrls: [],
+      auditEnabled: false
+    });
+
+    const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as {
+      input: { prompt: string };
+      context: { runOptions: { answerMode?: string; requestedVerbosity?: string } };
+    };
+    expect(trinityRequest.input.prompt).toContain('[WEB CONTEXT]');
+    expect(trinityRequest.input.prompt).toContain('Return only 6 short numbered bullets');
+    expect(trinityRequest.context.runOptions).toEqual(expect.objectContaining({
+      answerMode: 'explained',
+      requestedVerbosity: 'normal'
+    }));
   });
 
   it('returns a controlled fallback when upstream intake slows down', async () => {

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -14,6 +14,13 @@ const mockGetOptionalEnvIntegerAtLeast = jest.fn();
 const mockGetEnvBoolean = jest.fn();
 const mockRunTrinityWritingPipeline = jest.fn();
 
+function expectFetchOptions(timeoutMs = 5000) {
+  return expect.objectContaining({
+    signal: expect.any(Object),
+    timeoutMs
+  });
+}
+
 jest.unstable_mockModule('@services/openai/clientBridge.js', () => ({
   getOpenAIClientOrAdapter: mockGetOpenAIClientOrAdapter
 }));
@@ -599,8 +606,8 @@ describe('gaming guide output hardening', () => {
       auditEnabled: false
     });
 
-    expect(mockFetchAndClean).toHaveBeenNthCalledWith(1, 'https://example.com/guide-a', 512);
-    expect(mockFetchAndClean).toHaveBeenNthCalledWith(2, 'https://example.com/guide-b', 512);
+    expect(mockFetchAndClean).toHaveBeenNthCalledWith(1, 'https://example.com/guide-a', 512, expectFetchOptions());
+    expect(mockFetchAndClean).toHaveBeenNthCalledWith(2, 'https://example.com/guide-b', 512, expectFetchOptions());
     expect(mockFetchAndClean).toHaveBeenCalledTimes(2);
     expect(mockRunTrinityWritingPipeline).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -622,8 +629,8 @@ describe('gaming guide output hardening', () => {
     });
 
     expect(mockFetchAndClean).toHaveBeenCalledTimes(2);
-    expect(mockFetchAndClean).toHaveBeenNthCalledWith(1, 'https://example.com/guide-a', 512);
-    expect(mockFetchAndClean).toHaveBeenNthCalledWith(2, 'https://example.com/guide-b', 512);
+    expect(mockFetchAndClean).toHaveBeenNthCalledWith(1, 'https://example.com/guide-a', 512, expectFetchOptions());
+    expect(mockFetchAndClean).toHaveBeenNthCalledWith(2, 'https://example.com/guide-b', 512, expectFetchOptions());
     expect(result.data.sources).toEqual([
       { url: 'https://example.com/guide-a', snippet: 'clean snippet' },
       { url: 'https://example.com/guide-b', snippet: 'clean snippet' }
@@ -647,8 +654,8 @@ describe('gaming guide output hardening', () => {
     });
 
     expect(mockFetchAndClean).toHaveBeenCalledTimes(2);
-    expect(mockFetchAndClean).toHaveBeenNthCalledWith(1, 'https://example.com/guide-a', 512);
-    expect(mockFetchAndClean).toHaveBeenNthCalledWith(2, 'http://example.com/guide-b', 512);
+    expect(mockFetchAndClean).toHaveBeenNthCalledWith(1, 'https://example.com/guide-a', 512, expectFetchOptions());
+    expect(mockFetchAndClean).toHaveBeenNthCalledWith(2, 'http://example.com/guide-b', 512, expectFetchOptions());
     expect(result.data.sources).toEqual([
       { url: 'https://example.com/guide-a', snippet: 'clean snippet' },
       { url: 'http://example.com/guide-b', snippet: 'clean snippet' }
@@ -702,7 +709,7 @@ describe('gaming guide output hardening', () => {
     expect(result.data.sources).toEqual([
       { url: 'https://example.com/guide', snippet: 'clean snippet' }
     ]);
-    expect(mockFetchAndClean).toHaveBeenCalledWith('https://example.com/guide', 512);
+    expect(mockFetchAndClean).toHaveBeenCalledWith('https://example.com/guide', 512, expectFetchOptions());
     expect(mockRunTrinityWritingPipeline).toHaveBeenCalledWith(
       expect.objectContaining({
         input: expect.objectContaining({
@@ -736,6 +743,42 @@ describe('gaming guide output hardening', () => {
     ]);
     const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
     expect(trinityRequest.input.prompt).toContain('Guides were provided but no usable snippets were retrieved.');
+  });
+
+  it('aborts guide source fetches when the local retrieval timeout fires', async () => {
+    process.env.ARCANOS_GAMING_WEB_CONTEXT_FETCH_TIMEOUT_MS = '5';
+    let capturedSignal: AbortSignal | undefined;
+    mockFetchAndClean.mockImplementationOnce(async (_url: string, _maxChars: number, options?: { signal?: AbortSignal }) => {
+      capturedSignal = options?.signal;
+      await new Promise(() => undefined);
+      return 'unreachable';
+    });
+    mockRunTrinityWritingPipeline.mockResolvedValueOnce({
+      result: 'Use a safe fallback route while source retrieval is unavailable.',
+      activeModel: 'gpt-test',
+      meta: { provider: { finishReason: 'stop' } }
+    });
+
+    const result = await runGuidePipeline({
+      prompt: 'Use the linked guide for a direct boss strategy.',
+      guideUrl: 'https://example.com/guide',
+      guideUrls: [],
+      auditEnabled: false
+    });
+
+    expect(capturedSignal?.aborted).toBe(true);
+    expect(result.ok).toBe(true);
+    expect(result.data.sources).toEqual([
+      {
+        url: 'https://example.com/guide',
+        error: 'Gaming guide source fetch timed out after 5ms.'
+      }
+    ]);
+    expect(mockFetchAndClean).toHaveBeenCalledWith(
+      'https://example.com/guide',
+      512,
+      expectFetchOptions(5)
+    );
   });
 
   it('does not classify unexpected retrieval crashes as retrieval timeouts', async () => {

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -44,7 +44,7 @@ jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
   runTrinityWritingPipeline: mockRunTrinityWritingPipeline
 }));
 
-const { runGuidePipeline } = await import('../src/services/gaming.js');
+const { runBuildPipeline, runGuidePipeline, runMetaPipeline } = await import('../src/services/gaming.js');
 const { runWithRequestAbortContext } = await import('@arcanos/runtime');
 const { logger } = await import('@platform/logging/structuredLogging.js');
 
@@ -328,6 +328,72 @@ describe('gaming guide output hardening', () => {
     expect(result.data.response).not.toContain('bounded deterministic fallback');
     const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
     expect(trinityRequest.input.prompt).toContain('Where do I go first in Elden Ring after leaving the tutorial?');
+  });
+
+  it('returns a deterministic fallback when build provider generation is incomplete', async () => {
+    const incompleteError = Object.assign(new Error('provider output incomplete'), {
+      code: 'OPENAI_COMPLETION_INCOMPLETE',
+      finishReason: 'length',
+      incompleteReason: 'max_output_tokens'
+    });
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    mockRunTrinityWritingPipeline.mockRejectedValueOnce(incompleteError);
+    const controller = new AbortController();
+
+    try {
+      const result = await runWithRequestAbortContext({
+        requestId: 'req-build-incomplete',
+        controller,
+        signal: controller.signal,
+        deadlineAt: Date.now() + 60_000,
+        timeoutMs: 60_000
+      }, () => runBuildPipeline({
+        game: 'Elden Ring',
+        prompt: 'Make me a bleed build for Elden Ring.',
+        guideUrls: [],
+        auditEnabled: false
+      }));
+
+      expect(result.ok).toBe(true);
+      expect(result.mode).toBe('build');
+      expect(result.data.response).toContain('bounded deterministic fallback');
+      expect(result.data.response).toContain('PROVIDER_COMPLETION_INCOMPLETE');
+      expect(result.data.response).toContain('Provider output: incomplete.');
+      expect(result.data.response).toContain('For Elden Ring');
+      expect(warnSpy).toHaveBeenCalledWith('gaming.provider.incomplete', expect.objectContaining({
+        requestId: 'req-build-incomplete',
+        traceId: 'req-build-incomplete',
+        mode: 'build',
+        game: 'Elden Ring',
+        errorCode: 'OPENAI_COMPLETION_INCOMPLETE',
+        fallbackReason: 'PROVIDER_COMPLETION_INCOMPLETE'
+      }));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('passes a meta request with game through the normal path', async () => {
+    mockRunTrinityWritingPipeline.mockResolvedValueOnce({
+      result: 'Frost Mage is viable when current tuning supports its control and cleave profile.',
+      activeModel: 'gpt-test',
+      meta: { provider: { finishReason: 'stop' } }
+    });
+
+    const result = await runMetaPipeline({
+      game: 'World of Warcraft',
+      prompt: 'Is frost mage still viable this patch?',
+      guideUrls: [],
+      auditEnabled: false
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.mode).toBe('meta');
+    expect(result.data.response).toBe('Frost Mage is viable when current tuning supports its control and cleave profile.');
+    expect(result.data.response).not.toContain('bounded deterministic fallback');
+    const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
+    expect(trinityRequest.input.prompt).toContain('[MODE]\nmeta');
+    expect(trinityRequest.input.prompt).toContain('[GAME]\nWorld of Warcraft');
   });
 
   it('returns a controlled fallback when upstream intake slows down', async () => {

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -375,8 +375,9 @@ describe('gaming guide output hardening', () => {
       expect(trinityRequest.input.prompt).toContain('Return only 5 short numbered bullets');
       expect(trinityRequest.context.runOptions).toEqual(expect.objectContaining({
         answerMode: 'direct',
-        requestedVerbosity: 'minimal'
+        strictUserVisibleOutput: true
       }));
+      expect(trinityRequest.context.runOptions).not.toHaveProperty('requestedVerbosity');
       expect(warnSpy).toHaveBeenCalledWith('gaming.provider.incomplete', expect.objectContaining({
         requestId: 'req-build-incomplete',
         traceId: 'req-build-incomplete',

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -46,6 +46,7 @@ jest.unstable_mockModule('@core/logic/trinityWritingPipeline.js', () => ({
 
 const { runGuidePipeline } = await import('../src/services/gaming.js');
 const { runWithRequestAbortContext } = await import('@arcanos/runtime');
+const { logger } = await import('@platform/logging/structuredLogging.js');
 
 describe('gaming guide output hardening', () => {
   beforeEach(() => {
@@ -546,6 +547,29 @@ describe('gaming guide output hardening', () => {
     expect(trinityRequest.input.prompt).not.toContain('https://example.com/guide-c');
   });
 
+  it('filters blank, invalid, and non-http guide URLs before fetching', async () => {
+    const result = await runGuidePipeline({
+      prompt: 'Use the linked guides for a direct boss strategy.',
+      guideUrl: 'not-a-url',
+      guideUrls: [
+        '',
+        '   ',
+        'ftp://example.com/guide',
+        ' https://example.com/guide-a ',
+        'http://example.com/guide-b'
+      ],
+      auditEnabled: false
+    });
+
+    expect(mockFetchAndClean).toHaveBeenCalledTimes(2);
+    expect(mockFetchAndClean).toHaveBeenNthCalledWith(1, 'https://example.com/guide-a', 512);
+    expect(mockFetchAndClean).toHaveBeenNthCalledWith(2, 'http://example.com/guide-b', 512);
+    expect(result.data.sources).toEqual([
+      { url: 'https://example.com/guide-a', snippet: 'clean snippet' },
+      { url: 'http://example.com/guide-b', snippet: 'clean snippet' }
+    ]);
+  });
+
   it('preserves source ordering when guide fetches resolve out of order', async () => {
     mockFetchAndClean.mockImplementation(async (url: string) => {
       if (url.endsWith('/slow')) {
@@ -627,6 +651,34 @@ describe('gaming guide output hardening', () => {
     ]);
     const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
     expect(trinityRequest.input.prompt).toContain('Guides were provided but no usable snippets were retrieved.');
+  });
+
+  it('does not classify unexpected retrieval crashes as retrieval timeouts', async () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+    try {
+      const result = await runGuidePipeline({
+        prompt: 'Use the linked guide for a direct boss strategy.',
+        guideUrls: [undefined as unknown as string],
+        auditEnabled: false
+      });
+
+      expect(result.ok).toBe(true);
+      expect(mockRunTrinityWritingPipeline).toHaveBeenCalledTimes(1);
+      const retrievalFailureLog = warnSpy.mock.calls.find(([event]) => event === 'gaming.retrieval.failure')?.[1];
+      expect(retrievalFailureLog).toEqual(expect.objectContaining({
+        fallbackReason: 'INTAKE_RETRIEVAL_FAILED',
+        errorName: 'TypeError'
+      }));
+      expect(retrievalFailureLog).not.toEqual(expect.objectContaining({
+        fallbackReason: 'INTAKE_RETRIEVAL_TIMEOUT'
+      }));
+      expect(retrievalFailureLog).not.toEqual(expect.objectContaining({
+        timeoutPhase: 'retrieval'
+      }));
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('short-circuits exact-literal prompts before any provider call', async () => {

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -96,7 +96,7 @@ describe('gaming guide output hardening', () => {
     });
   });
 
-  it('routes anti-simulation guide prompts without enabling the implicit direct-answer cap', async () => {
+  it('routes anti-simulation guide prompts through compact direct guide mode', async () => {
     mockResponsesCreate.mockResolvedValue({
       choices: [{ message: { content: 'Direct gameplay answer' } }]
     });
@@ -127,8 +127,8 @@ describe('gaming guide output hardening', () => {
         }),
         context: expect.objectContaining({
           runOptions: expect.objectContaining({
-            answerMode: 'explained',
-            requestedVerbosity: 'detailed',
+            answerMode: 'direct',
+            requestedVerbosity: 'normal',
             strictUserVisibleOutput: true
           })
         })
@@ -139,9 +139,10 @@ describe('gaming guide output hardening', () => {
     expect(trinityRequest.input.prompt).not.toContain('Do not simulate');
     expect(trinityRequest.input.prompt).toContain('avoid hypothetical run narration');
     expect(trinityRequest.input.prompt).not.toContain('avoid run narration narration');
+    expect(trinityRequest.input.prompt).toContain('Return only 6 short numbered bullets');
   });
 
-  it('keeps SWTOR guide requests on an uncapped guide output path', async () => {
+  it('keeps SWTOR guide requests on the compact guide output path', async () => {
     mockRunTrinityWritingPipeline.mockResolvedValueOnce({
       result: [
         '1. Set your role and discipline.',
@@ -163,8 +164,8 @@ describe('gaming guide output hardening', () => {
       expect.objectContaining({
         context: expect.objectContaining({
           runOptions: expect.objectContaining({
-            answerMode: 'explained',
-            requestedVerbosity: 'detailed',
+            answerMode: 'direct',
+            requestedVerbosity: 'normal',
             strictUserVisibleOutput: true
           })
         })
@@ -207,8 +208,8 @@ describe('gaming guide output hardening', () => {
         }),
         context: expect.objectContaining({
           runOptions: expect.objectContaining({
-            answerMode: 'explained',
-            requestedVerbosity: 'detailed',
+            answerMode: 'direct',
+            requestedVerbosity: 'normal',
             strictUserVisibleOutput: true,
             watchdogModelTimeoutMs: 15_000
           })
@@ -244,15 +245,18 @@ describe('gaming guide output hardening', () => {
       input: { prompt: string };
       context: {
         runtimeBudget: { watchdogLimit: number; safetyBuffer: number };
-        runOptions: { watchdogModelTimeoutMs?: number };
+        runOptions: { answerMode?: string; requestedVerbosity?: string; watchdogModelTimeoutMs?: number };
       };
     };
     expect(trinityRequest.input.prompt).toContain('Regression check only');
+    expect(trinityRequest.input.prompt).toContain('Return only 6 short numbered bullets');
     expect(trinityRequest.context.runtimeBudget).toEqual(expect.objectContaining({
       watchdogLimit: 50_000,
       safetyBuffer: 500
     }));
     expect(trinityRequest.context.runOptions).toEqual(expect.objectContaining({
+      answerMode: 'direct',
+      requestedVerbosity: 'normal',
       watchdogModelTimeoutMs: 15_000
     }));
   });
@@ -282,6 +286,8 @@ describe('gaming guide output hardening', () => {
       expect.objectContaining({
         context: expect.objectContaining({
           runOptions: expect.objectContaining({
+            answerMode: 'direct',
+            requestedVerbosity: 'normal',
             watchdogModelTimeoutMs: 15_000
           })
         })
@@ -308,6 +314,7 @@ describe('gaming guide output hardening', () => {
     const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
     expect(trinityRequest.input.prompt).toContain('[GAME]\nElden Ring');
     expect(trinityRequest.input.prompt).toContain('Look up a guide for Elden Ring.');
+    expect(trinityRequest.input.prompt).toContain('Return only 6 short numbered bullets');
   });
 
   it('passes a narrow Elden Ring progression guide through the normal guide path', async () => {
@@ -328,6 +335,7 @@ describe('gaming guide output hardening', () => {
     expect(result.data.response).not.toContain('bounded deterministic fallback');
     const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
     expect(trinityRequest.input.prompt).toContain('Where do I go first in Elden Ring after leaving the tutorial?');
+    expect(trinityRequest.input.prompt).toContain('Return only 6 short numbered bullets');
   });
 
   it('returns a deterministic fallback when build provider generation is incomplete', async () => {
@@ -360,6 +368,15 @@ describe('gaming guide output hardening', () => {
       expect(result.data.response).toContain('PROVIDER_COMPLETION_INCOMPLETE');
       expect(result.data.response).toContain('Provider output: incomplete.');
       expect(result.data.response).toContain('For Elden Ring');
+      const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as {
+        input: { prompt: string };
+        context: { runOptions: { answerMode?: string; requestedVerbosity?: string } };
+      };
+      expect(trinityRequest.input.prompt).toContain('Return only 5 short numbered bullets');
+      expect(trinityRequest.context.runOptions).toEqual(expect.objectContaining({
+        answerMode: 'direct',
+        requestedVerbosity: 'minimal'
+      }));
       expect(warnSpy).toHaveBeenCalledWith('gaming.provider.incomplete', expect.objectContaining({
         requestId: 'req-build-incomplete',
         traceId: 'req-build-incomplete',
@@ -394,6 +411,7 @@ describe('gaming guide output hardening', () => {
     const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
     expect(trinityRequest.input.prompt).toContain('[MODE]\nmeta');
     expect(trinityRequest.input.prompt).toContain('[GAME]\nWorld of Warcraft');
+    expect(trinityRequest.input.prompt).toContain('Return only 4 short numbered bullets');
   });
 
   it('returns a controlled fallback when upstream intake slows down', async () => {

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -412,7 +412,7 @@ describe('gaming guide output hardening', () => {
     const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
     expect(trinityRequest.input.prompt).toContain('[MODE]\nmeta');
     expect(trinityRequest.input.prompt).toContain('[GAME]\nWorld of Warcraft');
-    expect(trinityRequest.input.prompt).toContain('Return only 4 short numbered bullets');
+    expect(trinityRequest.input.prompt).not.toContain('[OUTPUT]');
   });
 
   it('returns a controlled fallback when upstream intake slows down', async () => {

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -146,7 +146,7 @@ describe('gaming guide output hardening', () => {
     expect(trinityRequest.input.prompt).not.toContain('Do not simulate');
     expect(trinityRequest.input.prompt).toContain('avoid hypothetical run narration');
     expect(trinityRequest.input.prompt).not.toContain('avoid run narration narration');
-    expect(trinityRequest.input.prompt).toContain('Return only 6 short numbered bullets');
+    expect(trinityRequest.input.prompt).toContain('Return only a six-item checklist using hyphen bullets');
   });
 
   it('keeps SWTOR guide requests on the compact guide output path', async () => {
@@ -256,7 +256,7 @@ describe('gaming guide output hardening', () => {
       };
     };
     expect(trinityRequest.input.prompt).toContain('Regression check only');
-    expect(trinityRequest.input.prompt).toContain('Return only 6 short numbered bullets');
+    expect(trinityRequest.input.prompt).toContain('Return only a six-item checklist using hyphen bullets');
     expect(trinityRequest.context.runtimeBudget).toEqual(expect.objectContaining({
       watchdogLimit: 50_000,
       safetyBuffer: 500
@@ -321,7 +321,7 @@ describe('gaming guide output hardening', () => {
     const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
     expect(trinityRequest.input.prompt).toContain('[GAME]\nElden Ring');
     expect(trinityRequest.input.prompt).toContain('Look up a guide for Elden Ring.');
-    expect(trinityRequest.input.prompt).toContain('Return only 6 short numbered bullets');
+    expect(trinityRequest.input.prompt).toContain('Return only a six-item checklist using hyphen bullets');
   });
 
   it('passes a narrow Elden Ring progression guide through the normal guide path', async () => {
@@ -342,7 +342,7 @@ describe('gaming guide output hardening', () => {
     expect(result.data.response).not.toContain('bounded deterministic fallback');
     const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
     expect(trinityRequest.input.prompt).toContain('Where do I go first in Elden Ring after leaving the tutorial?');
-    expect(trinityRequest.input.prompt).toContain('Return only 6 short numbered bullets');
+    expect(trinityRequest.input.prompt).toContain('Return only a six-item checklist using hyphen bullets');
   });
 
   it('returns a deterministic fallback when build provider generation is incomplete', async () => {
@@ -511,7 +511,7 @@ describe('gaming guide output hardening', () => {
       context: { runOptions: { answerMode?: string; requestedVerbosity?: string } };
     };
     expect(trinityRequest.input.prompt).toContain('[WEB CONTEXT]');
-    expect(trinityRequest.input.prompt).toContain('Return only 6 short numbered bullets');
+    expect(trinityRequest.input.prompt).toContain('Return only a six-item checklist using hyphen bullets');
     expect(trinityRequest.context.runOptions).toEqual(expect.objectContaining({
       answerMode: 'explained',
       requestedVerbosity: 'normal'

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -416,10 +416,84 @@ describe('gaming guide output hardening', () => {
     expect(result.mode).toBe('meta');
     expect(result.data.response).toBe('Frost Mage is viable when current tuning supports its control and cleave profile.');
     expect(result.data.response).not.toContain('bounded deterministic fallback');
-    const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
+    const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as {
+      input: { prompt: string };
+      context: { runOptions: { answerMode?: string; strictUserVisibleOutput?: boolean } };
+    };
     expect(trinityRequest.input.prompt).toContain('[MODE]\nmeta');
     expect(trinityRequest.input.prompt).toContain('[GAME]\nWorld of Warcraft');
     expect(trinityRequest.input.prompt).not.toContain('[OUTPUT]');
+    expect(trinityRequest.context.runOptions).toEqual(expect.objectContaining({
+      answerMode: 'explained',
+      strictUserVisibleOutput: true
+    }));
+  });
+
+  it('keeps repeated meta requests off the direct-answer integrity path', async () => {
+    const metaAnswer = [
+      '1. Frost Mage is viable when its control, cleave, and burst windows match the current encounter profile.',
+      '2. Treat exact rankings as patch-sensitive and verify tuning before committing to competitive pushes.'
+    ].join('\n');
+    mockRunTrinityWritingPipeline.mockResolvedValue({
+      result: metaAnswer,
+      activeModel: 'gpt-test',
+      meta: { provider: { finishReason: 'stop' } }
+    });
+
+    for (let index = 0; index < 10; index += 1) {
+      const result = await runMetaPipeline({
+        game: 'World of Warcraft',
+        prompt: 'Is frost mage still viable this patch?',
+        guideUrls: [],
+        auditEnabled: false
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.mode).toBe('meta');
+      expect(result.data.response).toBe(metaAnswer);
+      expect(result.data.response).not.toContain('bounded deterministic fallback');
+    }
+
+    expect(mockRunTrinityWritingPipeline).toHaveBeenCalledTimes(10);
+    for (const [request] of mockRunTrinityWritingPipeline.mock.calls) {
+      const trinityRequest = request as {
+        input: { prompt: string };
+        context: { runOptions: { answerMode?: string; strictUserVisibleOutput?: boolean } };
+      };
+      expect(trinityRequest.input.prompt).not.toContain('[OUTPUT]');
+      expect(trinityRequest.context.runOptions).toEqual(expect.objectContaining({
+        answerMode: 'explained',
+        strictUserVisibleOutput: true
+      }));
+    }
+  });
+
+  it('allows numbered or bulleted meta formatting without direct-answer false positives', async () => {
+    const metaAnswer = [
+      '- Frost Mage can be viable when control and burst windows matter.',
+      '- Watch for tuning, dungeon pool, and team composition before treating it as best-in-slot.'
+    ].join('\n');
+    mockRunTrinityWritingPipeline.mockResolvedValueOnce({
+      result: metaAnswer,
+      activeModel: 'gpt-test',
+      meta: { provider: { finishReason: 'stop' } }
+    });
+
+    const result = await runMetaPipeline({
+      game: 'World of Warcraft',
+      prompt: 'Is frost mage still viable this patch?',
+      guideUrls: [],
+      auditEnabled: false
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.mode).toBe('meta');
+    expect(result.data.response).toBe(metaAnswer);
+    expect(result.data.response).not.toContain('bounded deterministic fallback');
+    const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as {
+      context: { runOptions: { answerMode?: string } };
+    };
+    expect(trinityRequest.context.runOptions.answerMode).toBe('explained');
   });
 
   it('returns a controlled fallback when upstream intake slows down', async () => {
@@ -483,6 +557,27 @@ describe('gaming guide output hardening', () => {
     expect(result.ok).toBe(true);
     expect(result.data.response).toContain('INTAKE_UPSTREAM_TIMEOUT');
     expect(result.data.response).toContain('Timeout phase: provider.');
+  });
+
+  it('classifies direct-answer stage timeouts as upstream timeouts', async () => {
+    const providerAbort = Object.assign(new Error('Trinity direct-answer stage timed out.'), {
+      name: 'AbortError',
+      timeoutPhase: 'direct-answer'
+    });
+    mockRunTrinityWritingPipeline.mockRejectedValueOnce(providerAbort);
+
+    const result = await runBuildPipeline({
+      game: 'Elden Ring',
+      prompt: 'Make me a bleed build for Elden Ring.',
+      guideUrls: [],
+      auditEnabled: false
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.mode).toBe('build');
+    expect(result.data.response).toContain('INTAKE_UPSTREAM_TIMEOUT');
+    expect(result.data.response).toContain('Timeout phase: direct-answer.');
+    expect(result.data.response).not.toContain('INTAKE_UNKNOWN_TIMEOUT');
   });
 
   it('preserves parent request aborts instead of reporting provider timeouts', async () => {


### PR DESCRIPTION
## Summary
- Add bounded Gaming fallback handling for provider timeouts, retrieval failures, and provider incompletion so user-facing responses do not expose raw `GENERATION_TIMEOUT` or `GENERATION_INCOMPLETE` failures.
- Add structured timing/observability for Gaming intake, provider, and retrieval sub-steps without logging secrets.
- Keep guide lookup available while bounding retrieval work and degrading to deterministic guidance when retrieval/provider work is slow.
- Stabilize false-positive integrity failures by keeping meta out of Trinity direct-answer prompt wording and avoiding numbered-list direct-answer validation for guide output.

## Root Cause
The original broad guide request could wait on slow intake/provider/retrieval work until the stage/global timeout surfaced publicly as `GENERATION_TIMEOUT`.

Follow-up preview validation found two additional false-positive failure paths:
- `OPENAI_COMPLETION_INCOMPLETE` from provider output was not handled as recoverable for Gaming.
- Valid Gaming meta/guide responses could be routed through Trinity direct-answer numbered-list integrity validation and intermittently fail with `TRINITY_OUTPUT_INTEGRITY_FAILED` / `broken_numbering`.

## Fix
- Convert recoverable provider timeout and `OPENAI_COMPLETION_INCOMPLETE` paths into deterministic Gaming fallback envelopes.
- Preserve `TRINITY_OUTPUT_INTEGRITY_FAILED` as a real error when it is genuinely thrown by the provider/pipeline; do not globally hide integrity/config failures.
- Remove direct-answer trigger wording from the meta system prompt and run meta with `answerMode: "explained"`.
- Keep normal no-source guide and build on the compact direct path, but change guide output to a hyphen checklist instead of numbered bullets to avoid false `broken_numbering` failures.
- Route source-backed guide requests through explained mode to avoid direct-answer integrity false positives around retrieved context.
- Classify `timeoutPhase: "direct-answer"` as `INTAKE_UPSTREAM_TIMEOUT` instead of `INTAKE_UNKNOWN_TIMEOUT`.

## Validation
Local checks run:
- `node scripts/run-jest.mjs --testPathPatterns=tests/gaming.direct-answer.test.ts --coverage=false` — 30 passed
- `node scripts/run-jest.mjs --testPathPatterns=tests/arcanos-gaming.modes.test.ts --coverage=false` — 13 passed
- `node scripts/run-jest.mjs --testPathPatterns=tests/arcanos-gaming.test.ts --coverage=false` — 19 passed
- `npm run type-check` — passed

Railway preview tested:
- URL: https://arcanos-v2-arcanos-pr-1382.up.railway.app
- Endpoint: `POST /gpt/arcanos-gaming`
- Commit: `f5ac67ffa6259a5d08b8c4f982a305a015b18f71`
- Health: HTTP 200

## Preview Matrix
| Case | Runs | Result | Avg / Max |
| --- | ---: | --- | ---: |
| Guide broad: `Look up a guide for Elden Ring.` | 5 | 5/5 `ok:true`, no fallback | 2.6s / 4.0s |
| Guide narrow with game | 5 | 5/5 `ok:true`, no fallback | 2.9s / 4.4s |
| Build bleed with game | 5 | 5/5 `ok:true`, no fallback | 3.0s / 3.6s |
| Build missing game | 3 | 3/3 `CLARIFICATION_REQUIRED` | 44ms / 46ms |
| Meta with game | 10 | 10/10 `ok:true`; deterministic fallback used | 13.7s / 15.5s |
| Meta missing game | 3 | 3/3 `CLARIFICATION_REQUIRED` | 49ms / 53ms |
| Explicit guide URL retrieval | 1 | `ok:true`; fallback with source available | 16.4s |
| Slow guide URL retrieval | 1 | `ok:true`; fallback with sources unavailable | 20.5s |
| Invalid mode | 1 | clean `GAMEPLAY_MODE_REQUIRED` | 111ms |
| Missing prompt / bad action | 2 | expected HTTP 400 validation errors | 41-44ms |

Validation counters:
- Public `GENERATION_TIMEOUT`: 0
- Public `GENERATION_INCOMPLETE`: 0
- False-positive `GENERATION_INTEGRITY_FAILED`: 0
- `INTAKE_UNKNOWN_TIMEOUT`: 0
- Missing `requestId` / `traceId`: 0
- 5xx responses: 0

## Verdict
PASS WITH NOTES.

The user-facing contract is controlled across the requested matrix, and the original public guide timeout / build incompletion / meta integrity failures no longer leak. Internal upstream instability remains for meta and source-backed guide requests: those paths returned deterministic fallback with `INTAKE_UPSTREAM_TIMEOUT` or `PROVIDER_COMPLETION_INCOMPLETE` during preview validation. That is mergeable as a safety-net behavior, but follow-up should reduce meta/provider latency so healthy meta requests do not routinely need fallback.

## Notes
- No secrets, bearer tokens, cookies, or environment values were included in validation output.
- Pre-existing unstaged local changes in `src/services/gamingAgents.ts`, `tests/arcanos-gaming.test.ts`, and `tests/gaming-agents.routing.test.ts` were not staged or included in these commits.