### PR TITLE
Improve Gaming RAG snippet extraction and ranking

### DIFF
--- a/src/services/gamingPipeline.ts
+++ b/src/services/gamingPipeline.ts
@@ -199,6 +199,19 @@ export function normalizeGamingInlineSourceReferences(response: string, sourceCo
     .replace(/\[(?:sources?)\s+([\d,\s]+)\]/gi, (fullMatch, rawNumbers: string) =>
       normalizeMatch(fullMatch, rawNumbers, "bracket")
     )
+    .replace(/\[([\d,\s]+)\]/g, (fullMatch, rawNumbers: string) => {
+      const numbers = parseCitationNumbers(rawNumbers);
+      for (const number of numbers) {
+        maxInlineSourceRef = Math.max(maxInlineSourceRef, number);
+      }
+
+      const validNumbers = Array.from(new Set(numbers.filter((number) => number <= sourceCount)));
+      const normalizedMatch = validNumbers.length > 0 ? `[${validNumbers.join(", ")}]` : "";
+      if (normalizedMatch !== fullMatch) {
+        applied = true;
+      }
+      return normalizedMatch;
+    })
     .replace(/\((?:sources?)\s+([\d,\s]+)\)/gi, (fullMatch, rawNumbers: string) =>
       normalizeMatch(fullMatch, rawNumbers, "paren")
     )

--- a/src/services/gamingWebContext.ts
+++ b/src/services/gamingWebContext.ts
@@ -2,7 +2,11 @@ import { createHash } from "node:crypto";
 import { resolveErrorMessage } from "@core/lib/errors/index.js";
 import { logger } from "@platform/logging/structuredLogging.js";
 import { getEnv } from "@platform/runtime/env.js";
-import { fetchAndClean } from "@shared/webFetcher.js";
+import {
+  fetchAndClean,
+  type FetchAndCleanExtractionMetrics,
+  type FetchAndCleanOptions
+} from "@shared/webFetcher.js";
 import {
   getGamingRagChunkChars,
   getGamingRagEnabled,
@@ -74,6 +78,7 @@ type GamingFetchedDocument = {
   text: string;
   fetchedAt: string;
   cacheHit: boolean;
+  extraction: FetchAndCleanExtractionMetrics;
 };
 
 type GamingRankedChunk = {
@@ -81,6 +86,8 @@ type GamingRankedChunk = {
   text: string;
   score: number;
   hash: string;
+  snippetQualityScore: number;
+  navigationPenalty: number;
 };
 
 const KNOWN_GAME_ALIASES: Array<{ pattern: RegExp; name: string }> = [
@@ -125,6 +132,102 @@ const LOW_QUALITY_DOMAINS = [
 ];
 
 const MAX_DOCUMENT_CACHE_ENTRIES = 100;
+const MAX_PUBLIC_SNIPPET_CHARS = 600;
+const LIMITED_ARTICLE_TEXT_SNIPPET = "Relevant source retrieved, but readable article text was limited.";
+const LIMITED_ARTICLE_CONTEXT_NOTE = "[No readable article evidence was extracted from this source.]";
+
+const GENERIC_CONTENT_SELECTORS = [
+  "main",
+  "article",
+  "[role='main']",
+  ".mw-parser-output",
+  ".entry-content",
+  ".page-content",
+  ".post-content",
+  ".content"
+] as const;
+
+const COMMON_JUNK_SELECTORS = [
+  "nav",
+  "header",
+  "footer",
+  "aside",
+  "form",
+  "template",
+  "[hidden]",
+  "[aria-hidden='true']",
+  "[aria-modal='true']",
+  "[role='dialog']",
+  "[role='navigation']",
+  "[role='banner']",
+  "[role='complementary']",
+  ".sidebar",
+  "#sidebar",
+  "[class$='-sidebar']",
+  "[class$='__sidebar']",
+  "[id$='-sidebar']",
+  "[id$='__sidebar']",
+  "[class*='cookie']",
+  "[id*='cookie']",
+  "[class*='newsletter']",
+  "[class*='modal']",
+  "[class*='popup']",
+  "[class*='popin']",
+  ".comments",
+  "#comments",
+  "[class*='comment-list']",
+  "[class*='breadcrumb']",
+  "[class*='social-share']",
+  "[class*='share-social']",
+  "[class*='advertisement']",
+  "[class*='ad-container']"
+] as const;
+
+const SOURCE_EXTRACTION_PROFILES: Array<{
+  domains: string[];
+  contentSelectors: readonly string[];
+  removeSelectors: readonly string[];
+}> = [
+  {
+    domains: ["wiki.fextralife.com", "fextralife.com"],
+    contentSelectors: ["#wiki-content-block", ".wiki-content-block", "#main-content", ".page-content"],
+    removeSelectors: [
+      ".wiki-header-container",
+      ".wiki-menu-2-left",
+      ".wikiMenuMobile",
+      ".left-side-menu-container",
+      ".side-bar-right",
+      "#featured-wikis",
+      "#related-games-content",
+      "#disqus_thread"
+    ]
+  },
+  {
+    domains: ["bandainamcoent.com", "bandainamcoent.eu"],
+    contentSelectors: [".article__edito-content", ".article__content", ".article", "article"],
+    removeSelectors: [
+      ".article__sidebar",
+      ".article__share-social",
+      "[class*='read-next']",
+      ".age-gate"
+    ]
+  },
+  {
+    domains: ["worldofwarcraft.blizzard.com", "news.blizzard.com", "blizzard.com"],
+    contentSelectors: [".NewsBlog-content", ".Article-content", ".article-content", "#main", "article"],
+    removeSelectors: [".SiteNav", ".SocialLinks", ".CommentTotal"]
+  },
+  {
+    domains: ["icy-veins.com"],
+    contentSelectors: [".left-column-content", ".left-column-main", ".guide-page-content", "article"],
+    removeSelectors: [
+      ".guide-header__breadcrumbs",
+      ".content-toc",
+      ".table-of-contents",
+      ".left-column-sidebar"
+    ]
+  }
+];
 
 const BUILTIN_SOURCE_CATALOG: Array<{ game: string; sources: Array<Omit<GamingSourceCandidate, "trustScore" | "supplied">> }> = [
   {
@@ -160,6 +263,14 @@ const BUILTIN_SOURCE_CATALOG: Array<{ game: string; sources: Array<Omit<GamingSo
         sourceType: "wiki",
         topics: ["bleed", "frost", "poison", "status", "build"],
         modes: ["build", "guide"],
+        stable: true
+      },
+      {
+        title: "Elden Ring wiki hemorrhage guide",
+        url: "https://eldenring.wiki.fextralife.com/Hemorrhage",
+        sourceType: "wiki",
+        topics: ["bleed", "blood loss", "hemorrhage", "arcane", "build"],
+        modes: ["build"],
         stable: true
       }
     ]
@@ -276,7 +387,12 @@ const BUILTIN_SOURCE_CATALOG: Array<{ game: string; sources: Array<Omit<GamingSo
   }
 ];
 
-const documentCache = new Map<string, { text: string; fetchedAt: string; expiresAt: number }>();
+const documentCache = new Map<string, {
+  text: string;
+  fetchedAt: string;
+  expiresAt: number;
+  extraction: FetchAndCleanExtractionMetrics;
+}>();
 
 export function collectGamingGuideUrls(params: GamingGuideUrlInput): string[] {
   return [
@@ -350,15 +466,21 @@ function runWithLocalTimeout<T>(operation: (signal: AbortSignal) => Promise<T>, 
   });
 }
 
-function buildSafeSourceLogTarget(url: string): { sourceHost: string; sourcePathLength: number } {
+function buildSafeSourceLogTarget(url: string): { sourceUrl: string; sourceHost: string; sourcePathLength: number } {
   try {
     const parsedUrl = new URL(url);
+    parsedUrl.username = "";
+    parsedUrl.password = "";
+    parsedUrl.search = "";
+    parsedUrl.hash = "";
     return {
+      sourceUrl: parsedUrl.origin,
       sourceHost: parsedUrl.host,
       sourcePathLength: parsedUrl.pathname.length
     };
   } catch {
     return {
+      sourceUrl: "invalid-url",
       sourceHost: "invalid-url",
       sourcePathLength: 0
     };
@@ -406,10 +528,29 @@ export async function buildGamingWebContext(
       }
 
       try {
-        const snippet = await runWithLocalTimeout(
-          (signal) => fetchAndClean(sourceUrl, maxContextChars, { signal, timeoutMs: fetchTimeoutMs }),
+        let extraction: FetchAndCleanExtractionMetrics = {
+          strategy: "body",
+          rawTextLength: 0,
+          cleanedTextLength: 0
+        };
+        const fetchedText = await runWithLocalTimeout(
+          (signal) => fetchAndClean(
+            sourceUrl,
+            maxContextChars,
+            buildGamingFetchOptions(sourceUrl, signal, fetchTimeoutMs, [], (metrics) => {
+              extraction = metrics;
+            })
+          ),
           fetchTimeoutMs
         );
+        if (extraction.rawTextLength === 0 && fetchedText.length > 0) {
+          extraction = {
+            strategy: "body",
+            rawTextLength: fetchedText.length,
+            cleanedTextLength: fetchedText.length
+          };
+        }
+        const snippet = shapePublicSnippet(fetchedText);
         if (logContext) {
           logger.info("gaming.retrieval.source.end", {
             ...logContext,
@@ -420,6 +561,10 @@ export async function buildGamingWebContext(
             elapsedMs: Date.now() - sourceStartedAt,
             fetchParseMs: Date.now() - sourceStartedAt,
             snippetChars: snippet.length,
+            extractionStrategy: extraction.strategy,
+            rawTextLength: extraction.rawTextLength,
+            cleanedTextLength: extraction.cleanedTextLength,
+            fallbackSnippetUsed: snippet === LIMITED_ARTICLE_TEXT_SNIPPET,
             maxContextChars,
             fetchTimeoutMs
           });
@@ -481,6 +626,35 @@ function normalizeDomain(rawUrl: string): string {
 
 function domainMatches(domain: string, candidate: string): boolean {
   return domain === candidate || domain.endsWith(`.${candidate}`);
+}
+
+function buildGamingFetchOptions(
+  url: string,
+  signal: AbortSignal,
+  timeoutMs: number,
+  preferredContentTerms: readonly string[],
+  onExtraction: (metrics: FetchAndCleanExtractionMetrics) => void
+): FetchAndCleanOptions {
+  const domain = normalizeDomain(url);
+  const profile = SOURCE_EXTRACTION_PROFILES.find((entry) =>
+    entry.domains.some((candidate) => domainMatches(domain, candidate))
+  );
+
+  return {
+    signal,
+    timeoutMs,
+    includeLinks: false,
+    preferredContentSelectors: [
+      ...(profile?.contentSelectors ?? []),
+      ...GENERIC_CONTENT_SELECTORS
+    ],
+    preferredContentTerms,
+    removeSelectors: [
+      ...COMMON_JUNK_SELECTORS,
+      ...(profile?.removeSelectors ?? [])
+    ],
+    onExtraction
+  };
 }
 
 function trustScoreForUrl(url: string, fallback: number): number {
@@ -688,7 +862,8 @@ function scoreCandidate(
   patchSensitive: boolean
 ): number {
   const haystack = `${candidate.title} ${candidate.url} ${candidate.topics.join(" ")}`.toLowerCase();
-  const termScore = terms.reduce((score, term) => score + (haystack.includes(term.toLowerCase()) ? 0.08 : 0), 0);
+  const matchedTermCount = terms.filter((term) => haystack.includes(term.toLowerCase())).length;
+  const termScore = Math.min(0.4, matchedTermCount * 0.08);
   const suppliedBoost = candidate.supplied ? 0.5 : 0;
   const modeBoost = candidate.modes.includes(input.mode) ? 0.16 : 0;
   const patchBoost = patchSensitive && candidate.sourceType === "patch_notes" ? 0.36 : 0;
@@ -705,8 +880,8 @@ function selectCandidates(input: GamingRagInput, candidates: GamingSourceCandida
   }
 
   return candidates
-    .map((candidate) => ({ candidate, score: scoreCandidate(input, candidate, terms, patchSensitive) }))
-    .sort((left, right) => right.score - left.score)
+    .map((candidate, index) => ({ candidate, index, score: scoreCandidate(input, candidate, terms, patchSensitive) }))
+    .sort((left, right) => right.score - left.score || left.index - right.index)
     .slice(0, maxSources)
     .map((entry) => entry.candidate);
 }
@@ -715,6 +890,7 @@ async function fetchGamingRagDocument(
   candidate: GamingSourceCandidate,
   input: GamingRagInput,
   patchSensitive: boolean,
+  contentTerms: readonly string[],
   maxDocumentChars: number,
   fetchTimeoutMs: number,
   logContext: GamingWebContextLogContext | undefined,
@@ -722,7 +898,8 @@ async function fetchGamingRagDocument(
   sourceCount: number
 ): Promise<GamingFetchedDocument | GamingWebSource> {
   const sourceUrl = redactUrlCredentials(candidate.url);
-  const cacheKey = normalizeCacheUrl(sourceUrl);
+  const contentTermKey = createHash("sha256").update(contentTerms.join("\n")).digest("hex").slice(0, 16);
+  const cacheKey = `${normalizeCacheUrl(sourceUrl)}#gaming-rag:${contentTermKey}`;
   const cached = documentCache.get(cacheKey);
   const now = Date.now();
   const sourceStartedAt = now;
@@ -739,6 +916,9 @@ async function fetchGamingRagDocument(
         elapsedMs: 0,
         fetchParseMs: 0,
         snippetChars: Math.min(cached.text.length, maxDocumentChars),
+        extractionStrategy: cached.extraction.strategy,
+        rawTextLength: cached.extraction.rawTextLength,
+        cleanedTextLength: cached.extraction.cleanedTextLength,
         fetchTimeoutMs
       });
     }
@@ -746,7 +926,8 @@ async function fetchGamingRagDocument(
       candidate,
       text: cached.text,
       fetchedAt: cached.fetchedAt,
-      cacheHit: true
+      cacheHit: true,
+      extraction: cached.extraction
     };
   }
 
@@ -763,16 +944,35 @@ async function fetchGamingRagDocument(
   }
 
   try {
+    let extraction: FetchAndCleanExtractionMetrics = {
+      strategy: "body",
+      rawTextLength: 0,
+      cleanedTextLength: 0
+    };
     const text = await runWithLocalTimeout(
-      (signal) => fetchAndClean(sourceUrl, maxDocumentChars, { signal, timeoutMs: fetchTimeoutMs }),
+      (signal) => fetchAndClean(
+        sourceUrl,
+        maxDocumentChars,
+        buildGamingFetchOptions(sourceUrl, signal, fetchTimeoutMs, contentTerms, (metrics) => {
+          extraction = metrics;
+        })
+      ),
       fetchTimeoutMs
     );
+    if (extraction.rawTextLength === 0 && text.length > 0) {
+      extraction = {
+        strategy: "body",
+        rawTextLength: text.length,
+        cleanedTextLength: text.length
+      };
+    }
     const fetchedAt = new Date().toISOString();
     pruneDocumentCache(now);
     documentCache.set(cacheKey, {
       text,
       fetchedAt,
-      expiresAt: now + getGamingRagTtlMs(input.mode, patchSensitive)
+      expiresAt: now + getGamingRagTtlMs(input.mode, patchSensitive),
+      extraction
     });
     if (logContext) {
       logger.info("gaming.retrieval.source.end", {
@@ -785,6 +985,9 @@ async function fetchGamingRagDocument(
         elapsedMs: Date.now() - sourceStartedAt,
         fetchParseMs: Date.now() - sourceStartedAt,
         snippetChars: text.length,
+        extractionStrategy: extraction.strategy,
+        rawTextLength: extraction.rawTextLength,
+        cleanedTextLength: extraction.cleanedTextLength,
         fetchTimeoutMs
       });
     }
@@ -792,7 +995,8 @@ async function fetchGamingRagDocument(
       candidate,
       text,
       fetchedAt,
-      cacheHit: false
+      cacheHit: false,
+      extraction
     };
   } catch (error) {
     const errorCode = readErrorString(error, "code") ?? "INTAKE_RETRIEVAL_FAILED";
@@ -856,8 +1060,86 @@ function splitIntoChunks(text: string, maxChunkChars: number): string[] {
   return chunks;
 }
 
-const NAVIGATION_JUNK_PATTERN = /\b(?:advertisement|cookie|privacy policy|terms of use|sign in|log in|subscribe|newsletter|menu|navigation|share this|edit source|page information|fandom apps|explore properties)\b/i;
+const NAVIGATION_JUNK_PATTERN = /\b(?:advertisement|cookie settings?|privacy policy|terms of use|sign in|log in|subscribe|newsletter|menu|navigation|footer|share this|edit source|page information|table of contents|all rights reserved|fandom apps|explore properties|category directory|wiki category)\b/i;
+const NAVIGATION_LABEL_PATTERN = /\b(?:home|menu|games?|news|guides?|builds?|weapons?|armor|talismans?|skills?|bosses?|locations?|quests?|walkthrough|classes?|community|forums?|wiki|categories|view all|go back|read next|follow us|related games?|popular games)\b/gi;
+const NAVIGATION_JUNK_MATCH_PATTERN = /\b(?:advertisement|cookie settings?|privacy policy|terms of use|sign in|log in|subscribe|newsletter|menu|navigation|footer|share this|edit source|page information|table of contents|all rights reserved|category directory|wiki category)\b/gi;
 const GAMEPLAY_CONTENT_PATTERN = /\b(?:boss|route|walkthrough|build|patch|weapon|stat|skill|class|quest|location|level|damage|bleed|frost|mage|limgrave|stormveil|grace|talent|gear|rotation|viable)\b/i;
+const MODE_CONTENT_TERMS: Record<GamingMode, readonly string[]> = {
+  guide: ["route", "walkthrough", "boss", "location", "beginner", "quest", "tutorial", "progress", "grace"],
+  build: ["build", "stats", "weapon", "armor", "talisman", "skill", "rotation", "talent", "gear"],
+  meta: ["patch", "update", "nerf", "buff", "viability", "viable", "tier", "changes", "balance", "hotfix"]
+};
+const NON_TOPICAL_QUERY_TERMS = new Set([
+  "about", "and", "best", "create", "current", "for", "from", "give", "help", "into", "latest", "look", "need", "please", "recommend", "show", "the", "use", "using", "want", "with"
+]);
+
+function clampScore(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function countPatternMatches(text: string, pattern: RegExp): number {
+  return text.match(pattern)?.length ?? 0;
+}
+
+function navigationDensity(text: string): number {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  const words = normalized.match(/[a-z0-9+]+/gi) ?? [];
+  if (words.length === 0) {
+    return 1;
+  }
+
+  const sentences = normalized.split(/(?<=[.!?])\s+/).filter(Boolean);
+  const shortLabelCount = sentences.filter((sentence) => {
+    const sentenceWords = sentence.match(/[a-z0-9+]+/gi) ?? [];
+    return sentenceWords.length <= 3 && countPatternMatches(sentence, NAVIGATION_LABEL_PATTERN) > 0;
+  }).length;
+  const navigationLabels = countPatternMatches(normalized, NAVIGATION_LABEL_PATTERN);
+  const explicitJunk = countPatternMatches(normalized, NAVIGATION_JUNK_MATCH_PATTERN);
+  const separators = countPatternMatches(normalized, /(?:\||›|»|→)/g);
+  return clampScore(
+    (navigationLabels * 0.55 + explicitJunk * 2 + separators * 0.5) / Math.max(8, words.length)
+    + (sentences.length > 1 ? (shortLabelCount / sentences.length) * 0.5 : 0)
+  );
+}
+
+function repeatedTextPenalty(text: string): number {
+  const sentences = text
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim())
+    .filter((sentence) => sentence.length >= 20);
+  if (sentences.length < 2) {
+    return 0;
+  }
+
+  return Math.min(0.35, (sentences.length - new Set(sentences).size) / sentences.length);
+}
+
+function readabilityScore(text: string): number {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  const words = normalized.match(/[a-z0-9]+/gi) ?? [];
+  if (words.length === 0) {
+    return 0;
+  }
+
+  const alphabeticChars = countPatternMatches(normalized, /[a-z]/gi);
+  const alphabeticRatio = alphabeticChars / Math.max(1, normalized.length);
+  const sentenceSignal = /[.!?]/.test(normalized) ? 0.18 : 0.08;
+  const lengthSignal = Math.min(0.35, normalized.length / 900);
+  const wordSignal = words.length >= 8 ? 0.18 : words.length / 50;
+  return clampScore(lengthSignal + wordSignal + sentenceSignal + Math.min(0.2, alphabeticRatio * 0.3));
+}
+
+function matchedTermRatio(text: string, terms: readonly string[]): number {
+  const normalizedTerms = Array.from(new Set(terms.map((term) => term.toLowerCase()).filter(Boolean))).slice(0, 12);
+  if (normalizedTerms.length === 0) {
+    return 0;
+  }
+  const textTokens = new Set(tokenize(text));
+  const matches = normalizedTerms.filter((term) =>
+    tokenize(term).every((token) => textTokens.has(token))
+  ).length;
+  return matches / normalizedTerms.length;
+}
 
 function isReadableGameplayChunk(text: string): boolean {
   const normalized = text.replace(/\s+/g, " ").trim();
@@ -865,15 +1147,73 @@ function isReadableGameplayChunk(text: string): boolean {
     return false;
   }
 
-  if (GAMEPLAY_CONTENT_PATTERN.test(normalized)) {
+  const density = navigationDensity(normalized);
+  if (density >= 0.62) {
+    return false;
+  }
+
+  return !(NAVIGATION_JUNK_PATTERN.test(normalized) && density >= 0.2);
+}
+
+function isRelevantGameplayChunk(
+  text: string,
+  candidate: GamingSourceCandidate,
+  terms: readonly string[],
+  input: GamingRagInput
+): boolean {
+  if (candidate.supplied) {
     return true;
   }
 
-  return !NAVIGATION_JUNK_PATTERN.test(normalized);
+  const haystack = text.toLowerCase();
+  const textTokens = new Set(tokenize(text));
+  const gameTerms = new Set(tokenize(normalizeGameName(input) ?? ""));
+  const topicalTerms = terms.filter((term) =>
+    tokenize(term).some((token) => !gameTerms.has(token) && !NON_TOPICAL_QUERY_TERMS.has(token))
+  );
+  const hasTopicalOverlap = topicalTerms.some((term) =>
+    tokenize(term).every((token) => textTokens.has(token))
+  );
+  const hasModeSignal = MODE_CONTENT_TERMS[input.mode].some((term) => haystack.includes(term));
+  const hasGenericGameplaySignal = topicalTerms.length === 0 && GAMEPLAY_CONTENT_PATTERN.test(text);
+  const hasCompactCuratedFallback = candidate.sourceType === "curated"
+    && text.trim().length <= 40
+    && !NAVIGATION_JUNK_PATTERN.test(text);
+  if (input.mode === "build" && topicalTerms.length > 0) {
+    return hasTopicalOverlap || hasCompactCuratedFallback;
+  }
+  return hasTopicalOverlap || hasModeSignal || hasGenericGameplaySignal || hasCompactCuratedFallback;
 }
 
 function hashChunk(text: string): string {
-  return createHash("sha256").update(text.toLowerCase().replace(/\s+/g, " ").slice(0, 600)).digest("hex");
+  return createHash("sha256").update(text.toLowerCase().replace(/\s+/g, " ")).digest("hex");
+}
+
+function areNearDuplicateChunks(left: string, right: string): boolean {
+  const normalize = (value: string): string[] => value
+    .toLowerCase()
+    .replace(/[^a-z0-9+]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter((word) => word.length >= 3);
+  const leftWords = normalize(left);
+  const rightWords = normalize(right);
+  if (leftWords.join(" ") === rightWords.join(" ")) {
+    return true;
+  }
+  if (leftWords.length < 8 || rightWords.length < 8) {
+    return false;
+  }
+  const lengthRatio = Math.min(leftWords.length, rightWords.length) / Math.max(leftWords.length, rightWords.length);
+  if (lengthRatio < 0.8) {
+    return false;
+  }
+
+  const leftSet = new Set(leftWords);
+  const rightSet = new Set(rightWords);
+  const intersectionSize = Array.from(leftSet).filter((word) => rightSet.has(word)).length;
+  const unionSize = new Set([...leftSet, ...rightSet]).size;
+  return unionSize > 0 && intersectionSize / unionSize >= 0.86;
 }
 
 function rankChunks(documents: GamingFetchedDocument[], terms: string[], input: GamingRagInput, patchSensitive: boolean): GamingRankedChunk[] {
@@ -886,45 +1226,104 @@ function rankChunks(documents: GamingFetchedDocument[], terms: string[], input: 
   const scoredChunks: GamingRankedChunk[] = [];
   for (const document of documents) {
     for (const chunk of splitIntoChunks(document.text, maxChunkChars)) {
-      if (!isReadableGameplayChunk(chunk)) {
+      if (!isReadableGameplayChunk(chunk) || !isRelevantGameplayChunk(chunk, document.candidate, terms, input)) {
         continue;
       }
 
       const haystack = chunk.toLowerCase();
-      const termScore = terms.reduce((score, term) => score + (haystack.includes(term.toLowerCase()) ? 0.14 : 0), 0);
+      const chunkTokens = new Set(tokenize(chunk));
+      const termScore = Math.min(0.7, terms.filter((term) =>
+        tokenize(term).every((token) => chunkTokens.has(token))
+      ).length * 0.14);
+      const gameTerms = tokenize(normalizeGameName(input) ?? "");
+      const gameScore = Math.min(0.24, gameTerms.filter((term) => chunkTokens.has(term)).length * 0.08);
+      const modeTermCount = MODE_CONTENT_TERMS[input.mode].filter((term) => haystack.includes(term)).length;
+      const modeScore = Math.min(0.35, modeTermCount * 0.07);
       const patchScore = patchSensitive && /\b(?:patch|hotfix|version|buff|nerf|balance|adjusted|changed)\b/i.test(chunk) ? 0.28 : 0;
       const buildScore = input.mode === "build" && /\b(?:build|stat|weapon|talent|gear|rotation|bleed|frost|mage)\b/i.test(chunk) ? 0.22 : 0;
       const guideScore = input.mode === "guide" && /\b(?:route|walkthrough|first|after|location|boss|quest|progress)\b/i.test(chunk) ? 0.18 : 0;
-      const navigationPenalty = NAVIGATION_JUNK_PATTERN.test(chunk) ? -0.35 : 0;
+      const density = navigationDensity(chunk);
+      const repetitionPenalty = repeatedTextPenalty(chunk);
+      const navigationPenalty = -(density * 1.1 + (NAVIGATION_JUNK_PATTERN.test(chunk) ? 0.35 : 0));
+      const snippetQualityScore = clampScore(
+        readabilityScore(chunk)
+        + matchedTermRatio(chunk, terms) * 0.35
+        + (GAMEPLAY_CONTENT_PATTERN.test(chunk) ? 0.12 : 0)
+        - density * 0.65
+        - repetitionPenalty
+      );
       scoredChunks.push({
         candidate: document.candidate,
         text: chunk,
-        score: scoreCandidate(input, document.candidate, terms, patchSensitive) + termScore + patchScore + buildScore + guideScore + navigationPenalty,
-        hash: hashChunk(chunk)
+        score: scoreCandidate(input, document.candidate, terms, patchSensitive)
+          + termScore
+          + gameScore
+          + modeScore
+          + patchScore
+          + buildScore
+          + guideScore
+          + snippetQualityScore * 0.35
+          + navigationPenalty
+          - repetitionPenalty,
+        hash: hashChunk(chunk),
+        snippetQualityScore,
+        navigationPenalty
       });
     }
   }
 
-  const deduped = new Map<string, GamingRankedChunk>();
-  for (const chunk of scoredChunks) {
-    const dedupeKey = chunk.candidate.supplied ? `${chunk.hash}:${chunk.candidate.url}` : chunk.hash;
-    const existing = deduped.get(dedupeKey);
-    if (!existing || chunk.score > existing.score) {
-      deduped.set(dedupeKey, chunk);
+  const sortedChunks = scoredChunks.sort((left, right) =>
+    right.score - left.score
+    || left.candidate.url.localeCompare(right.candidate.url)
+    || left.hash.localeCompare(right.hash)
+  );
+  const selectedChunks: GamingRankedChunk[] = [];
+  for (const chunk of sortedChunks) {
+    if (selectedChunks.some((selected) =>
+      selected.candidate.url === chunk.candidate.url
+      && (selected.hash === chunk.hash || areNearDuplicateChunks(selected.text, chunk.text))
+    )) {
+      continue;
+    }
+    selectedChunks.push(chunk);
+    if (selectedChunks.length >= maxChunks) {
+      break;
     }
   }
 
-  return Array.from(deduped.values())
-    .sort((left, right) => right.score - left.score)
-    .slice(0, maxChunks);
+  return selectedChunks;
 }
 
 function buildSourceNumberByUrl(sources: GamingWebSource[]): Map<string, number> {
   return new Map(sources.map((source, index) => [source.url, index + 1]));
 }
 
-function buildPublicSourcesFromChunks(chunks: GamingRankedChunk[]): GamingWebSource[] {
-  return Array.from(new Map(chunks.map((chunk) => [chunk.candidate.url, sourceFromChunk(chunk)])).values());
+function buildPublicSourcesFromChunks(
+  chunks: GamingRankedChunk[],
+  documents: GamingFetchedDocument[],
+  terms: readonly string[],
+  input: GamingRagInput
+): GamingWebSource[] {
+  const sourcesByUrl = new Map<string, GamingWebSource>();
+  const chunkChars = getGamingRagChunkChars();
+  for (const document of documents) {
+    const selectedChunk = chunks.find((chunk) => chunk.candidate.url === document.candidate.url);
+    if (selectedChunk) {
+      sourcesByUrl.set(document.candidate.url, sourceFromChunk(selectedChunk));
+      continue;
+    }
+    const hasReadableArticleText = splitIntoChunks(document.text, chunkChars).some((chunk) =>
+      isReadableGameplayChunk(chunk) && isRelevantGameplayChunk(chunk, document.candidate, terms, input)
+    );
+    if (!hasReadableArticleText) {
+      sourcesByUrl.set(document.candidate.url, {
+        url: document.candidate.url,
+        snippet: LIMITED_ARTICLE_TEXT_SNIPPET
+      });
+    }
+  }
+
+  return Array.from(sourcesByUrl.values());
 }
 
 function buildRagContext(
@@ -933,7 +1332,7 @@ function buildRagContext(
   retrievalQuery: string,
   maxContextChars: number
 ): string {
-  if (chunks.length === 0) {
+  if (sources.length === 0) {
     return "";
   }
 
@@ -943,27 +1342,70 @@ function buildRagContext(
     retrievalQuery || "prompt-only"
   ];
 
-  chunks.forEach((chunk) => {
+  const orderedChunks = chunks
+    .map((chunk, index) => ({ chunk, index, sourceNumber: sourceNumberByUrl.get(chunk.candidate.url) ?? Number.MAX_SAFE_INTEGER }))
+    .sort((left, right) => left.sourceNumber - right.sourceNumber || left.index - right.index)
+    .map((entry) => entry.chunk);
+
+  orderedChunks.forEach((chunk) => {
     const sourceNumber = sourceNumberByUrl.get(chunk.candidate.url);
-    if (!sourceNumber) {
+    const source = sourceNumber ? sources[sourceNumber - 1] : undefined;
+    if (!sourceNumber || source?.snippet === LIMITED_ARTICLE_TEXT_SNIPPET) {
       return;
     }
     const domain = normalizeDomain(chunk.candidate.url);
+    const evidenceText = extractReadableEvidenceText(chunk.text);
+    if (!evidenceText) {
+      return;
+    }
     parts.push(
       "",
       `[Source ${sourceNumber}] ${chunk.candidate.url}`,
       `Title: ${chunk.candidate.title}; Domain: ${domain}; Type: ${chunk.candidate.sourceType}; Trust: ${chunk.candidate.trustScore.toFixed(2)}`,
-      chunk.text
+      evidenceText
     );
+  });
+
+  sources.forEach((source, index) => {
+    if (source.snippet !== LIMITED_ARTICLE_TEXT_SNIPPET) {
+      return;
+    }
+    parts.push("", `[Source ${index + 1}] ${source.url}`, LIMITED_ARTICLE_CONTEXT_NOTE);
   });
 
   return parts.join("\n").slice(0, Math.max(0, maxContextChars));
 }
 
+function extractReadableEvidenceText(text: string): string {
+  const withoutLinks = text.replace(/\s*\[LINKS\][\s\S]*$/i, "").replace(/\s+/g, " ").trim();
+  if (!withoutLinks) {
+    return "";
+  }
+  const sentences = withoutLinks.split(/(?<=[.!?])\s+/).filter(Boolean);
+  return sentences.filter(isReadableGameplayChunk).join(" ").trim();
+}
+
+function truncateSnippet(text: string): string {
+  if (text.length <= MAX_PUBLIC_SNIPPET_CHARS) {
+    return text;
+  }
+  const candidate = text.slice(0, MAX_PUBLIC_SNIPPET_CHARS - 1);
+  const boundary = Math.max(candidate.lastIndexOf(". "), candidate.lastIndexOf("; "), candidate.lastIndexOf(" "));
+  const truncated = boundary >= Math.floor(MAX_PUBLIC_SNIPPET_CHARS * 0.6)
+    ? candidate.slice(0, boundary + (candidate.slice(boundary, boundary + 2) === ". " ? 1 : 0))
+    : candidate;
+  return `${truncated.trimEnd()}…`;
+}
+
+function shapePublicSnippet(text: string): string {
+  const evidenceText = extractReadableEvidenceText(text);
+  return evidenceText ? truncateSnippet(evidenceText) : LIMITED_ARTICLE_TEXT_SNIPPET;
+}
+
 function sourceFromChunk(chunk: GamingRankedChunk): GamingWebSource {
   return {
     url: chunk.candidate.url,
-    snippet: chunk.text
+    snippet: shapePublicSnippet(chunk.text)
   };
 }
 
@@ -989,8 +1431,8 @@ function buildClearChecks(params: {
   };
 }
 
-function sourceDomainsFromChunks(chunks: GamingRankedChunk[]): string[] {
-  return Array.from(new Set(chunks.map((chunk) => normalizeDomain(chunk.candidate.url)).filter(Boolean)));
+function sourceDomainsFromSources(sources: GamingWebSource[]): string[] {
+  return Array.from(new Set(sources.map((source) => normalizeDomain(source.url)).filter(Boolean)));
 }
 
 function retrievalReasonFor(input: GamingRagInput, game: string | undefined, suppliedSourceCount: number, patchSensitive: boolean): string {
@@ -1085,7 +1527,7 @@ export async function buildGamingRagContext(
       ...(game ? { game } : {}),
       retrievalEnabled,
       retrievalReason,
-      retrievalQuery,
+      retrievalQueryTermCount: terms.length,
       requestedSourceCount: suppliedSourceCount,
       sourceCount: candidates.length,
       sourceDomains: Array.from(new Set(candidates.map((candidate) => normalizeDomain(candidate.url)).filter(Boolean))),
@@ -1112,6 +1554,7 @@ export async function buildGamingRagContext(
         candidate,
         input,
         patchSensitive,
+        Array.from(new Set([...terms, ...MODE_CONTENT_TERMS[input.mode]])),
         maxContextChars,
         fetchTimeoutMs,
         logContext,
@@ -1126,10 +1569,10 @@ export async function buildGamingRagContext(
   const timedOut = errorSources.some((source) => source.error?.toLowerCase().includes("timed out"));
   const rankingStartedAt = Date.now();
   const chunks = rankChunks(documents, terms, input, patchSensitive);
-  const sources = buildPublicSourcesFromChunks(chunks);
+  const sources = buildPublicSourcesFromChunks(chunks, documents, terms, input);
   const context = buildRagContext(chunks, sources, retrievalQuery, maxContextChars);
   const rankingElapsedMs = Date.now() - rankingStartedAt;
-  const sourceDomains = sourceDomainsFromChunks(chunks);
+  const sourceDomains = sourceDomainsFromSources(sources);
   const cacheHit = documents.some((document) => document.cacheHit);
   const fallbackReason = documents.length === 0 && timedOut ? "INTAKE_RETRIEVAL_TIMEOUT" : undefined;
   const retrievedSourceCount = documents.length;
@@ -1143,12 +1586,32 @@ export async function buildGamingRagContext(
   });
 
   if (logContext) {
+    for (const document of documents) {
+      const selectedChunk = chunks.find((chunk) => chunk.candidate.url === document.candidate.url);
+      const publicSource = sources.find((source) => source.url === document.candidate.url);
+      logger.info("gaming.retrieval.source.selection", {
+        ...logContext,
+        ...(game ? { game } : {}),
+        ...buildSafeSourceLogTarget(document.candidate.url),
+        cacheHit: document.cacheHit,
+        extractionStrategy: document.extraction.strategy,
+        rawTextLength: document.extraction.rawTextLength,
+        cleanedTextLength: document.extraction.cleanedTextLength,
+        chunkCount: splitIntoChunks(document.text, getGamingRagChunkChars()).length,
+        selectedChunkScore: selectedChunk ? Number(selectedChunk.score.toFixed(4)) : null,
+        snippetQualityScore: selectedChunk ? Number(selectedChunk.snippetQualityScore.toFixed(4)) : null,
+        navigationPenalty: selectedChunk ? Number(selectedChunk.navigationPenalty.toFixed(4)) : null,
+        fallbackSnippetUsed: publicSource?.snippet === LIMITED_ARTICLE_TEXT_SNIPPET,
+        retrievalElapsedMs: Date.now() - retrievalStartedAt
+      });
+    }
+
     logger.info("gaming.retrieval.end", {
       ...logContext,
       ...(game ? { game } : {}),
       retrievalEnabled,
       retrievalReason,
-      retrievalQuery,
+      retrievalQueryTermCount: terms.length,
       sourceCount: sources.length,
       retrievedSourceCount,
       publicSourceCount,

--- a/src/shared/webFetcher.ts
+++ b/src/shared/webFetcher.ts
@@ -145,7 +145,7 @@ export async function fetchAndCleanDocument(
         })
       : undefined;
 
-  const { data } = await axios.get<string>(target.requestUrl.toString(), {
+  const response = await axios.get<string>(target.requestUrl.toString(), {
     timeout: options.timeoutMs ?? getConfiguredFetchTimeoutMs(),
     signal: options.signal,
     maxContentLength: maxFetchBytes,
@@ -163,9 +163,14 @@ export async function fetchAndCleanDocument(
     httpsAgent
   });
 
-  const $ = load(data);
-  const rawTextLength = normalizeExtractedText($('body').text()).length;
+  const contentType = String(response.headers['content-type'] ?? '').split(';', 1)[0].trim().toLowerCase();
+  if (contentType && !['text/html', 'text/plain', 'application/xhtml+xml'].includes(contentType)) {
+    throw new Error(`Unsupported content type for web fetching: ${contentType}`);
+  }
+
+  const $ = load(response.data);
   $('script, style, noscript').remove();
+  const rawTextLength = normalizeExtractedText($('body').text()).length;
   for (const selector of options.removeSelectors ?? []) {
     try {
       $(selector).remove();

--- a/src/shared/webFetcher.ts
+++ b/src/shared/webFetcher.ts
@@ -55,6 +55,29 @@ export interface FetchAndCleanDocument {
 export interface FetchAndCleanOptions {
   signal?: AbortSignal;
   timeoutMs?: number;
+  preferredContentSelectors?: readonly string[];
+  preferredContentTerms?: readonly string[];
+  removeSelectors?: readonly string[];
+  includeLinks?: boolean;
+  onExtraction?: (metrics: FetchAndCleanExtractionMetrics) => void;
+}
+
+export interface FetchAndCleanExtractionMetrics {
+  strategy: string;
+  rawTextLength: number;
+  cleanedTextLength: number;
+}
+
+function normalizeExtractedText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function contentTermScore(text: string, terms: readonly string[]): number {
+  const textTokens = new Set(text.toLowerCase().match(/[a-z0-9+]+/g) ?? []);
+  return terms.slice(0, 24).reduce((score, term) => {
+    const termTokens = term.toLowerCase().match(/[a-z0-9+]+/g) ?? [];
+    return score + (termTokens.length > 0 && termTokens.every((token) => textTokens.has(token)) ? 1 : 0);
+  }, 0);
 }
 
 /**
@@ -141,9 +164,52 @@ export async function fetchAndCleanDocument(
   });
 
   const $ = load(data);
+  const rawTextLength = normalizeExtractedText($('body').text()).length;
   $('script, style, noscript').remove();
-  const text = $('body').text();
-  const cleanedText = text.replace(/\s+/g, ' ').trim();
+  for (const selector of options.removeSelectors ?? []) {
+    try {
+      $(selector).remove();
+    } catch {
+      // Optional caller-owned extraction selectors must never break the generic body fallback.
+    }
+  }
+  $('br').replaceWith(' ');
+  $('p, h1, h2, h3, h4, h5, h6, li, dt, dd, div, section, article, tr, td').append(' ');
+
+  const bodyText = normalizeExtractedText($('body').text());
+  let cleanedText = bodyText;
+  let extractionStrategy = 'body';
+  for (const selector of options.preferredContentSelectors ?? []) {
+    try {
+      let selectedText = '';
+      let selectedTermScore = -1;
+      $(selector).each((_, element) => {
+        const candidateText = normalizeExtractedText($(element).text());
+        const candidateTermScore = contentTermScore(candidateText, options.preferredContentTerms ?? []);
+        if (candidateTermScore > selectedTermScore || (
+          candidateTermScore === selectedTermScore && candidateText.length > selectedText.length
+        )) {
+          selectedText = candidateText;
+          selectedTermScore = candidateTermScore;
+        }
+      });
+
+      const minimumUsefulLength = bodyText.length < 120 ? 1 : 120;
+      if (selectedText.length >= minimumUsefulLength) {
+        cleanedText = selectedText;
+        extractionStrategy = selector;
+        break;
+      }
+    } catch {
+      // Invalid optional selectors degrade to the next selector and then the generic body.
+    }
+  }
+
+  options.onExtraction?.({
+    strategy: extractionStrategy,
+    rawTextLength,
+    cleanedTextLength: cleanedText.length
+  });
 
   const seenLinks = new Set<string>();
   const links: FetchAndCleanLinkSummary[] = [];
@@ -170,7 +236,9 @@ export async function fetchAndCleanDocument(
     }
   });
 
-  const limitedLinks = links.slice(0, getConfiguredWebFetchMaxLinks());
+  const limitedLinks = options.includeLinks === false
+    ? []
+    : links.slice(0, getConfiguredWebFetchMaxLinks());
 
   return {
     text: cleanedText,

--- a/tests/gaming-web-context-quality.test.ts
+++ b/tests/gaming-web-context-quality.test.ts
@@ -1,0 +1,379 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockFetchAndClean = jest.fn();
+const mockGetEnv = jest.fn();
+const mockGetEnvBoolean = jest.fn();
+const mockGetEnvIntegerAtLeast = jest.fn();
+const mockGetEnvNumber = jest.fn();
+const mockGetOptionalEnvIntegerAtLeast = jest.fn();
+
+jest.unstable_mockModule('@shared/webFetcher.js', () => ({
+  fetchAndClean: mockFetchAndClean
+}));
+
+jest.unstable_mockModule('@platform/runtime/env.js', () => ({
+  getEnv: mockGetEnv,
+  getEnvBoolean: mockGetEnvBoolean,
+  getEnvIntegerAtLeast: mockGetEnvIntegerAtLeast,
+  getEnvNumber: mockGetEnvNumber,
+  getOptionalEnvIntegerAtLeast: mockGetOptionalEnvIntegerAtLeast
+}));
+
+const { buildGamingRagContext, clearGamingRagCache } = await import('../src/services/gamingWebContext.js');
+
+const TEST_ENV_KEYS = [
+  'ARCANOS_GAMING_CURATED_SOURCES_JSON',
+  'ARCANOS_GAMING_RAG_CHUNK_CHARS',
+  'ARCANOS_GAMING_RAG_ENABLED',
+  'ARCANOS_GAMING_RAG_MAX_CHUNKS',
+  'ARCANOS_GAMING_RAG_MAX_SOURCES',
+  'ARCANOS_GAMING_WEB_CONTEXT_CHARS',
+  'ARCANOS_GAMING_WEB_CONTEXT_FETCH_TIMEOUT_MS',
+  'ARCANOS_GAMING_WEB_CONTEXT_MAX_URLS'
+] as const;
+
+const NAVIGATION_TEXT = [
+  'Menu.',
+  'Games.',
+  'News.',
+  'Guides.',
+  'Builds.',
+  'Weapons.',
+  'Armor.',
+  'Talismans.',
+  'Skills.',
+  'Bosses.',
+  'Locations.',
+  'Quests.',
+  'Walkthrough.',
+  'Sign In.',
+  'Subscribe.',
+  'Privacy Policy.',
+  'Advertisement.',
+  'Community Navigation.'
+].join(' ');
+
+function countOccurrences(value: string, needle: string): number {
+  return value.split(needle).length - 1;
+}
+
+describe('gaming RAG snippet quality', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    for (const key of TEST_ENV_KEYS) {
+      delete process.env[key];
+    }
+
+    process.env.ARCANOS_GAMING_RAG_CHUNK_CHARS = '200';
+    process.env.ARCANOS_GAMING_RAG_MAX_CHUNKS = '8';
+    process.env.ARCANOS_GAMING_WEB_CONTEXT_CHARS = '5000';
+
+    mockGetEnv.mockImplementation((key: string, defaultValue?: string) => process.env[key] ?? defaultValue);
+    mockGetEnvBoolean.mockReturnValue(false);
+    mockGetEnvNumber.mockImplementation((_key: string, defaultValue: number) => defaultValue);
+    mockGetEnvIntegerAtLeast.mockImplementation((key: string, defaultValue: number, minValue: number) => {
+      const rawValue = process.env[key];
+      if (rawValue === undefined) {
+        return defaultValue;
+      }
+      const parsed = Number.parseInt(rawValue, 10);
+      return Number.isFinite(parsed) && parsed >= minValue ? parsed : defaultValue;
+    });
+    mockGetOptionalEnvIntegerAtLeast.mockImplementation((key: string, minValue: number) => {
+      const rawValue = process.env[key];
+      if (rawValue === undefined) {
+        return undefined;
+      }
+      const parsed = Number.parseInt(rawValue, 10);
+      return Number.isFinite(parsed) && parsed >= minValue ? parsed : undefined;
+    });
+    mockFetchAndClean.mockResolvedValue('Readable guide evidence about a boss route and safe progression.');
+    clearGamingRagCache();
+  });
+
+  it('keeps the best Fextralife article evidence instead of a lower-ranked navigation chunk', async () => {
+    mockFetchAndClean.mockResolvedValue([
+      NAVIGATION_TEXT,
+      'After leaving the Elden Ring tutorial, activate the First Step grace, visit the Church of Elleh, then follow the road toward Gatefront Ruins before approaching Stormveil.'
+    ].join(' '));
+
+    const result = await buildGamingRagContext({
+      mode: 'guide',
+      game: 'Elden Ring',
+      prompt: 'Where do I go first in Elden Ring after leaving the tutorial?',
+      guideUrl: 'https://eldenring.wiki.fextralife.com/Game+Progress+Route',
+      guideUrls: []
+    });
+
+    const routeSource = result.sources.find((source) => source.url.endsWith('/Game+Progress+Route'));
+    const routeFetch = mockFetchAndClean.mock.calls.find(([url]) =>
+      url === 'https://eldenring.wiki.fextralife.com/Game+Progress+Route'
+    );
+    expect(routeSource?.snippet).toContain('Gatefront Ruins');
+    expect(routeSource?.snippet).not.toMatch(/sign in|privacy policy|community navigation/i);
+    expect(routeFetch?.[2]).toEqual(expect.objectContaining({
+      includeLinks: false,
+      preferredContentSelectors: expect.arrayContaining(['#wiki-content-block', 'main', 'article']),
+      removeSelectors: expect.arrayContaining(['nav', '[hidden]', "[role='dialog']", '.wiki-menu-2-left', '.left-side-menu-container', '.side-bar-right'])
+    }));
+    expect(routeFetch?.[2]?.removeSelectors).not.toContain('.fex-main-sidebar-container');
+    expect(routeFetch?.[2]?.removeSelectors).not.toContain("[class*='sidebar']");
+  });
+
+  it('prefers official Bandai Namco patch changes over site chrome', async () => {
+    mockFetchAndClean.mockResolvedValue([
+      `${NAVIGATION_TEXT} Patch Notes.`,
+      'Elden Ring patch version 1.16.1 changed balance behavior and fixed several weapon skill interactions that affected current builds.'
+    ].join(' '));
+
+    const result = await buildGamingRagContext({
+      mode: 'meta',
+      game: 'Elden Ring',
+      prompt: 'What changed for Elden Ring builds in the latest patch?',
+      guideUrls: []
+    });
+
+    const officialSource = result.sources.find((source) => source.url.includes('bandainamcoent.eu'));
+    const officialFetch = mockFetchAndClean.mock.calls.find(([url]) =>
+      typeof url === 'string' && url.includes('bandainamcoent.eu')
+    );
+    expect(officialSource?.snippet).toContain('version 1.16.1 changed balance behavior');
+    expect(officialSource?.snippet).not.toMatch(/sign in|privacy policy|community navigation/i);
+    expect(officialFetch?.[2]).toEqual(expect.objectContaining({
+      includeLinks: false,
+      preferredContentSelectors: expect.arrayContaining(['.article__edito-content', 'main', 'article']),
+      removeSelectors: expect.arrayContaining(['nav', '.article__sidebar'])
+    }));
+  });
+
+  it('prefers bleed-specific evidence over unrelated build-adjacent patch text', async () => {
+    mockFetchAndClean.mockImplementation(async (url: string) => {
+      if (url.endsWith('/Hemorrhage')) {
+        return 'Hemorrhage inflicts blood loss after bleed buildup fills the meter; Arcane scaling and fast multi-hit weapons make the status reliable for an Elden Ring bleed build.';
+      }
+      if (url.includes('bandainamcoent.eu')) {
+        return 'Patch version 1.16.1 fixed an unrelated weapon skill interaction and updated online regulation files.';
+      }
+      return 'General Elden Ring status and build reference material.';
+    });
+
+    const result = await buildGamingRagContext({
+      mode: 'build',
+      game: 'Elden Ring',
+      prompt: 'Make me a bleed build for Elden Ring.',
+      guideUrls: []
+    });
+
+    expect(result.sources).toContainEqual(expect.objectContaining({
+      url: 'https://eldenring.wiki.fextralife.com/Hemorrhage',
+      snippet: expect.stringMatching(/Arcane scaling.*multi-hit weapons/i)
+    }));
+    expect(result.sources.find((source) => source.url.includes('bandainamcoent.eu'))?.snippet).toBe(
+      'Relevant source retrieved, but readable article text was limited.'
+    );
+  });
+
+  it('prefers Icy Veins Frost Mage guide content over navigation lists', async () => {
+    mockFetchAndClean.mockImplementation(async (url: string) => {
+      if (url.includes('icy-veins.com')) {
+        return [
+          NAVIGATION_TEXT,
+          'Frost Mage remains viable when its talents and rotation match the encounter; prioritize Shatter windows, cooldown alignment, and current patch tuning.'
+        ].join(' ');
+      }
+      return 'Frost Mage overview: current talents, damage profile, and rotation determine raid viability.';
+    });
+
+    const result = await buildGamingRagContext({
+      mode: 'guide',
+      game: 'World of Warcraft',
+      prompt: 'Is Frost Mage still viable this patch?',
+      guideUrls: []
+    });
+
+    const icyVeinsSource = result.sources.find((source) => source.url.includes('icy-veins.com'));
+    const icyVeinsFetch = mockFetchAndClean.mock.calls.find(([url]) =>
+      typeof url === 'string' && url.includes('icy-veins.com')
+    );
+    expect(icyVeinsSource?.snippet).toContain('Shatter windows');
+    expect(icyVeinsSource?.snippet).not.toMatch(/sign in|privacy policy|community navigation/i);
+    expect(icyVeinsFetch?.[2]).toEqual(expect.objectContaining({
+      includeLinks: false,
+      preferredContentSelectors: expect.arrayContaining(['.left-column-content', 'main', 'article']),
+      removeSelectors: expect.arrayContaining(['nav', '.content-toc'])
+    }));
+  });
+
+  it('does not expose unrelated Blizzard news prose as Frost Mage patch evidence', async () => {
+    mockFetchAndClean.mockImplementation(async (url: string) => {
+      if (url.includes('worldofwarcraft.blizzard.com')) {
+        return 'Warcraft Short Story: The Bitter Truth follows a new character journey through an unrelated narrative chapter.';
+      }
+      if (url.includes('icy-veins.com')) {
+        return 'Frost Mage patch evidence: current tuning keeps the specialization viable with the recommended talents and Shatter rotation.';
+      }
+      return 'Frost Mage class evidence covers current talents, rotation, damage profile, and raid viability.';
+    });
+
+    const result = await buildGamingRagContext({
+      mode: 'meta',
+      game: 'World of Warcraft',
+      prompt: 'Is Frost Mage still viable this patch?',
+      guideUrls: []
+    });
+
+    const blizzardSource = result.sources.find((source) => source.url.includes('worldofwarcraft.blizzard.com'));
+    const blizzardFetch = mockFetchAndClean.mock.calls.find(([url]) =>
+      typeof url === 'string' && url.includes('worldofwarcraft.blizzard.com')
+    );
+    const icyVeinsSource = result.sources.find((source) => source.url.includes('icy-veins.com'));
+    expect(
+      !blizzardSource
+      || blizzardSource.snippet === 'Relevant source retrieved, but readable article text was limited.'
+    ).toBe(true);
+    expect(blizzardFetch?.[2]).toEqual(expect.objectContaining({
+      preferredContentSelectors: expect.arrayContaining(['.NewsBlog-content', '#main']),
+      preferredContentTerms: expect.arrayContaining(['frost mage', 'patch', 'hotfix'])
+    }));
+    expect(blizzardFetch?.[2]?.preferredContentSelectors?.[0]).toBe('.NewsBlog-content');
+    expect(icyVeinsSource?.snippet).toContain('current tuning keeps the specialization viable');
+  });
+
+  it('keeps generic extraction support for an unknown supplied guide domain', async () => {
+    const url = 'https://guides.example.net/elden-ring-opening-route';
+    mockFetchAndClean.mockResolvedValue(
+      'Community route evidence: unlock the nearby grace, collect the map fragment, and upgrade the weapon before the first major boss.'
+    );
+
+    const result = await buildGamingRagContext({
+      mode: 'guide',
+      prompt: 'Use this supplied guide for the opening route.',
+      guideUrl: url,
+      guideUrls: []
+    });
+
+    expect(mockFetchAndClean).toHaveBeenCalledWith(
+      url,
+      5000,
+      expect.objectContaining({
+        signal: expect.any(Object),
+        timeoutMs: expect.any(Number),
+        includeLinks: false,
+        preferredContentSelectors: expect.arrayContaining(['main', 'article'])
+      })
+    );
+    const genericFetch = mockFetchAndClean.mock.calls.find(([fetchedUrl]) => fetchedUrl === url);
+    expect(genericFetch?.[2]?.preferredContentSelectors).not.toContain('#wiki-content-block');
+    expect(genericFetch?.[2]?.preferredContentSelectors).not.toContain('.article__edito-content');
+    expect(genericFetch?.[2]?.preferredContentSelectors).not.toContain('.left-column-content');
+    expect(result.sources).toEqual([
+      {
+        url,
+        snippet: 'Community route evidence: unlock the nearby grace, collect the map fragment, and upgrade the weapon before the first major boss.'
+      }
+    ]);
+  });
+
+  it('deduplicates repeated chunks so repeated page chrome cannot dominate context', async () => {
+    const repeated = 'Elden Ring menu route directory lists bosses, weapons, builds, locations, and quests for every wiki category.';
+    mockFetchAndClean.mockResolvedValue([
+      repeated,
+      repeated,
+      repeated,
+      'Opening route evidence: after the tutorial, activate the First Step grace and continue north to the Church of Elleh.'
+    ].join(' '));
+
+    const result = await buildGamingRagContext({
+      mode: 'guide',
+      prompt: 'Where should I go after the tutorial?',
+      guideUrl: 'https://example.com/repeated-guide',
+      guideUrls: []
+    });
+
+    expect(countOccurrences(result.context, repeated)).toBeLessThanOrEqual(1);
+    expect(result.sources[0]?.snippet).toContain('First Step grace');
+  });
+
+  it('bounds every public source snippet independently of the configured chunk size', async () => {
+    process.env.ARCANOS_GAMING_RAG_CHUNK_CHARS = '1600';
+    mockFetchAndClean.mockResolvedValue(
+      `Bleed build evidence recommends Arcane, Vigor, a fast weapon, and an upgraded bleed affinity because ${'measured damage and reliable status buildup '.repeat(32)}.`
+    );
+
+    const result = await buildGamingRagContext({
+      mode: 'build',
+      game: 'Test Game',
+      prompt: 'Make me a bleed build for Elden Ring.',
+      guideUrl: 'https://example.com/long-bleed-build',
+      guideUrls: []
+    });
+
+    expect(result.sources).toHaveLength(1);
+    expect(result.sources[0]?.snippet?.length).toBeLessThanOrEqual(600);
+    expect(result.sources[0]?.snippet).toMatch(/bleed build evidence/i);
+  });
+
+  it('uses a safe fallback snippet when retrieved text is only page chrome', async () => {
+    mockFetchAndClean.mockResolvedValue(
+      'Menu. Sign In. Subscribe. Cookie Settings. Privacy Policy. Terms of Use. Advertisement. Footer. Newsletter. Community Navigation.'
+    );
+
+    const result = await buildGamingRagContext({
+      mode: 'guide',
+      prompt: 'Use this supplied guide.',
+      guideUrl: 'https://example.com/chrome-only',
+      guideUrls: []
+    });
+
+    expect(result.sources).toEqual([
+      {
+        url: 'https://example.com/chrome-only',
+        snippet: 'Relevant source retrieved, but readable article text was limited.'
+      }
+    ]);
+    expect(result.context).not.toMatch(/cookie settings|privacy policy|community navigation/i);
+  });
+
+  it('keeps context citation numbers contiguous and mapped to public sources after dedupe', async () => {
+    mockFetchAndClean.mockImplementation(async (url: string) =>
+      url.endsWith('/one')
+        ? 'First route evidence: activate a grace and collect the map before fighting the boss.'
+        : 'Second route evidence: upgrade the weapon and flasks before entering the legacy dungeon.'
+    );
+
+    const result = await buildGamingRagContext({
+      mode: 'guide',
+      game: 'Elden Ring',
+      prompt: 'Compare these opening route guides.',
+      guideUrl: 'https://example.com/one',
+      guideUrls: ['https://example.com/one', 'https://example.com/two']
+    });
+
+    const citationNumbers = Array.from(result.context.matchAll(/\[Source (\d+)\]/g), (match) => Number(match[1]));
+    expect(new Set(citationNumbers)).toEqual(new Set(result.sources.map((_source, index) => index + 1)));
+    citationNumbers.forEach((citationNumber) => {
+      expect(citationNumber).toBeGreaterThanOrEqual(1);
+      expect(citationNumber).toBeLessThanOrEqual(result.sources.length);
+    });
+    result.sources.forEach((source, index) => {
+      expect(result.context).toContain(`[Source ${index + 1}] ${source.url}`);
+    });
+  });
+
+  it('degrades to an attributable source error when retrieval fails', async () => {
+    mockFetchAndClean.mockRejectedValue(new Error('network unavailable'));
+
+    const result = await buildGamingRagContext({
+      mode: 'guide',
+      prompt: 'Use the supplied guide.',
+      guideUrl: 'https://example.com/unreachable',
+      guideUrls: []
+    });
+
+    expect(result.context).toBe('');
+    expect(result.sources).toEqual([
+      { url: 'https://example.com/unreachable', error: 'network unavailable' }
+    ]);
+    expect(result.clear.robustFallback).toBe(true);
+  });
+});

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -22,8 +22,8 @@ function expectFetchOptions(timeoutMs = 5000) {
 }
 
 function extractInlineSourceRefs(text: string): number[] {
-  return Array.from(text.matchAll(/(?:\[(?:sources?)\s+([\d,\s]+)\]|\((?:sources?)\s+([\d,\s]+)\)|\b(?:sources?)\s+(\d+(?:\s*,\s*\d+)*))/gi))
-    .flatMap((match) => [match[1], match[2], match[3]])
+  return Array.from(text.matchAll(/(?:\[(?:sources?)\s+([\d,\s]+)\]|\[([\d,\s]+)\]|\((?:sources?)\s+([\d,\s]+)\)|\b(?:sources?)\s+(\d+(?:\s*,\s*\d+)*))/gi))
+    .flatMap((match) => [match[1], match[2], match[3], match[4]])
     .filter((value): value is string => typeof value === 'string' && value.length > 0)
     .flatMap((value) => Array.from(value.matchAll(/\d+/g)).map((numberMatch) => Number.parseInt(numberMatch[0], 10)))
     .filter((value) => Number.isInteger(value) && value > 0);
@@ -545,7 +545,7 @@ describe('gaming guide output hardening', () => {
   it('normalizes generated citations so inline source refs map to public sources', async () => {
     mockFetchAndClean.mockImplementation(async (url: string) => `Guide for ${url}: Elden Ring route, preparation, boss danger checks, and upgrades.`);
     mockRunTrinityWritingPipeline.mockResolvedValueOnce({
-      result: 'Use [Source 3] for the route, (sources 1, 4) for prep, and source 2 for upgrades.',
+      result: 'Use [Source 3] for the route, (sources 1, 4) for prep, [1, 4] for danger checks, and source 2 for upgrades.',
       activeModel: 'gpt-test',
       meta: { provider: { finishReason: 'stop' } }
     });
@@ -558,13 +558,13 @@ describe('gaming guide output hardening', () => {
     });
 
     expect(result.data.sources).toHaveLength(2);
-    expect(result.data.response).toBe('Use for the route, (source 1) for prep, and (source 2) for upgrades.');
+    expect(result.data.response).toBe('Use for the route, (source 1) for prep, [1] for danger checks, and (source 2) for upgrades.');
     expectInlineSourceRefsToMap(result.data.response, result.data.sources.length);
   });
 
   it('removes inline citation numbers when public sources are empty', async () => {
     mockRunTrinityWritingPipeline.mockResolvedValueOnce({
-      result: 'Start in Limgrave [Source 1] and verify source 2 later.',
+      result: 'Start in Limgrave [Source 1], verify [1], and check source 2 later.',
       activeModel: 'gpt-test',
       meta: { provider: { finishReason: 'stop' } }
     });

--- a/tests/webFetcher.test.ts
+++ b/tests/webFetcher.test.ts
@@ -51,6 +51,24 @@ describe('fetchAndClean', () => {
         return;
       }
 
+      if (req.url === '/metrics') {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end('<html><body>Visible text<script>ignored script</script><style>ignored style</style><noscript>ignored fallback</noscript></body></html>');
+        return;
+      }
+
+      if (req.url === '/binary') {
+        res.writeHead(200, { 'Content-Type': 'image/png' });
+        res.end(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+        return;
+      }
+
+      if (req.url === '/large') {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('A'.repeat(1024));
+        return;
+      }
+
       res.writeHead(200, { 'Content-Type': 'text/html' });
       res.end(`
         <html>
@@ -220,6 +238,37 @@ describe('fetchAndClean', () => {
     }));
     expect(document.text).not.toContain('Community Spotlight');
     expect(extractionMetrics?.rawTextLength).toBeGreaterThan(document.text.length);
+  });
+
+  it('excludes script, style, and noscript content from raw text metrics', async () => {
+    let rawTextLength = 0;
+
+    const document = await fetchAndCleanDocument(`${baseUrl}/metrics`, 12000, {
+      includeLinks: false,
+      onExtraction: (metrics) => {
+        rawTextLength = metrics.rawTextLength;
+      }
+    });
+
+    expect(document.text).toBe('Visible text');
+    expect(rawTextLength).toBe('Visible text'.length);
+  });
+
+  it('rejects unsupported response content types before parsing', async () => {
+    await expect(fetchAndClean(`${baseUrl}/binary`)).rejects.toThrow(
+      'Unsupported content type for web fetching: image/png'
+    );
+  });
+
+  it('enforces the configured response-size cap', async () => {
+    const previousMaxBytes = process.env.WEB_FETCH_MAX_BYTES;
+    process.env.WEB_FETCH_MAX_BYTES = '64';
+
+    try {
+      await expect(fetchAndClean(`${baseUrl}/large`)).rejects.toThrow(/maxContentLength|size/i);
+    } finally {
+      restoreEnvValue('WEB_FETCH_MAX_BYTES', previousMaxBytes);
+    }
   });
 
   it('blocks localhost fetches when local-development bypass is not explicitly enabled', async () => {

--- a/tests/webFetcher.test.ts
+++ b/tests/webFetcher.test.ts
@@ -26,6 +26,31 @@ describe('fetchAndClean', () => {
         return;
       }
 
+      if (req.url === '/article') {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(`
+          <html>
+            <body>
+              <header>Site Header Account Sign In</header>
+              <nav><a href="/menu">Home Guides Builds News</a></nav>
+              <div hidden>Hidden prompt text must not be extracted.</div>
+              <div class="main-sidebar-container">
+                <main>
+                  <article>
+                    <h1>Community Spotlight</h1>
+                    <p>This longer unrelated story covers fan art, event photos, community interviews, creator profiles, and convention highlights from across the year.</p>
+                  </article>
+                  <article><h1>Elden Ring Patch 1.16.1</h1><p>The patch fixes weapon skill interactions and adjusts balance behavior for current builds.</p><a href="/evidence">Read full evidence</a></article>
+                  <aside class="sidebar">Popular Games Category Directory</aside>
+                </main>
+              </div>
+              <footer>Privacy Policy Newsletter</footer>
+            </body>
+          </html>
+        `);
+        return;
+      }
+
       res.writeHead(200, { 'Content-Type': 'text/html' });
       res.end(`
         <html>
@@ -164,6 +189,37 @@ describe('fetchAndClean', () => {
       })
     ]));
     expect(document.combined).toContain('[LINKS]');
+  });
+
+  it('prefers semantic article content, removes caller-selected chrome, and reports extraction metrics', async () => {
+    let extractionMetrics: {
+      strategy: string;
+      rawTextLength: number;
+      cleanedTextLength: number;
+    } | undefined;
+
+    const document = await fetchAndCleanDocument(`${baseUrl}/article`, 12000, {
+      preferredContentSelectors: ['article', 'main'],
+      preferredContentTerms: ['patch', 'weapon skill'],
+      removeSelectors: ['header', 'nav', 'footer', '.sidebar', '[hidden]'],
+      includeLinks: false,
+      onExtraction: (metrics) => {
+        extractionMetrics = metrics;
+      }
+    });
+
+    expect(document.text).toContain('fixes weapon skill interactions');
+    expect(document.text).toContain('Patch 1.16.1 The patch');
+    expect(document.text).not.toMatch(/site header|home guides|category directory|privacy policy/i);
+    expect(document.text).not.toContain('Hidden prompt text');
+    expect(document.links).toEqual([]);
+    expect(document.combined).not.toContain('[LINKS]');
+    expect(extractionMetrics).toEqual(expect.objectContaining({
+      strategy: 'article',
+      cleanedTextLength: document.text.length
+    }));
+    expect(document.text).not.toContain('Community Spotlight');
+    expect(extractionMetrics?.rawTextLength).toBeGreaterThan(document.text.length);
   });
 
   it('blocks localhost fetches when local-development bypass is not explicitly enabled', async () => {


### PR DESCRIPTION
## Overview
Improves Gaming RAG extraction, ranking, deduplication, and public snippet shaping so source snippets contain readable evidence instead of navigation, sidebar, menu, or site-chrome text. The change preserves existing SSRF, redirect, timeout, document-size, URL, and public response contracts.

## Root cause
- Public source shaping overwrote each URL's best-ranked chunk with a later, lower-ranked chunk.
- Gaming retrieval flattened full-page body text and included the legacy `[LINKS]` directory.
- Navigation penalties were binary and weak, and trusted but unrelated news prose could still rank.
- Cheerio text extraction could concatenate adjacent block elements, and an over-broad sidebar selector could remove a Fextralife article wrapper.

## Changes
- Add optional semantic extraction selectors, removal selectors, query terms, link suppression, and bounded extraction metrics to the shared fetcher.
- Add safe generic and source-specific extraction profiles for Fextralife, Bandai Namco, Blizzard, and Icy Veins.
- Remove page chrome, hidden/dialog content, forms, comments, and link directories before chunking.
- Add token-aware query/game/mode scoring, navigation-density/readability/repetition penalties, deterministic ordering, and exact/near-duplicate suppression.
- Keep the best chunk per URL while preserving supplied-source order.
- Bound public snippets to 600 characters and use a safe limited-text fallback instead of junk.
- Add bleed-specific Hemorrhage evidence and safe structured retrieval observability without logging raw documents or prompts.

## Prerequisites
- [x] Branch is up to date with target base branch
- [x] Scope is limited to a single coherent change

## Setup
Validation run before requesting review:
- [x] `npm run type-check`
- [ ] `npm run lint` — targeted ESLint passed for all four changed files
- [ ] `npm test` — 146 focused Gaming/fetcher/dispatch tests passed; the repository-wide sweep remained CPU-active and exceeded its 304-second command cap without reporting a test failure
- [x] `npm run build`
- [x] `npm run validate:railway`

Additional checks:
- [x] Commit guard
- [x] Cross-codebase sync check
- [x] Dist alias validation
- [x] Existing SSRF and graceful-failure regressions

## Configuration
Configuration and secrets changes:
- [x] No env changes
- [x] No Railway variable changes
- [x] No secret/config values added
- [x] Security-sensitive fetch boundaries preserved

## Run locally
Manual verification performed:
- [ ] Backend startup and `/healthz` check — production `/health` returned HTTP 200 instead
- [x] Changed retrieval paths tested locally against the real public source pages
- [x] Confirmation-gated routes not applicable

## Deploy (Railway)
Deployment notes:
- [x] Backward-compatible deploy
- [x] Rollback plan documented

Commit `5864651c2d03ec43d8e1e8700c7119bf5230128a` was deployed to the production `ARCANOS V2` service and reached `SUCCESS`.

Post-deploy matrix:
- 34/34 requests returned HTTP 200 with request and trace IDs.
- 0 navigation/sidebar/menu dumps.
- 0 public generation timeout, incomplete, or integrity failures.
- 0 out-of-range citation references.
- Source count stayed at or below 3; snippets stayed at or below 598 characters.
- Duplicate URLs deduplicated correctly; unreachable URLs degraded gracefully.

Rollback: redeploy the immediately preceding successful `ARCANOS V2` Railway deployment if health, error rate, or snippet quality regresses.

## Troubleshooting
Known risks / follow-ups:
- [x] TODOs listed in PR description

Follow-ups:
- Malformed supplied URLs are silently ignored rather than returning explicit validation feedback.
- 31/34 production responses returned sources without inline numbered citations, though every emitted citation mapped correctly.
- Some secondary sources are clean but less topic-specific.
- Source DOM changes or JavaScript-only pages may use the safe limited-text fallback.
- Publication freshness is inferred from patch-sensitive ranking and cache policy rather than parsed dates.

## References
- Deployed/tested commit: `5864651c2d03ec43d8e1e8700c7119bf5230128a`
- Production URL tested: `https://acranos-production.up.railway.app`
- Evidence: 146 focused tests, local live-source probes, Railway health/smoke/watchdog checks, 34-request runtime matrix, and structured retrieval-log field verification
