### PR TITLE
security(deps): remediate 57 of 59 Dependabot alerts

### DIFF
--- a/arcanos-ai-runtime/package-lock.json
+++ b/arcanos-ai-runtime/package-lock.json
@@ -12,7 +12,7 @@
         "@arcanos/openai": "file:../packages/arcanos-openai",
         "@arcanos/runtime": "file:../packages/arcanos-runtime",
         "bullmq": "^5.69.3",
-        "express": "^5.2.1",
+        "express": "^4.21.2",
         "ioredis": "^5.9.3",
         "openai": "^6.25.0",
         "uuid": "^13.0.0"
@@ -257,7 +257,6 @@
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -305,13 +304,13 @@
       "license": "MIT"
     },
     "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "license": "MIT",
       "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
       },
       "engines": {
         "node": ">= 0.6"
@@ -350,29 +349,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/bullmq": {
       "version": "5.69.3",
@@ -474,16 +494,15 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "safe-buffer": "5.2.1"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/content-type": {
@@ -505,13 +524,10 @@
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -565,6 +581,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-libc": {
@@ -635,9 +661,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -662,68 +688,98 @@
       }
     },
     "node_modules/express": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.1",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 0.10.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/finalhandler": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "node": ">= 0.8"
       }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -735,12 +791,12 @@
       }
     },
     "node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.6"
       }
     },
     "node_modules/function-bind": {
@@ -814,9 +870,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -846,19 +902,15 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "safer-buffer": ">= 2.1.2 < 3"
       },
       "engines": {
         "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/inherits": {
@@ -900,12 +952,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
-    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -944,49 +990,63 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.6"
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
       "dependencies": {
-        "mime-db": "^1.54.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "node": ">= 0.6"
       }
     },
     "node_modules/ms": {
@@ -1027,9 +1087,9 @@
       }
     },
     "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1080,15 +1140,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/openai": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.25.0.tgz",
@@ -1120,14 +1171,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -1143,12 +1190,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -1167,18 +1215,18 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
-        "iconv-lite": "~0.7.0",
+        "iconv-lite": "~0.4.24",
         "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 0.8"
       }
     },
     "node_modules/redis-errors": {
@@ -1202,21 +1250,25 @@
         "node": ">=4"
       }
     },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1237,48 +1289,57 @@
       }
     },
     "node_modules/send": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.3",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.1",
-        "mime-types": "^3.0.2",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.2"
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
       },
       "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "node": ">= 0.8.0"
       }
     },
-    "node_modules/serve-static": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
       },
       "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/setprototypeof": {
@@ -1288,14 +1349,14 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -1307,13 +1368,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1434,14 +1495,13 @@
       "license": "0BSD"
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
       },
       "engines": {
         "node": ">= 0.6"
@@ -1453,7 +1513,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1476,6 +1535,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/uuid": {
@@ -1506,12 +1574,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/arcanos-ai-runtime/package-lock.json
+++ b/arcanos-ai-runtime/package-lock.json
@@ -15,7 +15,7 @@
         "express": "^4.21.2",
         "ioredis": "^5.9.3",
         "openai": "^6.25.0",
-        "uuid": "^13.0.0"
+        "uuid": "13.0.1"
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
@@ -1547,9 +1547,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
+      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/arcanos-ai-runtime/package-lock.json
+++ b/arcanos-ai-runtime/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@arcanos/openai": "file:../packages/arcanos-openai",
         "@arcanos/runtime": "file:../packages/arcanos-runtime",
-        "bullmq": "^5.69.3",
+        "bullmq": "5.76.2",
         "express": "^4.21.2",
         "ioredis": "^5.9.3",
         "openai": "^6.25.0",
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@ioredis/commands": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
-      "integrity": "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -395,55 +395,20 @@
       "license": "MIT"
     },
     "node_modules/bullmq": {
-      "version": "5.69.3",
-      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.69.3.tgz",
-      "integrity": "sha512-P9uLsR7fDvejH/1m6uur6j7U9mqY6nNt+XvhlhStOUe7jdwbZoP/c2oWNtE+8ljOlubw4pRUKymtRqkyvloc4A==",
+      "version": "5.76.2",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.76.2.tgz",
+      "integrity": "sha512-kkNU6TPAjqV3Ep0kIaYhT79Z2IMoA7vadqjmr/zvmPicg0K/cOAecqZTihD726LbI043yPU0MBv/nMQmd5rNIg==",
       "license": "MIT",
       "dependencies": {
         "cron-parser": "4.9.0",
-        "ioredis": "5.9.2",
+        "ioredis": "5.10.1",
         "msgpackr": "1.11.5",
         "node-abort-controller": "3.1.1",
         "semver": "7.7.4",
-        "tslib": "2.8.1",
-        "uuid": "11.1.0"
-      }
-    },
-    "node_modules/bullmq/node_modules/ioredis": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.2.tgz",
-      "integrity": "sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@ioredis/commands": "1.5.0",
-        "cluster-key-slot": "^1.1.0",
-        "debug": "^4.3.4",
-        "denque": "^2.1.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.isarguments": "^3.1.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0",
-        "standard-as-callback": "^2.1.0"
+        "tslib": "2.8.1"
       },
       "engines": {
         "node": ">=12.22.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ioredis"
-      }
-    },
-    "node_modules/bullmq/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/bytes": {
@@ -920,12 +885,12 @@
       "license": "ISC"
     },
     "node_modules/ioredis": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.3.tgz",
-      "integrity": "sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
       "dependencies": {
-        "@ioredis/commands": "1.5.0",
+        "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.3.4",
         "denque": "^2.1.0",

--- a/arcanos-ai-runtime/package-lock.json
+++ b/arcanos-ai-runtime/package-lock.json
@@ -12,7 +12,7 @@
         "@arcanos/openai": "file:../packages/arcanos-openai",
         "@arcanos/runtime": "file:../packages/arcanos-runtime",
         "bullmq": "5.76.2",
-        "express": "^4.21.2",
+        "express": "^4.22.2",
         "ioredis": "^5.9.3",
         "openai": "^6.25.0",
         "uuid": "13.0.1"

--- a/arcanos-ai-runtime/package.json
+++ b/arcanos-ai-runtime/package.json
@@ -17,7 +17,7 @@
     "express": "^4.21.2",
     "ioredis": "^5.9.3",
     "openai": "^6.25.0",
-    "uuid": "^13.0.0",
+    "uuid": "13.0.1",
     "@arcanos/runtime": "file:../packages/arcanos-runtime",
     "@arcanos/openai": "file:../packages/arcanos-openai"
   },

--- a/arcanos-ai-runtime/package.json
+++ b/arcanos-ai-runtime/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "bullmq": "^5.69.3",
+    "bullmq": "5.76.2",
     "express": "^4.21.2",
     "ioredis": "^5.9.3",
     "openai": "^6.25.0",

--- a/arcanos-ai-runtime/package.json
+++ b/arcanos-ai-runtime/package.json
@@ -14,7 +14,7 @@
   "type": "module",
   "dependencies": {
     "bullmq": "5.76.2",
-    "express": "^4.21.2",
+    "express": "^4.22.2",
     "ioredis": "^5.9.3",
     "openai": "^6.25.0",
     "uuid": "13.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "pino": "^10.3.1",
         "prom-client": "^15.1.3",
         "redis": "^5.10.0",
-        "uuid": "^13.0.0",
+        "uuid": "13.0.1",
         "ws": "^8.18.0",
         "yauzl": "https://codeload.github.com/thejoshwolfe/yauzl/tar.gz/refs/tags/3.2.1",
         "zod": "^3.25.76"
@@ -86,7 +86,7 @@
         "express": "^4.21.2",
         "ioredis": "^5.9.3",
         "openai": "^6.25.0",
-        "uuid": "^13.0.0"
+        "uuid": "13.0.1"
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
@@ -12037,9 +12037,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
+      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package-lock.json
+++ b/package-lock.json
@@ -820,9 +820,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5624,9 +5624,9 @@
       }
     },
     "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6800,9 +6800,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.17",
-      "resolved": "https://codeload.github.com/honojs/hono/tar.gz/refs/tags/v4.12.17",
-      "integrity": "sha512-1g/MLK40WGM8rQS3gDd5TRctCn8ZrEl7cfH39zAmG+JnHvtJV44Z4QaiHgRslHEZovHdwmlQEV5hEpGAjncfhQ==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8194,9 +8194,9 @@
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9623,9 +9623,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11924,9 +11924,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.3",
-      "resolved": "https://codeload.github.com/nodejs/undici/tar.gz/refs/tags/v7.24.3",
-      "integrity": "sha512-nzcyTH/1dYTAa99SNTOEmqplCP9xkq3myhoINdUKn1xJxzjb6WHT9WS5HYRqzvPgbma0UzQDWxcPq4EjiCIicg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/pg": "^8.15.5",
         "ajv": "^8.18.0",
         "async-mutex": "^0.5.0",
-        "axios": "https://codeload.github.com/axios/axios/tar.gz/refs/tags/v1.15.2",
+        "axios": "1.16.0",
         "busboy": "^1.6.0",
         "cheerio": "^1.1.0",
         "cors": "^2.8.5",
@@ -3664,12 +3664,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://codeload.github.com/axios/axios/tar.gz/refs/tags/v1.15.2",
-      "integrity": "sha512-qVLqknFBrT3tJgK1AptlqbfcMDJBShY7BJDr3FGgGeO1GjhpArE3kEBvZoIWBJS5gFwOeYWfrY+BpsOy2ivVdw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -6222,9 +6222,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -6288,16 +6288,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -6788,9 +6788,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,13 +130,13 @@
       "link": true
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
-      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -155,22 +155,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
-      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "version": "7.29.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.6.tgz",
+      "integrity": "sha512-QdxmAo/ikZqqRGA8s43ww8lcql6naWRvEz0FFrl6MIlc7Gi6TroXnSdWa5U/kq6fzcpqpHesicQxFZIieZbyIA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.4",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.4",
-        "@babel/types": "^7.28.4",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.6",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.29.2",
+        "@babel/parser": "^7.29.3",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -197,14 +197,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
-      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "version": "7.29.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.6.tgz",
+      "integrity": "sha512-J3gJ6S0Bqi9kJMaFCs6Q6eYeM1MmI+n6QN7ooL5nXlrT4P/DmDaNcmbexMyleewHlVI4nzuukYjEE7muiNOUNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.3",
-        "@babel/types": "^7.28.2",
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -214,13 +214,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
+        "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -251,29 +251,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -323,23 +323,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -592,33 +592,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
-      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.3",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.4",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1062,9 +1062,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6215,9 +6215,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -8307,10 +8307,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "prom-client": "^15.1.3",
         "redis": "^5.10.0",
         "uuid": "13.0.1",
-        "ws": "^8.18.0",
+        "ws": "8.21.0",
         "yauzl": "https://codeload.github.com/thejoshwolfe/yauzl/tar.gz/refs/tags/3.2.1",
         "zod": "^3.25.76"
       },
@@ -12393,9 +12393,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -12620,7 +12620,7 @@
         "@arcanos/runtime": "file:../packages/arcanos-runtime",
         "openai": "^6.25.0",
         "typescript": "^5.9.2",
-        "ws": "^8.18.0"
+        "ws": "8.21.0"
       },
       "devDependencies": {
         "@types/node": "^24.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9794,9 +9794,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "cheerio": "^1.1.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
-        "express": "^4.21.2",
+        "express": "^4.22.2",
         "file-type": "https://codeload.github.com/sindresorhus/file-type/tar.gz/refs/tags/v21.3.2",
         "jose": "^6.1.3",
         "knex": "^2.5.1",
@@ -83,7 +83,7 @@
         "@arcanos/openai": "file:../packages/arcanos-openai",
         "@arcanos/runtime": "file:../packages/arcanos-runtime",
         "bullmq": "5.76.2",
-        "express": "^4.21.2",
+        "express": "^4.22.2",
         "ioredis": "^5.9.3",
         "openai": "^6.25.0",
         "uuid": "13.0.1"
@@ -3843,9 +3843,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -3856,7 +3856,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -5873,15 +5873,15 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -5900,7 +5900,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -10043,15 +10043,51 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/qs/node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/qs/node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10785,6 +10821,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10804,6 +10841,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6687,9 +6687,9 @@
       "license": "MIT"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6010,9 +6010,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
       "dependencies": {
         "@arcanos/openai": "file:../packages/arcanos-openai",
         "@arcanos/runtime": "file:../packages/arcanos-runtime",
-        "bullmq": "^5.69.3",
+        "bullmq": "5.76.2",
         "express": "^4.21.2",
         "ioredis": "^5.9.3",
         "openai": "^6.25.0",
@@ -968,9 +968,9 @@
       }
     },
     "node_modules/@ioredis/commands": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.0.tgz",
-      "integrity": "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
@@ -4052,55 +4052,20 @@
       "license": "MIT"
     },
     "node_modules/bullmq": {
-      "version": "5.69.3",
-      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.69.3.tgz",
-      "integrity": "sha512-P9uLsR7fDvejH/1m6uur6j7U9mqY6nNt+XvhlhStOUe7jdwbZoP/c2oWNtE+8ljOlubw4pRUKymtRqkyvloc4A==",
+      "version": "5.76.2",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.76.2.tgz",
+      "integrity": "sha512-kkNU6TPAjqV3Ep0kIaYhT79Z2IMoA7vadqjmr/zvmPicg0K/cOAecqZTihD726LbI043yPU0MBv/nMQmd5rNIg==",
       "license": "MIT",
       "dependencies": {
         "cron-parser": "4.9.0",
-        "ioredis": "5.9.2",
+        "ioredis": "5.10.1",
         "msgpackr": "1.11.5",
         "node-abort-controller": "3.1.1",
         "semver": "7.7.4",
-        "tslib": "2.8.1",
-        "uuid": "11.1.0"
-      }
-    },
-    "node_modules/bullmq/node_modules/ioredis": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.2.tgz",
-      "integrity": "sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@ioredis/commands": "1.5.0",
-        "cluster-key-slot": "^1.1.0",
-        "debug": "^4.3.4",
-        "denque": "^2.1.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.isarguments": "^3.1.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0",
-        "standard-as-callback": "^2.1.0"
+        "tslib": "2.8.1"
       },
       "engines": {
         "node": ">=12.22.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ioredis"
-      }
-    },
-    "node_modules/bullmq/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/busboy": {
@@ -7045,12 +7010,12 @@
       }
     },
     "node_modules/ioredis": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.3.tgz",
-      "integrity": "sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
       "dependencies": {
-        "@ioredis/commands": "1.5.0",
+        "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.3.4",
         "denque": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -255,7 +255,6 @@
     "express-rate-limit": "https://codeload.github.com/express-rate-limit/express-rate-limit/tar.gz/refs/tags/v8.3.0",
     "ip-address": "10.1.1",
     "proxy-from-env": "https://codeload.github.com/Rob--W/proxy-from-env/tar.gz/refs/tags/v2.1.0",
-    "undici": "https://codeload.github.com/nodejs/undici/tar.gz/refs/tags/v7.24.3",
     "express": {
       "path-to-regexp": "https://codeload.github.com/pillarjs/path-to-regexp/tar.gz/refs/tags/v.0.1.13"
     },

--- a/package.json
+++ b/package.json
@@ -249,8 +249,10 @@
     "typescript": "^5.9.2"
   },
   "overrides": {
+    "@modelcontextprotocol/sdk": {
+      "hono": "4.12.25"
+    },
     "express-rate-limit": "https://codeload.github.com/express-rate-limit/express-rate-limit/tar.gz/refs/tags/v8.3.0",
-    "hono": "https://codeload.github.com/honojs/hono/tar.gz/refs/tags/v4.12.17",
     "ip-address": "10.1.1",
     "proxy-from-env": "https://codeload.github.com/Rob--W/proxy-from-env/tar.gz/refs/tags/v2.1.0",
     "undici": "https://codeload.github.com/nodejs/undici/tar.gz/refs/tags/v7.24.3",

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "@types/pg": "^8.15.5",
     "ajv": "^8.18.0",
     "async-mutex": "^0.5.0",
-    "axios": "https://codeload.github.com/axios/axios/tar.gz/refs/tags/v1.15.2",
+    "axios": "1.16.0",
     "busboy": "^1.6.0",
     "cheerio": "^1.1.0",
     "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -268,11 +268,11 @@
       "minimatch": "3.1.5"
     },
     "@eslint/eslintrc": {
-      "ajv": "6.12.6",
+      "ajv": "6.14.0",
       "minimatch": "3.1.5"
     },
     "eslint": {
-      "ajv": "6.12.6",
+      "ajv": "6.14.0",
       "minimatch": "3.1.5"
     },
     "eslint-plugin-import": {

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "prom-client": "^15.1.3",
     "redis": "^5.10.0",
     "uuid": "13.0.1",
-    "ws": "^8.18.0",
+    "ws": "8.21.0",
     "yauzl": "https://codeload.github.com/thejoshwolfe/yauzl/tar.gz/refs/tags/3.2.1",
     "zod": "^3.25.76"
   },

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
     "pino": "^10.3.1",
     "prom-client": "^15.1.3",
     "redis": "^5.10.0",
-    "uuid": "^13.0.0",
+    "uuid": "13.0.1",
     "ws": "^8.18.0",
     "yauzl": "https://codeload.github.com/thejoshwolfe/yauzl/tar.gz/refs/tags/3.2.1",
     "zod": "^3.25.76"

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "cheerio": "^1.1.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
-    "express": "^4.21.2",
+    "express": "^4.22.2",
     "file-type": "https://codeload.github.com/sindresorhus/file-type/tar.gz/refs/tags/v21.3.2",
     "jose": "^6.1.3",
     "knex": "^2.5.1",

--- a/scripts/check-npm-audit.js
+++ b/scripts/check-npm-audit.js
@@ -16,23 +16,16 @@ if (!reportText) {
 const report = JSON.parse(reportText);
 const vulnerabilities = report.vulnerabilities ?? {};
 
-// Temporary exception register. Review by 2026-10-01, or immediately when the
-// configured registry publishes a patched artifact or an owning parent release.
-// - lodash (Knex -> lodash): patched 4.18.0 is unpublished; affected template/
-//   unset gadgets are not used by the repository's query stores. Retest Knex
-//   stores when a registry artifact or Knex parent fix is available.
-// - follow-redirects/axios/form-data: patched artifacts are unpublished. The
-//   caller-controlled fetch path disables redirects and proxying and does not
-//   construct multipart bodies. Re-run network regression tests on publication.
-// - @modelcontextprotocol/sdk: the server exposes no resource templates and
-//   creates a fresh HTTP server/transport pair per request. Review on SDK update.
-// - brace-expansion (vendored minimatch -> brace-expansion): remediation needs
-//   the separately reviewed vendor/postinstall redesign; exposure is tooling-only.
-// - fast-uri (Ajv -> fast-uri): schemas are repository-owned, not request-supplied.
-// - hono (@modelcontextprotocol/sdk -> hono): no direct Hono API use was found.
-// - undici (Cheerio -> undici): callers use Cheerio.load, not Cheerio.fromURL.
-// - ws (root/workers/OpenAI -> ws): setupBridgeSocket has no live caller and
-//   workers do not import ws. Review before activating that latent entry point.
+// Temporary exception register. Review by 2026-10-01, or immediately when an
+// owning parent publishes a supported resolution.
+// - lodash (Knex -> lodash): GHSA-r5fr-rjxr-66jc/CVE-2026-4800 and
+//   GHSA-f23m-r3pf-42rh/CVE-2026-2950 require lodash 4.18.0, which npm marks as
+//   a deprecated bad release. The affected template/unset gadgets are not used
+//   by the repository's query stores. Retest the Knex stores when Knex adopts a
+//   supported patched lodash release or npm publishes a non-deprecated patch.
+// - brace-expansion (vendored minimatch -> brace-expansion): GHSA-jxxr-4gwj-5jf2
+//   remediation needs the separately reviewed vendor/postinstall redesign;
+//   exposure is tooling-only. Review when that architecture is replaced.
 // Advisory IDs for every exception are deliberately source-scoped below so an
 // unexpected advisory for the same package remains actionable.
 const IGNORED_LODASH_SOURCES = new Set([1115806, 1115810]);
@@ -40,98 +33,9 @@ const IGNORED_LODASH_URLS = new Set([
   'https://github.com/advisories/GHSA-r5fr-rjxr-66jc',
   'https://github.com/advisories/GHSA-f23m-r3pf-42rh',
 ]);
-const IGNORED_FOLLOW_REDIRECTS_SOURCES = new Set([1116560]);
-const IGNORED_FOLLOW_REDIRECTS_URLS = new Set([
-  'https://github.com/advisories/GHSA-r4q5-vmmm-2653',
-]);
-const IGNORED_AXIOS_SOURCES = new Set([
-  1119667,
-  1120547,
-  1120643,
-  1120645,
-  1120647,
-  1120650,
-  1120652,
-  1120653,
-]);
-const IGNORED_AXIOS_URLS = new Set([
-  'https://github.com/advisories/GHSA-pjwm-pj3p-43mv',
-  'https://github.com/advisories/GHSA-hfxv-24rg-xrqf',
-  'https://github.com/advisories/GHSA-777c-7fjr-54vf',
-  'https://github.com/advisories/GHSA-p92q-9vqr-4j8v',
-  'https://github.com/advisories/GHSA-j5f8-grm9-p9fc',
-  'https://github.com/advisories/GHSA-35jp-ww65-95wh',
-  'https://github.com/advisories/GHSA-898c-q2cr-xwhg',
-  'https://github.com/advisories/GHSA-654m-c8p4-x5fp',
-]);
-const IGNORED_FORM_DATA_SOURCES = new Set([1120743]);
-const IGNORED_FORM_DATA_URLS = new Set([
-  'https://github.com/advisories/GHSA-hmw2-7cc7-3qxx',
-]);
-const IGNORED_MCP_SDK_SOURCES = new Set([1111906, 1113080]);
-const IGNORED_MCP_SDK_URLS = new Set([
-  'https://github.com/advisories/GHSA-8r9q-7v3j-jr4g',
-  'https://github.com/advisories/GHSA-345p-7cg4-v4c7',
-]);
 const IGNORED_BRACE_EXPANSION_SOURCES = new Set([1119088]);
 const IGNORED_BRACE_EXPANSION_URLS = new Set([
   'https://github.com/advisories/GHSA-jxxr-4gwj-5jf2',
-]);
-const IGNORED_FAST_URI_SOURCES = new Set([1117870, 1117884]);
-const IGNORED_FAST_URI_URLS = new Set([
-  'https://github.com/advisories/GHSA-q3j6-qgpj-74h6',
-  'https://github.com/advisories/GHSA-v39h-62p7-jpjc',
-]);
-const IGNORED_HONO_SOURCES = new Set([
-  1117915,
-  1118963,
-  1118964,
-  1120082,
-  1120083,
-  1120084,
-  1120085,
-  1120910,
-  1120911,
-  1120913,
-  1120921,
-  1120922,
-]);
-const IGNORED_HONO_URLS = new Set([
-  'https://github.com/advisories/GHSA-qp7p-654g-cw7p',
-  'https://github.com/advisories/GHSA-hm8q-7f3q-5f36',
-  'https://github.com/advisories/GHSA-p77w-8qqv-26rm',
-  'https://github.com/advisories/GHSA-xrhx-7g5j-rcj5',
-  'https://github.com/advisories/GHSA-3hrh-pfw6-9m5x',
-  'https://github.com/advisories/GHSA-f577-qrjj-4474',
-  'https://github.com/advisories/GHSA-2gcr-mfcq-wcc3',
-  'https://github.com/advisories/GHSA-wwfh-h76j-fc44',
-  'https://github.com/advisories/GHSA-j6c9-x7qj-28xf',
-  'https://github.com/advisories/GHSA-88fw-hqm2-52qc',
-  'https://github.com/advisories/GHSA-rv63-4mwf-qqc2',
-  'https://github.com/advisories/GHSA-wgpf-jwqj-8h8p',
-]);
-const IGNORED_UNDICI_SOURCES = new Set([
-  1121187,
-  1121241,
-  1121244,
-  1121247,
-  1121249,
-  1121254,
-  1121428,
-]);
-const IGNORED_UNDICI_URLS = new Set([
-  'https://github.com/advisories/GHSA-vmh5-mc38-953g',
-  'https://github.com/advisories/GHSA-p88m-4jfj-68fv',
-  'https://github.com/advisories/GHSA-vxpw-j846-p89q',
-  'https://github.com/advisories/GHSA-hm92-r4w5-c3mj',
-  'https://github.com/advisories/GHSA-35p6-xmwp-9g52',
-  'https://github.com/advisories/GHSA-g8m3-5g58-fq7m',
-  'https://github.com/advisories/GHSA-pr7r-676h-xcf6',
-]);
-const IGNORED_WS_SOURCES = new Set([1119108, 1120730]);
-const IGNORED_WS_URLS = new Set([
-  'https://github.com/advisories/GHSA-58qx-3vcg-4xpx',
-  'https://github.com/advisories/GHSA-96hv-2xvq-fx4p',
 ]);
 
 function isIgnoredLodashAdvisory(advisory) {
@@ -148,78 +52,6 @@ function isIgnoredLodashAdvisory(advisory) {
   }
 
   return typeof advisory.url === 'string' && IGNORED_LODASH_URLS.has(advisory.url);
-}
-
-function isIgnoredFollowRedirectsAdvisory(advisory) {
-  if (!advisory || typeof advisory !== 'object') {
-    return false;
-  }
-
-  if (advisory.name !== 'follow-redirects') {
-    return false;
-  }
-
-  if (
-    typeof advisory.source === 'number' &&
-    IGNORED_FOLLOW_REDIRECTS_SOURCES.has(advisory.source)
-  ) {
-    return true;
-  }
-
-  return (
-    typeof advisory.url === 'string' && IGNORED_FOLLOW_REDIRECTS_URLS.has(advisory.url)
-  );
-}
-
-function isIgnoredAxiosAdvisory(advisory) {
-  if (!advisory || typeof advisory !== 'object') {
-    return false;
-  }
-
-  if (advisory.name !== 'axios') {
-    return false;
-  }
-
-  if (typeof advisory.source === 'number' && IGNORED_AXIOS_SOURCES.has(advisory.source)) {
-    return true;
-  }
-
-  return typeof advisory.url === 'string' && IGNORED_AXIOS_URLS.has(advisory.url);
-}
-
-function isIgnoredFormDataAdvisory(advisory) {
-  if (!advisory || typeof advisory !== 'object') {
-    return false;
-  }
-
-  if (advisory.name !== 'form-data') {
-    return false;
-  }
-
-  if (
-    typeof advisory.source === 'number' &&
-    IGNORED_FORM_DATA_SOURCES.has(advisory.source)
-  ) {
-    return true;
-  }
-
-  return typeof advisory.url === 'string' && IGNORED_FORM_DATA_URLS.has(advisory.url);
-}
-
-function isIgnoredMcpSdkAdvisory(advisory) {
-  if (!advisory || typeof advisory !== 'object') {
-    return false;
-  }
-
-  if (advisory.name !== '@modelcontextprotocol/sdk') {
-    return false;
-  }
-
-  if (typeof advisory.source === 'number' && IGNORED_MCP_SDK_SOURCES.has(advisory.source)) {
-    return true;
-  }
-
-  return typeof advisory.url === 'string' && IGNORED_MCP_SDK_URLS.has(advisory.url);
 }
 
 function isIgnoredBraceExpansionAdvisory(advisory) {
@@ -243,70 +75,6 @@ function isIgnoredBraceExpansionAdvisory(advisory) {
   );
 }
 
-function isIgnoredFastUriAdvisory(advisory) {
-  if (!advisory || typeof advisory !== 'object') {
-    return false;
-  }
-
-  if (advisory.name !== 'fast-uri') {
-    return false;
-  }
-
-  if (typeof advisory.source === 'number' && IGNORED_FAST_URI_SOURCES.has(advisory.source)) {
-    return true;
-  }
-
-  return typeof advisory.url === 'string' && IGNORED_FAST_URI_URLS.has(advisory.url);
-}
-
-function isIgnoredHonoAdvisory(advisory) {
-  if (!advisory || typeof advisory !== 'object') {
-    return false;
-  }
-
-  if (advisory.name !== 'hono') {
-    return false;
-  }
-
-  if (typeof advisory.source === 'number' && IGNORED_HONO_SOURCES.has(advisory.source)) {
-    return true;
-  }
-
-  return typeof advisory.url === 'string' && IGNORED_HONO_URLS.has(advisory.url);
-}
-
-function isIgnoredUndiciAdvisory(advisory) {
-  if (!advisory || typeof advisory !== 'object') {
-    return false;
-  }
-
-  if (advisory.name !== 'undici') {
-    return false;
-  }
-
-  if (typeof advisory.source === 'number' && IGNORED_UNDICI_SOURCES.has(advisory.source)) {
-    return true;
-  }
-
-  return typeof advisory.url === 'string' && IGNORED_UNDICI_URLS.has(advisory.url);
-}
-
-function isIgnoredWsAdvisory(advisory) {
-  if (!advisory || typeof advisory !== 'object') {
-    return false;
-  }
-
-  if (advisory.name !== 'ws') {
-    return false;
-  }
-
-  if (typeof advisory.source === 'number' && IGNORED_WS_SOURCES.has(advisory.source)) {
-    return true;
-  }
-
-  return typeof advisory.url === 'string' && IGNORED_WS_URLS.has(advisory.url);
-}
-
 function isIgnoredVulnerability(name, vulnerability) {
   if (!vulnerability || typeof vulnerability !== 'object') {
     return false;
@@ -322,67 +90,10 @@ function isIgnoredVulnerability(name, vulnerability) {
     return via.length > 0 && via.every(entry => entry === 'lodash');
   }
 
-  if (name === 'follow-redirects') {
-    return via.length > 0 && via.every(isIgnoredFollowRedirectsAdvisory);
-  }
-
-  if (name === 'axios') {
-    return (
-      via.length > 0 &&
-      via.every(entry => entry === 'form-data' || isIgnoredAxiosAdvisory(entry))
-    );
-  }
-
-  if (name === 'form-data') {
-    return via.length > 0 && via.every(isIgnoredFormDataAdvisory);
-  }
-
-  if (name === '@modelcontextprotocol/sdk') {
-    // GHSA-8r9q-7v3j-jr4g applies to resource template handling with exploded
-    // array patterns; this server exposes tools only and does not register MCP
-    // resources or resource templates. GHSA-345p-7cg4-v4c7 applies when a
-    // server/transport pair is reused across clients; our HTTP MCP route
-    // constructs a fresh server and transport for every request.
-    return (
-      via.length > 0 &&
-      via.every(
-        entry => entry === 'express' || entry === 'hono' || isIgnoredMcpSdkAdvisory(entry),
-      )
-    );
-  }
-
   // These upstream advisories are source-scoped so new advisories or unrelated
   // transitive chains still fail the CI audit gate.
   if (name === 'brace-expansion') {
     return via.length > 0 && via.every(isIgnoredBraceExpansionAdvisory);
-  }
-
-  if (name === 'fast-uri') {
-    return via.length > 0 && via.every(isIgnoredFastUriAdvisory);
-  }
-
-  if (name === 'hono') {
-    return via.length > 0 && via.every(isIgnoredHonoAdvisory);
-  }
-
-  if (name === 'undici') {
-    return via.length > 0 && via.every(isIgnoredUndiciAdvisory);
-  }
-
-  if (name === 'cheerio') {
-    return via.length > 0 && via.every(entry => entry === 'undici');
-  }
-
-  if (name === 'ws') {
-    return via.length > 0 && via.every(isIgnoredWsAdvisory);
-  }
-
-  if (name === '@hono/node-server') {
-    return via.length > 0 && via.every(entry => entry === 'hono');
-  }
-
-  if (name === 'openai') {
-    return via.length > 0 && via.every(entry => entry === 'ws');
   }
 
   return false;

--- a/scripts/check-npm-audit.js
+++ b/scripts/check-npm-audit.js
@@ -16,6 +16,25 @@ if (!reportText) {
 const report = JSON.parse(reportText);
 const vulnerabilities = report.vulnerabilities ?? {};
 
+// Temporary exception register. Review by 2026-10-01, or immediately when the
+// configured registry publishes a patched artifact or an owning parent release.
+// - lodash (Knex -> lodash): patched 4.18.0 is unpublished; affected template/
+//   unset gadgets are not used by the repository's query stores. Retest Knex
+//   stores when a registry artifact or Knex parent fix is available.
+// - follow-redirects/axios/form-data: patched artifacts are unpublished. The
+//   caller-controlled fetch path disables redirects and proxying and does not
+//   construct multipart bodies. Re-run network regression tests on publication.
+// - @modelcontextprotocol/sdk: the server exposes no resource templates and
+//   creates a fresh HTTP server/transport pair per request. Review on SDK update.
+// - brace-expansion (vendored minimatch -> brace-expansion): remediation needs
+//   the separately reviewed vendor/postinstall redesign; exposure is tooling-only.
+// - fast-uri (Ajv -> fast-uri): schemas are repository-owned, not request-supplied.
+// - hono (@modelcontextprotocol/sdk -> hono): no direct Hono API use was found.
+// - undici (Cheerio -> undici): callers use Cheerio.load, not Cheerio.fromURL.
+// - ws (root/workers/OpenAI -> ws): setupBridgeSocket has no live caller and
+//   workers do not import ws. Review before activating that latent entry point.
+// Advisory IDs for every exception are deliberately source-scoped below so an
+// unexpected advisory for the same package remains actionable.
 const IGNORED_LODASH_SOURCES = new Set([1115806, 1115810]);
 const IGNORED_LODASH_URLS = new Set([
   'https://github.com/advisories/GHSA-r5fr-rjxr-66jc',
@@ -53,10 +72,6 @@ const IGNORED_MCP_SDK_SOURCES = new Set([1111906, 1113080]);
 const IGNORED_MCP_SDK_URLS = new Set([
   'https://github.com/advisories/GHSA-8r9q-7v3j-jr4g',
   'https://github.com/advisories/GHSA-345p-7cg4-v4c7',
-]);
-const IGNORED_UUID_SOURCES = new Set([1116970]);
-const IGNORED_UUID_URLS = new Set([
-  'https://github.com/advisories/GHSA-w5hq-g745-h8pq',
 ]);
 const IGNORED_BRACE_EXPANSION_SOURCES = new Set([1119088]);
 const IGNORED_BRACE_EXPANSION_URLS = new Set([
@@ -112,10 +127,6 @@ const IGNORED_UNDICI_URLS = new Set([
   'https://github.com/advisories/GHSA-35p6-xmwp-9g52',
   'https://github.com/advisories/GHSA-g8m3-5g58-fq7m',
   'https://github.com/advisories/GHSA-pr7r-676h-xcf6',
-]);
-const IGNORED_QS_SOURCES = new Set([1119502]);
-const IGNORED_QS_URLS = new Set([
-  'https://github.com/advisories/GHSA-q8mj-m7cp-5q26',
 ]);
 const IGNORED_WS_SOURCES = new Set([1119108, 1120730]);
 const IGNORED_WS_URLS = new Set([
@@ -211,22 +222,6 @@ function isIgnoredMcpSdkAdvisory(advisory) {
   return typeof advisory.url === 'string' && IGNORED_MCP_SDK_URLS.has(advisory.url);
 }
 
-function isIgnoredUuidAdvisory(advisory) {
-  if (!advisory || typeof advisory !== 'object') {
-    return false;
-  }
-
-  if (advisory.name !== 'uuid') {
-    return false;
-  }
-
-  if (typeof advisory.source === 'number' && IGNORED_UUID_SOURCES.has(advisory.source)) {
-    return true;
-  }
-
-  return typeof advisory.url === 'string' && IGNORED_UUID_URLS.has(advisory.url);
-}
-
 function isIgnoredBraceExpansionAdvisory(advisory) {
   if (!advisory || typeof advisory !== 'object') {
     return false;
@@ -296,22 +291,6 @@ function isIgnoredUndiciAdvisory(advisory) {
   return typeof advisory.url === 'string' && IGNORED_UNDICI_URLS.has(advisory.url);
 }
 
-function isIgnoredQsAdvisory(advisory) {
-  if (!advisory || typeof advisory !== 'object') {
-    return false;
-  }
-
-  if (advisory.name !== 'qs') {
-    return false;
-  }
-
-  if (typeof advisory.source === 'number' && IGNORED_QS_SOURCES.has(advisory.source)) {
-    return true;
-  }
-
-  return typeof advisory.url === 'string' && IGNORED_QS_URLS.has(advisory.url);
-}
-
 function isIgnoredWsAdvisory(advisory) {
   if (!advisory || typeof advisory !== 'object') {
     return false;
@@ -372,18 +351,6 @@ function isIgnoredVulnerability(name, vulnerability) {
     );
   }
 
-  if (name === 'uuid') {
-    // GHSA-w5hq-g745-h8pq applies to uuid v3/v5/v6 when callers provide a buf
-    // argument. uuid@14.0.0 is the audit-reported fixed version but is not
-    // published yet; this service does not call uuid directly, and BullMQ's
-    // bundled usage is limited to v4() for queue/worker ids.
-    return via.length > 0 && via.every(isIgnoredUuidAdvisory);
-  }
-
-  if (name === 'bullmq') {
-    return via.length > 0 && via.every(entry => entry === 'uuid');
-  }
-
   // These upstream advisories are source-scoped so new advisories or unrelated
   // transitive chains still fail the CI audit gate.
   if (name === 'brace-expansion') {
@@ -406,24 +373,12 @@ function isIgnoredVulnerability(name, vulnerability) {
     return via.length > 0 && via.every(entry => entry === 'undici');
   }
 
-  if (name === 'qs') {
-    return via.length > 0 && via.every(isIgnoredQsAdvisory);
-  }
-
   if (name === 'ws') {
     return via.length > 0 && via.every(isIgnoredWsAdvisory);
   }
 
   if (name === '@hono/node-server') {
     return via.length > 0 && via.every(entry => entry === 'hono');
-  }
-
-  if (name === 'body-parser') {
-    return via.length > 0 && via.every(entry => entry === 'qs');
-  }
-
-  if (name === 'express') {
-    return via.length > 0 && via.every(entry => entry === 'body-parser' || entry === 'qs');
   }
 
   if (name === 'openai') {

--- a/tests/check-npm-audit-policy.test.ts
+++ b/tests/check-npm-audit-policy.test.ts
@@ -75,6 +75,7 @@ describe('npm audit policy', () => {
   it.each([
     ['uuid', 1_116_970, 'GHSA-w5hq-g745-h8pq'],
     ['qs', 1_119_502, 'GHSA-q8mj-m7cp-5q26'],
+    ['axios', 1_119_667, 'GHSA-pjwm-pj3p-43mv'],
   ] as const)('no longer suppresses the remediated %s advisory', (name, source, ghsa) => {
     const result = runAuditPolicy({
       [name]: advisory(name, 'high', source, ghsa),
@@ -84,12 +85,12 @@ describe('npm audit policy', () => {
     expect(JSON.parse(result.stdout).actionable[0].name).toBe(name);
   });
 
-  it('retains the source-scoped exception for a blocked Axios advisory', () => {
+  it('retains the source-scoped exception for blocked lodash advisories', () => {
     const result = runAuditPolicy({
-      axios: advisory('axios', 'high', 1_119_667, 'GHSA-pjwm-pj3p-43mv'),
+      lodash: advisory('lodash', 'high', 1_115_806, 'GHSA-r5fr-rjxr-66jc'),
     });
 
     expect(result.status).toBe(0);
-    expect(JSON.parse(result.stdout).ignored[0].name).toBe('axios');
+    expect(JSON.parse(result.stdout).ignored[0].name).toBe('lodash');
   });
 });

--- a/tests/check-npm-audit-policy.test.ts
+++ b/tests/check-npm-audit-policy.test.ts
@@ -1,0 +1,95 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+type AuditVulnerability = {
+  severity: string;
+  via: Array<string | { name: string; source: number; url: string }>;
+  nodes: string[];
+  fixAvailable: boolean;
+};
+
+function runAuditPolicy(vulnerabilities: Record<string, AuditVulnerability>) {
+  const directory = mkdtempSync(path.join(tmpdir(), 'arcanos-audit-policy-'));
+  const reportPath = path.join(directory, 'audit.json');
+
+  try {
+    writeFileSync(
+      reportPath,
+      JSON.stringify({ auditReportVersion: 2, vulnerabilities }),
+      'utf8',
+    );
+
+    return spawnSync(process.execPath, ['scripts/check-npm-audit.js', reportPath], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    });
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function advisory(name: string, severity: 'high' | 'critical', source: number, ghsa: string) {
+  return {
+    severity,
+    via: [
+      {
+        name,
+        source,
+        url: `https://github.com/advisories/${ghsa}`,
+      },
+    ],
+    nodes: [`node_modules/${name}`],
+    fixAvailable: false,
+  };
+}
+
+describe('npm audit policy', () => {
+  it.each(['high', 'critical'] as const)(
+    'fails for an unexpected %s advisory',
+    severity => {
+      const result = runAuditPolicy({
+        'unexpected-package': advisory(
+          'unexpected-package',
+          severity,
+          9_999_999,
+          'GHSA-xxxx-yyyy-zzzz',
+        ),
+      });
+
+      expect(result.status).toBe(1);
+      expect(JSON.parse(result.stdout).actionable).toHaveLength(1);
+    },
+  );
+
+  it('fails for an unexpected advisory on an otherwise excepted package', () => {
+    const result = runAuditPolicy({
+      axios: advisory('axios', 'high', 9_999_998, 'GHSA-neww-advi-sory'),
+    });
+
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout).actionable[0].name).toBe('axios');
+  });
+
+  it.each([
+    ['uuid', 1_116_970, 'GHSA-w5hq-g745-h8pq'],
+    ['qs', 1_119_502, 'GHSA-q8mj-m7cp-5q26'],
+  ] as const)('no longer suppresses the remediated %s advisory', (name, source, ghsa) => {
+    const result = runAuditPolicy({
+      [name]: advisory(name, 'high', source, ghsa),
+    });
+
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout).actionable[0].name).toBe(name);
+  });
+
+  it('retains the source-scoped exception for a blocked Axios advisory', () => {
+    const result = runAuditPolicy({
+      axios: advisory('axios', 'high', 1_119_667, 'GHSA-pjwm-pj3p-43mv'),
+    });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).ignored[0].name).toBe('axios');
+  });
+});

--- a/tests/check-npm-audit-policy.test.ts
+++ b/tests/check-npm-audit-policy.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 type AuditVulnerability = {
   severity: string;
@@ -9,6 +10,10 @@ type AuditVulnerability = {
   nodes: string[];
   fixAvailable: boolean;
 };
+
+const auditPolicyScriptPath = fileURLToPath(
+  new URL('../scripts/check-npm-audit.js', import.meta.url),
+);
 
 function runAuditPolicy(vulnerabilities: Record<string, AuditVulnerability>) {
   const directory = mkdtempSync(path.join(tmpdir(), 'arcanos-audit-policy-'));
@@ -21,12 +26,26 @@ function runAuditPolicy(vulnerabilities: Record<string, AuditVulnerability>) {
       'utf8',
     );
 
-    return spawnSync(process.execPath, ['scripts/check-npm-audit.js', reportPath], {
+    return spawnSync(process.execPath, [auditPolicyScriptPath, reportPath], {
       cwd: process.cwd(),
       encoding: 'utf8',
     });
   } finally {
     rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function parseStdout(result: { stdout: string; stderr: string }) {
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    throw new Error(
+      [
+        'Failed to parse audit policy output as JSON.',
+        `Stdout: ${result.stdout || '<empty>'}`,
+        `Stderr: ${result.stderr || '<empty>'}`,
+      ].join('\n'),
+    );
   }
 }
 
@@ -46,6 +65,14 @@ function advisory(name: string, severity: 'high' | 'critical', source: number, g
 }
 
 describe('npm audit policy', () => {
+  it('includes child-process output when policy JSON parsing fails', () => {
+    expect(() => parseStdout({ stdout: '', stderr: 'spawn failed' })).toThrow(
+      'Failed to parse audit policy output as JSON.\n' +
+        'Stdout: <empty>\n' +
+        'Stderr: spawn failed',
+    );
+  });
+
   it.each(['high', 'critical'] as const)(
     'fails for an unexpected %s advisory',
     severity => {
@@ -59,7 +86,7 @@ describe('npm audit policy', () => {
       });
 
       expect(result.status).toBe(1);
-      expect(JSON.parse(result.stdout).actionable).toHaveLength(1);
+      expect(parseStdout(result).actionable).toHaveLength(1);
     },
   );
 
@@ -69,7 +96,7 @@ describe('npm audit policy', () => {
     });
 
     expect(result.status).toBe(1);
-    expect(JSON.parse(result.stdout).actionable[0].name).toBe('axios');
+    expect(parseStdout(result).actionable[0].name).toBe('axios');
   });
 
   it.each([
@@ -82,7 +109,7 @@ describe('npm audit policy', () => {
     });
 
     expect(result.status).toBe(1);
-    expect(JSON.parse(result.stdout).actionable[0].name).toBe(name);
+    expect(parseStdout(result).actionable[0].name).toBe(name);
   });
 
   it('retains the source-scoped exception for blocked lodash advisories', () => {
@@ -91,6 +118,6 @@ describe('npm audit policy', () => {
     });
 
     expect(result.status).toBe(0);
-    expect(JSON.parse(result.stdout).ignored[0].name).toBe('lodash');
+    expect(parseStdout(result).ignored[0].name).toBe('lodash');
   });
 });

--- a/workers/package-lock.json
+++ b/workers/package-lock.json
@@ -12,7 +12,7 @@
         "@arcanos/runtime": "file:../packages/arcanos-runtime",
         "openai": "^6.25.0",
         "typescript": "^5.9.2",
-        "ws": "^8.18.0"
+        "ws": "8.21.0"
       },
       "devDependencies": {
         "@types/node": "^24.3.0",
@@ -101,9 +101,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/workers/package.json
+++ b/workers/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "openai": "^6.25.0",
-    "ws": "^8.18.0",
+    "ws": "8.21.0",
     "@arcanos/runtime": "file:../packages/arcanos-runtime",
     "@arcanos/openai": "file:../packages/arcanos-openai",
     "typescript": "^5.9.2"


### PR DESCRIPTION
## Summary

Remediates 57 of the repository’s 59 open Dependabot alerts using canonical npm
artifacts, supported parent-package upgrades, and narrowly scoped dependency
overrides.

The remediation covers:

- Express and the stale `path-to-regexp` runtime path
- direct and BullMQ-owned UUID paths
- Express-owned `qs`
- Axios, `follow-redirects`, and `form-data`
- root and worker `ws`
- MCP-owned Hono
- Ajv-owned `fast-uri`
- Cheerio-owned Undici
- ts-jest-owned Handlebars
- ESLint and Jest development-tool dependencies
- Babel, js-yaml, picomatch, PostCSS, flatted, and ESLint-owned Ajv

Axios was moved from a GitHub-tag dependency to the canonical npm package.

No new non-registry artifact was introduced. No global dependency override was
added.

## Dependabot disposition

Locally verified remediated and expected to close after merge to `main` and a
default-branch dependency-graph rescan:

- 57 alerts across 15 remediation clusters

Still blocked:

- Dependabot alert 66 — Lodash through Knex; medium severity
- Dependabot alert 67 — Lodash through Knex; high severity

Both remaining alerts resolve to:

`knex@2.5.1 → lodash@4.17.23`

The advisory identifies Lodash 4.18.0 as patched, but npm marks that artifact as
a bad release and directs consumers to the older vulnerable 4.17.21 release.
This PR therefore does not force or override Knex to Lodash 4.18.0.

A narrowly scoped local npm-audit exception remains for this documented path,
with a review trigger tied to a supported Knex parent resolution or safe Lodash
release.

No Dependabot alert was dismissed. The local npm-audit policy retains one
narrowly scoped Lodash exception and the separately documented vendored
brace-expansion exception.

## Alert counts

At the refreshed GitHub inventory timestamp
`2026-07-11T03:52:59.0033227Z`:

- Open remote alerts: 59
- Critical: 1
- High: 21
- Medium: 31
- Low: 6

Local candidate disposition:

- Expected to close after merge and default-branch rescan: 57
- Remaining blocked: 2
- Remaining critical: 0
- Remaining high: 1
- Remaining medium: 1
- Remaining low: 0

The remote count is expected to remain 59 until the changes reach the default
branch and GitHub refreshes the dependency graph.

## npm audit comparison

| Point | Full audit package entries | Production-only entries |
|---|---:|---:|
| Baseline `b83700e9` | 68 | 17 |
| Intermediate `66026757` | 63 | 12 |
| Final `6d6b6c4a` | 3 | 2 |

The final full-audit entries consist of:

- development-only vendored `brace-expansion`
- runtime Lodash
- Knex propagation of the same Lodash path

npm-audit package-entry totals are not equivalent to Dependabot alert totals.

## Supply-chain controls

For newly introduced package versions:

- exact package versions were queried against `registry.npmjs.org`
- fresh temporary npm cache was used
- package tarballs were packed and inspected
- registry SHA-512 integrity matched the inspected tarball and lockfile
- expected runtime and declaration files were present
- no install-time `preinstall`, `install`, or `postinstall` hooks were found
- registry signatures were present
- lockfiles remain version 3

Changed supported overrides are narrowly scoped:

- `@modelcontextprotocol/sdk → hono@4.12.25`
- `@eslint/eslintrc → ajv@6.14.0`
- `eslint → ajv@6.14.0`

The two ESLint parents declare Ajv ranges compatible with the selected version.

## Validation

Passed:

- root `npm ci`
- commit guard
- repository boundary checks
- CEF boundary checks
- routing boundary checks
- TypeScript type check
- lint with zero errors and 92 existing warnings
- root build
- integration suite: 62 passed, 1 skipped
- root installed-tree Jest suite
- workers clean install and zero-vulnerability audit
- runtime clean install and zero-vulnerability audit
- runtime smoke test
- Railway validation
- Python daemon tests: 132 passed
- Python dependency audit: no known vulnerabilities

Expected nonzero results:

- `npm audit` remains nonzero for the documented Lodash and vendored
  brace-expansion paths
- `npm ls --all` remains nonzero for the pre-existing vendored minimatch
  architecture

## Known limitations and follow-up

### Clean-checkout Jest portability

A clean Windows checkout reproduces one pre-existing CRLF-sensitive failure in:

`gptoss-private-serving-durable-replay-migration-guard.test.ts`

The same failure is present at baseline SHA `b83700e9` under the same clean
environment and is not reproduced in the original installed tree.

The test performs an LF-only string replacement against CRLF checkout content.

### Node engine declaration

The root package currently declares Node `>=18.14.0`, while the resolved
Cheerio/Undici path requires Node `>=20.18.1`.

This mismatch predates the final candidate and is intentionally reserved for a
separate runtime-policy change covering package metadata, `.nvmrc`, Docker, and
CI together.

Primary validation for this PR used Node 20.19.0 and npm 10.8.2.

### Standalone workspace builds

Workers and `arcanos-ai-runtime` are deployed through the supported root
workspace installation and build path.

Direct standalone builds retain the pre-existing duplicate private OpenAI type
identity failure. CI, Docker, Railway, production scripts, and bootstrap paths
do not use standalone `--install-links=true` builds.

The supported root workspace build passes.

### Docker

Docker validation was not executed because the Docker CLI was unavailable in
the validation environment.

### Remaining Lodash alerts

Dependabot alerts 66 and 67 remain open pending:

- a supported Knex parent resolution
- or a non-deprecated, safely installable patched Lodash artifact

Review date: no later than 2026-10-01.

## Risk

Overall risk is low-to-moderate.

The most behavior-sensitive dependency changes are:

- Axios networking
- MCP/Hono HTTP transport
- Cheerio/Undici
- WebSocket transport
- BullMQ

Focused validation, root build, type checking, linting, integration tests, and
package-level smoke tests passed.

## Rollback

Every remediation batch is a separate commit and may be reverted with ordinary
`git revert`, starting from the newest commit.

Do not force-reset or regenerate lockfiles during rollback.

Axios and its related transport dependencies should be reverted together.
Root and worker WebSocket changes should also be reverted together.