### PR TITLE
Fix ARCANOS Gaming public action boundary

### DIFF
--- a/.github/workflows/register.yml
+++ b/.github/workflows/register.yml
@@ -104,7 +104,7 @@ jobs:
 
           # Send registration request to ARCANOS backend
           HTTP_CODE=$(curl -s -w "%{http_code}" -o response.json \
-            -X POST https://arcanos-v2-production.up.railway.app/gpt/arcanos-daemon \
+            -X POST https://acranos-production.up.railway.app/gpt/arcanos-daemon \
             -H "Content-Type: application/json" \
             -H "User-Agent: ARCANOS-GitHub-Actions/1.0" \
             -d "$(jq -nc --arg prompt "Register repository features and persist the attached metadata for later retrieval. Payload: $PAYLOAD" --argjson metadata "$PAYLOAD" '{action: \"query\", prompt: $prompt, metadata: $metadata}')")

--- a/contracts/custom_gpt_route.openapi.v1.json
+++ b/contracts/custom_gpt_route.openapi.v1.json
@@ -2,9 +2,15 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Arcanos GPT Route API",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Canonical public contract for GPT-routed writing requests and the safe DAG bridge. GPT identity is path-bound at /gpt/{gptId}; generated tool clients may also echo the same gptId in the JSON body, and mismatched body/path IDs are rejected. POST /gpt/{gptId} accepts flexible request bodies with action as a string and payload as an open object so durable GPT writing actions, safe DAG bridge actions, and prompt-only fast-path generation can share one public endpoint. For generated clients that place operation metadata outside the JSON body, the route also accepts action as a query parameter or operation-style body alias. Simple prompt-generation requests that omit action can opt into inline fast-path execution with executionMode=fast. Runtime diagnostics, worker status, queue inspection, job lookups, self-heal status, MCP calls, root diagnostics, and arbitrary internal endpoint forwarding remain blocked on this route and must use direct control-plane endpoints, /gpt-access/*, or POST /mcp."
   },
+  "servers": [
+    {
+      "url": "https://acranos-production.up.railway.app",
+      "description": "Canonical ARCANOS production deployment"
+    }
+  ],
   "paths": {
     "/gpt/{gptId}": {
       "post": {
@@ -38,7 +44,14 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/GptRouteRequest"
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/GamingQueryRequest"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GptRouteRequest"
+                  }
+                ]
               },
               "examples": {
                 "genericPrompt": {
@@ -168,6 +181,8 @@
                     "summary": "Structured job lookup actions are rejected on /gpt/{gptId}",
                     "value": {
                       "ok": false,
+                      "requestId": "req_example",
+                      "traceId": "trace_example",
                       "action": "get_status",
                       "error": {
                         "code": "CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT",
@@ -185,6 +200,8 @@
                     "summary": "Canonical query requires a prompt",
                     "value": {
                       "ok": false,
+                      "requestId": "req_example",
+                      "traceId": "trace_example",
                       "action": "query",
                       "error": {
                         "code": "PROMPT_REQUIRED",
@@ -196,6 +213,8 @@
                     "summary": "Prompt-based job retrieval is rejected",
                     "value": {
                       "ok": false,
+                      "requestId": "req_example",
+                      "traceId": "trace_example",
                       "action": "result_lookup",
                       "error": {
                         "code": "JOB_LOOKUP_REQUIRES_JOBS_API",
@@ -211,6 +230,8 @@
                     "summary": "Prompt-based runtime inspection remains rejected without an explicit allowlisted action",
                     "value": {
                       "ok": false,
+                      "requestId": "req_example",
+                      "traceId": "trace_example",
                       "action": "runtime.inspect",
                       "error": {
                         "code": "CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT",
@@ -233,6 +254,8 @@
                     "summary": "Natural-language DAG diagnostic prompts are rejected with DAG endpoint guidance",
                     "value": {
                       "ok": false,
+                      "requestId": "req_example",
+                      "traceId": "trace_example",
                       "action": "dag.run.create",
                       "error": {
                         "code": "DAG_CONTROL_REQUIRES_DIRECT_ENDPOINT",
@@ -252,6 +275,8 @@
                     "summary": "Unknown reserved control actions are rejected safely",
                     "value": {
                       "ok": false,
+                      "requestId": "req_example",
+                      "traceId": "trace_example",
                       "action": "runtime.unknown",
                       "error": {
                         "code": "UNSUPPORTED_GPT_ACTION",
@@ -266,6 +291,8 @@
                     "summary": "Explicit runtime inspection payloads are rejected before planner validation",
                     "value": {
                       "ok": false,
+                      "requestId": "req_example",
+                      "traceId": "trace_example",
                       "action": "runtime.inspect",
                       "error": {
                         "code": "CONTROL_PLANE_REQUIRES_DIRECT_ENDPOINT",
@@ -311,6 +338,16 @@
               }
             }
           },
+          "500": {
+            "description": "Unexpected GPT route defect returned as bounded JSON",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GptRouteErrorResponse"
+                }
+              }
+            }
+          },
           "503": {
             "description": "Durable async GPT jobs unavailable for canonical bridge operations",
             "content": {
@@ -323,6 +360,8 @@
                     "summary": "Canonical query is unavailable when durable job persistence is down",
                     "value": {
                       "ok": false,
+                      "requestId": "req_example",
+                      "traceId": "trace_example",
                       "action": "query",
                       "error": {
                         "code": "ASYNC_GPT_JOBS_UNAVAILABLE",
@@ -333,6 +372,16 @@
                 }
               }
             }
+          },
+          "504": {
+            "description": "GPT module or route timeout returned as bounded JSON",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GptRouteErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -340,6 +389,278 @@
   },
   "components": {
     "schemas": {
+      "GamingQueryRequest": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "action",
+          "payload"
+        ],
+        "properties": {
+          "action": {
+            "const": "query"
+          },
+          "payload": {
+            "$ref": "#/components/schemas/GamingQueryPayload"
+          }
+        }
+      },
+      "GamingQueryPayload": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "mode",
+          "prompt"
+        ],
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "guide",
+              "build",
+              "meta"
+            ]
+          },
+          "game": {
+            "type": "string",
+            "minLength": 1
+          },
+          "prompt": {
+            "type": "string",
+            "minLength": 1
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "urls": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            }
+          },
+          "guideUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "guideUrls": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            }
+          }
+        }
+      },
+      "GamingSource": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "url"
+        ],
+        "properties": {
+          "url": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Sanitized public source URL or stable safe source identifier when the supplied value was malformed."
+          },
+          "snippet": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          }
+        }
+      },
+      "GamingResponseData": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "response",
+          "sources"
+        ],
+        "properties": {
+          "response": {
+            "type": "string"
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GamingSource"
+            }
+          },
+          "fallbackReason": {
+            "type": "string",
+            "enum": [
+              "CURRENT_EVIDENCE_UNAVAILABLE",
+              "GAMING_PROVIDER_ERROR",
+              "GAMING_PROVIDER_UNAVAILABLE",
+              "INTAKE_PARSE_TIMEOUT",
+              "INTAKE_RETRIEVAL_FAILED",
+              "INTAKE_RETRIEVAL_TIMEOUT",
+              "INTAKE_UNKNOWN_TIMEOUT",
+              "INTAKE_UPSTREAM_TIMEOUT",
+              "PROVIDER_COMPLETION_INCOMPLETE"
+            ]
+          },
+          "discoveryReason": {
+            "type": "string",
+            "enum": [
+              "DISCOVERY_CURATED_SOURCE_UNAVAILABLE",
+              "DISCOVERY_DISABLED",
+              "DISCOVERY_EVIDENCE_BELOW_THRESHOLD",
+              "DISCOVERY_EXPLICIT_CURRENT_LOOKUP",
+              "DISCOVERY_MISSING_GAME",
+              "DISCOVERY_NOT_NEEDED",
+              "DISCOVERY_NO_SOURCE_CANDIDATES",
+              "DISCOVERY_PATCH_SENSITIVE",
+              "DISCOVERY_SUPPLIED_SOURCE_FAILED"
+            ]
+          },
+          "discoveryFailureReason": {
+            "type": "string",
+            "enum": [
+              "DISCOVERY_ALL_CANDIDATES_REJECTED",
+              "DISCOVERY_BUDGET_EXHAUSTED",
+              "DISCOVERY_DISABLED",
+              "DISCOVERY_FETCH_FAILED",
+              "DISCOVERY_LOW_QUALITY",
+              "DISCOVERY_NOT_NEEDED",
+              "DISCOVERY_NO_RESULTS",
+              "DISCOVERY_PROVIDER_ERROR",
+              "DISCOVERY_PROVIDER_TIMEOUT",
+              "DISCOVERY_PROVIDER_UNCONFIGURED"
+            ]
+          }
+        }
+      },
+      "GamingSuccessResult": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "ok",
+          "route",
+          "mode",
+          "data"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "route": {
+            "const": "gaming"
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "guide",
+              "build",
+              "meta"
+            ]
+          },
+          "data": {
+            "$ref": "#/components/schemas/GamingResponseData"
+          }
+        }
+      },
+      "GamingErrorResult": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "ok",
+          "route",
+          "mode",
+          "error"
+        ],
+        "properties": {
+          "ok": {
+            "const": false
+          },
+          "route": {
+            "const": "gaming"
+          },
+          "mode": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "guide",
+              "build",
+              "meta",
+              null
+            ]
+          },
+          "error": {
+            "$ref": "#/components/schemas/GptRouteError"
+          }
+        }
+      },
+      "GamingResult": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/GamingSuccessResult"
+          },
+          {
+            "$ref": "#/components/schemas/GamingErrorResult"
+          }
+        ]
+      },
+      "GamingRouteMeta": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/GptRouteMeta"
+          },
+          {
+            "type": "object",
+            "required": [
+              "requestId",
+              "traceId"
+            ],
+            "properties": {
+              "requestId": {
+                "type": "string",
+                "minLength": 1
+              },
+              "traceId": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        ]
+      },
+      "GamingPublicResponse": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "ok",
+          "requestId",
+          "traceId",
+          "result",
+          "_route"
+        ],
+        "properties": {
+          "ok": {
+            "const": true
+          },
+          "requestId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "traceId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "result": {
+            "$ref": "#/components/schemas/GamingResult"
+          },
+          "_route": {
+            "$ref": "#/components/schemas/GamingRouteMeta"
+          }
+        }
+      },
       "GptRouteRequest": {
         "type": "object",
         "additionalProperties": true,
@@ -573,7 +894,10 @@
         }
       },
       "GptRouteSuccessResponse": {
-        "oneOf": [
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/GamingPublicResponse"
+          },
           {
             "$ref": "#/components/schemas/GptDirectActionCompletedResponse"
           },
@@ -1001,11 +1325,21 @@
         "additionalProperties": true,
         "required": [
           "ok",
+          "requestId",
+          "traceId",
           "error"
         ],
         "properties": {
           "ok": {
             "const": false
+          },
+          "requestId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "traceId": {
+            "type": "string",
+            "minLength": 1
           },
           "action": {
             "type": [
@@ -1055,6 +1389,9 @@
         "additionalProperties": true,
         "properties": {
           "requestId": {
+            "type": "string"
+          },
+          "traceId": {
             "type": "string"
           },
           "gptId": {

--- a/contracts/custom_gpt_route.openapi.v1.json
+++ b/contracts/custom_gpt_route.openapi.v1.json
@@ -661,6 +661,36 @@
           }
         }
       },
+      "GptDiagnosticResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "status",
+          "route",
+          "message",
+          "requestId",
+          "traceId"
+        ],
+        "properties": {
+          "status": {
+            "const": "ok"
+          },
+          "route": {
+            "const": "diagnostic"
+          },
+          "message": {
+            "const": "backend operational"
+          },
+          "requestId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "traceId": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
       "GptRouteRequest": {
         "type": "object",
         "additionalProperties": true,
@@ -899,13 +929,13 @@
             "$ref": "#/components/schemas/GamingPublicResponse"
           },
           {
+            "$ref": "#/components/schemas/GptDiagnosticResponse"
+          },
+          {
             "$ref": "#/components/schemas/GptDirectActionCompletedResponse"
           },
           {
             "$ref": "#/components/schemas/GptAsyncCompletedResponse"
-          },
-          {
-            "$ref": "#/components/schemas/RootDeepDiagnosticsResponse"
           },
           {
             "$ref": "#/components/schemas/GptRouteGenericResponse"

--- a/docs/CUSTOM_GPTS.md
+++ b/docs/CUSTOM_GPTS.md
@@ -70,11 +70,11 @@ The router injects the module name server-side, so your Custom GPT does not need
 The machine-readable contract lives at [contracts/custom_gpt_route.openapi.v1.json](../contracts/custom_gpt_route.openapi.v1.json).
 
 For live integrations, prefer the backend-served contract URL instead of a manually copied local file:
-- `https://<your-backend>/contracts/custom_gpt_route.openapi.v1.json`
+- `https://acranos-production.up.railway.app/contracts/custom_gpt_route.openapi.v1.json`
 
 Important:
 - Updating the repo file alone does not update an already-configured Custom GPT action.
-- After changing the contract, refresh or re-import the action schema in the Custom GPT builder.
+- After changing the contract or production hostname, refresh or re-import the action schema in the Custom GPT builder so its server target remains `https://acranos-production.up.railway.app`.
 - `arcanos-core` is the built-in GPT ID for the main `ARCANOS:CORE` route.
 - `arcanos-tutor` and `tutor` remain separate tutor-only GPT IDs for `ARCANOS:TUTOR`.
 - Use `GPT_MODULE_MAP` only when you need additional custom GPT IDs beyond the built-in routes.
@@ -190,7 +190,7 @@ success_response:
 ```yaml
 name: Arcanos Gaming
 gpt_id: arcanos-gaming
-base_url: https://<your-backend>
+base_url: https://acranos-production.up.railway.app
 endpoint: /gpt/arcanos-gaming
 method: POST
 headers:
@@ -205,7 +205,7 @@ success_response:
   description: Direct Gaming module response envelope plus _route metadata for `ARCANOS:GAMING`.
 ```
 
-**Payload contract:** `mode: "guide"` needs a prompt and may include `game`; `mode: "build"` and `mode: "meta"` require both `prompt` and `game`. Optional `url`, `urls`, `guideUrls`, `audit` / `enableAudit`, and `hrc` / `enableHrc` fields are validated by `gamingModes` before any pipeline runs. When callers send a partial explicit `payload`, top-level Gaming fields are merged only where the explicit payload omits them; explicit `payload` fields keep precedence.
+**Payload contract:** `mode: "guide"` needs a prompt and may include `game`; `mode: "build"` and `mode: "meta"` require both `prompt` and `game`. Optional `url`, `urls`, `guideUrl`, `guideUrls`, `audit` / `enableAudit`, and `hrc` / `enableHrc` fields are validated by `gamingModes` before any pipeline runs. When callers send a partial explicit `payload`, top-level Gaming fields are merged only where the explicit payload omits them; explicit `payload` fields keep precedence.
 
 **Boundary:** Gaming can call its own module action through `/gpt/arcanos-gaming` or `/gpt/gaming`. It cannot use `/gpt/:gptId` to run `runtime.inspect`, `workers.status`, `queue.inspect`, `self_heal.status`, `system_state`, `get_status`, `get_result`, MCP control actions, DAG control actions, or Core diagnostics; those are rejected by the writing-plane guard before Gaming dispatch.
 

--- a/src/middleware/requestContext.ts
+++ b/src/middleware/requestContext.ts
@@ -35,24 +35,23 @@ interface RequestLogPayload {
   data?: Record<string, unknown>;
 }
 
+const SAFE_CORRELATION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+function normalizeCorrelationId(value: string): string | undefined {
+  const trimmed = value.trim();
+  return SAFE_CORRELATION_ID_PATTERN.test(trimmed) ? trimmed : undefined;
+}
+
 function resolveRequestId(req: Request): string {
   const rawHeader = req.headers['x-request-id'];
   const candidate = typeof rawHeader === 'string' ? rawHeader : Array.isArray(rawHeader) ? rawHeader[0] : '';
-  const trimmed = candidate.trim();
-  if (trimmed.length > 0) {
-    return trimmed;
-  }
-  return generateRequestId('req');
+  return normalizeCorrelationId(candidate) ?? generateRequestId('req');
 }
 
 function resolveTraceId(req: Request): string {
   const rawHeader = req.headers['x-trace-id'];
   const candidate = typeof rawHeader === 'string' ? rawHeader : Array.isArray(rawHeader) ? rawHeader[0] : '';
-  const trimmed = candidate.trim();
-  if (trimmed.length > 0) {
-    return trimmed;
-  }
-  return generateRequestId('trace');
+  return normalizeCorrelationId(candidate) ?? generateRequestId('trace');
 }
 
 function emitRequestLog(payload: RequestLogPayload): void {
@@ -105,7 +104,7 @@ function createRequestLogger(req: Request, requestId: string, traceId: string): 
 /**
  * Purpose: Attach request-scoped logging context with request ID, redaction, and latency metrics.
  * Inputs/Outputs: Express middleware; enriches req with `requestId`, `logger`, and `log` helpers.
- * Edge cases: Preserves inbound x-request-id when provided, otherwise generates a new request id.
+ * Edge cases: Preserves bounded safe inbound correlation IDs and regenerates missing or invalid values.
  */
 export function requestContext(req: Request, res: Response, next: NextFunction): void {
   const requestId = resolveRequestId(req);

--- a/src/routes/_core/gptDispatch.ts
+++ b/src/routes/_core/gptDispatch.ts
@@ -123,6 +123,7 @@ const FORWARDED_TOP_LEVEL_PAYLOAD_KEYS = [
   'game',
   'url',
   'urls',
+  'guideUrl',
   'guideUrls',
   'audit',
   'enableAudit',

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -81,8 +81,6 @@ import {
 import { getRequestActorKey } from '@platform/runtime/security.js';
 import {
   GPT_QUERY_ACTION,
-  GPT_GET_STATUS_ACTION,
-  GPT_GET_RESULT_ACTION,
   GPT_QUERY_AND_WAIT_ACTION
 } from '@shared/gpt/gptJobResult.js';
 import { classifyGptRequestPlane } from './_core/gptPlaneClassification.js';
@@ -93,9 +91,10 @@ import {
 } from '@shared/gpt/gptFastPath.js';
 import { ARCANOS_SUPPRESS_TIMEOUT_FALLBACK_FLAG } from '@shared/gpt/gptDirectAction.js';
 import { extractLastUserMessageText } from '@shared/gpt/messageContentText.js';
+import { resolveRequestedGptActionFromRequest } from '@shared/gpt/gptRequestAction.js';
 import { executeDirectGptAction, executeFastGptPrompt } from '@services/gptFastPath.js';
 import { DEFAULT_GAMING_MODULE_TIMEOUT_MS } from '@services/gamingConfig.js';
-import { formatGamingError, resolveGamingMode } from '@services/gamingModes.js';
+import { formatGamingError, resolveGamingMode, validatePublicGamingQueryRequest } from '@services/gamingModes.js';
 import { getConfig } from '@platform/runtime/unifiedConfig.js';
 import { handleGptDagBridge } from '@services/gptDagBridge.js';
 import {
@@ -272,111 +271,6 @@ function extractDispatcherResultText(result: unknown): string {
   } catch {
     return String(result ?? '');
   }
-}
-
-function readFirstNonEmptyString(value: unknown): string | null {
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : null;
-  }
-
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      const normalizedEntry = readFirstNonEmptyString(entry);
-      if (normalizedEntry) {
-        return normalizedEntry;
-      }
-    }
-  }
-
-  return null;
-}
-
-function normalizeRequestedActionName(value: string): string | null {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  const lowered = trimmed.toLowerCase();
-  const decamelized = trimmed.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
-  const compact = decamelized.replace(/[^a-z0-9]+/g, '');
-
-  if (compact === 'invokegptroute' || compact === 'gptroute' || compact === 'invokegpt') {
-    return null;
-  }
-
-  if (
-    compact === 'queryandwait' ||
-    compact === 'requestqueryandwait' ||
-    compact === 'gptqueryandwait'
-  ) {
-    return GPT_QUERY_AND_WAIT_ACTION;
-  }
-
-  if (compact === 'query') {
-    return GPT_QUERY_ACTION;
-  }
-
-  if (compact === 'getstatus') {
-    return GPT_GET_STATUS_ACTION;
-  }
-
-  if (compact === 'getresult') {
-    return GPT_GET_RESULT_ACTION;
-  }
-
-  if (compact === 'systemstate') {
-    return 'system_state';
-  }
-
-  return lowered;
-}
-
-function readActionAlias(record: Record<string, unknown>): string | null {
-  const actionValue =
-    readFirstNonEmptyString(record.action) ??
-    readFirstNonEmptyString(record.operation) ??
-    readFirstNonEmptyString(record.operationId) ??
-    readFirstNonEmptyString(record.operation_id) ??
-    readFirstNonEmptyString(record.toolAction) ??
-    readFirstNonEmptyString(record.tool_action) ??
-    readFirstNonEmptyString(record.gptAction) ??
-    readFirstNonEmptyString(record.gpt_action);
-
-  return actionValue ? normalizeRequestedActionName(actionValue) : null;
-}
-
-function resolveRequestedAction(body: unknown): string | null {
-  const normalizedBody = normalizeGptRequestBody(body);
-  if (!normalizedBody) {
-    return null;
-  }
-
-  const directAction = readActionAlias(normalizedBody);
-  if (directAction) {
-    return directAction.toLowerCase();
-  }
-
-  const payload = normalizedBody.payload;
-  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-    return null;
-  }
-
-  const payloadAction = readActionAlias(payload as Record<string, unknown>);
-  return payloadAction;
-}
-
-function resolveRequestedActionFromRequest(req: express.Request): string | null {
-  return (
-    resolveRequestedAction(req.body) ??
-    readActionAlias(req.query as Record<string, unknown>) ??
-    normalizeRequestedActionName(
-      readFirstNonEmptyString(req.header('x-gpt-action')) ??
-      readFirstNonEmptyString(req.header('x-arcanos-action')) ??
-      ''
-    )
-  );
 }
 
 function readPayloadRecord(
@@ -813,7 +707,7 @@ function isDirectModuleQueryGpt(gptId: string): boolean {
 function resolvePublicGamingMode(body: unknown) {
   const normalizedBody = normalizeGptRequestBody(body);
   const payload = readPayloadRecord(normalizedBody);
-  return resolveGamingMode(payload ?? normalizedBody);
+  return resolveGamingMode(payload) ?? resolveGamingMode(normalizedBody);
 }
 
 function isControlledGamingDispatcherError(
@@ -1363,7 +1257,7 @@ function applyGptQueueBypassedHeader(
 router.post("/:gptId", async (req, res, next) => {
   const routeGptId = req.params.gptId;
   const priorityGpt = isPriorityGpt(routeGptId);
-  const requestedAction = resolveRequestedActionFromRequest(req);
+  const requestedAction = resolveRequestedGptActionFromRequest(req);
   const queryRequested = requestedAction === GPT_QUERY_ACTION;
   const queryAndWaitRequested = requestedAction === GPT_QUERY_AND_WAIT_ACTION;
   const bypassIntentRouting = queryRequested || queryAndWaitRequested;
@@ -1499,6 +1393,41 @@ router.post("/:gptId", async (req, res, next) => {
             bodyGptId,
             traceId
           });
+        }
+
+        const publicGamingValidationError = isDirectModuleQueryGpt(incomingGptId)
+          ? validatePublicGamingQueryRequest(normalizedBody, requestedAction)
+          : null;
+
+        if (publicGamingValidationError) {
+          const action = requestedAction ?? GPT_QUERY_ACTION;
+          const errorPayload = buildGptDispatcherErrorPayload({
+            requestId,
+            traceId,
+            gptId: incomingGptId,
+            action,
+            code: publicGamingValidationError.code,
+            message: publicGamingValidationError.message,
+            route: 'gaming_validation'
+          });
+          logGptDispatcherOutcome({
+            req,
+            traceId,
+            gptId: incomingGptId,
+            action,
+            status: 400,
+            error: {
+              name: publicGamingValidationError.code,
+              message: publicGamingValidationError.message
+            }
+          });
+          return sendGuardedGptJsonResponse(
+            req,
+            res,
+            errorPayload,
+            'gpt.response.gaming_validation',
+            400
+          );
         }
 
         requestLogger?.info?.("gpt.request.auth_state", {
@@ -3062,13 +2991,11 @@ router.post("/:gptId", async (req, res, next) => {
           const diagnosticSerializationStartedAt = Date.now();
           const diagnosticResult = shapeClientRouteResult(envelope.result) as Record<string, unknown>;
           const diagnosticPayload = prepareBoundedClientJsonPayload(
-            isDirectModuleQueryGpt(incomingGptId)
-              ? {
-                  ...diagnosticResult,
-                  requestId: requestId ?? traceId,
-                  traceId
-                }
-              : diagnosticResult,
+            {
+              ...diagnosticResult,
+              requestId: requestId ?? traceId,
+              traceId
+            },
             {
               logger: req.logger,
               logEvent: 'gpt.response.diagnostic',

--- a/src/routes/gptRouter.ts
+++ b/src/routes/gptRouter.ts
@@ -94,6 +94,8 @@ import {
 import { ARCANOS_SUPPRESS_TIMEOUT_FALLBACK_FLAG } from '@shared/gpt/gptDirectAction.js';
 import { extractLastUserMessageText } from '@shared/gpt/messageContentText.js';
 import { executeDirectGptAction, executeFastGptPrompt } from '@services/gptFastPath.js';
+import { DEFAULT_GAMING_MODULE_TIMEOUT_MS } from '@services/gamingConfig.js';
+import { formatGamingError, resolveGamingMode } from '@services/gamingModes.js';
 import { getConfig } from '@platform/runtime/unifiedConfig.js';
 import { handleGptDagBridge } from '@services/gptDagBridge.js';
 import {
@@ -225,6 +227,7 @@ function buildGptDispatcherErrorPayload(params: {
 }) {
   return {
     ok: false,
+    requestId: params.requestId ?? params.traceId,
     gptId: params.gptId,
     action: params.action,
     route: GPT_DISPATCHER_ROUTE,
@@ -807,6 +810,72 @@ function isDirectModuleQueryGpt(gptId: string): boolean {
   return DIRECT_MODULE_QUERY_GPT_IDS.has(gptId.trim().toLowerCase());
 }
 
+function resolvePublicGamingMode(body: unknown) {
+  const normalizedBody = normalizeGptRequestBody(body);
+  const payload = readPayloadRecord(normalizedBody);
+  return resolveGamingMode(payload ?? normalizedBody);
+}
+
+function isControlledGamingDispatcherError(
+  code: string
+): code is 'MODULE_TIMEOUT' | 'REQUEST_ABORTED' {
+  return code === 'MODULE_TIMEOUT' || code === 'REQUEST_ABORTED';
+}
+
+function buildControlledGamingErrorResponse(params: {
+  body: unknown;
+  requestId: string | undefined;
+  traceId: string;
+  gptId: string;
+  dispatcherCode: 'MODULE_TIMEOUT' | 'REQUEST_ABORTED';
+  timeoutMs?: number;
+  timeoutPhase?: string;
+  routeMeta?: Record<string, unknown>;
+}) {
+  const requestId = params.requestId ?? params.traceId;
+  const errorCode = params.dispatcherCode === 'MODULE_TIMEOUT'
+    ? 'GENERATION_TIMEOUT'
+    : params.dispatcherCode;
+  const message = params.dispatcherCode === 'MODULE_TIMEOUT'
+    ? 'Gaming generation timed out before a complete answer was available.'
+    : 'Gaming generation was aborted before a complete answer was available.';
+  const timeoutDetails = params.dispatcherCode === 'MODULE_TIMEOUT'
+    ? {
+        ...(typeof params.timeoutMs === 'number' ? { timeoutMs: params.timeoutMs } : {}),
+        ...(params.timeoutPhase ? { timeoutPhase: params.timeoutPhase } : {})
+      }
+    : undefined;
+
+  return {
+    ok: true as const,
+    requestId,
+    traceId: params.traceId,
+    result: formatGamingError({
+      mode: resolvePublicGamingMode(params.body),
+      error: {
+        code: errorCode,
+        message,
+        ...(timeoutDetails && Object.keys(timeoutDetails).length > 0
+          ? { details: timeoutDetails }
+          : {})
+      }
+    }),
+    _route: {
+      ...(params.routeMeta ?? {}),
+      requestId,
+      traceId: params.traceId,
+      gptId: params.gptId,
+      module: 'ARCANOS:GAMING',
+      action: GPT_QUERY_ACTION,
+      route: 'gaming',
+      timestamp:
+        typeof params.routeMeta?.timestamp === 'string'
+          ? params.routeMeta.timestamp
+          : new Date().toISOString()
+    }
+  };
+}
+
 function resolveGptExecutionPlan(params: {
   req: express.Request;
   gptId: string;
@@ -1081,7 +1150,26 @@ function sendGuardedGptJsonResponse(
   logEvent: string,
   statusCode = 200
 ) {
-  return sendBoundedJsonResponse(req, res, payload as Record<string, unknown>, {
+  const payloadRecord = payload as Record<string, unknown>;
+  const requestId = req.requestId ?? req.traceId ?? 'unknown';
+  const traceId = req.traceId ?? requestId;
+  const correlatedPayload = payloadRecord.ok === false
+    ? {
+        ...payloadRecord,
+        requestId,
+        traceId,
+        ...(payloadRecord._route && typeof payloadRecord._route === 'object' && !Array.isArray(payloadRecord._route)
+          ? {
+              _route: {
+                ...(payloadRecord._route as Record<string, unknown>),
+                requestId,
+                traceId
+              }
+            }
+          : {})
+      }
+    : payloadRecord;
+  return sendBoundedJsonResponse(req, res, correlatedPayload, {
     logEvent,
     statusCode,
   });
@@ -1288,9 +1376,13 @@ router.post("/:gptId", async (req, res, next) => {
   const explicitAsyncPollIntervalMs = readRequestedAsyncGptPollIntervalMs(req, req.body);
   const queryAndWaitRequestedTimeoutMs =
     explicitAsyncWaitForResultMs ?? resolveGptWaitTimeoutMs();
+  const directGamingRoute = isDirectModuleQueryGpt(routeGptId);
   const routeTimeoutMs = resolveGptRouteHardTimeoutMs({
-    profile: routeTimeoutProfile,
-    ...(queryAndWaitRequested && routeTimeoutProfile === 'default'
+    profile: directGamingRoute ? 'default' : routeTimeoutProfile,
+    ...(directGamingRoute
+      ? { minimumMsOverride: DEFAULT_GAMING_MODULE_TIMEOUT_MS }
+      : {}),
+    ...(queryAndWaitRequested && !directGamingRoute && routeTimeoutProfile === 'default'
       ? {
           defaultMsOverride: Math.max(
             resolveDefaultGptQueryAndWaitRouteTimeoutMs(),
@@ -1691,6 +1783,7 @@ router.post("/:gptId", async (req, res, next) => {
 
         if (
           (queryRequested || queryAndWaitRequested) &&
+          !isDirectModuleQueryGpt(incomingGptId) &&
           process.env.NODE_ENV !== 'test' &&
           !hasConfiguredOpenAIKey()
         ) {
@@ -1733,7 +1826,7 @@ router.post("/:gptId", async (req, res, next) => {
             kind: planeClassification.kind,
             reason: planeClassification.reason
           });
-          return res.status(500).json({
+          return sendGuardedGptJsonResponse(req, res, {
             ok: false,
             error: {
               code: 'CONTROL_PLANE_ROUTING_BREACH',
@@ -1741,12 +1834,13 @@ router.post("/:gptId", async (req, res, next) => {
             },
             _route: {
               requestId,
+              traceId,
               gptId: incomingGptId,
               route: 'control_guard',
               action: planeClassification.action,
               timestamp: new Date().toISOString()
             }
-          });
+          }, 'gpt.response.control_plane_routing_breach', 500);
         }
 
         const explicitIdempotencyKey = normalizeExplicitIdempotencyKey(
@@ -2749,15 +2843,73 @@ router.post("/:gptId", async (req, res, next) => {
         });
 
         if (!envelope.ok) {
+          if (
+            isDirectModuleQueryGpt(incomingGptId) &&
+            isControlledGamingDispatcherError(envelope.error.code)
+          ) {
+            const controlledGamingResponse = buildControlledGamingErrorResponse({
+              body: effectiveBody,
+              requestId,
+              traceId,
+              gptId: incomingGptId,
+              dispatcherCode: envelope.error.code,
+              ...(envelope.error.code === 'MODULE_TIMEOUT'
+                ? { timeoutMs: routeTimeoutMs, timeoutPhase: 'module-dispatch' }
+                : {}),
+              routeMeta: envelope._route as Record<string, unknown>
+            });
+            if (envelope.error.code === 'MODULE_TIMEOUT') {
+              applyAIDegradedResponseHeaders(res, {
+                timeoutKind: 'pipeline_timeout',
+                degradedModeReason: 'gaming_module_timeout',
+                bypassedSubsystems: ['gaming_generation']
+              });
+            }
+            requestLogger?.warn?.('gpt.request.route_result', {
+              endpoint: req.originalUrl,
+              gptId: incomingGptId,
+              statusCode: 200,
+              ok: false,
+              errorCode: envelope.error.code,
+              controlledGamingFailure: true
+            });
+            logGptDispatcherOutcome({
+              req,
+              traceId,
+              gptId: incomingGptId,
+              action: requestedAction ?? GPT_QUERY_ACTION,
+              status: 200
+            });
+            return sendGuardedGptJsonResponse(
+              req,
+              res,
+              controlledGamingResponse,
+              'gpt.response.gaming_controlled_failure',
+              200
+            );
+          }
+
           applyAIDegradedResponseHeaders(res, extractAIDegradedResponseMetadata(envelope.error.details));
+          const unexpectedGamingRouteFailure =
+            isDirectModuleQueryGpt(incomingGptId) && envelope.error.code === 'MODULE_ERROR';
           const publicErrorEnvelope = {
             ...envelope,
+            ...(unexpectedGamingRouteFailure
+              ? {
+                  error: {
+                    code: 'GAMING_ROUTE_ERROR',
+                    message: 'ARCANOS Gaming encountered an unexpected route error.'
+                  }
+                }
+              : {}),
+            requestId: requestId ?? traceId,
             gptId: incomingGptId,
             action: requestedAction ?? GPT_QUERY_ACTION,
             route: GPT_DISPATCHER_ROUTE,
             traceId,
             _route: {
               ...envelope._route,
+              requestId: requestId ?? traceId,
               traceId
             }
           };
@@ -2766,6 +2918,8 @@ router.post("/:gptId", async (req, res, next) => {
               ? 404
               : envelope.error.code === "SYSTEM_STATE_CONFLICT"
               ? 409
+              : unexpectedGamingRouteFailure
+              ? 500
               : envelope.error.code === "MODULE_TIMEOUT"
               ? 504
               : 400;
@@ -2793,6 +2947,26 @@ router.post("/:gptId", async (req, res, next) => {
           }
           if (envelope.error.code === "SYSTEM_STATE_CONFLICT") {
             return sendGuardedGptJsonResponse(req, res, publicErrorEnvelope, 'gpt.response.route_error', 409);
+          }
+          if (unexpectedGamingRouteFailure) {
+            logGptDispatcherOutcome({
+              req,
+              traceId,
+              gptId: incomingGptId,
+              action: requestedAction ?? GPT_QUERY_ACTION,
+              status: 500,
+              error: {
+                name: 'GAMING_ROUTE_ERROR',
+                message: 'ARCANOS Gaming encountered an unexpected route error.'
+              }
+            });
+            return sendGuardedGptJsonResponse(
+              req,
+              res,
+              publicErrorEnvelope,
+              'gpt.response.gaming_unexpected_failure',
+              500
+            );
           }
           if (envelope.error.code === "MODULE_TIMEOUT") {
             return sendGuardedGptJsonResponse(req, res, publicErrorEnvelope, 'gpt.response.route_error', 504);
@@ -2886,8 +3060,15 @@ router.post("/:gptId", async (req, res, next) => {
           (envelope.result as Record<string, unknown>).route === 'diagnostic'
         ) {
           const diagnosticSerializationStartedAt = Date.now();
+          const diagnosticResult = shapeClientRouteResult(envelope.result) as Record<string, unknown>;
           const diagnosticPayload = prepareBoundedClientJsonPayload(
-            shapeClientRouteResult(envelope.result) as Record<string, unknown>,
+            isDirectModuleQueryGpt(incomingGptId)
+              ? {
+                  ...diagnosticResult,
+                  requestId: requestId ?? traceId,
+                  traceId
+                }
+              : diagnosticResult,
             {
               logger: req.logger,
               logEvent: 'gpt.response.diagnostic',
@@ -2907,6 +3088,17 @@ router.post("/:gptId", async (req, res, next) => {
         const responseSerializationStartedAt = Date.now();
         const publicEnvelope = prepareBoundedClientJsonPayload({
           ...envelope,
+          ...(isDirectModuleQueryGpt(incomingGptId)
+            ? {
+                requestId: requestId ?? traceId,
+                traceId,
+                _route: {
+                  ...envelope._route,
+                  requestId: requestId ?? traceId,
+                  traceId
+                }
+              }
+            : {}),
           result: shapeClientRouteResult(envelope.result),
         }, {
           logger: req.logger,
@@ -2968,6 +3160,36 @@ router.post("/:gptId", async (req, res, next) => {
           202
         );
       }
+      if (routeTimedOut && responseOpen && isDirectModuleQueryGpt(gptId)) {
+        const controlledGamingResponse = buildControlledGamingErrorResponse({
+          body: req.body,
+          requestId,
+          traceId,
+          gptId,
+          dispatcherCode: 'MODULE_TIMEOUT',
+          timeoutMs: routeTimeoutMs,
+          timeoutPhase: 'gpt-route'
+        });
+        applyAIDegradedResponseHeaders(res, {
+          timeoutKind: 'pipeline_timeout',
+          degradedModeReason: 'gaming_route_timeout',
+          bypassedSubsystems: ['gaming_generation']
+        });
+        logGptDispatcherOutcome({
+          req,
+          traceId,
+          gptId,
+          action: requestedAction ?? GPT_QUERY_ACTION,
+          status: 200
+        });
+        return sendGuardedGptJsonResponse(
+          req,
+          res,
+          controlledGamingResponse,
+          'gpt.response.gaming_route_timeout',
+          200
+        );
+      }
       if (
         routeTimedOut &&
         responseOpen &&
@@ -3004,12 +3226,15 @@ router.post("/:gptId", async (req, res, next) => {
       if (routeTimedOut && responseOpen) {
         return sendGuardedGptJsonResponse(req, res, {
           ok: false,
+          requestId: requestId ?? traceId,
+          traceId,
           error: {
             code: 'MODULE_TIMEOUT',
             message: timeoutMessage
           },
           _route: {
-            requestId,
+            requestId: requestId ?? traceId,
+            traceId,
             gptId: req.params.gptId,
             timestamp: new Date().toISOString()
           }
@@ -3022,12 +3247,15 @@ router.post("/:gptId", async (req, res, next) => {
       if (responseOpen) {
         return sendGuardedGptJsonResponse(req, res, {
           ok: false,
+          requestId: requestId ?? traceId,
+          traceId,
           error: {
             code: 'REQUEST_ABORTED',
             message: 'Request was aborted before completion.'
           },
           _route: {
-            requestId,
+            requestId: requestId ?? traceId,
+            traceId,
             gptId: req.params.gptId,
             timestamp: new Date().toISOString()
           }
@@ -3045,14 +3273,14 @@ router.post("/:gptId", async (req, res, next) => {
     });
     const responseOpen = !res.headersSent && !res.writableEnded && !res.destroyed;
     if (responseOpen) {
-      const message = resolveErrorMessage(err);
+      const internalMessage = resolveErrorMessage(err);
       const errorPayload = buildGptDispatcherErrorPayload({
         requestId,
         traceId,
         gptId: req.params.gptId,
         action: requestedAction ?? GPT_QUERY_ACTION,
         code: 'GPT_DISPATCHER_UNEXPECTED_ERROR',
-        message,
+        message: 'An unexpected GPT route error occurred.',
         route: 'unexpected_failure'
       });
       logGptDispatcherOutcome({
@@ -3063,7 +3291,7 @@ router.post("/:gptId", async (req, res, next) => {
         status: 500,
         error: {
           name: err instanceof Error ? err.name : 'Error',
-          message
+          message: internalMessage
         }
       });
       return sendGuardedGptJsonResponse(

--- a/src/services/arcanos-gaming.ts
+++ b/src/services/arcanos-gaming.ts
@@ -1,7 +1,6 @@
 import { runBuildPipeline, runGuidePipeline, runMetaPipeline } from "@services/gaming.js";
 import { getGamingModuleTimeoutMs } from "@services/gamingConfig.js";
 import { evaluateWithHRC } from "./hrcWrapper.js";
-import { resolveErrorMessage } from "@core/lib/errors/index.js";
 import { getRequestAbortContext, getRequestAbortSignal, isAbortError } from "@arcanos/runtime";
 import { logger } from "@platform/logging/structuredLogging.js";
 import {
@@ -14,6 +13,7 @@ import {
 } from "@services/gamingAgents.js";
 import {
   formatGamingError,
+  resolveGamingMode,
   type GamingErrorEnvelope,
   type GamingMode,
   type GamingSuccessEnvelope,
@@ -198,12 +198,12 @@ async function executeGamingBackendQuery(payload: GamingBackendActionPayload): P
         hrc
       }
     };
-  } catch (error: unknown) {
+  } catch {
     return formatGamingError({
       mode,
       error: {
         code: "MODULE_ERROR",
-        message: `HRC evaluation failed: ${resolveErrorMessage(error)}`
+        message: "Gaming response verification could not be completed safely."
       }
     });
   }
@@ -370,7 +370,8 @@ async function handleGamingRequest(payload: unknown): Promise<GamingEnvelope> {
       if (backendEnvelope.error.code === "GENERATION_TIMEOUT") {
         return ResponseComposerAgent.composeBackendFailureFallback({
           intent: gamingIntent,
-          error: new Error(describeGamingErrorEnvelope(backendEnvelope.error))
+          error: new Error(describeGamingErrorEnvelope(backendEnvelope.error)),
+          fallbackReason: "INTAKE_UPSTREAM_TIMEOUT"
         });
       }
       return backendEnvelope;
@@ -431,7 +432,24 @@ export const ArcanosGaming = {
   defaultTimeoutMs: getGamingModuleTimeoutMs(),
   actions: {
     async query(payload: unknown) {
-      return handleGamingRequest(payload);
+      try {
+        return await handleGamingRequest(payload);
+      } catch (error: unknown) {
+        if (getRequestAbortSignal()?.aborted || isAbortError(error)) {
+          throw error;
+        }
+        logger.error("gaming.request.failure", {
+          ...buildGamingRequestLogContext(),
+          errorCode: "MODULE_ERROR"
+        });
+        return formatGamingError({
+          mode: resolveGamingMode(payload),
+          error: {
+            code: "MODULE_ERROR",
+            message: "ARCANOS Gaming could not complete the request safely."
+          }
+        });
+      }
     },
   },
 };

--- a/src/services/gamingAgents.ts
+++ b/src/services/gamingAgents.ts
@@ -341,7 +341,7 @@ function extractPlatform(payload: unknown, prompt: string): string | undefined {
   return match?.[1];
 }
 
-function extractVersion(payload: unknown, prompt: string): string | undefined {
+function extractVersion(payload: unknown, prompt: string, game?: string): string | undefined {
   const explicit = getStringField(payload, "version") ?? getStringField(payload, "patch");
   if (explicit) {
     return explicit;
@@ -352,9 +352,24 @@ function extractVersion(payload: unknown, prompt: string): string | undefined {
   }
 
   const match = prompt.match(/\b(?:patch|version|season)\s+([A-Za-z0-9._ -]{1,32})/i) ??
-    prompt.match(/\bin\s+(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\b/i) ??
-    prompt.match(/\b(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\b/);
-  return match?.[1]?.trim();
+    prompt.match(/\bwhat\s+changed\b[^.!?\n]{0,32}\bin\s+(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\b/i) ??
+    prompt.match(/\(\s*(?:v(?:ersion)?\.?\s*)?(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\s*\)/i) ??
+    prompt.match(/\b(\d{1,3}\.\d{1,3}\.\d{1,3})\b/);
+  if (match?.[1]) {
+    return match[1].trim();
+  }
+
+  if (!game) {
+    return undefined;
+  }
+
+  const escapedGame = game.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const gameVersionPattern = new RegExp(
+    `\\b${escapedGame}\\s+(?:v(?:ersion)?\\.?\\s*)?(\\d{1,3}\\.\\d{1,3}(?:\\.\\d{1,3})?)\\b(?!\\.\\d)(?!\\s*(?:%|percent\\b|minutes?\\b|mins?\\b|hours?\\b|seconds?\\b|milliseconds?\\b|ms\\b|fps\\b|hz\\b))`,
+    "i"
+  );
+  const gameVersionMatch = prompt.match(gameVersionPattern);
+  return gameVersionMatch?.[1]?.trim();
 }
 
 function extractClass(payload: unknown, prompt: string): string | undefined {
@@ -597,7 +612,7 @@ export const IntentRouterAgent = {
       : { confidence: rawGameDetection.confidence, source: rawGameDetection.source };
     const scoredIntent = scoreIntent(payload, prompt, gameDetection);
     const rawPlatform = extractPlatform(payload, prompt);
-    const rawVersion = extractVersion(payload, prompt);
+    const rawVersion = extractVersion(payload, prompt, gameDetection.game);
 
     return {
       mode: scoredIntent.mode,

--- a/src/services/gamingAgents.ts
+++ b/src/services/gamingAgents.ts
@@ -1,4 +1,5 @@
 import { detectGamingGame, type GamingGameDetectionSource } from "@services/gamingGameDetection.js";
+import { extractExplicitGamingVersions } from "@services/gamingVersion.js";
 import {
   formatGamingSuccess,
   resolveGamingMode,
@@ -351,25 +352,15 @@ function extractVersion(payload: unknown, prompt: string, game?: string): string
     return "this patch";
   }
 
-  const match = prompt.match(/\b(?:patch|version|season)\s+([A-Za-z0-9._ -]{1,32})/i) ??
-    prompt.match(/\bwhat\s+changed\b[^.!?\n]{0,32}\bin\s+(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\b/i) ??
-    prompt.match(/\(\s*(?:v(?:ersion)?\.?\s*)?(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\s*\)/i) ??
-    prompt.match(/\b(\d{1,3}\.\d{1,3}\.\d{1,3})\b/);
-  if (match?.[1]) {
-    return match[1].trim();
+  const semanticVersion = extractExplicitGamingVersions({ prompt, game })[0];
+  if (semanticVersion) {
+    return semanticVersion;
   }
 
-  if (!game) {
-    return undefined;
-  }
-
-  const escapedGame = game.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const gameVersionPattern = new RegExp(
-    `\\b${escapedGame}\\s+(?:v(?:ersion)?\\.?\\s*)?(\\d{1,3}\\.\\d{1,3}(?:\\.\\d{1,3})?)\\b(?!\\.\\d)(?!\\s*(?:%|percent\\b|minutes?\\b|mins?\\b|hours?\\b|seconds?\\b|milliseconds?\\b|ms\\b|fps\\b|hz\\b))`,
-    "i"
-  );
-  const gameVersionMatch = prompt.match(gameVersionPattern);
-  return gameVersionMatch?.[1]?.trim();
+  const labeledToken = prompt.match(/\b(?:patch|version|season)\s+([A-Za-z0-9][A-Za-z0-9._-]{0,31})\b/i)?.[1];
+  return labeledToken && !/^(?:for|is|notes?|of|the)$/i.test(labeledToken)
+    ? labeledToken
+    : undefined;
 }
 
 function extractClass(payload: unknown, prompt: string): string | undefined {

--- a/src/services/gamingAgents.ts
+++ b/src/services/gamingAgents.ts
@@ -1,5 +1,12 @@
 import { detectGamingGame, type GamingGameDetectionSource } from "@services/gamingGameDetection.js";
-import { formatGamingSuccess, resolveGamingMode, type GamingErrorEnvelope, type GamingMode, type GamingSuccessEnvelope } from "@services/gamingModes.js";
+import {
+  formatGamingSuccess,
+  resolveGamingMode,
+  type GamingErrorEnvelope,
+  type GamingFallbackReason,
+  type GamingMode,
+  type GamingSuccessEnvelope
+} from "@services/gamingModes.js";
 import { isRecord } from "@shared/typeGuards.js";
 import { extractTextPrompt, normalizeStringList } from "@transport/http/payloadNormalization.js";
 
@@ -345,7 +352,8 @@ function extractVersion(payload: unknown, prompt: string): string | undefined {
   }
 
   const match = prompt.match(/\b(?:patch|version|season)\s+([A-Za-z0-9._ -]{1,32})/i) ??
-    prompt.match(/\bin\s+(\d{1,2}\.\d{1,2})\b/i);
+    prompt.match(/\bin\s+(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\b/i) ??
+    prompt.match(/\b(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\b/);
   return match?.[1]?.trim();
 }
 
@@ -725,6 +733,7 @@ export const ResponseComposerAgent = {
   composeBackendFailureFallback(params: {
     intent: GamingIntent & { mode: GamingMode };
     error: unknown;
+    fallbackReason?: GamingFallbackReason;
   }): GamingSuccessEnvelope {
     const { intent, error } = params;
     const fallback = fallbackBodyForMode(intent);
@@ -753,6 +762,7 @@ export const ResponseComposerAgent = {
       data: {
         response,
         sources: [],
+        fallbackReason: params.fallbackReason ?? "GAMING_PROVIDER_ERROR"
       },
     });
   },

--- a/src/services/gamingGameDetection.ts
+++ b/src/services/gamingGameDetection.ts
@@ -20,6 +20,7 @@ const OPTIONAL_GAME_ALIASES: Array<{ pattern: RegExp; name: string }> = [
   { pattern: /\b(?:star\s+wars:\s*)?the\s+old\s+republic\b|\bswtor\b/i, name: "Star Wars: The Old Republic" },
   { pattern: /\bworld\s+of\s+warcraft\b/i, name: "World of Warcraft" },
   { pattern: /\b(?:WoW|WOW)\b/, name: "World of Warcraft" },
+  { pattern: /\belden\s+ring\s+nightreign\b/i, name: "Elden Ring Nightreign" },
   { pattern: /\belden\s+ring\b/i, name: "Elden Ring" },
   { pattern: /\bdestiny\s+2\b/i, name: "Destiny 2" },
   { pattern: /\bdiablo\s+(?:4|iv)\b/i, name: "Diablo 4" },

--- a/src/services/gamingModes.ts
+++ b/src/services/gamingModes.ts
@@ -3,6 +3,40 @@ import { extractTextPrompt, normalizeStringList } from "@transport/http/payloadN
 
 export type GamingMode = "guide" | "build" | "meta";
 
+export type GamingFallbackReason =
+  | "CURRENT_EVIDENCE_UNAVAILABLE"
+  | "GAMING_PROVIDER_ERROR"
+  | "GAMING_PROVIDER_UNAVAILABLE"
+  | "INTAKE_PARSE_TIMEOUT"
+  | "INTAKE_RETRIEVAL_FAILED"
+  | "INTAKE_RETRIEVAL_TIMEOUT"
+  | "INTAKE_UNKNOWN_TIMEOUT"
+  | "INTAKE_UPSTREAM_TIMEOUT"
+  | "PROVIDER_COMPLETION_INCOMPLETE";
+
+export type GamingDiscoveryReason =
+  | "DISCOVERY_CURATED_SOURCE_UNAVAILABLE"
+  | "DISCOVERY_DISABLED"
+  | "DISCOVERY_EVIDENCE_BELOW_THRESHOLD"
+  | "DISCOVERY_EXPLICIT_CURRENT_LOOKUP"
+  | "DISCOVERY_MISSING_GAME"
+  | "DISCOVERY_NOT_NEEDED"
+  | "DISCOVERY_NO_SOURCE_CANDIDATES"
+  | "DISCOVERY_PATCH_SENSITIVE"
+  | "DISCOVERY_SUPPLIED_SOURCE_FAILED";
+
+export type GamingDiscoveryFailureReason =
+  | "DISCOVERY_ALL_CANDIDATES_REJECTED"
+  | "DISCOVERY_BUDGET_EXHAUSTED"
+  | "DISCOVERY_DISABLED"
+  | "DISCOVERY_FETCH_FAILED"
+  | "DISCOVERY_LOW_QUALITY"
+  | "DISCOVERY_NOT_NEEDED"
+  | "DISCOVERY_NO_RESULTS"
+  | "DISCOVERY_PROVIDER_ERROR"
+  | "DISCOVERY_PROVIDER_TIMEOUT"
+  | "DISCOVERY_PROVIDER_UNCONFIGURED";
+
 export type GamingError = {
   code: string;
   message: string;
@@ -16,6 +50,9 @@ export type GamingSuccessEnvelope = {
   data: {
     response: string;
     sources: Array<{ url: string; snippet?: string; error?: string }>;
+    fallbackReason?: GamingFallbackReason;
+    discoveryReason?: GamingDiscoveryReason;
+    discoveryFailureReason?: GamingDiscoveryFailureReason;
     auditTrace?: {
       draft: string;
       finalized: string;

--- a/src/services/gamingModes.ts
+++ b/src/services/gamingModes.ts
@@ -83,6 +83,35 @@ export type PublicGamingRequestValidationError = {
   message: string;
 };
 
+const MAX_PUBLIC_GAMING_PAYLOAD_DEPTH = 32;
+const MAX_PUBLIC_GAMING_PAYLOAD_NODES = 4096;
+
+function publicGamingRequestExceedsStructuralLimits(body: Record<string, unknown>): boolean {
+  const stack: Array<{ value: unknown; depth: number }> = [{ value: body, depth: 0 }];
+  let visited = 0;
+
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    visited += 1;
+    if (current.depth > MAX_PUBLIC_GAMING_PAYLOAD_DEPTH) {
+      return true;
+    }
+    const children = Array.isArray(current.value)
+      ? current.value
+      : isRecord(current.value)
+        ? Object.values(current.value)
+        : [];
+    if (visited + stack.length + children.length > MAX_PUBLIC_GAMING_PAYLOAD_NODES) {
+      return true;
+    }
+    for (const child of children) {
+      stack.push({ value: child, depth: current.depth + 1 });
+    }
+  }
+
+  return false;
+}
+
 function getStringField(payload: unknown, key: string): string | undefined {
   if (!isRecord(payload)) {
     return undefined;
@@ -122,6 +151,12 @@ export function validatePublicGamingQueryRequest(
     return {
       code: "BAD_REQUEST",
       message: "Gaming query requests require a payload object."
+    };
+  }
+  if (publicGamingRequestExceedsStructuralLimits(body)) {
+    return {
+      code: "BAD_REQUEST",
+      message: "Gaming query request exceeds the supported structural limits."
     };
   }
 

--- a/src/services/gamingModes.ts
+++ b/src/services/gamingModes.ts
@@ -78,6 +78,11 @@ export type ValidatedGamingRequest = {
   hrcEnabled: boolean;
 };
 
+export type PublicGamingRequestValidationError = {
+  code: "GPT_ACTION_REQUIRED" | "BAD_REQUEST" | "GAMEPLAY_MODE_REQUIRED" | "PROMPT_REQUIRED";
+  message: string;
+};
+
 function getStringField(payload: unknown, key: string): string | undefined {
   if (!isRecord(payload)) {
     return undefined;
@@ -98,6 +103,46 @@ export function resolveGamingMode(payload: unknown): GamingMode | null {
   }
 
   return null;
+}
+
+export function validatePublicGamingQueryRequest(
+  body: unknown,
+  requestedAction: string | null
+): PublicGamingRequestValidationError | null {
+  if (!requestedAction) {
+    return {
+      code: "GPT_ACTION_REQUIRED",
+      message: "Gaming requests require action 'query'."
+    };
+  }
+  if (requestedAction !== "query") {
+    return null;
+  }
+  if (!isRecord(body) || !isRecord(body.payload)) {
+    return {
+      code: "BAD_REQUEST",
+      message: "Gaming query requests require a payload object."
+    };
+  }
+
+  const payloadHasMode = Object.prototype.hasOwnProperty.call(body.payload, "mode");
+  const mode = payloadHasMode ? resolveGamingMode(body.payload) : resolveGamingMode(body);
+  if (!mode) {
+    return {
+      code: "GAMEPLAY_MODE_REQUIRED",
+      message: "Gameplay requests require explicit mode 'guide', 'build', or 'meta'."
+    };
+  }
+
+  const promptKeys = ["prompt", "message", "text", "content", "query"];
+  const payloadHasPromptAlias = promptKeys.some((key) => Object.prototype.hasOwnProperty.call(body.payload, key));
+  const prompt = payloadHasPromptAlias ? extractTextPrompt(body.payload) : extractTextPrompt(body);
+  return prompt
+    ? null
+    : {
+        code: "PROMPT_REQUIRED",
+        message: "query requires a non-empty prompt."
+      };
 }
 
 export function formatGamingSuccess(params: {

--- a/src/services/gamingPipeline.ts
+++ b/src/services/gamingPipeline.ts
@@ -18,6 +18,9 @@ import { generateMockResponse } from "@services/openai.js";
 import { tryExtractExactLiteralPromptShortcut } from "@services/exactLiteralPromptShortcut.js";
 import {
   formatGamingSuccess,
+  type GamingDiscoveryFailureReason,
+  type GamingDiscoveryReason,
+  type GamingFallbackReason,
   type GamingMode,
   type GamingSuccessEnvelope,
   type ValidatedGamingRequest
@@ -26,6 +29,7 @@ import { buildGamingTrinityPrompt } from "@services/gamingPromptBuilder.js";
 import {
   buildGamingRagContext,
   collectGamingGuideUrls,
+  isGamingFreshnessSensitive,
   isCitableGamingWebSource
 } from "@services/gamingWebContext.js";
 
@@ -120,7 +124,7 @@ function isGamingProviderCompletionIncompleteError(error: unknown): boolean {
   return readErrorString(error, "code") === "OPENAI_COMPLETION_INCOMPLETE";
 }
 
-function classifyGamingProviderFallbackReason(timeoutPhase?: string): string {
+function classifyGamingProviderFallbackReason(timeoutPhase?: string): GamingFallbackReason {
   const normalizedPhase = timeoutPhase?.toLowerCase();
   if (
     normalizedPhase === "intake" ||
@@ -264,7 +268,9 @@ function formatGameplaySuccessWithLogs(params: {
   requestStartedAt: number;
   retrievedSourceCount?: number;
   omittedSourceCount?: number;
-  fallbackReason?: string;
+  fallbackReason?: GamingFallbackReason;
+  discoveryReason?: GamingDiscoveryReason;
+  discoveryFailureReason?: GamingDiscoveryFailureReason;
 }): GamingSuccessEnvelope {
   const postprocessStartedAt = Date.now();
   const citableSourceCount = params.sources.filter(isCitableGamingWebSource).length;
@@ -287,7 +293,12 @@ function formatGameplaySuccessWithLogs(params: {
     mode: params.mode,
     data: {
       response,
-      sources: params.sources
+      sources: params.sources,
+      ...(params.fallbackReason ? { fallbackReason: params.fallbackReason } : {}),
+      ...(params.discoveryReason ? { discoveryReason: params.discoveryReason } : {}),
+      ...(params.discoveryFailureReason
+        ? { discoveryFailureReason: params.discoveryFailureReason }
+        : {})
     }
   });
 
@@ -481,6 +492,7 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
   }
 
   const guideUrls = collectGamingGuideUrls(params);
+  const freshnessSensitive = isGamingFreshnessSensitive(params);
   const retrievalStartedAt = Date.now();
   let webContext = "";
   let sources: GamingWebSource[] = [];
@@ -490,6 +502,10 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
   let publicSourceCount = 0;
   let omittedSourceCount = 0;
   let retrievedGame: string | undefined;
+  let fallbackReason: GamingFallbackReason | undefined;
+  let discoveryReason: GamingDiscoveryReason | undefined;
+  let discoveryFailureReason: GamingDiscoveryFailureReason | undefined;
+  let currentEvidenceAvailable = false;
   try {
     const webContextResult = await buildGamingRagContext(params, baseLogContext, getRequestAbortSignal());
     webContext = webContextResult.context;
@@ -500,6 +516,10 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
     publicSourceCount = webContextResult.publicSourceCount;
     omittedSourceCount = webContextResult.omittedSourceCount;
     retrievedGame = webContextResult.detectedGame;
+    fallbackReason = webContextResult.fallbackReason;
+    discoveryReason = webContextResult.discoveryReason;
+    discoveryFailureReason = webContextResult.discoveryFailureReason;
+    currentEvidenceAvailable = webContextResult.currentEvidenceAvailable;
     logGamingIntakeStep(baseLogContext, "retrieval", retrievalStartedAt, {
       ok: true,
       retrievalEnabled: webContextResult.retrievalEnabled,
@@ -582,13 +602,17 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
         requestStartedAt,
         retrievedSourceCount,
         omittedSourceCount,
-        fallbackReason: webContextResult.fallbackReason
+        fallbackReason: webContextResult.fallbackReason,
+        discoveryReason,
+        discoveryFailureReason
       });
     }
   } catch (error) {
     const errorCode = readErrorString(error, "code");
     const timeoutPhase = readTimeoutPhase(error) ?? (errorCode === "INTAKE_RETRIEVAL_TIMEOUT" ? "retrieval" : undefined);
-    const fallbackReason = errorCode ?? (timeoutPhase ? classifyGamingProviderFallbackReason(timeoutPhase) : "INTAKE_RETRIEVAL_FAILED");
+    fallbackReason = timeoutPhase
+      ? classifyGamingProviderFallbackReason(timeoutPhase)
+      : "INTAKE_RETRIEVAL_FAILED";
     logger.warn("gaming.retrieval.failure", {
       ...baseLogContext,
       elapsedMs: Date.now() - retrievalStartedAt,
@@ -619,6 +643,32 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
     throw createGamingGameRequiredError(resolvedParams.mode);
   }
 
+  if (freshnessSensitive && !currentEvidenceAvailable) {
+    const currentEvidenceFallbackReason: GamingFallbackReason = "CURRENT_EVIDENCE_UNAVAILABLE";
+    logger.warn("gaming.fallback.used", {
+      ...baseLogContext,
+      fallbackReason: currentEvidenceFallbackReason,
+      ...(discoveryReason ? { discoveryReason } : {}),
+      ...(discoveryFailureReason ? { discoveryFailureReason } : {})
+    });
+    return formatGameplaySuccessWithLogs({
+      mode: params.mode,
+      response: buildGamingProviderFallbackResponse({
+        input: resolvedParams,
+        sources,
+        fallbackReason: currentEvidenceFallbackReason
+      }),
+      sources,
+      logContext: baseLogContext,
+      requestStartedAt,
+      retrievedSourceCount,
+      omittedSourceCount,
+      fallbackReason: currentEvidenceFallbackReason,
+      discoveryReason,
+      discoveryFailureReason
+    });
+  }
+
   const { client } = getOpenAIClientOrAdapter();
 
   if (!client) {
@@ -635,7 +685,10 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
       logContext: baseLogContext,
       requestStartedAt,
       retrievedSourceCount,
-      omittedSourceCount
+      omittedSourceCount,
+      fallbackReason: "GAMING_PROVIDER_UNAVAILABLE",
+      discoveryReason,
+      discoveryFailureReason
     });
   }
 
@@ -758,7 +811,9 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
         requestStartedAt,
         retrievedSourceCount,
         omittedSourceCount,
-        fallbackReason
+        fallbackReason,
+        discoveryReason,
+        discoveryFailureReason
       });
     }
 
@@ -806,8 +861,14 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
         requestStartedAt,
         retrievedSourceCount,
         omittedSourceCount,
-        fallbackReason
+        fallbackReason,
+        discoveryReason,
+        discoveryFailureReason
       });
+    }
+
+    if (readErrorString(error, "code") === "TRINITY_OUTPUT_INTEGRITY_FAILED") {
+      throw error;
     }
 
     logGamingIntakeStep(baseLogContext, "provider", providerStartedAt, {
@@ -826,7 +887,7 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
       errorName: error instanceof Error ? error.name : typeof error,
       errorCode: readErrorString(error, "code")
     });
-    const fallbackReason = readErrorString(error, "code") || "GAMING_PROVIDER_ERROR";
+    const fallbackReason: GamingFallbackReason = "GAMING_PROVIDER_ERROR";
     logger.warn("gaming.fallback.used", {
       ...baseLogContext,
       provider: "trinity",
@@ -847,7 +908,9 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
       requestStartedAt,
       retrievedSourceCount,
       omittedSourceCount,
-      fallbackReason
+      fallbackReason,
+      discoveryReason,
+      discoveryFailureReason
     });
   }
 
@@ -885,6 +948,9 @@ export async function runGameplayPipeline(params: GamingPipelineInput): Promise<
     logContext: baseLogContext,
     requestStartedAt,
     retrievedSourceCount,
-    omittedSourceCount
+    omittedSourceCount,
+    fallbackReason,
+    discoveryReason,
+    discoveryFailureReason
   });
 }

--- a/src/services/gamingSourceDiscovery.ts
+++ b/src/services/gamingSourceDiscovery.ts
@@ -17,7 +17,10 @@ import {
   getGamingDiscoverySearchResultLimit,
   getGamingDiscoveryTimeoutMs
 } from "@services/gamingConfig.js";
-import type { GamingMode } from "@services/gamingModes.js";
+import type {
+  GamingDiscoveryFailureReason as GamingDiscoveryFailureReasonContract,
+  GamingMode
+} from "@services/gamingModes.js";
 
 export type GamingSearchFreshnessPreference = "current" | "stable";
 
@@ -47,16 +50,7 @@ export interface GamingSearchProvider {
   search(input: GamingSearchRequest): Promise<GamingSearchResult[]>;
 }
 
-export type GamingDiscoveryFailureReason =
-  | "DISCOVERY_DISABLED"
-  | "DISCOVERY_NOT_NEEDED"
-  | "DISCOVERY_NO_RESULTS"
-  | "DISCOVERY_PROVIDER_TIMEOUT"
-  | "DISCOVERY_PROVIDER_ERROR"
-  | "DISCOVERY_ALL_CANDIDATES_REJECTED"
-  | "DISCOVERY_FETCH_FAILED"
-  | "DISCOVERY_BUDGET_EXHAUSTED"
-  | "DISCOVERY_LOW_QUALITY";
+export type GamingDiscoveryFailureReason = GamingDiscoveryFailureReasonContract;
 
 export interface GamingDiscoveredCandidate extends GamingSearchResult {
   score: number;
@@ -692,7 +686,7 @@ export async function discoverGamingSources(input: GamingDiscoveryInput): Promis
         searchProvider: providerId ?? getGamingDiscoveryProvider() ?? "unsupported"
       });
     }
-    return emptyDiscoveryResult(startedAt, "DISCOVERY_DISABLED", {
+    return emptyDiscoveryResult(startedAt, "DISCOVERY_PROVIDER_UNCONFIGURED", {
       ...(providerId ? { searchProvider: providerId } : {})
     });
   }

--- a/src/services/gamingVersion.ts
+++ b/src/services/gamingVersion.ts
@@ -37,7 +37,7 @@ function addPatternMatches(
     let cursor = match.index + match[0].length;
     while (cursor < prompt.length) {
       const continuation = new RegExp(
-        String.raw`^\s*(?:,|and\b|or\b|vs\.?(?=\s)|versus\b|to\b)\s*(?:["'“‘]\s*)?(?:v(?:ersion)?\.?\s*)?${VERSION_TOKEN_SOURCE}${VERSION_END_SOURCE}`,
+        String.raw`^\s*(?:,|and\b|or\b|vs\.?(?=\s)|versus\b|to\b)\s*(?:["'“‘]\s*)?(?:v(?:ersion)?\.?\s*)?${VERSION_TOKEN_SOURCE}${VERSION_END_SOURCE}${NON_VERSION_GAME_SUFFIX_SOURCE}`,
         "i"
       ).exec(prompt.slice(cursor));
       const continuedVersion = continuation?.[1];
@@ -73,7 +73,10 @@ export function extractExplicitGamingVersions(input: GamingVersionTextInput): st
   );
   addPatternMatches(
     prompt,
-    new RegExp(String.raw`\bwhat\s+changed\b[^.!?\n]{0,32}\bin\s+${VERSION_TOKEN_SOURCE}${VERSION_END_SOURCE}`, "gi"),
+    new RegExp(
+      String.raw`\bwhat\s+changed\b[^.!?\n]{0,32}\bin\s+${VERSION_TOKEN_SOURCE}${VERSION_END_SOURCE}${NON_VERSION_GAME_SUFFIX_SOURCE}`,
+      "gi"
+    ),
     matches
   );
   addPatternMatches(

--- a/src/services/gamingVersion.ts
+++ b/src/services/gamingVersion.ts
@@ -1,0 +1,105 @@
+export type GamingVersionTextInput = {
+  prompt: string;
+  game?: string;
+};
+
+type IndexedVersion = {
+  index: number;
+  version: string;
+};
+
+const VERSION_TOKEN_SOURCE = String.raw`(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)`;
+const VERSION_END_SOURCE = String.raw`(?!\d|[.\/-]\d)`;
+const NON_VERSION_GAME_SUFFIX_SOURCE = String.raw`(?!\s*(?:%|percent\b|milliseconds?\b|ms\b|seconds?\b|secs?\b|minutes?\b|mins?\b|hours?\b|hrs?\b|days?\b|fps\b|hz\b|pixels?\b|resolution\b|kilograms?\b|kgs?\b|grams?\b|pounds?\b|lbs?\b|ounces?\b|oz\b|meters?\b|metres?\b|centimeters?\b|centimetres?\b|miles?\b|dollars?\b|usd\b|euros?\b|gbp\b|items?\b|copies?\b|units?\b|damage\b|health\b|points?\b|stats?\b|multiplier\b|k\s*\/\s*d\b|am\b|pm\b|[$€£¥]|release(?:d)?\b|date\b))`;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function addPatternMatches(
+  prompt: string,
+  pattern: RegExp,
+  matches: IndexedVersion[],
+  collectContinuations = false
+): void {
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(prompt)) !== null) {
+    const version = match[1];
+    if (!version) {
+      continue;
+    }
+    const versionOffset = match[0].lastIndexOf(version);
+    matches.push({ index: match.index + Math.max(0, versionOffset), version });
+
+    if (!collectContinuations) {
+      continue;
+    }
+    let cursor = match.index + match[0].length;
+    while (cursor < prompt.length) {
+      const continuation = new RegExp(
+        String.raw`^\s*(?:,|and\b|or\b|vs\.?(?=\s)|versus\b|to\b)\s*(?:["'“‘]\s*)?(?:v(?:ersion)?\.?\s*)?${VERSION_TOKEN_SOURCE}${VERSION_END_SOURCE}`,
+        "i"
+      ).exec(prompt.slice(cursor));
+      const continuedVersion = continuation?.[1];
+      if (!continuation || !continuedVersion) {
+        break;
+      }
+      matches.push({
+        index: cursor + continuation[0].lastIndexOf(continuedVersion),
+        version: continuedVersion
+      });
+      cursor += continuation[0].length;
+    }
+  }
+}
+
+/** Extract explicit semantic game versions in prompt order without treating arbitrary decimals as versions. */
+export function extractExplicitGamingVersions(input: GamingVersionTextInput): string[] {
+  const prompt = input.prompt;
+  const matches: IndexedVersion[] = [];
+  addPatternMatches(
+    prompt,
+    new RegExp(
+      String.raw`\b(?:patch|version|update)s?\s*(?:[:#=-]\s*)?(?:["'“‘]\s*)?(?:v(?:ersion)?\.?\s*)?${VERSION_TOKEN_SOURCE}${VERSION_END_SOURCE}`,
+      "gi"
+    ),
+    matches,
+    true
+  );
+  addPatternMatches(
+    prompt,
+    new RegExp(String.raw`\bv(?:ersion)?\.?\s*${VERSION_TOKEN_SOURCE}${VERSION_END_SOURCE}`, "gi"),
+    matches
+  );
+  addPatternMatches(
+    prompt,
+    new RegExp(String.raw`\bwhat\s+changed\b[^.!?\n]{0,32}\bin\s+${VERSION_TOKEN_SOURCE}${VERSION_END_SOURCE}`, "gi"),
+    matches
+  );
+  addPatternMatches(
+    prompt,
+    new RegExp(String.raw`\(\s*(?:v(?:ersion)?\.?\s*)?${VERSION_TOKEN_SOURCE}${VERSION_END_SOURCE}\s*\)`, "gi"),
+    matches
+  );
+
+  const game = input.game?.replace(/\s+/g, " ").trim();
+  if (game) {
+    addPatternMatches(
+      prompt,
+      new RegExp(
+        String.raw`\b${escapeRegExp(game)}\s+(?:(?:version|patch)\s+|v(?:ersion)?\.?\s*)?${VERSION_TOKEN_SOURCE}${VERSION_END_SOURCE}${NON_VERSION_GAME_SUFFIX_SOURCE}`,
+        "gi"
+      ),
+      matches,
+      true
+    );
+  }
+
+  matches.sort((left, right) => left.index - right.index);
+  return Array.from(new Set(matches.map((match) => match.version)));
+}
+
+export function textContainsExactGamingVersion(text: string, version: string): boolean {
+  const escapedVersion = escapeRegExp(version);
+  return new RegExp(`(?:^|[^0-9.])${escapedVersion}(?![0-9]|\\.[0-9])`, "i").test(text);
+}

--- a/src/services/gamingWebContext.ts
+++ b/src/services/gamingWebContext.ts
@@ -24,8 +24,7 @@ import {
 import {
   clearGamingDiscoveryCache,
   discoverGamingSources,
-  type GamingDiscoveredCandidate,
-  type GamingDiscoveryFailureReason
+  type GamingDiscoveredCandidate
 } from "@services/gamingSourceDiscovery.js";
 import {
   canonicalizeGamingGameName,
@@ -42,7 +41,14 @@ import {
   type GamingBuildResourceResult,
   type GamingResourceType
 } from "@services/gamingBuildResources.js";
-import type { GamingMode, GamingSuccessEnvelope, ValidatedGamingRequest } from "@services/gamingModes.js";
+import type {
+  GamingDiscoveryFailureReason,
+  GamingDiscoveryReason,
+  GamingFallbackReason,
+  GamingMode,
+  GamingSuccessEnvelope,
+  ValidatedGamingRequest
+} from "@services/gamingModes.js";
 
 export type GamingWebSource = GamingSuccessEnvelope["data"]["sources"][number];
 
@@ -65,10 +71,11 @@ export type GamingRagContext = GamingWebContext & {
   detectedGame?: string;
   gameDetectionConfidence: number;
   gameDetectionSource: GamingGameDetectionSource;
-  fallbackReason?: string;
+  currentEvidenceAvailable: boolean;
+  fallbackReason?: GamingFallbackReason;
   discoveryEnabled: boolean;
   discoveryTriggered: boolean;
-  discoveryReason: string;
+  discoveryReason: GamingDiscoveryReason;
   searchProvider?: string;
   searchQueryHash?: string;
   searchResultCount: number;
@@ -177,6 +184,7 @@ const LOW_QUALITY_DOMAINS = [
 ];
 
 const MAX_DOCUMENT_CACHE_ENTRIES = 100;
+const MAX_PUBLIC_GAMING_SOURCES = 8;
 const MAX_PUBLIC_SNIPPET_CHARS = 600;
 const LIMITED_ARTICLE_TEXT_SNIPPET = "Relevant source retrieved, but readable article text was limited.";
 const LIMITED_ARTICLE_CONTEXT_NOTE = "[No readable article evidence was extracted from this source.]";
@@ -1061,8 +1069,19 @@ function candidateWithFetchedGameCorroboration(
   };
 }
 
-function isPatchSensitive(input: GamingRagInput): boolean {
-  return input.mode === "meta" || /\b(?:patch|hotfix|version|season|latest|current|right\s+now|meta|buff|nerf|balance|viable)\b/i.test(input.prompt);
+export function isGamingFreshnessSensitive(input: GamingRagInput): boolean {
+  return input.mode === "meta"
+    || /\b(?:patch|hotfix|version|season|latest|current|right\s+now|meta|buff|nerf|balance|viable)\b|\b\d+\.\d+(?:\.\d+)?\b/i.test(input.prompt);
+}
+
+function extractRequestedSemanticVersion(input: GamingRagInput): string | undefined {
+  return input.prompt.match(/\b(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\b/)?.[1];
+}
+
+function sourceMatchesRequestedVersion(chunk: GamingRankedChunk, requestedVersion: string): boolean {
+  const escapedVersion = requestedVersion.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const versionPattern = new RegExp(`(?:^|[^0-9.])${escapedVersion}(?![0-9.])`, "i");
+  return versionPattern.test(chunk.text);
 }
 
 function tokenize(value: string): string[] {
@@ -1094,7 +1113,7 @@ function buildRetrievalQuery(input: GamingRagInput, game: string | undefined, te
   return [
     game,
     input.mode,
-    isPatchSensitive(input) ? "latest patch notes current meta" : "",
+    isGamingFreshnessSensitive(input) ? "latest patch notes current meta" : "",
     ...terms
   ].filter(Boolean).join(" ").replace(/\s+/g, " ").trim();
 }
@@ -2248,7 +2267,7 @@ function discoveryTriggerReason(params: {
   suppliedSourceCount: number;
   initialDocumentCount: number;
   patchSensitive: boolean;
-}): string {
+}): GamingDiscoveryReason {
   if (params.suppliedSourceCount > 0 && params.initialDocumentCount === 0) {
     return "DISCOVERY_SUPPLIED_SOURCE_FAILED";
   }
@@ -2270,7 +2289,8 @@ function discoveryTriggerReason(params: {
 function hasSufficientGamingEvidence(
   chunks: readonly GamingRankedChunk[],
   sources: readonly GamingWebSource[],
-  patchSensitive: boolean
+  patchSensitive: boolean,
+  requestedVersion?: string
 ): boolean {
   const citableUrls = new Set(sources.filter(isCitableGamingWebSource).map((source) => source.url));
   const minimumQuality = getGamingDiscoveryMinEvidenceQuality();
@@ -2282,15 +2302,15 @@ function hasSufficientGamingEvidence(
       return true;
     }
     const sourceDate = chunk.candidate.updatedAt ?? chunk.candidate.publishedAt;
-    const recentDatedSource = sourceDate
-      ? Date.now() - Date.parse(sourceDate) <= 540 * 24 * 60 * 60_000
-      : false;
-    const suppliedFreshnessSignal = chunk.candidate.supplied
-      && /\b(?:updated?|published|latest|current|hotfix|version|\d{4}-\d{2}-\d{2})\b/i.test(chunk.text);
-    return chunk.candidate.sourceType === "official"
-      || chunk.candidate.sourceType === "patch_notes"
-      || recentDatedSource
-      || suppliedFreshnessSignal;
+    const parsedSourceDate = sourceDate ? Date.parse(sourceDate) : Number.NaN;
+    const sourceAgeMs = Date.now() - parsedSourceDate;
+    const recentDatedSource = Number.isFinite(parsedSourceDate)
+      && sourceAgeMs >= 0
+      && sourceAgeMs <= 540 * 24 * 60 * 60_000;
+    if (requestedVersion) {
+      return sourceMatchesRequestedVersion(chunk, requestedVersion);
+    }
+    return recentDatedSource;
   });
 }
 
@@ -2302,7 +2322,7 @@ function emptyRagContext(params: {
   gameDetection: GamingGameDetection;
   sources?: GamingWebSource[];
   rankingStartedAt?: number;
-  fallbackReason?: string;
+  fallbackReason?: GamingFallbackReason;
 }): GamingRagContext {
   const sources = params.sources ?? [];
   const clear = buildClearChecks({
@@ -2327,6 +2347,7 @@ function emptyRagContext(params: {
     ...(params.gameDetection.game ? { detectedGame: params.gameDetection.game } : {}),
     gameDetectionConfidence: params.gameDetection.confidence,
     gameDetectionSource: params.gameDetection.source,
+    currentEvidenceAvailable: false,
     discoveryEnabled: false,
     discoveryTriggered: false,
     discoveryReason: "DISCOVERY_DISABLED",
@@ -2362,7 +2383,8 @@ export async function buildGamingRagContext(
   const initialGameDetection = detectGameFromRagInput(input);
   const game = initialGameDetection.game;
   const terms = extractTopicTerms(input, game);
-  const patchSensitive = isPatchSensitive(input);
+  const patchSensitive = isGamingFreshnessSensitive(input);
+  const requestedVersion = extractRequestedSemanticVersion(input);
   const retrievalQuery = buildRetrievalQuery(input, game, terms);
   const retrievalEnabled = getGamingRagEnabled();
   const discoveryEnabled = retrievalEnabled && getGamingDiscoveryEnabled();
@@ -2470,7 +2492,12 @@ export async function buildGamingRagContext(
     input,
     suppliedConflictingDocumentUrls
   );
-  const suppliedEvidenceSufficient = hasSufficientGamingEvidence(suppliedChunks, suppliedSources, patchSensitive);
+  const suppliedEvidenceSufficient = hasSufficientGamingEvidence(
+    suppliedChunks,
+    suppliedSources,
+    patchSensitive,
+    requestedVersion
+  );
   if (!suppliedEvidenceSufficient && curatedCandidates.length > 0) {
     const curatedFetchResults = await fetchCandidateBatch(curatedCandidates);
     candidates = [...candidates, ...curatedCandidates];
@@ -2504,10 +2531,15 @@ export async function buildGamingRagContext(
     input,
     initialConflictingDocumentUrls
   );
-  const initialEvidenceSufficient = hasSufficientGamingEvidence(initialChunks, initialSources, patchSensitive);
+  const initialEvidenceSufficient = hasSufficientGamingEvidence(
+    initialChunks,
+    initialSources,
+    patchSensitive,
+    requestedVersion
+  );
 
   let discoveryTriggered = false;
-  let discoveryReason = discoveryEnabled ? "DISCOVERY_NOT_NEEDED" : "DISCOVERY_DISABLED";
+  let discoveryReason: GamingDiscoveryReason = discoveryEnabled ? "DISCOVERY_NOT_NEEDED" : "DISCOVERY_DISABLED";
   let searchProvider: string | undefined;
   let searchQueryHash: string | undefined;
   let searchResultCount = 0;
@@ -2648,7 +2680,7 @@ export async function buildGamingRagContext(
   const effectiveRetrievalQuery = buildRetrievalQuery(effectiveInput, effectiveGameDetection.game, effectiveTerms);
   const rankingStartedAt = Date.now();
   const chunks = rankChunks(rankableDocuments, effectiveTerms, effectiveInput, patchSensitive);
-  const sources = buildPublicSourcesFromChunks(
+  const rankedSources = buildPublicSourcesFromChunks(
     chunks,
     documents,
     effectiveTerms,
@@ -2656,27 +2688,43 @@ export async function buildGamingRagContext(
     conflictingDocumentUrls,
     discoveryTriggered
   );
-  const context = buildRagContext(chunks, sources, effectiveRetrievalQuery, maxContextChars);
+  const publicSourceLimit = Math.min(getGamingRagMaxSources(), MAX_PUBLIC_GAMING_SOURCES);
+  const publicErrorSources = errorSources
+    .filter((source) => !discoveredCandidateUrls.has(source.url))
+    .filter((errorSource) =>
+      !rankedSources.some((source) => source.url === errorSource.url)
+    );
+  const reservedErrorSourceCount = publicErrorSources.length > 0
+    ? Math.min(publicErrorSources.length, publicSourceLimit, rankedSources.length > 0 ? 1 : publicSourceLimit)
+    : 0;
+  const retainedSources = rankedSources.slice(0, Math.max(0, publicSourceLimit - reservedErrorSourceCount));
+  const returnedSources = [
+    ...retainedSources,
+    ...publicErrorSources.slice(0, reservedErrorSourceCount)
+  ];
+  const context = buildRagContext(chunks, retainedSources, effectiveRetrievalQuery, maxContextChars);
   const rankingElapsedMs = Date.now() - rankingStartedAt;
-  const sourceDomains = sourceDomainsFromSources(sources);
+  const sourceDomains = sourceDomainsFromSources(returnedSources);
   const cacheHit = documents.some((document) => document.cacheHit);
   const fallbackReason = documents.length === 0 && timedOut ? "INTAKE_RETRIEVAL_TIMEOUT" : undefined;
   const retrievedSourceCount = documents.length;
-  const publicSourceCount = sources.length;
-  const acceptedSourceCount = sources.filter((source) =>
+  const acceptedSourceCount = retainedSources.filter((source) =>
     discoveredCandidateUrls.has(source.url) && isCitableGamingWebSource(source)
   ).length;
   if (discoveryTriggered && fetchedCandidateCount > 0 && acceptedSourceCount === 0 && !discoveryFailureReason) {
     discoveryFailureReason = "DISCOVERY_LOW_QUALITY";
   }
-  const publicErrorSources = errorSources
-    .filter((source) => !discoveredCandidateUrls.has(source.url))
-    .slice(0, getGamingRagMaxSources());
-  const returnedPublicSourceCount = sources.length > 0 ? publicSourceCount : publicErrorSources.length;
-  const omittedSourceCount = Math.max(0, chunks.length - publicSourceCount);
+  const returnedPublicSourceCount = returnedSources.length;
+  const omittedSourceCount = Math.max(0, chunks.length - retainedSources.length);
+  const currentEvidenceAvailable = hasSufficientGamingEvidence(
+    chunks,
+    retainedSources,
+    true,
+    requestedVersion
+  );
   const clear = buildClearChecks({
     retrievalEnabled,
-    sourceCount: sources.length,
+    sourceCount: retainedSources.length,
     context,
     fallbackReason
   });
@@ -2684,7 +2732,7 @@ export async function buildGamingRagContext(
   if (logContext) {
     for (const document of documents) {
       const selectedChunk = chunks.find((chunk) => chunk.candidate.url === document.candidate.url);
-      const publicSource = sources.find((source) => source.url === document.candidate.url);
+      const publicSource = retainedSources.find((source) => source.url === document.candidate.url);
       logger.info("gaming.retrieval.source.selection", {
         ...logContext,
         ...(effectiveGameDetection.game ? { game: effectiveGameDetection.game, detectedGame: effectiveGameDetection.game } : {}),
@@ -2745,7 +2793,7 @@ export async function buildGamingRagContext(
       candidateRankingElapsedMs,
       ...(discoveryFailureReason ? { discoveryFailureReason } : {}),
       retrievalQueryTermCount: effectiveTerms.length,
-      sourceCount: sources.length,
+      sourceCount: returnedSources.length,
       retrievedSourceCount,
       publicSourceCount: returnedPublicSourceCount,
       omittedSourceCount,
@@ -2753,7 +2801,7 @@ export async function buildGamingRagContext(
       cacheHit,
       retrievalElapsedMs: Date.now() - retrievalStartedAt,
       rankingElapsedMs,
-      usableSourceCount: sources.filter(isCitableGamingWebSource).length,
+      usableSourceCount: retainedSources.filter(isCitableGamingWebSource).length,
       failedSourceCount: errorSources.length,
       contextChars: context.length,
       chunkCount: chunks.length,
@@ -2768,10 +2816,10 @@ export async function buildGamingRagContext(
 
   return {
     context,
-    sources: sources.length > 0 ? sources : publicErrorSources,
+    sources: returnedSources,
     retrievedSourceCount,
     publicSourceCount: returnedPublicSourceCount,
-    omittedSourceCount: sources.length > 0 ? omittedSourceCount : 0,
+    omittedSourceCount: retainedSources.length > 0 ? omittedSourceCount : 0,
     retrievalEnabled,
     retrievalReason,
     retrievalQuery: effectiveRetrievalQuery,
@@ -2782,6 +2830,7 @@ export async function buildGamingRagContext(
     ...(effectiveGameDetection.game ? { detectedGame: effectiveGameDetection.game } : {}),
     gameDetectionConfidence: effectiveGameDetection.confidence,
     gameDetectionSource: effectiveGameDetection.source,
+    currentEvidenceAvailable,
     discoveryEnabled,
     discoveryTriggered,
     discoveryReason,

--- a/src/services/gamingWebContext.ts
+++ b/src/services/gamingWebContext.ts
@@ -33,6 +33,10 @@ import {
   type GamingGameDetectionSource
 } from "@services/gamingGameDetection.js";
 import {
+  extractExplicitGamingVersions,
+  textContainsExactGamingVersion
+} from "@services/gamingVersion.js";
+import {
   GAMING_BUILD_RESOURCE_HARD_LIMITS,
   classifyGamingResource,
   clearGamingBuildResourceCache,
@@ -602,6 +606,11 @@ function safeGamingSourceError(error: unknown): string {
   return "Source could not be retrieved.";
 }
 
+function sourceUrlForGamingError(sourceUrl: string, error: unknown): string {
+  const message = resolveErrorMessage(error, "").toLowerCase();
+  return /private\/internal|containing credentials/.test(message) ? "invalid-source" : sourceUrl;
+}
+
 function isStructuredGamingResourceType(type: GamingResourceType): boolean {
   return type === "build_planner"
     || type === "loadout"
@@ -782,7 +791,7 @@ export async function buildGamingWebContext(
             fetchTimeoutMs
           });
         }
-        return { url: sourceUrl, error: safeGamingSourceError(error) };
+        return { url: sourceUrlForGamingError(sourceUrl, error), error: safeGamingSourceError(error) };
       }
     })
   );
@@ -987,6 +996,45 @@ function detectReliableDocumentGame(document: GamingFetchedDocument): string | u
   return undefined;
 }
 
+function detectGameFromDocumentIntro(document: GamingFetchedDocument): string | undefined {
+  const normalizedBody = document.text.replace(/\s+/g, " ").trim();
+  const sentenceEnd = normalizedBody.search(/[.!?](?:\s|$)/);
+  const intro = normalizedBody.slice(0, Math.min(sentenceEnd >= 0 ? sentenceEnd + 1 : normalizedBody.length, 320));
+  if (!/\b(?:guide|build|loadout|meta|walkthrough|wiki|tips?|tier\s+list|patch\s+notes|progression|route|boss)\b/i.test(intro)) {
+    return undefined;
+  }
+  const detection = detectGamingGame({ pageTitle: intro });
+  if (!detection.game || detection.confidence < 0.8) {
+    return undefined;
+  }
+  const detectedGame = canonicalizeGamingGameName(detection.game);
+  const detectedGameWords = detectedGame.match(/[a-z0-9+]+/gi) ?? [];
+  return detection.confidence >= 0.88 || detectedGameWords.length >= 2 ? detectedGame : undefined;
+}
+
+function collectConflictingDocumentUrls(
+  documents: readonly GamingFetchedDocument[],
+  requestedGame: string | undefined
+): Set<string> {
+  if (!requestedGame) {
+    return new Set();
+  }
+  const normalizedRequestedGame = canonicalizeGamingGameName(requestedGame).toLowerCase();
+  return new Set(documents
+    .filter((document) => {
+      const reliableGame = detectReliableDocumentGame(document);
+      if (reliableGame) {
+        return canonicalizeGamingGameName(reliableGame).toLowerCase() !== normalizedRequestedGame;
+      }
+      if (fetchedDocumentCorroboratesGame(document.text, document.extraction, requestedGame)) {
+        return false;
+      }
+      const introGame = detectGameFromDocumentIntro(document);
+      return Boolean(introGame && canonicalizeGamingGameName(introGame).toLowerCase() !== normalizedRequestedGame);
+    })
+    .map((document) => document.candidate.url));
+}
+
 function detectGameFromFetchedDocuments(
   initialDetection: GamingGameDetection,
   documents: GamingFetchedDocument[]
@@ -1072,36 +1120,7 @@ function candidateWithFetchedGameCorroboration(
 export function isGamingFreshnessSensitive(input: GamingRagInput): boolean {
   return input.mode === "meta"
     || /\b(?:patch|hotfix|version|season|latest|current|right\s+now|meta|buff|nerf|balance|viable)\b/i.test(input.prompt)
-    || Boolean(extractRequestedSemanticVersion(input));
-}
-
-function extractRequestedSemanticVersion(input: GamingRagInput): string | undefined {
-  const contextualMatch = input.prompt.match(/\b(?:patch|version|update)\s+(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\b/i)
-    ?? input.prompt.match(/\bv\.?\s*(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\b/i)
-    ?? input.prompt.match(/\bwhat\s+changed\b[^.!?\n]{0,32}\bin\s+(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\b/i)
-    ?? input.prompt.match(/\(\s*(?:v(?:ersion)?\.?\s*)?(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\s*\)/i)
-    ?? input.prompt.match(/\b(\d{1,3}\.\d{1,3}\.\d{1,3})\b/);
-  if (contextualMatch?.[1]) {
-    return contextualMatch[1];
-  }
-
-  const game = normalizeGameName(input);
-  if (!game) {
-    return undefined;
-  }
-
-  const escapedGame = game.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const gameVersionPattern = new RegExp(
-    `\\b${escapedGame}\\s+(?:v(?:ersion)?\\.?\\s*)?(\\d{1,3}\\.\\d{1,3}(?:\\.\\d{1,3})?)\\b(?!\\.\\d)(?!\\s*(?:%|percent\\b|minutes?\\b|mins?\\b|hours?\\b|seconds?\\b|milliseconds?\\b|ms\\b|fps\\b|hz\\b))`,
-    "i"
-  );
-  return input.prompt.match(gameVersionPattern)?.[1];
-}
-
-function sourceMatchesRequestedVersion(chunk: GamingRankedChunk, requestedVersion: string): boolean {
-  const escapedVersion = requestedVersion.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const versionPattern = new RegExp(`(?:^|[^0-9.])${escapedVersion}(?![0-9]|\\.[0-9])`, "i");
-  return versionPattern.test(chunk.text);
+    || extractExplicitGamingVersions({ prompt: input.prompt, game: normalizeGameName(input) }).length > 0;
 }
 
 function tokenize(value: string): string[] {
@@ -1278,12 +1297,13 @@ function makeDiscoveredSourceCandidate(
 }
 
 function buildSourceCandidates(input: GamingRagInput, game: string | undefined): GamingSourceCandidate[] {
-  const suppliedUrls = Array.from(new Set(
+  const suppliedUrls = Array.from(new Map(
     collectGamingGuideUrls(input)
       .filter((url): url is string => typeof url === "string")
       .map((url) => url.trim())
       .filter(isFetchableGuideUrl)
-  )).slice(0, getGamingWebContextMaxUrls());
+      .map((url) => [normalizeCacheUrl(url).toLowerCase(), url] as const)
+  ).values()).slice(0, getGamingWebContextMaxUrls());
   const suppliedCandidates = suppliedUrls.map((url) => makeSourceCandidate({
     url,
     title: safeSourceTitleFromUrl(url),
@@ -1644,7 +1664,7 @@ async function fetchGamingRagDocument(
         fetchTimeoutMs
       });
     }
-    return { url: sourceUrl, error: safeGamingSourceError(error) };
+    return { url: sourceUrlForGamingError(sourceUrl, error), error: safeGamingSourceError(error) };
   }
 }
 
@@ -2310,26 +2330,28 @@ function hasSufficientGamingEvidence(
   chunks: readonly GamingRankedChunk[],
   sources: readonly GamingWebSource[],
   patchSensitive: boolean,
-  requestedVersion?: string
+  requestedVersions: readonly string[] = []
 ): boolean {
   const citableUrls = new Set(sources.filter(isCitableGamingWebSource).map((source) => source.url));
   const minimumQuality = getGamingDiscoveryMinEvidenceQuality();
-  return chunks.some((chunk) => {
-    if (!citableUrls.has(chunk.candidate.url) || chunk.snippetQualityScore < minimumQuality) {
-      return false;
-    }
-    if (!patchSensitive) {
-      return true;
-    }
+  const eligibleChunks = chunks.filter((chunk) =>
+    citableUrls.has(chunk.candidate.url) && chunk.snippetQualityScore >= minimumQuality
+  );
+  if (!patchSensitive) {
+    return eligibleChunks.length > 0;
+  }
+  if (requestedVersions.length > 0) {
+    return requestedVersions.every((version) =>
+      eligibleChunks.some((chunk) => textContainsExactGamingVersion(chunk.text, version))
+    );
+  }
+  return eligibleChunks.some((chunk) => {
     const sourceDate = chunk.candidate.updatedAt ?? chunk.candidate.publishedAt;
     const parsedSourceDate = sourceDate ? Date.parse(sourceDate) : Number.NaN;
     const sourceAgeMs = Date.now() - parsedSourceDate;
     const recentDatedSource = Number.isFinite(parsedSourceDate)
       && sourceAgeMs >= 0
       && sourceAgeMs <= 540 * 24 * 60 * 60_000;
-    if (requestedVersion) {
-      return sourceMatchesRequestedVersion(chunk, requestedVersion);
-    }
     return recentDatedSource;
   });
 }
@@ -2404,7 +2426,7 @@ export async function buildGamingRagContext(
   const game = initialGameDetection.game;
   const terms = extractTopicTerms(input, game);
   const patchSensitive = isGamingFreshnessSensitive(input);
-  const requestedVersion = extractRequestedSemanticVersion(input);
+  const requestedVersions = extractExplicitGamingVersions({ prompt: input.prompt, game });
   const retrievalQuery = buildRetrievalQuery(input, game, terms);
   const retrievalEnabled = getGamingRagEnabled();
   const discoveryEnabled = retrievalEnabled && getGamingDiscoveryEnabled();
@@ -2490,17 +2512,7 @@ export async function buildGamingRagContext(
     errorSources = [...errorSources, { url: "invalid-source", error: "Malformed or unsupported source URL." }];
   }
 
-  const requestedGameForSuppliedEvidence = initialGameDetection.game?.toLowerCase();
-  const suppliedConflictingDocumentUrls = new Set(
-    requestedGameForSuppliedEvidence
-      ? documents
-        .filter((document) => {
-          const documentGame = detectReliableDocumentGame(document);
-          return Boolean(documentGame && documentGame.toLowerCase() !== requestedGameForSuppliedEvidence);
-        })
-        .map((document) => document.candidate.url)
-      : []
-  );
+  const suppliedConflictingDocumentUrls = collectConflictingDocumentUrls(documents, initialGameDetection.game);
   const suppliedRankableDocuments = documents.filter((document) =>
     !suppliedConflictingDocumentUrls.has(document.candidate.url)
   );
@@ -2516,7 +2528,7 @@ export async function buildGamingRagContext(
     suppliedChunks,
     suppliedSources,
     patchSensitive,
-    requestedVersion
+    requestedVersions
   );
   if (!suppliedEvidenceSufficient && curatedCandidates.length > 0) {
     const curatedFetchResults = await fetchCandidateBatch(curatedCandidates);
@@ -2531,17 +2543,7 @@ export async function buildGamingRagContext(
     ];
   }
 
-  const requestedGameForInitialEvidence = initialGameDetection.game?.toLowerCase();
-  const initialConflictingDocumentUrls = new Set(
-    requestedGameForInitialEvidence
-      ? documents
-        .filter((document) => {
-          const documentGame = detectReliableDocumentGame(document);
-          return Boolean(documentGame && documentGame.toLowerCase() !== requestedGameForInitialEvidence);
-        })
-        .map((document) => document.candidate.url)
-      : []
-  );
+  const initialConflictingDocumentUrls = collectConflictingDocumentUrls(documents, initialGameDetection.game);
   const initialRankableDocuments = documents.filter((document) => !initialConflictingDocumentUrls.has(document.candidate.url));
   const initialChunks = rankChunks(initialRankableDocuments, terms, input, patchSensitive);
   const initialSources = buildPublicSourcesFromChunks(
@@ -2555,7 +2557,7 @@ export async function buildGamingRagContext(
     initialChunks,
     initialSources,
     patchSensitive,
-    requestedVersion
+    requestedVersions
   );
 
   let discoveryTriggered = false;
@@ -2681,17 +2683,7 @@ export async function buildGamingRagContext(
 
   const timedOut = errorSources.some((source) => source.error?.toLowerCase().includes("timed out"));
   const effectiveGameDetection = detectGameFromFetchedDocuments(initialGameDetection, documents);
-  const requestedGame = initialGameDetection.game?.toLowerCase();
-  const conflictingDocumentUrls = new Set(
-    requestedGame
-      ? documents
-        .filter((document) => {
-          const documentGame = detectReliableDocumentGame(document);
-          return Boolean(documentGame && documentGame.toLowerCase() !== requestedGame);
-        })
-        .map((document) => document.candidate.url)
-      : []
-  );
+  const conflictingDocumentUrls = collectConflictingDocumentUrls(documents, initialGameDetection.game);
   const rankableDocuments = documents.filter((document) => !conflictingDocumentUrls.has(document.candidate.url));
   const effectiveInput: GamingRagInput = effectiveGameDetection.game
     ? { ...input, game: effectiveGameDetection.game }
@@ -2740,7 +2732,7 @@ export async function buildGamingRagContext(
     chunks,
     retainedSources,
     true,
-    requestedVersion
+    requestedVersions
   );
   const clear = buildClearChecks({
     retrievalEnabled,

--- a/src/services/gamingWebContext.ts
+++ b/src/services/gamingWebContext.ts
@@ -1071,16 +1071,36 @@ function candidateWithFetchedGameCorroboration(
 
 export function isGamingFreshnessSensitive(input: GamingRagInput): boolean {
   return input.mode === "meta"
-    || /\b(?:patch|hotfix|version|season|latest|current|right\s+now|meta|buff|nerf|balance|viable)\b|\b\d+\.\d+(?:\.\d+)?\b/i.test(input.prompt);
+    || /\b(?:patch|hotfix|version|season|latest|current|right\s+now|meta|buff|nerf|balance|viable)\b/i.test(input.prompt)
+    || Boolean(extractRequestedSemanticVersion(input));
 }
 
 function extractRequestedSemanticVersion(input: GamingRagInput): string | undefined {
-  return input.prompt.match(/\b(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\b/)?.[1];
+  const contextualMatch = input.prompt.match(/\b(?:patch|version|update)\s+(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\b/i)
+    ?? input.prompt.match(/\bv\.?\s*(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\b/i)
+    ?? input.prompt.match(/\bwhat\s+changed\b[^.!?\n]{0,32}\bin\s+(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\b/i)
+    ?? input.prompt.match(/\(\s*(?:v(?:ersion)?\.?\s*)?(\d{1,3}\.\d{1,3}(?:\.\d{1,3})?)\s*\)/i)
+    ?? input.prompt.match(/\b(\d{1,3}\.\d{1,3}\.\d{1,3})\b/);
+  if (contextualMatch?.[1]) {
+    return contextualMatch[1];
+  }
+
+  const game = normalizeGameName(input);
+  if (!game) {
+    return undefined;
+  }
+
+  const escapedGame = game.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const gameVersionPattern = new RegExp(
+    `\\b${escapedGame}\\s+(?:v(?:ersion)?\\.?\\s*)?(\\d{1,3}\\.\\d{1,3}(?:\\.\\d{1,3})?)\\b(?!\\.\\d)(?!\\s*(?:%|percent\\b|minutes?\\b|mins?\\b|hours?\\b|seconds?\\b|milliseconds?\\b|ms\\b|fps\\b|hz\\b))`,
+    "i"
+  );
+  return input.prompt.match(gameVersionPattern)?.[1];
 }
 
 function sourceMatchesRequestedVersion(chunk: GamingRankedChunk, requestedVersion: string): boolean {
   const escapedVersion = requestedVersion.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const versionPattern = new RegExp(`(?:^|[^0-9.])${escapedVersion}(?![0-9.])`, "i");
+  const versionPattern = new RegExp(`(?:^|[^0-9.])${escapedVersion}(?![0-9]|\\.[0-9])`, "i");
   return versionPattern.test(chunk.text);
 }
 

--- a/src/services/gamingWebContext.ts
+++ b/src/services/gamingWebContext.ts
@@ -996,12 +996,36 @@ function detectReliableDocumentGame(document: GamingFetchedDocument): string | u
   return undefined;
 }
 
-function detectGameFromDocumentIntro(document: GamingFetchedDocument): string | undefined {
+function detectGameFromDocumentIntro(
+  document: GamingFetchedDocument,
+  requestedGame?: string
+): string | undefined {
   const normalizedBody = document.text.replace(/\s+/g, " ").trim();
   const sentenceEnd = normalizedBody.search(/[.!?](?:\s|$)/);
   const intro = normalizedBody.slice(0, Math.min(sentenceEnd >= 0 ? sentenceEnd + 1 : normalizedBody.length, 320));
   if (!/\b(?:guide|build|loadout|meta|walkthrough|wiki|tips?|tier\s+list|patch\s+notes|progression|route|boss)\b/i.test(intro)) {
     return undefined;
+  }
+  const normalizedIntro = intro.replace(/^[\s'"“‘([{]+/u, "").toLowerCase();
+  const canonicalRequested = requestedGame
+    ? canonicalizeGamingGameName(requestedGame)
+    : undefined;
+  const normalizedRequested = canonicalRequested
+    ? canonicalRequested.toLowerCase()
+    : undefined;
+  if (canonicalRequested && normalizedRequested && normalizedIntro.startsWith(normalizedRequested)) {
+    const boundary = normalizedIntro.charAt(normalizedRequested.length);
+    if (!boundary || /[^a-z0-9]/i.test(boundary)) {
+      const suffix = normalizedIntro
+        .slice(normalizedRequested.length)
+        .trimStart()
+        .replace(/^[:\-–—]\s*/u, "");
+      const dottedVersion = /^(?:v(?:ersion)?\.?\s*)?\d{1,3}\.\d{1,3}(?:\.\d{1,3})?\b/i.test(suffix);
+      const descriptiveSuffix = /^(?:beginner|boss|build|class|combat|community|current|early|endgame|exploration|first|guide|late|legacy|leveling|loadout|main|mechanics?|meta|mining|patch|progression|pve|pvp|quest|raids?|route|season|strategy|survival|tier|tips?|update|walkthrough|wiki)\b/i.test(suffix);
+      if (dottedVersion || descriptiveSuffix) {
+        return canonicalRequested;
+      }
+    }
   }
   const detection = detectGamingGame({ pageTitle: intro });
   if (!detection.game || detection.confidence < 0.8) {
@@ -1009,7 +1033,23 @@ function detectGameFromDocumentIntro(document: GamingFetchedDocument): string | 
   }
   const detectedGame = canonicalizeGamingGameName(detection.game);
   const detectedGameWords = detectedGame.match(/[a-z0-9+]+/gi) ?? [];
-  return detection.confidence >= 0.88 || detectedGameWords.length >= 2 ? detectedGame : undefined;
+  const gameAnchorsIntro = normalizedIntro.startsWith(detectedGame.toLowerCase());
+  return detection.confidence >= 0.88 || (detectedGameWords.length >= 2 && gameAnchorsIntro)
+    ? detectedGame
+    : undefined;
+}
+
+function gamingGameNamesMatch(candidateGame: string, requestedGame: string): boolean {
+  const normalizedCandidate = canonicalizeGamingGameName(candidateGame).toLowerCase();
+  const normalizedRequested = canonicalizeGamingGameName(requestedGame).toLowerCase();
+  if (normalizedCandidate === normalizedRequested) {
+    return true;
+  }
+  if (!normalizedCandidate.startsWith(`${normalizedRequested} `)) {
+    return false;
+  }
+  const suffix = normalizedCandidate.slice(normalizedRequested.length).trim();
+  return /^(?:v(?:ersion)?\.?\s*)?\d{1,3}\.\d{1,3}(?:\.\d{1,3})?$/i.test(suffix);
 }
 
 function collectConflictingDocumentUrls(
@@ -1019,18 +1059,14 @@ function collectConflictingDocumentUrls(
   if (!requestedGame) {
     return new Set();
   }
-  const normalizedRequestedGame = canonicalizeGamingGameName(requestedGame).toLowerCase();
   return new Set(documents
     .filter((document) => {
       const reliableGame = detectReliableDocumentGame(document);
       if (reliableGame) {
-        return canonicalizeGamingGameName(reliableGame).toLowerCase() !== normalizedRequestedGame;
+        return !gamingGameNamesMatch(reliableGame, requestedGame);
       }
-      if (fetchedDocumentCorroboratesGame(document.text, document.extraction, requestedGame)) {
-        return false;
-      }
-      const introGame = detectGameFromDocumentIntro(document);
-      return Boolean(introGame && canonicalizeGamingGameName(introGame).toLowerCase() !== normalizedRequestedGame);
+      const introGame = detectGameFromDocumentIntro(document, requestedGame);
+      return Boolean(introGame && !gamingGameNamesMatch(introGame, requestedGame));
     })
     .map((document) => document.candidate.url));
 }

--- a/src/shared/gpt/gptRequestAction.ts
+++ b/src/shared/gpt/gptRequestAction.ts
@@ -7,18 +7,43 @@ import {
   GPT_QUERY_AND_WAIT_ACTION
 } from '@shared/gpt/gptJobResult.js';
 
-function readFirstNonEmptyString(value: unknown): string | null {
-  if (typeof value === 'string') {
-    const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : null;
-  }
+const MAX_ACTION_ALIAS_DEPTH = 8;
+const MAX_ACTION_ALIAS_VALUES = 64;
 
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      const normalizedEntry = readFirstNonEmptyString(entry);
-      if (normalizedEntry) {
-        return normalizedEntry;
+function readFirstNonEmptyString(value: unknown): string | null {
+  const frames: Array<{ values: unknown[]; nextIndex: number; depth: number }> = [];
+  let current = value;
+  let depth = 0;
+  let visited = 0;
+
+  while (visited < MAX_ACTION_ALIAS_VALUES) {
+    visited += 1;
+    if (typeof current === 'string') {
+      const trimmed = current.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
       }
+    } else if (Array.isArray(current) && depth < MAX_ACTION_ALIAS_DEPTH && current.length > 0) {
+      frames.push({ values: current, nextIndex: 1, depth });
+      current = current[0];
+      depth += 1;
+      continue;
+    }
+
+    let advanced = false;
+    while (frames.length > 0) {
+      const frame = frames[frames.length - 1];
+      if (frame && frame.nextIndex < frame.values.length) {
+        current = frame.values[frame.nextIndex];
+        frame.nextIndex += 1;
+        depth = frame.depth + 1;
+        advanced = true;
+        break;
+      }
+      frames.pop();
+    }
+    if (!advanced) {
+      return null;
     }
   }
 

--- a/src/shared/gpt/gptRequestAction.ts
+++ b/src/shared/gpt/gptRequestAction.ts
@@ -1,0 +1,109 @@
+import type { Request } from 'express';
+import { normalizeGptRequestBody } from '@shared/gpt/gptIdempotency.js';
+import {
+  GPT_GET_RESULT_ACTION,
+  GPT_GET_STATUS_ACTION,
+  GPT_QUERY_ACTION,
+  GPT_QUERY_AND_WAIT_ACTION
+} from '@shared/gpt/gptJobResult.js';
+
+function readFirstNonEmptyString(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const normalizedEntry = readFirstNonEmptyString(entry);
+      if (normalizedEntry) {
+        return normalizedEntry;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function normalizeRequestedGptActionName(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const lowered = trimmed.toLowerCase();
+  const decamelized = trimmed.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase();
+  const compact = decamelized.replace(/[^a-z0-9]+/g, '');
+
+  if (compact === 'invokegptroute' || compact === 'gptroute' || compact === 'invokegpt') {
+    return null;
+  }
+  if (
+    compact === 'queryandwait' ||
+    compact === 'requestqueryandwait' ||
+    compact === 'gptqueryandwait'
+  ) {
+    return GPT_QUERY_AND_WAIT_ACTION;
+  }
+  if (compact === 'query') {
+    return GPT_QUERY_ACTION;
+  }
+  if (compact === 'getstatus') {
+    return GPT_GET_STATUS_ACTION;
+  }
+  if (compact === 'getresult') {
+    return GPT_GET_RESULT_ACTION;
+  }
+  if (compact === 'systemstate') {
+    return 'system_state';
+  }
+  return lowered;
+}
+
+function readActionAlias(record: Record<string, unknown> | null | undefined): string | null {
+  if (!record) {
+    return null;
+  }
+  const actionValue =
+    readFirstNonEmptyString(record.action) ??
+    readFirstNonEmptyString(record.operation) ??
+    readFirstNonEmptyString(record.operationId) ??
+    readFirstNonEmptyString(record.operation_id) ??
+    readFirstNonEmptyString(record.toolAction) ??
+    readFirstNonEmptyString(record.tool_action) ??
+    readFirstNonEmptyString(record.gptAction) ??
+    readFirstNonEmptyString(record.gpt_action);
+
+  return actionValue ? normalizeRequestedGptActionName(actionValue) : null;
+}
+
+function resolveRequestedAction(body: unknown): string | null {
+  const normalizedBody = normalizeGptRequestBody(body);
+  if (!normalizedBody) {
+    return null;
+  }
+
+  const directAction = readActionAlias(normalizedBody);
+  if (directAction) {
+    return directAction.toLowerCase();
+  }
+
+  const payload = normalizedBody.payload;
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return null;
+  }
+
+  return readActionAlias(payload as Record<string, unknown>);
+}
+
+export function resolveRequestedGptActionFromRequest(req: Request): string | null {
+  const headerAction = typeof req.header === 'function'
+    ? readFirstNonEmptyString(req.header('x-gpt-action')) ??
+      readFirstNonEmptyString(req.header('x-arcanos-action'))
+    : null;
+  return (
+    resolveRequestedAction(req.body) ??
+    readActionAlias(req.query as Record<string, unknown> | undefined) ??
+    normalizeRequestedGptActionName(headerAction ?? '')
+  );
+}

--- a/src/shared/http/clientJsonPayload.ts
+++ b/src/shared/http/clientJsonPayload.ts
@@ -30,6 +30,42 @@ function extractPreviewText(payload: Record<string, unknown>): string {
   return truncateText(JSON.stringify(payload), STRING_PREVIEW_MAX_BYTES);
 }
 
+function buildTruncatedGamingPayload(
+  payload: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  if (!isRecord(payload.result) || payload.result.route !== 'gaming') {
+    return undefined;
+  }
+
+  const mode = readString(payload.result.mode);
+  const publicMode = mode === 'guide' || mode === 'build' || mode === 'meta' ? mode : null;
+  const routeMeta = isRecord(payload._route) ? payload._route : {};
+  return {
+    ok: true,
+    ...(readString(payload.requestId) ? { requestId: readString(payload.requestId) } : {}),
+    ...(readString(payload.traceId) ? { traceId: readString(payload.traceId) } : {}),
+    result: {
+      ok: false,
+      route: 'gaming',
+      mode: publicMode,
+      error: {
+        code: 'GAMING_RESPONSE_TOO_LARGE',
+        message: 'The Gaming response exceeded the public response size limit.'
+      }
+    },
+    _route: {
+      ...(readString(routeMeta.requestId) ? { requestId: readString(routeMeta.requestId) } : {}),
+      ...(readString(routeMeta.traceId) ? { traceId: readString(routeMeta.traceId) } : {}),
+      ...(readString(routeMeta.gptId) ? { gptId: readString(routeMeta.gptId) } : {}),
+      ...(readString(routeMeta.module) ? { module: readString(routeMeta.module) } : {}),
+      ...(readString(routeMeta.action) ? { action: readString(routeMeta.action) } : {}),
+      ...(readString(routeMeta.route) ? { route: readString(routeMeta.route) } : {}),
+      ...(readString(routeMeta.timestamp) ? { timestamp: readString(routeMeta.timestamp) } : {}),
+      truncated: true
+    }
+  };
+}
+
 function buildTruncatedPayloadFromPreview(
   payload: Record<string, unknown>,
   preview: string
@@ -50,8 +86,12 @@ function buildTruncatedPayloadFromPreview(
   if (isRecord(payload._route)) {
     return {
       ...(typeof payload.ok === 'boolean' ? { ok: payload.ok } : {}),
+      ...(readString(payload.requestId) ? { requestId: readString(payload.requestId) } : {}),
+      ...(readString(payload.traceId) ? { traceId: readString(payload.traceId) } : {}),
       result: preview,
       _route: {
+        ...(readString(payload._route.requestId) ? { requestId: readString(payload._route.requestId) } : {}),
+        ...(readString(payload._route.traceId) ? { traceId: readString(payload._route.traceId) } : {}),
         ...(readString(payload._route.gptId) ? { gptId: readString(payload._route.gptId) } : {}),
         ...(readString(payload._route.module) ? { module: readString(payload._route.module) } : {}),
         ...(readString(payload._route.route) ? { route: readString(payload._route.route) } : {}),
@@ -123,6 +163,11 @@ function buildMinimalTruncatedPayload(previewSource: string): Record<string, unk
 }
 
 function buildTruncatedPayload(payload: Record<string, unknown>, maxBytes: number): Record<string, unknown> {
+  const truncatedGamingPayload = buildTruncatedGamingPayload(payload);
+  if (truncatedGamingPayload && measureJsonBytes(truncatedGamingPayload) <= maxBytes) {
+    return truncatedGamingPayload;
+  }
+
   const previewSource = extractPreviewText(payload);
   const maxPreviewBytes = Math.max(512, Math.floor(maxBytes * 0.45));
   let lowerPreviewBytes = 0;

--- a/src/shared/http/clientRouteResultShape.ts
+++ b/src/shared/http/clientRouteResultShape.ts
@@ -776,6 +776,11 @@ function shapeGamingSource(value: unknown): Record<string, unknown> | null {
   };
 }
 
+function readGamingReason(value: unknown): string | undefined {
+  const reason = readString(value);
+  return reason && /^[A-Z][A-Z0-9_]{0,63}$/.test(reason) ? reason : undefined;
+}
+
 function shapeGamingResult(value: Record<string, unknown>): Record<string, unknown> | null {
   if (value.ok !== true || readString(value.route) !== 'gaming' || !isRecord(value.data)) {
     return null;
@@ -783,6 +788,9 @@ function shapeGamingResult(value: Record<string, unknown>): Record<string, unkno
 
   const response = readString(value.data.response);
   const mode = readString(value.mode);
+  const fallbackReason = readGamingReason(value.data.fallbackReason);
+  const discoveryReason = readGamingReason(value.data.discoveryReason);
+  const discoveryFailureReason = readGamingReason(value.data.discoveryFailureReason);
   const sources = Array.isArray(value.data.sources)
     ? value.data.sources
       .map(shapeGamingSource)
@@ -797,6 +805,9 @@ function shapeGamingResult(value: Record<string, unknown>): Record<string, unkno
     data: {
       ...(response ? { response: truncateText(response, STRING_PREVIEW_MAX_BYTES) } : {}),
       sources,
+      ...(fallbackReason ? { fallbackReason } : {}),
+      ...(discoveryReason ? { discoveryReason } : {}),
+      ...(discoveryFailureReason ? { discoveryFailureReason } : {}),
     },
   };
 }

--- a/src/shared/http/gptRouteTimeout.ts
+++ b/src/shared/http/gptRouteTimeout.ts
@@ -8,6 +8,7 @@ export function resolveGptRouteHardTimeoutMs(
   options: {
     profile?: 'default' | 'dag_execution';
     defaultMsOverride?: number;
+    minimumMsOverride?: number;
   } = {},
 ): number {
   const profile = options.profile ?? 'default';
@@ -20,6 +21,15 @@ export function resolveGptRouteHardTimeoutMs(
           Math.min(MAX_GPT_ROUTE_HARD_TIMEOUT_MS, Math.trunc(options.defaultMsOverride))
         )
       : undefined;
+  const normalizedMinimumMsOverride =
+    typeof options.minimumMsOverride === 'number' &&
+    Number.isFinite(options.minimumMsOverride) &&
+    options.minimumMsOverride > 0
+      ? Math.max(
+          MIN_GPT_ROUTE_HARD_TIMEOUT_MS,
+          Math.min(MAX_GPT_ROUTE_HARD_TIMEOUT_MS, Math.trunc(options.minimumMsOverride))
+        )
+      : undefined;
   const envKey =
     profile === 'dag_execution'
       ? 'GPT_ROUTE_DAG_EXECUTION_HARD_TIMEOUT_MS'
@@ -28,23 +38,31 @@ export function resolveGptRouteHardTimeoutMs(
 
   if (profile === 'dag_execution') {
     if (!Number.isFinite(configuredTimeoutMs) || configuredTimeoutMs <= 0) {
-      return DEFAULT_GPT_ROUTE_DAG_EXECUTION_HARD_TIMEOUT_MS;
+      return Math.max(
+        DEFAULT_GPT_ROUTE_DAG_EXECUTION_HARD_TIMEOUT_MS,
+        normalizedMinimumMsOverride ?? 0
+      );
     }
 
-    return Math.max(
+    const resolvedTimeoutMs = Math.max(
       DEFAULT_GPT_ROUTE_HARD_TIMEOUT_MS,
       Math.min(MAX_GPT_ROUTE_DAG_EXECUTION_HARD_TIMEOUT_MS, Math.trunc(configuredTimeoutMs))
     );
+    return Math.max(resolvedTimeoutMs, normalizedMinimumMsOverride ?? 0);
   }
 
   if (!Number.isFinite(configuredTimeoutMs) || configuredTimeoutMs <= 0) {
-    return normalizedDefaultMsOverride ?? DEFAULT_GPT_ROUTE_HARD_TIMEOUT_MS;
+    return Math.max(
+      normalizedDefaultMsOverride ?? DEFAULT_GPT_ROUTE_HARD_TIMEOUT_MS,
+      normalizedMinimumMsOverride ?? 0
+    );
   }
 
-  return Math.max(
+  const resolvedTimeoutMs = Math.max(
     MIN_GPT_ROUTE_HARD_TIMEOUT_MS,
     Math.min(MAX_GPT_ROUTE_HARD_TIMEOUT_MS, Math.trunc(configuredTimeoutMs))
   );
+  return Math.max(resolvedTimeoutMs, normalizedMinimumMsOverride ?? 0);
 }
 
 export const GPT_ROUTE_HARD_TIMEOUT_BOUNDS = {

--- a/src/shared/http/publicGamingPath.ts
+++ b/src/shared/http/publicGamingPath.ts
@@ -1,0 +1,10 @@
+export type PublicGamingGptId = 'arcanos-gaming' | 'gaming';
+
+export function resolvePublicGamingGptIdFromPath(path: string): PublicGamingGptId | null {
+  const lowerPath = path.toLowerCase();
+  const normalizedPath = lowerPath.endsWith('/') ? lowerPath.slice(0, -1) : lowerPath;
+  if (normalizedPath === '/gpt/arcanos-gaming') {
+    return 'arcanos-gaming';
+  }
+  return normalizedPath === '/gpt/gaming' ? 'gaming' : null;
+}

--- a/src/transport/http/middleware/errorHandler.ts
+++ b/src/transport/http/middleware/errorHandler.ts
@@ -31,6 +31,38 @@ function isJsonSchemaParseError(err: unknown): boolean {
   return type === 'entity.parse.failed' || (status === 400 && typeof body === 'string');
 }
 
+function isRequestEntityTooLarge(err: unknown): boolean {
+  if (!err || typeof err !== 'object') {
+    return false;
+  }
+
+  const candidate = err as Record<string, unknown>;
+  return candidate.type === 'entity.too.large'
+    || candidate.status === 413
+    || candidate.statusCode === 413;
+}
+
+function isPublicGptRequestPath(requestPath: string): boolean {
+  return requestPath === '/gpt' || requestPath.startsWith('/gpt/');
+}
+
+function buildPublicGptErrorPayload(params: {
+  code: string;
+  message: string;
+  requestId: string;
+  traceId: string;
+}): Record<string, unknown> {
+  return {
+    ok: false,
+    requestId: params.requestId,
+    traceId: params.traceId,
+    error: {
+      code: params.code,
+      message: params.message
+    }
+  };
+}
+
 /**
  * Purpose: Centralize HTTP error responses with request-id correlation and stack logging.
  * Inputs/Outputs: Express error middleware; writes JSON error payload and status code.
@@ -45,6 +77,7 @@ const errorHandler = (err: unknown, req: Request, res: Response, next: NextFunct
   const requestId = req.requestId ?? 'unknown';
   const traceId = req.traceId ?? requestId;
   const requestPath = resolveSafeRequestPath(req);
+  const publicGptRequest = isPublicGptRequestPath(requestPath);
 
   // Normalize unknown error input into an Error-like shape for safe logging.
   let name = 'UnknownError';
@@ -73,24 +106,61 @@ const errorHandler = (err: unknown, req: Request, res: Response, next: NextFunct
   }
 
   let statusCode = 500;
-  let payload: Record<string, unknown> = {
-    error: 'Internal Server Error',
-    code: 500
-  };
+  let payload: Record<string, unknown> = publicGptRequest
+    ? buildPublicGptErrorPayload({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'An unexpected GPT route error occurred.',
+        requestId,
+        traceId
+      })
+    : {
+        error: 'Internal Server Error',
+        code: 500,
+        requestId,
+        traceId
+      };
 
   if (isJsonSchemaParseError(err)) {
     statusCode = 400;
-    payload = {
-      error: 'invalid request schema',
-      code: 400
-    };
+    payload = publicGptRequest
+      ? buildPublicGptErrorPayload({
+          code: 'INVALID_JSON',
+          message: 'Request body must be valid JSON.',
+          requestId,
+          traceId
+        })
+      : {
+          error: 'invalid request schema',
+          code: 400,
+          requestId,
+          traceId
+        };
+  } else if (publicGptRequest && isRequestEntityTooLarge(err)) {
+    statusCode = 400;
+    payload = buildPublicGptErrorPayload({
+      code: 'REQUEST_BODY_TOO_LARGE',
+      message: 'Request body exceeds the configured JSON size limit.',
+      requestId,
+      traceId
+    });
   } else if (isAppError(err)) {
     const appError = err as AppError;
     statusCode = appError.httpCode;
-    payload = {
-      error: appError.message,
-      code: appError.httpCode
-    };
+    payload = publicGptRequest
+      ? buildPublicGptErrorPayload({
+          code: statusCode >= 500 ? 'INTERNAL_SERVER_ERROR' : 'GPT_REQUEST_REJECTED',
+          message: statusCode >= 500
+            ? 'An unexpected GPT route error occurred.'
+            : 'The GPT request could not be accepted.',
+          requestId,
+          traceId
+        })
+      : {
+          error: appError.message,
+          code: appError.httpCode,
+          requestId,
+          traceId
+        };
   }
 
   const logDetails = {

--- a/src/transport/http/middleware/fallbackHandler.ts
+++ b/src/transport/http/middleware/fallbackHandler.ts
@@ -18,6 +18,7 @@ import {
 import { logger } from "@platform/logging/structuredLogging.js";
 import { sendTimestampedStatus } from "@platform/resilience/serviceUnavailable.js";
 import { applyAIDegradedResponseHeaders } from '@shared/http/aiDegradedHeaders.js';
+import { resolvePublicGamingGptIdFromPath } from '@shared/http/publicGamingPath.js';
 
 export interface DegradedResponse {
   status: 'degraded';
@@ -82,7 +83,7 @@ function isGptDispatcherPath(path: string): boolean {
 }
 
 function isPublicGamingPath(path: string): boolean {
-  return path === '/gpt/arcanos-gaming' || path === '/gpt/gaming';
+  return resolvePublicGamingGptIdFromPath(path) !== null;
 }
 
 function isFallbackEligibleAiEndpoint(path: string): boolean {

--- a/src/transport/http/middleware/fallbackHandler.ts
+++ b/src/transport/http/middleware/fallbackHandler.ts
@@ -115,6 +115,10 @@ function logFallbackEvent(
  */
 export function createFallbackMiddleware() {
   return (err: unknown, req: Request, res: Response, next: NextFunction) => {
+    if (isGptDispatcherPath(req.path)) {
+      return next(err);
+    }
+
     const errorRecord = err && typeof err === 'object' ? (err as Record<string, unknown>) : {};
     const errorMessage = typeof errorRecord.message === 'string' ? errorRecord.message : '';
     // Check if this is an AI service error

--- a/src/transport/http/middleware/fallbackHandler.ts
+++ b/src/transport/http/middleware/fallbackHandler.ts
@@ -81,6 +81,10 @@ function isGptDispatcherPath(path: string): boolean {
   return path === '/gpt' || path.startsWith('/gpt/');
 }
 
+function isPublicGamingPath(path: string): boolean {
+  return path === '/gpt/arcanos-gaming' || path === '/gpt/gaming';
+}
+
 function isFallbackEligibleAiEndpoint(path: string): boolean {
   if (isGptDispatcherPath(path)) {
     return false;
@@ -115,7 +119,7 @@ function logFallbackEvent(
  */
 export function createFallbackMiddleware() {
   return (err: unknown, req: Request, res: Response, next: NextFunction) => {
-    if (isGptDispatcherPath(req.path)) {
+    if (isPublicGamingPath(req.path)) {
       return next(err);
     }
 

--- a/src/transport/http/middleware/unsafeExecutionGate.ts
+++ b/src/transport/http/middleware/unsafeExecutionGate.ts
@@ -18,6 +18,25 @@ function isGptAccessReadOnlyRequest(req: Request): boolean {
   return req.method.toUpperCase() === 'POST' && GPT_ACCESS_READONLY_POST_PATHS.has(req.path);
 }
 
+function isPublicGamingRequest(req: Request): boolean {
+  return req.method.toUpperCase() === 'POST'
+    && (req.path === '/gpt/arcanos-gaming' || req.path === '/gpt/gaming');
+}
+
+function resolvePublicGamingMode(body: unknown): 'guide' | 'build' | 'meta' | null {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return null;
+  }
+
+  const bodyRecord = body as Record<string, unknown>;
+  const payload = bodyRecord.payload;
+  const modeOwner = payload && typeof payload === 'object' && !Array.isArray(payload)
+    ? payload as Record<string, unknown>
+    : bodyRecord;
+  const mode = typeof modeOwner.mode === 'string' ? modeOwner.mode.trim().toLowerCase() : '';
+  return mode === 'guide' || mode === 'build' || mode === 'meta' ? mode : null;
+}
+
 /**
  * Purpose: Block mutating requests when unsafe safety conditions are active.
  * Inputs/Outputs: Express middleware; returns 503 unsafe contract on block.
@@ -51,7 +70,47 @@ export function unsafeExecutionGate(req: Request, res: Response, next: NextFunct
     return;
   }
 
-  res.status(503).json(buildUnsafeToProceedPayload());
+  const requestId = typeof req.requestId === 'string' && req.requestId.trim().length > 0
+    ? req.requestId.trim()
+    : undefined;
+  const traceId = typeof req.traceId === 'string' && req.traceId.trim().length > 0
+    ? req.traceId.trim()
+    : requestId;
+  if (isPublicGamingRequest(req)) {
+    const gamingRequestId = requestId ?? traceId ?? 'unknown';
+    const gamingTraceId = traceId ?? gamingRequestId;
+    const gptId = req.path.endsWith('/gaming') ? 'gaming' : 'arcanos-gaming';
+    res.status(200).json({
+      ok: true,
+      requestId: gamingRequestId,
+      traceId: gamingTraceId,
+      result: {
+        ok: false,
+        route: 'gaming',
+        mode: resolvePublicGamingMode(req.body),
+        error: {
+          code: 'UNSAFE_TO_PROCEED',
+          message: 'ARCANOS Gaming is temporarily unavailable because runtime integrity checks did not pass.'
+        }
+      },
+      _route: {
+        requestId: gamingRequestId,
+        traceId: gamingTraceId,
+        gptId,
+        module: 'ARCANOS:GAMING',
+        action: 'query',
+        route: 'gaming',
+        timestamp: new Date().toISOString()
+      }
+    });
+    return;
+  }
+
+  res.status(503).json({
+    ...buildUnsafeToProceedPayload(),
+    ...(requestId ? { requestId } : {}),
+    ...(traceId ? { traceId } : {})
+  });
 }
 
 export default unsafeExecutionGate;

--- a/src/transport/http/middleware/unsafeExecutionGate.ts
+++ b/src/transport/http/middleware/unsafeExecutionGate.ts
@@ -3,6 +3,7 @@ import {
   buildUnsafeToProceedPayload,
   hasUnsafeBlockingConditions
 } from '@services/safety/runtimeState.js';
+import { resolveGamingMode } from '@services/gamingModes.js';
 
 const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 const SAFETY_RELEASE_PATH_PATTERN = /^\/status\/safety\/quarantine\/[^/]+\/release$/;
@@ -23,18 +24,16 @@ function isPublicGamingRequest(req: Request): boolean {
     && (req.path === '/gpt/arcanos-gaming' || req.path === '/gpt/gaming');
 }
 
-function resolvePublicGamingMode(body: unknown): 'guide' | 'build' | 'meta' | null {
+function resolvePublicGamingMode(body: unknown) {
   if (!body || typeof body !== 'object' || Array.isArray(body)) {
-    return null;
+    return resolveGamingMode(body);
   }
 
   const bodyRecord = body as Record<string, unknown>;
   const payload = bodyRecord.payload;
-  const modeOwner = payload && typeof payload === 'object' && !Array.isArray(payload)
-    ? payload as Record<string, unknown>
-    : bodyRecord;
-  const mode = typeof modeOwner.mode === 'string' ? modeOwner.mode.trim().toLowerCase() : '';
-  return mode === 'guide' || mode === 'build' || mode === 'meta' ? mode : null;
+  return resolveGamingMode(payload && typeof payload === 'object' && !Array.isArray(payload)
+    ? payload
+    : bodyRecord);
 }
 
 /**

--- a/src/transport/http/middleware/unsafeExecutionGate.ts
+++ b/src/transport/http/middleware/unsafeExecutionGate.ts
@@ -3,7 +3,9 @@ import {
   buildUnsafeToProceedPayload,
   hasUnsafeBlockingConditions
 } from '@services/safety/runtimeState.js';
-import { resolveGamingMode } from '@services/gamingModes.js';
+import { resolveGamingMode, validatePublicGamingQueryRequest } from '@services/gamingModes.js';
+import { resolveRequestedGptActionFromRequest } from '@shared/gpt/gptRequestAction.js';
+import { resolvePublicGamingGptIdFromPath } from '@shared/http/publicGamingPath.js';
 
 const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 const SAFETY_RELEASE_PATH_PATTERN = /^\/status\/safety\/quarantine\/[^/]+\/release$/;
@@ -19,21 +21,10 @@ function isGptAccessReadOnlyRequest(req: Request): boolean {
   return req.method.toUpperCase() === 'POST' && GPT_ACCESS_READONLY_POST_PATHS.has(req.path);
 }
 
-function isPublicGamingRequest(req: Request): boolean {
-  return req.method.toUpperCase() === 'POST'
-    && (req.path === '/gpt/arcanos-gaming' || req.path === '/gpt/gaming');
-}
-
 function resolvePublicGamingMode(body: unknown) {
-  if (!body || typeof body !== 'object' || Array.isArray(body)) {
-    return resolveGamingMode(body);
-  }
-
   const bodyRecord = body as Record<string, unknown>;
-  const payload = bodyRecord.payload;
-  return resolveGamingMode(payload && typeof payload === 'object' && !Array.isArray(payload)
-    ? payload
-    : bodyRecord);
+  const payload = bodyRecord.payload as Record<string, unknown>;
+  return resolveGamingMode(payload) ?? resolveGamingMode(bodyRecord);
 }
 
 /**
@@ -64,6 +55,10 @@ export function unsafeExecutionGate(req: Request, res: Response, next: NextFunct
     return;
   }
 
+  const publicGamingGptId = method === 'POST'
+    ? resolvePublicGamingGptIdFromPath(req.path)
+    : null;
+
   if (!hasUnsafeBlockingConditions()) {
     next();
     return;
@@ -75,34 +70,58 @@ export function unsafeExecutionGate(req: Request, res: Response, next: NextFunct
   const traceId = typeof req.traceId === 'string' && req.traceId.trim().length > 0
     ? req.traceId.trim()
     : requestId;
-  if (isPublicGamingRequest(req)) {
+  if (publicGamingGptId) {
     const gamingRequestId = requestId ?? traceId ?? 'unknown';
     const gamingTraceId = traceId ?? gamingRequestId;
-    const gptId = req.path.endsWith('/gaming') ? 'gaming' : 'arcanos-gaming';
-    res.status(200).json({
-      ok: true,
-      requestId: gamingRequestId,
-      traceId: gamingTraceId,
-      result: {
+    const requestedAction = resolveRequestedGptActionFromRequest(req);
+    const validationError = validatePublicGamingQueryRequest(req.body, requestedAction);
+    if (validationError) {
+      const action = requestedAction ?? 'query';
+      res.status(400).json({
         ok: false,
-        route: 'gaming',
-        mode: resolvePublicGamingMode(req.body),
-        error: {
-          code: 'UNSAFE_TO_PROCEED',
-          message: 'ARCANOS Gaming is temporarily unavailable because runtime integrity checks did not pass.'
-        }
-      },
-      _route: {
         requestId: gamingRequestId,
         traceId: gamingTraceId,
-        gptId,
-        module: 'ARCANOS:GAMING',
-        action: 'query',
-        route: 'gaming',
-        timestamp: new Date().toISOString()
-      }
-    });
-    return;
+        gptId: publicGamingGptId,
+        action,
+        route: '/gpt/:gptId',
+        error: validationError,
+        _route: {
+          requestId: gamingRequestId,
+          traceId: gamingTraceId,
+          gptId: publicGamingGptId,
+          action,
+          route: 'gaming_validation',
+          timestamp: new Date().toISOString()
+        }
+      });
+      return;
+    }
+    if (requestedAction === 'query') {
+      res.status(200).json({
+        ok: true,
+        requestId: gamingRequestId,
+        traceId: gamingTraceId,
+        result: {
+          ok: false,
+          route: 'gaming',
+          mode: resolvePublicGamingMode(req.body),
+          error: {
+            code: 'UNSAFE_TO_PROCEED',
+            message: 'ARCANOS Gaming is temporarily unavailable because runtime integrity checks did not pass.'
+          }
+        },
+        _route: {
+          requestId: gamingRequestId,
+          traceId: gamingTraceId,
+          gptId: publicGamingGptId,
+          module: 'ARCANOS:GAMING',
+          action: 'query',
+          route: 'gaming',
+          timestamp: new Date().toISOString()
+        }
+      });
+      return;
+    }
   }
 
   res.status(503).json({

--- a/tests/api-sessions.route.test.ts
+++ b/tests/api-sessions.route.test.ts
@@ -361,7 +361,9 @@ describe('canonical /api session system routes', () => {
     expect(response.status).toBe(500);
     expect(response.body).toEqual({
       error: 'Internal Server Error',
-      code: 500
+      code: 500,
+      requestId: 'unknown',
+      traceId: 'unknown'
     });
   });
 });

--- a/tests/arcanos-gaming.modes.test.ts
+++ b/tests/arcanos-gaming.modes.test.ts
@@ -115,6 +115,28 @@ describe("ArcanosGaming mode routing", () => {
     expect((result as any).data.response).toContain("Watch Outs");
   });
 
+  it("returns a fixed-safe envelope when HRC verification fails", async () => {
+    mockEvaluateWithHRC.mockRejectedValueOnce(new Error("secret provider response body"));
+
+    const result = await ArcanosGaming.actions.query({
+      mode: "guide",
+      game: "Elden Ring",
+      prompt: "Give me a concise beginner guide.",
+      hrc: true
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      route: "gaming",
+      mode: "guide",
+      error: {
+        code: "MODULE_ERROR",
+        message: "Gaming response verification could not be completed safely."
+      }
+    });
+    expect(JSON.stringify(result)).not.toContain("secret provider response body");
+  });
+
   it("accepts guideUrl as the single guide URL field", async () => {
     await ArcanosGaming.actions.query({
       mode: "guide",

--- a/tests/arcanos-gaming.test.ts
+++ b/tests/arcanos-gaming.test.ts
@@ -45,7 +45,7 @@ jest.unstable_mockModule('../src/platform/logging/structuredLogging.js', () => (
 }));
 
 const { default: ArcanosGaming } = await import('../src/modules/arcanos-gaming.js');
-const { BackendQueryAgent, IntentRouterAgent } = await import('../src/services/gamingAgents.js');
+const { BackendQueryAgent, IntentRouterAgent, ResponseComposerAgent } = await import('../src/services/gamingAgents.js');
 
 describe('ArcanosGaming module', () => {
 
@@ -314,6 +314,38 @@ describe('ArcanosGaming module', () => {
     }));
     expect((result as any).data.response).toContain('safe deterministic fallback was used');
     expect((result as any).data.response).not.toContain('Malformed backend response');
+  });
+
+  it('contains final response-composer failures in a fixed-safe Gaming envelope', async () => {
+    const composeSpy = jest.spyOn(ResponseComposerAgent, 'compose').mockImplementationOnce(() => {
+      throw new Error('secret response-postprocessing detail');
+    });
+    const fallbackSpy = jest.spyOn(ResponseComposerAgent, 'composeBackendFailureFallback').mockImplementationOnce(() => {
+      throw new Error('secret fallback-postprocessing detail');
+    });
+
+    try {
+      const result = await ArcanosGaming.actions.query({
+        mode: 'guide',
+        game: 'Elden Ring',
+        prompt: 'Give me a concise beginner guide.',
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        route: 'gaming',
+        mode: 'guide',
+        error: {
+          code: 'MODULE_ERROR',
+          message: 'ARCANOS Gaming could not complete the request safely.',
+        },
+      });
+      expect(JSON.stringify(result)).not.toContain('secret response-postprocessing detail');
+      expect(JSON.stringify(result)).not.toContain('secret fallback-postprocessing detail');
+    } finally {
+      composeSpy.mockRestore();
+      fallbackSpy.mockRestore();
+    }
   });
 
   it('refuses security-blocked internal control-plane requests', async () => {

--- a/tests/client-response-guards.test.ts
+++ b/tests/client-response-guards.test.ts
@@ -270,6 +270,9 @@ describe('client response guards', () => {
       mode: 'guide',
       data: {
         response: 'Use the source-backed route.',
+        fallbackReason: 'CURRENT_EVIDENCE_UNAVAILABLE',
+        discoveryReason: 'DISCOVERY_NO_SOURCE_CANDIDATES',
+        discoveryFailureReason: 'DISCOVERY_PROVIDER_UNCONFIGURED',
         sources: [
           { url: 'https://example.com/guide-1', snippet: 'First source snippet.' },
           { url: 'https://example.com/guide-2', error: 'Fetch failed.' },
@@ -294,6 +297,9 @@ describe('client response guards', () => {
       mode: 'guide',
       data: {
         response: 'Use the source-backed route.',
+        fallbackReason: 'CURRENT_EVIDENCE_UNAVAILABLE',
+        discoveryReason: 'DISCOVERY_NO_SOURCE_CANDIDATES',
+        discoveryFailureReason: 'DISCOVERY_PROVIDER_UNCONFIGURED',
         sources: [
           { url: 'https://example.com/guide-1', snippet: 'First source snippet.' },
           { url: 'https://example.com/guide-2', error: 'Fetch failed.' },
@@ -533,6 +539,90 @@ describe('client response guards', () => {
         truncated: true,
       },
     });
+  });
+
+  it('preserves public request and trace IDs when a route envelope is truncated', () => {
+    const prepared = prepareBoundedClientJsonPayload({
+      ok: true,
+      requestId: 'req-gaming-truncated',
+      traceId: 'trace-gaming-truncated',
+      result: 'x'.repeat(10_000),
+      _route: {
+        requestId: 'req-gaming-truncated',
+        traceId: 'trace-gaming-truncated',
+        gptId: 'arcanos-gaming',
+        module: 'ARCANOS:GAMING',
+        route: 'gaming',
+        timestamp: '2026-07-11T00:00:00.000Z'
+      }
+    }, {
+      maxBytes: 1200
+    });
+
+    expect(prepared.truncated).toBe(true);
+    expect(prepared.payload).toMatchObject({
+      requestId: 'req-gaming-truncated',
+      traceId: 'trace-gaming-truncated',
+      _route: {
+        requestId: 'req-gaming-truncated',
+        traceId: 'trace-gaming-truncated'
+      }
+    });
+  });
+
+  it('preserves a structured Gaming result when a Gaming response is truncated', () => {
+    const prepared = prepareBoundedClientJsonPayload({
+      ok: true,
+      requestId: 'req-gaming-structured-truncated',
+      traceId: 'trace-gaming-structured-truncated',
+      result: {
+        ok: true,
+        route: 'gaming',
+        mode: 'guide',
+        data: {
+          response: 'x'.repeat(12_000),
+          sources: [{
+            url: `https://example.com/${'source-path-'.repeat(500)}`,
+            snippet: 'large source metadata'
+          }]
+        }
+      },
+      _route: {
+        requestId: 'req-gaming-structured-truncated',
+        traceId: 'trace-gaming-structured-truncated',
+        gptId: 'arcanos-gaming',
+        module: 'ARCANOS:GAMING',
+        action: 'query',
+        route: 'gaming',
+        timestamp: '2026-07-11T00:00:00.000Z'
+      }
+    }, {
+      maxBytes: 2048
+    });
+
+    expect(prepared.truncated).toBe(true);
+    expect(prepared.responseBytes).toBeLessThanOrEqual(2048);
+    expect(prepared.payload).toMatchObject({
+      ok: true,
+      requestId: 'req-gaming-structured-truncated',
+      traceId: 'trace-gaming-structured-truncated',
+      result: {
+        ok: false,
+        route: 'gaming',
+        mode: 'guide',
+        error: {
+          code: 'GAMING_RESPONSE_TOO_LARGE'
+        }
+      },
+      _route: {
+        requestId: 'req-gaming-structured-truncated',
+        traceId: 'trace-gaming-structured-truncated',
+        module: 'ARCANOS:GAMING',
+        route: 'gaming',
+        truncated: true
+      }
+    });
+    expect(typeof prepared.payload.result).toBe('object');
   });
 
   it('emits a warning event when a response is truncated', () => {

--- a/tests/fallback-handler.test.ts
+++ b/tests/fallback-handler.test.ts
@@ -75,7 +75,9 @@ describe('fallback health-check middleware', () => {
 
   it.each([
     '/gpt/arcanos-gaming',
-    '/gpt/gaming'
+    '/gpt/gaming',
+    '/gpt/ARCANOS-GAMING/',
+    '/gpt/Gaming/'
   ])('does not replace %s route errors with a generic degraded response', async (path) => {
     const { createFallbackMiddleware } = await import(
       '../src/transport/http/middleware/fallbackHandler.js'

--- a/tests/fallback-handler.test.ts
+++ b/tests/fallback-handler.test.ts
@@ -72,4 +72,21 @@ describe('fallback health-check middleware', () => {
       'fallback_handler_preemptive'
     );
   });
+
+  it('does not replace GPT route errors with a generic degraded response', async () => {
+    const { createFallbackMiddleware } = await import(
+      '../src/transport/http/middleware/fallbackHandler.js'
+    );
+    const middleware = createFallbackMiddleware();
+    const req = createMockRequest('/gpt/arcanos-gaming');
+    const res = createMockResponse();
+    const next = jest.fn() as NextFunction;
+    const error = Object.assign(new Error('provider timeout'), { status: 504 });
+
+    middleware(error, req, res, next);
+
+    expect(next).toHaveBeenCalledWith(error);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
 });

--- a/tests/fallback-handler.test.ts
+++ b/tests/fallback-handler.test.ts
@@ -73,12 +73,15 @@ describe('fallback health-check middleware', () => {
     );
   });
 
-  it('does not replace GPT route errors with a generic degraded response', async () => {
+  it.each([
+    '/gpt/arcanos-gaming',
+    '/gpt/gaming'
+  ])('does not replace %s route errors with a generic degraded response', async (path) => {
     const { createFallbackMiddleware } = await import(
       '../src/transport/http/middleware/fallbackHandler.js'
     );
     const middleware = createFallbackMiddleware();
-    const req = createMockRequest('/gpt/arcanos-gaming');
+    const req = createMockRequest(path);
     const res = createMockResponse();
     const next = jest.fn() as NextFunction;
     const error = Object.assign(new Error('provider timeout'), { status: 504 });
@@ -88,5 +91,25 @@ describe('fallback health-check middleware', () => {
     expect(next).toHaveBeenCalledWith(error);
     expect(res.status).not.toHaveBeenCalled();
     expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('preserves degraded fallback handling for non-Gaming GPT route errors', async () => {
+    const { createFallbackMiddleware } = await import(
+      '../src/transport/http/middleware/fallbackHandler.js'
+    );
+    const middleware = createFallbackMiddleware();
+    const req = createMockRequest('/gpt/arcanos-core');
+    const res = createMockResponse();
+    const next = jest.fn() as NextFunction;
+    const error = Object.assign(new Error('provider timeout'), { status: 504 });
+
+    middleware(error, req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'degraded',
+      fallbackMode: expect.any(String)
+    }));
   });
 });

--- a/tests/gaming-agents.routing.test.ts
+++ b/tests/gaming-agents.routing.test.ts
@@ -34,6 +34,19 @@ describe('Gaming agent routing model', () => {
     expect(ClarificationAgent.evaluate(intent)).toEqual({ required: false });
   });
 
+  it('extracts a bare semantic version from an explicit recent-game request', () => {
+    const intent = IntentRouterAgent.classify({
+      mode: 'guide',
+      game: 'Palworld',
+      prompt: 'Look up a beginner guide for Palworld 1.0.',
+    });
+
+    expect(intent).toEqual(expect.objectContaining({
+      game: 'Palworld',
+      version: '1.0',
+    }));
+  });
+
   it.each([
     ['Elite Dangerous exploration guide', 'guide', 'Elite Dangerous'],
     ['Factorio progression guide', 'guide', 'Factorio'],

--- a/tests/gaming-agents.routing.test.ts
+++ b/tests/gaming-agents.routing.test.ts
@@ -47,6 +47,29 @@ describe('Gaming agent routing model', () => {
     }));
   });
 
+  it('extracts a parenthesized semantic version without relying on a nearby game name', () => {
+    const intent = IntentRouterAgent.classify({
+      mode: 'meta',
+      game: 'Palworld',
+      prompt: 'Use the supplied article for this meta request (1.0).',
+    });
+
+    expect(intent.version).toBe('1.0');
+  });
+
+  it.each([
+    'How do I beat the boss in under 3.5 minutes?',
+    'What is the strategy for a 99.9% success rate?',
+  ])('does not extract a general decimal as a game version: %s', (prompt) => {
+    const intent = IntentRouterAgent.classify({
+      mode: 'guide',
+      game: 'Palworld',
+      prompt,
+    });
+
+    expect(intent.version).toBeUndefined();
+  });
+
   it.each([
     ['Elite Dangerous exploration guide', 'guide', 'Elite Dangerous'],
     ['Factorio progression guide', 'guide', 'Factorio'],

--- a/tests/gaming-agents.routing.test.ts
+++ b/tests/gaming-agents.routing.test.ts
@@ -57,9 +57,30 @@ describe('Gaming agent routing model', () => {
     expect(intent.version).toBe('1.0');
   });
 
+  it('keeps the first of multiple explicit versions without trailing sentence text', () => {
+    const intent = IntentRouterAgent.classify({
+      mode: 'meta',
+      game: 'Palworld',
+      prompt: 'Compare Palworld version 0.9 with version 1.0.',
+    });
+
+    expect(intent.version).toBe('0.9');
+  });
+
+  it.each([
+    ['What changed in patch Dragonflight?', 'Dragonflight'],
+    ['Show the meta for season 4.', '4'],
+  ])('preserves a bounded non-semantic patch token: %s', (prompt, version) => {
+    const intent = IntentRouterAgent.classify({ mode: 'meta', game: 'Palworld', prompt });
+
+    expect(intent.version).toBe(version);
+  });
+
   it.each([
     'How do I beat the boss in under 3.5 minutes?',
     'What is the strategy for a 99.9% success rate?',
+    'Connect to 192.168.1.1 for Palworld matchmaking.',
+    'Palworld 2.0 kilograms is the download estimate.',
   ])('does not extract a general decimal as a game version: %s', (prompt) => {
     const intent = IntentRouterAgent.classify({
       mode: 'guide',

--- a/tests/gaming-rag-local-fetch.integration.test.ts
+++ b/tests/gaming-rag-local-fetch.integration.test.ts
@@ -1,0 +1,110 @@
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+
+import {
+  buildGamingRagContext,
+  clearGamingRagCache,
+  isCitableGamingWebSource,
+} from '../src/services/gamingWebContext.js';
+
+const ENV_KEYS = [
+  'ARCANOS_ALLOW_LOCALHOST_FETCH',
+  'ARCANOS_GAMING_DISCOVERY_ENABLED',
+  'ARCANOS_GAMING_RAG_CHUNK_CHARS',
+  'ARCANOS_GAMING_RAG_ENABLED',
+  'ARCANOS_GAMING_RAG_MAX_CHUNKS',
+  'ARCANOS_GAMING_RAG_MAX_SOURCES',
+  'ARCANOS_GAMING_WEB_CONTEXT_CHARS',
+  'ARCANOS_GAMING_WEB_CONTEXT_FETCH_TIMEOUT_MS',
+] as const;
+
+const previousEnv = new Map<string, string | undefined>();
+let server: Server;
+let baseUrl = '';
+
+function article(body: string): string {
+  return `<!doctype html><html><head><title>Community gameplay article</title></head><body><main><article>${body}</article></main></body></html>`;
+}
+
+describe('Gaming RAG real local fetch integration', () => {
+  beforeAll(async () => {
+    for (const key of ENV_KEYS) {
+      previousEnv.set(key, process.env[key]);
+    }
+    process.env.ARCANOS_ALLOW_LOCALHOST_FETCH = 'true';
+    process.env.ARCANOS_GAMING_DISCOVERY_ENABLED = 'false';
+    process.env.ARCANOS_GAMING_RAG_CHUNK_CHARS = '320';
+    process.env.ARCANOS_GAMING_RAG_ENABLED = 'true';
+    process.env.ARCANOS_GAMING_RAG_MAX_CHUNKS = '8';
+    process.env.ARCANOS_GAMING_RAG_MAX_SOURCES = '4';
+    process.env.ARCANOS_GAMING_WEB_CONTEXT_CHARS = '5000';
+    process.env.ARCANOS_GAMING_WEB_CONTEXT_FETCH_TIMEOUT_MS = '2000';
+
+    server = createServer((request, response) => {
+      response.statusCode = 200;
+      response.setHeader('Content-Type', 'text/html; charset=utf-8');
+      if (request.url === '/wrong-game') {
+        response.end(article(
+          '<p>Elden Ring beginner guide route explains flask preparation, weapon upgrades, and safe progress through Stormveil Castle.</p>'
+          + '<p>Players should confirm the nearby grace, save resources, and learn the boss attack windows before advancing.</p>'
+        ));
+        return;
+      }
+      response.end(article(
+        '<p>Palworld version 0.9 progression guide evidence explains a reliable beginner route with concrete preparation steps.</p>'
+        + '<p>Players should gather supplies, confirm the nearby landmark, and save before starting this Palworld objective.</p>'
+      ));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  beforeEach(() => {
+    clearGamingRagCache();
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    for (const key of ENV_KEYS) {
+      const value = previousEnv.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it('rejects a fetched wrong-game body introduction without exposing it as evidence', async () => {
+    const result = await buildGamingRagContext({
+      mode: 'guide',
+      game: 'Factorio',
+      prompt: 'Use this source for a Factorio progression guide.',
+      guideUrl: `${baseUrl}/wrong-game`,
+      guideUrls: [],
+    });
+
+    expect(result.sources).toEqual([{
+      url: `${baseUrl}/wrong-game`,
+      snippet: 'Relevant source retrieved, but readable article text was limited.',
+    }]);
+    expect(result.sources.some(isCitableGamingWebSource)).toBe(false);
+    expect(result.context).not.toContain('Stormveil Castle');
+  });
+
+  it('does not satisfy a multi-version request from a fetched page covering only one version', async () => {
+    const result = await buildGamingRagContext({
+      mode: 'guide',
+      game: 'Palworld',
+      prompt: 'Compare Palworld versions 0.9 and 1.0.',
+      guideUrl: `${baseUrl}/one-version`,
+      guideUrls: [],
+    });
+
+    expect(result.sources.some(isCitableGamingWebSource)).toBe(true);
+    expect(result.context).toContain('Palworld version 0.9');
+    expect(result.currentEvidenceAvailable).toBe(false);
+  });
+});

--- a/tests/gaming-rag-local-fetch.integration.test.ts
+++ b/tests/gaming-rag-local-fetch.integration.test.ts
@@ -51,6 +51,27 @@ describe('Gaming RAG real local fetch integration', () => {
         ));
         return;
       }
+      if (request.url === '/wrong-game-with-requested-mention') {
+        response.end(article(
+          '<p>Elden Ring beginner guide route explains flask preparation, weapon upgrades, and safe progress through Stormveil Castle.</p>'
+          + '<p>Unlike Palworld, this route rewards deliberate dodge timing and careful stamina management.</p>'
+        ));
+        return;
+      }
+      if (request.url === '/sequel-game') {
+        response.end(article(
+          '<p>Path of Exile 2 beginner guide explains the new campaign systems, combat pacing, and early progression route.</p>'
+          + '<p>Players should prepare their equipment before entering the next campaign zone.</p>'
+        ));
+        return;
+      }
+      if (request.url === '/sibling-game') {
+        response.end(article(
+          '<p>Elden Ring Nightreign beginner guide explains expeditions, character roles, and early progression strategy.</p>'
+          + '<p>Players should coordinate their route before the next Nightlord encounter.</p>'
+        ));
+        return;
+      }
       response.end(article(
         '<p>Palworld version 0.9 progression guide evidence explains a reliable beginner route with concrete preparation steps.</p>'
         + '<p>Players should gather supplies, confirm the nearby landmark, and save before starting this Palworld objective.</p>'
@@ -92,6 +113,59 @@ describe('Gaming RAG real local fetch integration', () => {
     }]);
     expect(result.sources.some(isCitableGamingWebSource)).toBe(false);
     expect(result.context).not.toContain('Stormveil Castle');
+  });
+
+  it('rejects a wrong-game introduction despite an incidental requested-game body mention', async () => {
+    const result = await buildGamingRagContext({
+      mode: 'guide',
+      game: 'Palworld',
+      prompt: 'Use this source for a Palworld progression guide.',
+      guideUrl: `${baseUrl}/wrong-game-with-requested-mention`,
+      guideUrls: [],
+    });
+
+    expect(result.sources).toEqual([{
+      url: `${baseUrl}/wrong-game-with-requested-mention`,
+      snippet: 'Relevant source retrieved, but readable article text was limited.',
+    }]);
+    expect(result.sources.some(isCitableGamingWebSource)).toBe(false);
+    expect(result.context).not.toContain('Stormveil Castle');
+  });
+
+  it('does not treat a sequel source as evidence for the original game', async () => {
+    const result = await buildGamingRagContext({
+      mode: 'guide',
+      game: 'Path of Exile',
+      prompt: 'Use this source for a Path of Exile beginner guide.',
+      guideUrl: `${baseUrl}/sequel-game`,
+      guideUrls: [],
+    });
+
+    const suppliedSource = result.sources.find((source) => source.url === `${baseUrl}/sequel-game`);
+    expect(suppliedSource).toEqual({
+      url: `${baseUrl}/sequel-game`,
+      snippet: 'Relevant source retrieved, but readable article text was limited.',
+    });
+    expect(isCitableGamingWebSource(suppliedSource!)).toBe(false);
+    expect(result.context).not.toContain('new campaign systems');
+  });
+
+  it('does not treat a sibling game source as evidence for the original game', async () => {
+    const result = await buildGamingRagContext({
+      mode: 'guide',
+      game: 'Elden Ring',
+      prompt: 'Use this source for an Elden Ring beginner guide.',
+      guideUrl: `${baseUrl}/sibling-game`,
+      guideUrls: [],
+    });
+
+    const suppliedSource = result.sources.find((source) => source.url === `${baseUrl}/sibling-game`);
+    expect(suppliedSource).toEqual({
+      url: `${baseUrl}/sibling-game`,
+      snippet: 'Relevant source retrieved, but readable article text was limited.',
+    });
+    expect(isCitableGamingWebSource(suppliedSource!)).toBe(false);
+    expect(result.context).not.toContain('Nightlord encounter');
   });
 
   it('does not satisfy a multi-version request from a fetched page covering only one version', async () => {

--- a/tests/gaming-search-discovery.test.ts
+++ b/tests/gaming-search-discovery.test.ts
@@ -327,6 +327,8 @@ describe('gaming open-web source discovery', () => {
   });
 
   it.each([
+    Object.assign(new Error('unauthorized'), { status: 401 }),
+    Object.assign(new Error('forbidden'), { status: 403 }),
     Object.assign(new Error('rate limited'), { status: 429 }),
     new Error('provider unavailable')
   ])('maps provider errors to a controlled failure result', async (error) => {

--- a/tests/gaming-search-discovery.test.ts
+++ b/tests/gaming-search-discovery.test.ts
@@ -318,6 +318,14 @@ describe('gaming open-web source discovery', () => {
     expect(result.discoveryFailureReason).toBe('DISCOVERY_PROVIDER_TIMEOUT');
   });
 
+  it('distinguishes an unconfigured provider from disabled discovery', async () => {
+    const result = await discoverGamingSources(guideInput());
+
+    expect(result.candidates).toEqual([]);
+    expect(result.searchProvider).toBe('brave');
+    expect(result.discoveryFailureReason).toBe('DISCOVERY_PROVIDER_UNCONFIGURED');
+  });
+
   it.each([
     Object.assign(new Error('rate limited'), { status: 429 }),
     new Error('provider unavailable')

--- a/tests/gaming-source-discovery.integration.test.ts
+++ b/tests/gaming-source-discovery.integration.test.ts
@@ -29,7 +29,8 @@ jest.unstable_mockModule('@platform/runtime/env.js', () => ({
 const {
   buildGamingRagContext,
   clearGamingRagCache,
-  isCitableGamingWebSource
+  isCitableGamingWebSource,
+  isGamingFreshnessSensitive
 } = await import('../src/services/gamingWebContext.js');
 
 const TEST_ENV_KEYS = [
@@ -220,6 +221,23 @@ describe('Gaming RAG discovery integration', () => {
     expect(result.currentEvidenceAvailable).toBe(false);
   });
 
+  it('treats a parenthesized semantic version as freshness-sensitive without a known game', () => {
+    expect(isGamingFreshnessSensitive(baseInput({
+      game: undefined,
+      prompt: 'Use the supplied article for this guide request (1.0).'
+    }))).toBe(true);
+  });
+
+  it.each([
+    'How do I beat the boss in under 3.5 minutes?',
+    'What is the strategy for a 99.9% success rate?',
+  ])('does not treat a general decimal as freshness-sensitive: %s', (prompt) => {
+    expect(isGamingFreshnessSensitive(baseInput({
+      game: 'Palworld',
+      prompt,
+    }))).toBe(false);
+  });
+
   it('accepts a validated supplied semantic-version article as current evidence', async () => {
     const suppliedUrl = 'https://palworld-guides.example/palworld-1-0-beginner-guide';
     mockFetchAndClean.mockResolvedValue(
@@ -238,6 +256,40 @@ describe('Gaming RAG discovery integration', () => {
     expect(result.sources).toEqual([
       expect.objectContaining({ url: suppliedUrl, snippet: expect.any(String) })
     ]);
+  });
+
+  it('accepts an exact requested version followed by sentence-ending punctuation', async () => {
+    const suppliedUrl = 'https://palworld-guides.example/palworld-1-0-beginner-guide';
+    mockFetchAndClean.mockResolvedValue(
+      'Palworld beginner guide evidence explains a current progression route with preparation and combat steps. '
+      + 'Players should gather supplies, confirm the nearby landmark, and save before starting the objective. '
+      + 'This guidance applies to Palworld version 1.0.'
+    );
+
+    const result = await buildGamingRagContext(baseInput({
+      game: 'Palworld',
+      prompt: 'Use this Palworld 1.0 article as a current guide source.',
+      guideUrl: suppliedUrl
+    }));
+
+    expect(result.currentEvidenceAvailable).toBe(true);
+  });
+
+  it('does not accept a longer patch as an exact requested version', async () => {
+    const suppliedUrl = 'https://palworld-guides.example/palworld-1-0-1-beginner-guide';
+    mockFetchAndClean.mockResolvedValue(
+      'Palworld beginner guide evidence explains a current progression route with preparation and combat steps. '
+      + 'Players should gather supplies, confirm the nearby landmark, and save before starting the objective. '
+      + 'This guidance applies to Palworld version 1.0.1.'
+    );
+
+    const result = await buildGamingRagContext(baseInput({
+      game: 'Palworld',
+      prompt: 'Use this Palworld 1.0 article as a current guide source.',
+      guideUrl: suppliedUrl
+    }));
+
+    expect(result.currentEvidenceAvailable).toBe(false);
   });
 
   it('does not treat a different semantic version as current evidence', async () => {

--- a/tests/gaming-source-discovery.integration.test.ts
+++ b/tests/gaming-source-discovery.integration.test.ts
@@ -52,6 +52,8 @@ type DiscoveryCandidate = {
   providerRank: number;
   provider: string;
   score: number;
+  publishedAt?: string;
+  updatedAt?: string;
   suggestedSourceType: 'official' | 'patch_notes' | 'wiki' | 'curated';
   stable: boolean;
   freshnessKnown: boolean;
@@ -203,6 +205,112 @@ describe('Gaming RAG discovery integration', () => {
     expect(result.context).toContain(`[Source 1] ${discoveredUrl}`);
   });
 
+  it('treats a bare semantic version as freshness-sensitive discovery', async () => {
+    const result = await buildGamingRagContext(baseInput({
+      game: 'Palworld',
+      prompt: 'Look up a beginner guide for Palworld 1.0.'
+    }));
+
+    expect(mockDiscoverGamingSources).toHaveBeenCalledWith(expect.objectContaining({
+      game: 'Palworld',
+      mode: 'guide',
+      patchSensitive: true
+    }));
+    expect(result.retrievalReason).toBe('patch_or_meta_sensitive');
+    expect(result.currentEvidenceAvailable).toBe(false);
+  });
+
+  it('accepts a validated supplied semantic-version article as current evidence', async () => {
+    const suppliedUrl = 'https://palworld-guides.example/palworld-1-0-beginner-guide';
+    mockFetchAndClean.mockResolvedValue(
+      'Palworld 1.0 beginner guide evidence explains a current progression route with preparation and combat steps. '
+      + 'Players should gather supplies, confirm the nearby landmark, and save before starting the Palworld objective.'
+    );
+
+    const result = await buildGamingRagContext(baseInput({
+      game: 'Palworld',
+      prompt: 'Use this Palworld 1.0 article as a guide source.',
+      guideUrl: suppliedUrl
+    }));
+
+    expect(mockDiscoverGamingSources).not.toHaveBeenCalled();
+    expect(result.currentEvidenceAvailable).toBe(true);
+    expect(result.sources).toEqual([
+      expect.objectContaining({ url: suppliedUrl, snippet: expect.any(String) })
+    ]);
+  });
+
+  it('does not treat a different semantic version as current evidence', async () => {
+    const suppliedUrl = 'https://palworld-guides.example/palworld-1-0-beginner-guide';
+    mockFetchAndClean.mockResolvedValue(
+      'Palworld 0.9 beginner guide evidence explains a progression route with preparation and combat steps. '
+      + 'Players should gather supplies, confirm the nearby landmark, and save before starting the Palworld objective.'
+    );
+
+    const result = await buildGamingRagContext(baseInput({
+      game: 'Palworld',
+      prompt: 'Use this Palworld 1.0 article as a current guide source.',
+      guideUrl: suppliedUrl
+    }));
+
+    expect(mockDiscoverGamingSources).toHaveBeenCalledWith(expect.objectContaining({
+      game: 'Palworld',
+      patchSensitive: true
+    }));
+    expect(result.currentEvidenceAvailable).toBe(false);
+    expect(result.sources).toEqual([
+      expect.objectContaining({ url: suppliedUrl, snippet: expect.any(String) })
+    ]);
+  });
+
+  it('does not treat stale official evidence as current without a requested version', async () => {
+    const staleOfficialUrl = 'https://official-palworld.example/guides/beginner';
+    mockDiscoverGamingSources.mockResolvedValue(makeDiscoveryResult({
+      candidates: [{
+        ...makeDiscoveredCandidate(staleOfficialUrl, 1, 'official'),
+        updatedAt: '2020-01-01T00:00:00.000Z'
+      }]
+    }));
+    mockFetchAndClean.mockResolvedValue(
+      'Palworld current beginner guide evidence explains a progression route with preparation and combat steps. '
+      + 'Players should gather supplies, confirm the nearby landmark, and save before starting the Palworld objective.'
+    );
+
+    const result = await buildGamingRagContext(baseInput({
+      game: 'Palworld',
+      prompt: 'Look up a current beginner guide for Palworld.'
+    }));
+
+    expect(result.sources).toEqual([
+      expect.objectContaining({ url: staleOfficialUrl, snippet: expect.any(String) })
+    ]);
+    expect(result.currentEvidenceAvailable).toBe(false);
+  });
+
+  it('accepts recently dated current evidence when no version is requested', async () => {
+    const currentOfficialUrl = 'https://official-palworld.example/guides/current-beginner';
+    mockDiscoverGamingSources.mockResolvedValue(makeDiscoveryResult({
+      candidates: [{
+        ...makeDiscoveredCandidate(currentOfficialUrl, 1, 'official'),
+        updatedAt: new Date().toISOString()
+      }]
+    }));
+    mockFetchAndClean.mockResolvedValue(
+      'Palworld current beginner guide evidence explains a progression route with preparation and combat steps. '
+      + 'Players should gather supplies, confirm the nearby landmark, and save before starting the Palworld objective.'
+    );
+
+    const result = await buildGamingRagContext(baseInput({
+      game: 'Palworld',
+      prompt: 'Look up a current beginner guide for Palworld.'
+    }));
+
+    expect(result.sources).toEqual([
+      expect.objectContaining({ url: currentOfficialUrl, snippet: expect.any(String) })
+    ]);
+    expect(result.currentEvidenceAvailable).toBe(true);
+  });
+
   it('skips discovery when a supplied source already provides high-quality evidence', async () => {
     const suppliedUrl = 'https://community-guides.example/caves-of-qud/early-progression-guide';
     mockFetchAndClean.mockResolvedValue(guideEvidence('Caves of Qud', 'early progression'));
@@ -302,9 +410,9 @@ describe('Gaming RAG discovery integration', () => {
     expect(result.discoveryTriggered).toBe(true);
     expect(result.discoveryReason).toBe('DISCOVERY_SUPPLIED_SOURCE_FAILED');
     expect(result.sources).toEqual([
-      expect.objectContaining({ url: discoveredUrl, snippet: expect.any(String) })
+      expect.objectContaining({ url: discoveredUrl, snippet: expect.any(String) }),
+      { url: 'invalid-source', error: 'Malformed or unsupported source URL.' }
     ]);
-    expect(result.sources).not.toContainEqual(expect.objectContaining({ url: 'invalid-source' }));
     expect(mockFetchAndClean).toHaveBeenCalledTimes(1);
   });
 
@@ -355,6 +463,42 @@ describe('Gaming RAG discovery integration', () => {
     expect(result.sources).not.toContainEqual(expect.objectContaining({ url: failedUrl }));
     expect(result.sources).not.toContainEqual(expect.objectContaining({ url: searchOnlyUrl }));
     expect(mockFetchAndClean).not.toHaveBeenCalledWith(searchOnlyUrl, expect.anything(), expect.anything());
+  });
+
+  it('keeps a safe supplied-source error after accepted discovered evidence', async () => {
+    process.env.ARCANOS_GAMING_RAG_MAX_SOURCES = '2';
+    const suppliedUrl = 'https://medium.example/palworld-1-0-guide';
+    const discoveredUrl = 'https://palworld.example/news/palworld-1-0-guide';
+    const secondDiscoveredUrl = 'https://palworld-community.example/guides/palworld-1-0';
+    mockDiscoverGamingSources.mockResolvedValue(makeDiscoveryResult({
+      candidates: [
+        makeDiscoveredCandidate(discoveredUrl, 1, 'patch_notes'),
+        makeDiscoveredCandidate(secondDiscoveredUrl, 2, 'patch_notes')
+      ]
+    }));
+    mockFetchAndClean.mockImplementation(async (url: string) => {
+      if (url === suppliedUrl) {
+        throw Object.assign(new Error('secret upstream forbidden response'), {
+          response: { status: 403 }
+        });
+      }
+      return guideEvidence('Palworld', '1.0 current progression');
+    });
+
+    const result = await buildGamingRagContext(baseInput({
+      game: 'Palworld',
+      prompt: 'Use this Palworld 1.0 article as a guide source.',
+      guideUrl: suppliedUrl
+    }));
+
+    expect(result.sources).toEqual([
+      expect.objectContaining({ url: discoveredUrl, snippet: expect.any(String) }),
+      { url: suppliedUrl, error: 'Source access was blocked.' }
+    ]);
+    expect(result.context).toContain(`[Source 1] ${discoveredUrl}`);
+    expect(result.context).not.toContain('[Source 2]');
+    expect(result.sources).not.toContainEqual(expect.objectContaining({ url: secondDiscoveredUrl }));
+    expect(result.currentEvidenceAvailable).toBe(true);
   });
 
   it('does not cite a fetched discovered page that fails to corroborate the requested game', async () => {

--- a/tests/gaming-source-discovery.integration.test.ts
+++ b/tests/gaming-source-discovery.integration.test.ts
@@ -231,6 +231,9 @@ describe('Gaming RAG discovery integration', () => {
   it.each([
     'How do I beat the boss in under 3.5 minutes?',
     'What is the strategy for a 99.9% success rate?',
+    'Connect to 192.168.1.1 for Palworld matchmaking.',
+    'Palworld 2.0 kilograms is the download estimate.',
+    'Palworld was released on 7.11.26.',
   ])('does not treat a general decimal as freshness-sensitive: %s', (prompt) => {
     expect(isGamingFreshnessSensitive(baseInput({
       game: 'Palworld',
@@ -313,6 +316,43 @@ describe('Gaming RAG discovery integration', () => {
     expect(result.sources).toEqual([
       expect.objectContaining({ url: suppliedUrl, snippet: expect.any(String) })
     ]);
+  });
+
+  it('requires every explicitly requested version across eligible citable chunks', async () => {
+    const olderUrl = 'https://palworld-guides.example/palworld-0-9-guide';
+    const currentUrl = 'https://palworld-guides.example/palworld-1-0-guide';
+    mockFetchAndClean.mockImplementation(async (url: string) => url === olderUrl
+      ? guideEvidence('Palworld version 0.9', 'progression route')
+      : guideEvidence('Palworld version 1.0', 'progression route'));
+
+    const result = await buildGamingRagContext(baseInput({
+      game: 'Palworld',
+      prompt: 'Compare Palworld version 0.9 with Palworld version 1.0.',
+      guideUrls: [olderUrl, currentUrl]
+    }));
+
+    expect(result.currentEvidenceAvailable).toBe(true);
+    expect(result.sources).toEqual(expect.arrayContaining([
+      expect.objectContaining({ url: olderUrl, snippet: expect.any(String) }),
+      expect.objectContaining({ url: currentUrl, snippet: expect.any(String) })
+    ]));
+  });
+
+  it('does not satisfy a multi-version request with evidence for only the first version', async () => {
+    const suppliedUrl = 'https://palworld-guides.example/palworld-0-9-guide';
+    mockFetchAndClean.mockResolvedValue(guideEvidence('Palworld version 0.9', 'progression route'));
+
+    const result = await buildGamingRagContext(baseInput({
+      game: 'Palworld',
+      prompt: 'Compare versions 0.9 and 1.0 for Palworld.',
+      guideUrl: suppliedUrl
+    }));
+
+    expect(result.currentEvidenceAvailable).toBe(false);
+    expect(mockDiscoverGamingSources).toHaveBeenCalledWith(expect.objectContaining({
+      game: 'Palworld',
+      patchSensitive: true
+    }));
   });
 
   it('does not treat stale official evidence as current without a requested version', async () => {
@@ -429,6 +469,25 @@ describe('Gaming RAG discovery integration', () => {
     expect(result.sources[0]).toEqual(expect.objectContaining({ url: curatedUrl }));
     expect(isCitableGamingWebSource(result.sources[0])).toBe(true);
     expect(mockDiscoverGamingSources).not.toHaveBeenCalled();
+  });
+
+  it('rejects a supplied wrong-game article identified only by its body introduction', async () => {
+    process.env.ARCANOS_GAMING_DISCOVERY_ENABLED = 'false';
+    const suppliedUrl = 'https://supplied.example/article-without-metadata';
+    mockFetchAndClean.mockResolvedValue(guideEvidence('Elden Ring', 'beginner guide route'));
+
+    const result = await buildGamingRagContext(baseInput({
+      game: 'Factorio',
+      prompt: 'Use this source for a Factorio progression guide.',
+      guideUrl: suppliedUrl
+    }));
+
+    expect(result.sources).toEqual([{
+      url: suppliedUrl,
+      snippet: 'Relevant source retrieved, but readable article text was limited.'
+    }]);
+    expect(result.context).not.toContain('Elden Ring');
+    expect(result.sources.some(isCitableGamingWebSource)).toBe(false);
   });
 
   it('orders final capped sources by chunk rank after low-quality supplied evidence triggers discovery', async () => {

--- a/tests/gaming-version.test.ts
+++ b/tests/gaming-version.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  extractExplicitGamingVersions,
+  textContainsExactGamingVersion,
+} from '../src/services/gamingVersion.js';
+
+describe('Gaming semantic version parsing', () => {
+  it.each([
+    ['Palworld 1.0', ['1.0']],
+    ['Palworld version 1.0', ['1.0']],
+    ['Palworld (1.0)', ['1.0']],
+    ['Palworld v1.0', ['1.0']],
+    ['Palworld 1.0.1', ['1.0.1']],
+    ['What changed in patch 1.0?', ['1.0']],
+    ['This applies to version 1.0.', ['1.0']],
+    ['Use version "1.0" for this guide.', ['1.0']],
+    ['Compare versions 0.9 and 1.0.', ['0.9', '1.0']],
+    ['Compare Palworld 0.9 and 1.0.', ['0.9', '1.0']],
+    ['Compare Palworld 0.9 with Palworld 1.0.', ['0.9', '1.0']],
+  ])('extracts explicit versions without trailing prose: %s', (prompt, expected) => {
+    expect(extractExplicitGamingVersions({ prompt, game: 'Palworld' })).toEqual(expected);
+  });
+
+  it.each([
+    'Finish the run in 3.5 minutes.',
+    'Palworld 2.0 kilograms is the download estimate.',
+    'Palworld 1.5 hours is the expected duration.',
+    'Use Palworld 1920.1080 resolution.',
+    'Connect to 192.168.1.1 for Palworld matchmaking.',
+    'Palworld costs $1.99 during the sale.',
+    'Palworld 1.25 K/D is the displayed statistic.',
+    'Palworld 2.0 items are required.',
+    'Palworld was released on 7.11.26.',
+  ])('rejects non-version numeric text: %s', (prompt) => {
+    expect(extractExplicitGamingVersions({ prompt, game: 'Palworld' })).toEqual([]);
+  });
+
+  it('matches exact versions without accepting a longer patch', () => {
+    expect(textContainsExactGamingVersion('This guide applies to version 1.0.', '1.0')).toBe(true);
+    expect(textContainsExactGamingVersion('This guide applies to version 1.0.1.', '1.0')).toBe(false);
+  });
+});

--- a/tests/gaming-version.test.ts
+++ b/tests/gaming-version.test.ts
@@ -18,12 +18,18 @@ describe('Gaming semantic version parsing', () => {
     ['Compare versions 0.9 and 1.0.', ['0.9', '1.0']],
     ['Compare Palworld 0.9 and 1.0.', ['0.9', '1.0']],
     ['Compare Palworld 0.9 with Palworld 1.0.', ['0.9', '1.0']],
+    ['Compare versions 1.0 and 2.0 kilograms.', ['1.0']],
+    ['Compare Palworld 1.0 and 3.5 minutes of setup.', ['1.0']],
   ])('extracts explicit versions without trailing prose: %s', (prompt, expected) => {
     expect(extractExplicitGamingVersions({ prompt, game: 'Palworld' })).toEqual(expected);
   });
 
   it.each([
     'Finish the run in 3.5 minutes.',
+    'What changed in 3.5 minutes?',
+    'What changed in 2.0 kilograms?',
+    'What changed in 1.5 hours?',
+    'What changed in 99.9 percent?',
     'Palworld 2.0 kilograms is the download estimate.',
     'Palworld 1.5 hours is the expected duration.',
     'Use Palworld 1920.1080 resolution.',

--- a/tests/gaming-web-context-quality.test.ts
+++ b/tests/gaming-web-context-quality.test.ts
@@ -665,6 +665,22 @@ describe('gaming RAG snippet quality', () => {
     expect(JSON.stringify(result.sources)).not.toMatch(/secret upstream|private-host/i);
   });
 
+  it('masks a blocked private target instead of returning the internal URL', async () => {
+    mockFetchAndClean.mockRejectedValue(new Error('Private/internal IP addresses are not allowed for security reasons'));
+    const result = await buildGamingRagContext({
+      mode: 'guide',
+      prompt: 'Use this supplied guide.',
+      guideUrl: 'http://127.0.0.1/internal-guide',
+      guideUrls: []
+    });
+
+    expect(result.sources).toEqual([{
+      url: 'invalid-source',
+      error: 'Source URL was blocked or could not be resolved.'
+    }]);
+    expect(JSON.stringify(result.sources)).not.toContain('127.0.0.1');
+  });
+
   it('returns safe metadata for a malformed-only source without fetching', async () => {
     const result = await buildGamingRagContext({
       mode: 'guide',

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -424,6 +424,10 @@ describe('gaming guide output hardening', () => {
   });
 
   it('passes a meta request with game through the normal path', async () => {
+    mockFetchAndClean.mockResolvedValue(
+      'World of Warcraft 11.2.7 Frost Mage current patch guide explains tuning, talents, rotation, and encounter tradeoffs. '
+      + 'Players should verify current hotfixes before changing a competitive build.'
+    );
     mockRunTrinityWritingPipeline.mockResolvedValueOnce({
       result: 'Frost Mage is viable when current tuning supports its control and cleave profile.',
       activeModel: 'gpt-test',
@@ -432,7 +436,7 @@ describe('gaming guide output hardening', () => {
 
     const result = await runMetaPipeline({
       game: 'World of Warcraft',
-      prompt: 'Is frost mage still viable this patch?',
+      prompt: 'Is frost mage still viable in World of Warcraft 11.2.7?',
       guideUrls: [],
       auditEnabled: false
     });
@@ -472,7 +476,7 @@ describe('gaming guide output hardening', () => {
         cleanedTextLength: 150,
         ...(mode === 'build' ? { documentTitle: pageHeading } : { headingText: pageHeading })
       });
-      return `${expectedGame} ${mode} evidence explains readable gameplay choices, priorities, tradeoffs, and current recommendations.`;
+      return `${expectedGame} ${mode} 1.0 evidence explains readable gameplay choices, priorities, tradeoffs, and current recommendations.`;
     });
     mockRunTrinityWritingPipeline.mockResolvedValueOnce({
       result: `Source-backed ${mode} response`,
@@ -482,7 +486,7 @@ describe('gaming guide output hardening', () => {
 
     const pipeline = mode === 'build' ? runBuildPipeline : runMetaPipeline;
     const result = await pipeline({
-      prompt: `Use the supplied article for this ${mode} request.`,
+      prompt: `Use the supplied article for this ${mode} request${mode === 'meta' ? ' (1.0)' : ''}.`,
       guideUrl: url,
       guideUrls: [],
       auditEnabled: false
@@ -512,6 +516,10 @@ describe('gaming guide output hardening', () => {
   });
 
   it('keeps repeated meta requests off the direct-answer integrity path', async () => {
+    mockFetchAndClean.mockResolvedValue(
+      'World of Warcraft 11.2.7 Frost Mage current patch guide explains tuning, talents, rotation, and encounter tradeoffs. '
+      + 'Players should verify current hotfixes before changing a competitive build.'
+    );
     const metaAnswer = [
       '1. Frost Mage is viable when its control, cleave, and burst windows match the current encounter profile.',
       '2. Treat exact rankings as patch-sensitive and verify tuning before committing to competitive pushes.'
@@ -525,7 +533,7 @@ describe('gaming guide output hardening', () => {
     for (let index = 0; index < 10; index += 1) {
       const result = await runMetaPipeline({
         game: 'World of Warcraft',
-        prompt: 'Is frost mage still viable this patch?',
+        prompt: 'Is frost mage still viable in World of Warcraft 11.2.7?',
         guideUrls: [],
         auditEnabled: false
       });
@@ -552,6 +560,10 @@ describe('gaming guide output hardening', () => {
   });
 
   it('allows numbered or bulleted meta formatting without direct-answer false positives', async () => {
+    mockFetchAndClean.mockResolvedValue(
+      'World of Warcraft 11.2.7 Frost Mage current patch guide explains tuning, talents, rotation, and encounter tradeoffs. '
+      + 'Players should verify current hotfixes before changing a competitive build.'
+    );
     const metaAnswer = [
       '- Frost Mage can be viable when control and burst windows matter.',
       '- Watch for tuning, dungeon pool, and team composition before treating it as best-in-slot.'
@@ -564,7 +576,7 @@ describe('gaming guide output hardening', () => {
 
     const result = await runMetaPipeline({
       game: 'World of Warcraft',
-      prompt: 'Is frost mage still viable this patch?',
+      prompt: 'Is frost mage still viable in World of Warcraft 11.2.7?',
       guideUrls: [],
       auditEnabled: false
     });
@@ -663,9 +675,7 @@ describe('gaming guide output hardening', () => {
     const warnSpy = jest.spyOn(logger, 'warn');
     try {
       mockFetchAndClean.mockResolvedValueOnce('Elden Ring route guide: start in Limgrave, follow Sites of Grace, upgrade flasks, and prepare before Stormveil Castle.');
-      mockRunTrinityWritingPipeline.mockRejectedValueOnce(Object.assign(new Error('provider unavailable'), {
-        code: 'TRINITY_OUTPUT_INTEGRITY_FAILED'
-      }));
+      mockRunTrinityWritingPipeline.mockRejectedValueOnce(new Error('provider unavailable'));
 
       const result = await runGuidePipeline({
         game: 'Elden Ring',
@@ -682,14 +692,69 @@ describe('gaming guide output hardening', () => {
       expect(result.data.response).not.toContain('TRINITY_OUTPUT_INTEGRITY_FAILED');
       expect(result.data.response).not.toMatch(/provider|incomplete|integrity|timeout/i);
       expect(result.data.response).not.toContain('Backend-supported: none');
+      expect(result.data.fallbackReason).toBe('GAMING_PROVIDER_ERROR');
       expectInlineSourceRefsToMap(result.data.response, result.data.sources.length);
       expect(warnSpy).toHaveBeenCalledWith('gaming.fallback.used', expect.objectContaining({
-        fallbackReason: 'TRINITY_OUTPUT_INTEGRITY_FAILED',
-        errorCode: 'TRINITY_OUTPUT_INTEGRITY_FAILED'
+        fallbackReason: 'GAMING_PROVIDER_ERROR'
       }));
     } finally {
       warnSpy.mockRestore();
     }
+  });
+
+  it('preserves genuine output-integrity failures for the module formatter', async () => {
+    const integrityError = Object.assign(new Error('secret provider integrity detail'), {
+      code: 'TRINITY_OUTPUT_INTEGRITY_FAILED',
+      integrityIssues: ['broken_numbering']
+    });
+    mockRunTrinityWritingPipeline.mockRejectedValueOnce(integrityError);
+
+    await expect(runGuidePipeline({
+      game: 'Elden Ring',
+      prompt: 'Look up a guide for Elden Ring.',
+      guideUrls: [],
+      auditEnabled: false
+    })).rejects.toBe(integrityError);
+  });
+
+  it.each([
+    ['Palworld', 'Look up a current beginner guide for Palworld 1.0.'],
+    ['Clockwork Odyssey', 'Look up a current beginner guide for Clockwork Odyssey 1.0.']
+  ])('returns a current-evidence fallback for freshness-sensitive %s guidance', async (game, prompt) => {
+    mockGetEnvBoolean.mockImplementation((key: string, defaultValue: boolean) =>
+      key === 'ARCANOS_GAMING_DISCOVERY_ENABLED' ? true : defaultValue
+    );
+
+    const result = await runGuidePipeline({
+      game,
+      prompt,
+      guideUrls: [],
+      auditEnabled: false
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.data.fallbackReason).toBe('CURRENT_EVIDENCE_UNAVAILABLE');
+    expect(result.data.discoveryReason).toBe('DISCOVERY_NO_SOURCE_CANDIDATES');
+    expect(result.data.discoveryFailureReason).toBe('DISCOVERY_PROVIDER_UNCONFIGURED');
+    expect(result.data.sources).toEqual([]);
+    expect(result.data.response).toContain('Sources unavailable');
+    expect(mockRunTrinityWritingPipeline).not.toHaveBeenCalled();
+  });
+
+  it('marks the deterministic no-client path with bounded fallback metadata', async () => {
+    mockGetOpenAIClientOrAdapter.mockReturnValueOnce({ client: null });
+
+    const result = await runGuidePipeline({
+      game: 'Caves of Qud',
+      prompt: 'Give me a concise beginner progression guide.',
+      guideUrls: [],
+      auditEnabled: false
+    });
+
+    expect(result.data.fallbackReason).toBe('GAMING_PROVIDER_UNAVAILABLE');
+    expect(result.data.discoveryReason).toBe('DISCOVERY_DISABLED');
+    expect(mockGenerateMockResponse).toHaveBeenCalledTimes(1);
+    expect(mockRunTrinityWritingPipeline).not.toHaveBeenCalled();
   });
 
   it('returns a controlled fallback when upstream intake slows down', async () => {
@@ -1154,11 +1219,14 @@ describe('gaming guide output hardening', () => {
   });
 
   it('prefers official patch notes for patch-sensitive Elden Ring meta requests', async () => {
-    mockFetchAndClean.mockResolvedValue('Official patch notes: balance adjustments changed several weapon and skill interactions.');
+    mockFetchAndClean.mockResolvedValue(
+      'Elden Ring 1.16.1 official current patch notes explain balance adjustments to weapons, skills, and build interactions. '
+      + 'Players should review the current version before changing a patch-sensitive build.'
+    );
 
     await runMetaPipeline({
       game: 'Elden Ring',
-      prompt: 'What changed for Elden Ring builds in the latest patch?',
+      prompt: 'What changed for Elden Ring builds in patch 1.16.1?',
       guideUrls: [],
       auditEnabled: false
     });
@@ -1171,19 +1239,20 @@ describe('gaming guide output hardening', () => {
     );
     const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
     expect(trinityRequest.input.prompt).toContain('Type: patch_notes');
-    expect(trinityRequest.input.prompt).toContain('Official patch notes');
+    expect(trinityRequest.input.prompt).toContain('official current patch notes');
   });
 
   it('retrieves WoW patch and Frost Mage guide context for current viability requests', async () => {
+    process.env.ARCANOS_GAMING_WEB_CONTEXT_CHARS = '1024';
     mockFetchAndClean.mockImplementation(async (url: string) =>
       url.includes('worldofwarcraft.blizzard.com')
-        ? 'Official WoW news: current hotfixes and class tuning can change spec viability this patch.'
-        : 'Frost Mage guide: Frost Mage viability depends on tuning, talents, damage profile, and encounter needs.'
+        ? 'World of Warcraft 11.2.7 official current patch news explains hotfixes and class tuning that can change Frost Mage viability.'
+        : 'World of Warcraft 11.2.7 Frost Mage guide explains current talents, rotation, damage profile, and encounter needs.'
     );
 
     await runMetaPipeline({
       game: 'World of Warcraft',
-      prompt: 'Is Frost Mage still viable this patch?',
+      prompt: 'Is Frost Mage still viable in World of Warcraft 11.2.7?',
       guideUrls: [],
       auditEnabled: false
     });
@@ -1191,11 +1260,11 @@ describe('gaming guide output hardening', () => {
     expect(mockFetchAndClean).toHaveBeenNthCalledWith(
       1,
       'https://worldofwarcraft.blizzard.com/en-us/news',
-      512,
+      1024,
       expectFetchOptions()
     );
     const trinityRequest = mockRunTrinityWritingPipeline.mock.calls[0][0] as { input: { prompt: string } };
-    expect(trinityRequest.input.prompt).toContain('Official WoW news');
+    expect(trinityRequest.input.prompt).toContain('official current patch news');
     expect(trinityRequest.input.prompt).toContain('Frost Mage guide');
   });
 

--- a/tests/gaming.direct-answer.test.ts
+++ b/tests/gaming.direct-answer.test.ts
@@ -1347,8 +1347,8 @@ describe('gaming guide output hardening', () => {
 
     const result = await runGuidePipeline({
       prompt: 'Use the linked guides for source numbering.',
-      guideUrl: 'https://example.com/guide-a',
-      guideUrls: ['https://example.com/guide-a', 'https://example.com/guide-b', 'https://example.com/guide-c'],
+      guideUrl: 'https://example.com/guide-a#first',
+      guideUrls: ['https://example.com/guide-a#duplicate', 'https://example.com/guide-b', 'https://example.com/guide-c'],
       auditEnabled: false
     });
 

--- a/tests/gpt-dispatch.gaming.test.ts
+++ b/tests/gpt-dispatch.gaming.test.ts
@@ -710,6 +710,34 @@ describe('routeGptRequest gaming routing', () => {
     );
   });
 
+  it('merges a top-level guideUrl into the explicit Gaming payload', async () => {
+    const guideUrl = 'https://guides.example/palworld-1-0';
+    await routeGptRequest({
+      gptId: 'arcanos-gaming',
+      body: {
+        action: 'query',
+        guideUrl,
+        payload: {
+          mode: 'guide',
+          game: 'Palworld',
+          prompt: 'Use the supplied Palworld 1.0 guide.'
+        }
+      },
+      requestId: 'req-gaming-top-level-guide-url'
+    });
+
+    expect(mockDispatchModuleAction).toHaveBeenCalledWith(
+      'ARCANOS:GAMING',
+      'query',
+      expect.objectContaining({
+        mode: 'guide',
+        game: 'Palworld',
+        prompt: 'Use the supplied Palworld 1.0 guide.',
+        guideUrl
+      })
+    );
+  });
+
   it('preserves explicit payload Gaming mode over conflicting top-level mode', async () => {
     const envelope = await routeGptRequest({
       gptId: 'arcanos-gaming',

--- a/tests/gpt-router-auth-logging.test.ts
+++ b/tests/gpt-router-auth-logging.test.ts
@@ -61,6 +61,8 @@ describe('gpt router auth logging', () => {
   let consoleLogSpy: ReturnType<typeof jest.spyOn>;
   const originalGptRouteHardTimeoutMs = process.env.GPT_ROUTE_HARD_TIMEOUT_MS;
   const originalGptRouteAsyncCoreDefault = process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT;
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalOpenAIApiKey = process.env.OPENAI_API_KEY;
 
   beforeEach(() => {
     consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
@@ -98,6 +100,16 @@ describe('gpt router auth logging', () => {
       delete process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT;
     } else {
       process.env.GPT_ROUTE_ASYNC_CORE_DEFAULT = originalGptRouteAsyncCoreDefault;
+    }
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+    if (originalOpenAIApiKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      Reflect.set(process.env, 'OPENAI_API_KEY', originalOpenAIApiKey);
     }
     consoleLogSpy.mockRestore();
   });
@@ -247,7 +259,7 @@ describe('gpt router auth logging', () => {
     });
   });
 
-  it('returns bare diagnostic JSON instead of the dispatcher envelope for ping probes', async () => {
+  it('returns correlated diagnostic JSON instead of the dispatcher envelope for ping probes', async () => {
     mockRouteGptRequest.mockResolvedValue({
       ok: true,
       result: {
@@ -277,6 +289,8 @@ describe('gpt router auth logging', () => {
       status: 'ok',
       route: 'diagnostic',
       message: 'backend operational',
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
     });
   });
 
@@ -312,7 +326,11 @@ describe('gpt router auth logging', () => {
     expect(response.status).toBe(200);
     expect(response.body).toMatchObject({
       ok: true,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
       _route: {
+        requestId: response.headers['x-request-id'],
+        traceId: response.headers['x-trace-id'],
         gptId: 'arcanos-gaming',
         module: 'ARCANOS:GAMING',
         route: 'gaming',
@@ -395,6 +413,308 @@ describe('gpt router auth logging', () => {
         }),
       })
     );
+  });
+
+  it.each([
+    [
+      'Elden Ring without a supplied URL',
+      {
+        mode: 'guide',
+        game: 'Elden Ring',
+        prompt: 'Look up a concise beginner guide for Elden Ring.'
+      }
+    ],
+    [
+      'Palworld without a supplied URL',
+      {
+        mode: 'guide',
+        game: 'Palworld',
+        prompt: 'Look up a current beginner guide for Palworld 1.0.'
+      }
+    ],
+    [
+      'Palworld with payload.url',
+      {
+        mode: 'guide',
+        game: 'Palworld',
+        prompt: 'Use the supplied Palworld 1.0 article as a guide source.',
+        url: 'https://medium.com/worth-playing-pc/the-ultimate-palworld-1-0-guide-why-your-old-strategy-wont-cut-it-c90d8460c96b'
+      }
+    ],
+    [
+      'Palworld with payload.guideUrls',
+      {
+        mode: 'guide',
+        game: 'Palworld',
+        prompt: 'Use the supplied Palworld 1.0 article as a guide source.',
+        guideUrls: [
+          'https://medium.com/worth-playing-pc/the-ultimate-palworld-1-0-guide-why-your-old-strategy-wont-cut-it-c90d8460c96b'
+        ]
+      }
+    ]
+  ])('preserves the public action payload for %s', async (_caseName, payload) => {
+    mockRouteGptRequest.mockResolvedValue({
+      ok: true,
+      result: {
+        ok: true,
+        route: 'gaming',
+        mode: 'guide',
+        data: {
+          response: 'Guide response',
+          sources: []
+        }
+      },
+      _route: {
+        gptId: 'arcanos-gaming',
+        module: 'ARCANOS:GAMING',
+        action: 'query',
+        route: 'gaming',
+        availableActions: ['query']
+      }
+    });
+    const app = express();
+    app.use(express.json());
+    app.use(requestContext);
+    app.use('/gpt', gptRouter);
+
+    const response = await request(app)
+      .post('/gpt/arcanos-gaming')
+      .send({ action: 'query', payload });
+
+    expect(response.status).toBe(200);
+    expect(response.type).toBe('application/json');
+    expect(response.body).toMatchObject({
+      ok: true,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
+      _route: {
+        requestId: response.headers['x-request-id'],
+        traceId: response.headers['x-trace-id']
+      },
+      result: {
+        ok: true,
+        route: 'gaming',
+        mode: 'guide'
+      }
+    });
+    const dispatchInput = mockRouteGptRequest.mock.calls[0]?.[0] as {
+      body?: { action?: unknown; prompt?: unknown; payload?: unknown };
+    };
+    expect(dispatchInput.body).toEqual({
+      action: 'query',
+      payload,
+      prompt: payload.prompt
+    });
+  });
+
+  it('lets Gaming use its deterministic provider fallback when the OpenAI key is unavailable', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.OPENAI_API_KEY = '';
+    mockRouteGptRequest.mockResolvedValue({
+      ok: true,
+      result: {
+        ok: true,
+        route: 'gaming',
+        mode: 'guide',
+        data: {
+          response: 'Deterministic Gaming fallback',
+          sources: []
+        }
+      },
+      _route: {
+        gptId: 'arcanos-gaming',
+        module: 'ARCANOS:GAMING',
+        action: 'query',
+        route: 'gaming',
+        availableActions: ['query']
+      }
+    });
+    const app = express();
+    app.use(express.json());
+    app.use(requestContext);
+    app.use('/gpt', gptRouter);
+
+    const response = await request(app)
+      .post('/gpt/arcanos-gaming')
+      .send({
+        action: 'query',
+        payload: {
+          mode: 'guide',
+          game: 'Elden Ring',
+          prompt: 'Look up a concise beginner guide for Elden Ring.'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.result).toMatchObject({
+      ok: true,
+      route: 'gaming',
+      mode: 'guide'
+    });
+    expect(mockRouteGptRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['MODULE_TIMEOUT', 'GENERATION_TIMEOUT'],
+    ['REQUEST_ABORTED', 'REQUEST_ABORTED']
+  ])('contains Gaming dispatcher %s as an HTTP 200 Gaming error envelope', async (dispatcherCode, publicCode) => {
+    const rawErrorMarker = 'raw-provider-body-must-not-escape';
+    mockRouteGptRequest.mockResolvedValue({
+      ok: false,
+      error: {
+        code: dispatcherCode,
+        message: rawErrorMarker
+      },
+      _route: {
+        gptId: 'arcanos-gaming',
+        module: 'ARCANOS:GAMING',
+        action: 'query',
+        route: 'gaming'
+      }
+    });
+    const app = express();
+    app.use(express.json());
+    app.use(requestContext);
+    app.use('/gpt', gptRouter);
+
+    const response = await request(app)
+      .post('/gpt/arcanos-gaming')
+      .send({
+        action: 'query',
+        payload: {
+          mode: 'guide',
+          game: 'Palworld',
+          prompt: 'Look up a current beginner guide for Palworld 1.0.'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.type).toBe('application/json');
+    expect(response.body).toMatchObject({
+      ok: true,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
+      _route: {
+        requestId: response.headers['x-request-id'],
+        traceId: response.headers['x-trace-id'],
+        module: 'ARCANOS:GAMING',
+        route: 'gaming'
+      },
+      result: {
+        ok: false,
+        route: 'gaming',
+        mode: 'guide',
+        error: {
+          code: publicCode
+        }
+      }
+    });
+    expect(JSON.stringify(response.body)).not.toContain(rawErrorMarker);
+  });
+
+  it('returns an unexpected Gaming dispatcher defect as safe JSON HTTP 500', async () => {
+    const rawErrorMarker = 'raw-provider-body-must-not-escape';
+    mockRouteGptRequest.mockResolvedValue({
+      ok: false,
+      error: {
+        code: 'MODULE_ERROR',
+        message: rawErrorMarker
+      },
+      _route: {
+        gptId: 'arcanos-gaming',
+        module: 'ARCANOS:GAMING',
+        action: 'query',
+        route: 'gaming'
+      }
+    });
+    const app = express();
+    app.use(express.json());
+    app.use(requestContext);
+    app.use('/gpt', gptRouter);
+
+    const response = await request(app)
+      .post('/gpt/arcanos-gaming')
+      .send({
+        action: 'query',
+        payload: {
+          mode: 'guide',
+          game: 'Palworld',
+          prompt: 'Look up a current beginner guide for Palworld 1.0.'
+        }
+      });
+
+    expect(response.status).toBe(500);
+    expect(response.type).toBe('application/json');
+    expect(response.body).toMatchObject({
+      ok: false,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
+      error: {
+        code: 'GAMING_ROUTE_ERROR',
+        message: 'ARCANOS Gaming encountered an unexpected route error.'
+      },
+      _route: {
+        requestId: response.headers['x-request-id'],
+        traceId: response.headers['x-trace-id'],
+        module: 'ARCANOS:GAMING',
+        route: 'gaming'
+      }
+    });
+    expect(JSON.stringify(response.body)).not.toContain(rawErrorMarker);
+    expect(JSON.stringify(response.body)).not.toContain('stack');
+  });
+
+  it('uses a 60-second Gaming route minimum and contains an outer route timeout as HTTP 200', async () => {
+    process.env.GPT_ROUTE_HARD_TIMEOUT_MS = '6000';
+    const timeoutError = new Error('GPT route timeout after 60000ms');
+    timeoutError.name = 'AbortError';
+    mockRouteGptRequest.mockRejectedValue(timeoutError);
+    const app = express();
+    app.use(express.json());
+    app.use(requestContext);
+    app.use('/gpt', gptRouter);
+
+    const response = await request(app)
+      .post('/gpt/arcanos-gaming')
+      .send({
+        action: 'query',
+        payload: {
+          mode: 'guide',
+          game: 'Elden Ring',
+          prompt: 'Look up a concise beginner guide for Elden Ring.'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.type).toBe('application/json');
+    expect(response.body).toMatchObject({
+      ok: true,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
+      result: {
+        ok: false,
+        route: 'gaming',
+        mode: 'guide',
+        error: {
+          code: 'GENERATION_TIMEOUT',
+          details: {
+            timeoutMs: 60000,
+            timeoutPhase: 'gpt-route'
+          }
+        }
+      },
+      _route: {
+        requestId: response.headers['x-request-id'],
+        traceId: response.headers['x-trace-id'],
+        module: 'ARCANOS:GAMING',
+        route: 'gaming'
+      }
+    });
+    const logs = collectStructuredLogs(consoleLogSpy.mock.calls);
+    expect(logs.find((entry) => entry.event === 'gpt.request.timeout_plan')?.data).toMatchObject({
+      gptId: 'arcanos-gaming',
+      timeoutMs: 60000
+    });
   });
 
   it('returns structured gaming errors when explicit mode is missing', async () => {
@@ -678,6 +998,8 @@ describe('gpt router auth logging', () => {
     expect(response.status).toBe(503);
     expect(response.body).toEqual({
       ok: false,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
       error: {
         code: 'REQUEST_ABORTED',
         message: 'Request was aborted before completion.',

--- a/tests/gpt-router-auth-logging.test.ts
+++ b/tests/gpt-router-auth-logging.test.ts
@@ -347,6 +347,66 @@ describe('gpt router auth logging', () => {
     });
   });
 
+  it('keeps Gaming integrity rejections inside the HTTP 200 result envelope', async () => {
+    mockRouteGptRequest.mockResolvedValue({
+      ok: true,
+      result: {
+        ok: false,
+        route: 'gaming',
+        mode: 'meta',
+        error: {
+          code: 'GENERATION_INTEGRITY_FAILED',
+          message: 'Gaming generation did not complete cleanly; no partial answer was returned.'
+        }
+      },
+      _route: {
+        gptId: 'arcanos-gaming',
+        module: 'ARCANOS:GAMING',
+        action: 'query',
+        route: 'gaming',
+        availableActions: ['query']
+      }
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use(requestContext);
+    app.use('/gpt', gptRouter);
+
+    const response = await request(app)
+      .post('/gpt/arcanos-gaming')
+      .send({
+        action: 'query',
+        payload: {
+          mode: 'meta',
+          game: 'World of Warcraft',
+          prompt: 'Is frost mage still viable this patch?'
+        }
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.type).toBe('application/json');
+    expect(response.body).toMatchObject({
+      ok: true,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
+      result: {
+        ok: false,
+        route: 'gaming',
+        mode: 'meta',
+        error: {
+          code: 'GENERATION_INTEGRITY_FAILED'
+        }
+      },
+      _route: {
+        requestId: response.headers['x-request-id'],
+        traceId: response.headers['x-trace-id'],
+        module: 'ARCANOS:GAMING',
+        route: 'gaming'
+      }
+    });
+  });
+
   it('routes explicit Gaming query actions directly through the module dispatcher', async () => {
     mockRouteGptRequest.mockResolvedValue({
       ok: true,

--- a/tests/gpt-router-auth-logging.test.ts
+++ b/tests/gpt-router-auth-logging.test.ts
@@ -890,6 +890,12 @@ describe('gpt router auth logging', () => {
       "Gameplay requests require explicit mode 'guide', 'build', or 'meta'."
     ],
     [
+      'invalid mode behind a bounded action alias array',
+      { action: ['', ['query']], payload: { mode: 'speedrun', prompt: 'Give me a walkthrough.' } },
+      'GAMEPLAY_MODE_REQUIRED',
+      "Gameplay requests require explicit mode 'guide', 'build', or 'meta'."
+    ],
+    [
       'missing prompt',
       { action: 'query', payload: { mode: 'guide' } },
       'PROMPT_REQUIRED',
@@ -923,6 +929,33 @@ describe('gpt router auth logging', () => {
       error: {
         code,
         message
+      }
+    }));
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('bounds deeply nested action aliases and returns correlated JSON 400', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(requestContext);
+    app.use('/gpt', gptRouter);
+    const depth = 10_000;
+    const rawBody = `{"action":${'['.repeat(depth)}"query"${']'.repeat(depth)},"payload":{"mode":"guide","prompt":"Guide me."}}`;
+
+    const response = await request(app)
+      .post('/gpt/arcanos-gaming')
+      .set('Content-Type', 'application/json')
+      .send(rawBody);
+
+    expect(response.status).toBe(400);
+    expect(response.type).toBe('application/json');
+    expect(response.body).toEqual(expect.objectContaining({
+      ok: false,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
+      error: {
+        code: 'GPT_ACTION_REQUIRED',
+        message: "Gaming requests require action 'query'."
       }
     }));
     expect(mockRouteGptRequest).not.toHaveBeenCalled();

--- a/tests/gpt-router-auth-logging.test.ts
+++ b/tests/gpt-router-auth-logging.test.ts
@@ -136,7 +136,14 @@ describe('gpt router auth logging', () => {
       .set('Authorization', 'Bearer test-session-token')
       .set('Cookie', 'session=abc123')
       .set('x-confirmed', 'yes')
-      .send({ prompt: 'Ping the gaming backend' });
+      .send({
+        action: 'query',
+        payload: {
+          mode: 'guide',
+          game: 'Minecraft',
+          prompt: 'Ping the gaming backend'
+        }
+      });
 
     expect(response.status).toBe(200);
 
@@ -187,6 +194,12 @@ describe('gpt router auth logging', () => {
     const response = await request(app)
       .post('/gpt/arcanos-gaming')
       .send({
+        action: 'query',
+        payload: {
+          mode: 'guide',
+          game: 'Minecraft',
+          prompt: `Inspect ${promptMarker} carefully`
+        },
         prompt: `Inspect ${promptMarker} carefully`,
         messages: [{ role: 'user', content: `Inspect ${promptMarker} carefully` }],
       });
@@ -207,7 +220,7 @@ describe('gpt router auth logging', () => {
       promptLikeFields: ['messages', 'prompt'],
     });
     expect(requestMetaLog?.data?.promptHash).toEqual(expect.any(String));
-    expect(requestMetaLog?.data?.bodyKeys).toEqual(['messages', 'prompt']);
+    expect(requestMetaLog?.data?.bodyKeys).toEqual(['action', 'messages', 'payload', 'prompt']);
     expect(rawStructuredLogs).not.toContain(promptMarker);
   });
 
@@ -294,7 +307,42 @@ describe('gpt router auth logging', () => {
     });
   });
 
-  it('returns bare gaming envelopes for explicit guide mode responses', async () => {
+  it('includes current request IDs in non-Gaming diagnostic bodies', async () => {
+    mockRouteGptRequest.mockResolvedValue({
+      ok: true,
+      result: {
+        ok: true,
+        route: 'diagnostic',
+        message: 'backend operational'
+      },
+      _route: {
+        gptId: 'arcanos-core',
+        module: 'diagnostic',
+        route: 'diagnostic',
+        availableActions: []
+      }
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use(requestContext);
+    app.use('/gpt', gptRouter);
+
+    const response = await request(app)
+      .post('/gpt/arcanos-core')
+      .send({ action: 'ping' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      status: 'ok',
+      route: 'diagnostic',
+      message: 'backend operational',
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id']
+    });
+  });
+
+  it('preserves top-level Gaming fields that fill a partial explicit payload', async () => {
     mockRouteGptRequest.mockResolvedValue({
       ok: true,
       result: {
@@ -321,7 +369,13 @@ describe('gpt router auth logging', () => {
 
     const response = await request(app)
       .post('/gpt/arcanos-gaming')
-      .send({ mode: 'guide', prompt: 'Where do I go next?' });
+      .send({
+        action: 'query',
+        mode: 'guide',
+        payload: {
+          prompt: 'Where do I go next?'
+        }
+      });
 
     expect(response.status).toBe(200);
     expect(response.body).toMatchObject({
@@ -344,6 +398,45 @@ describe('gpt router auth logging', () => {
           sources: [],
         },
       },
+    });
+  });
+
+  it.each([
+    ['/gpt/gaming', 'gaming'],
+    ['/gpt/Gaming/', 'Gaming'],
+    ['/gpt/ARCANOS-GAMING/', 'ARCANOS-GAMING']
+  ])('keeps the accepted Gaming alias %s on the correlated Gaming boundary', async (path, expectedGptId) => {
+    mockRouteGptRequest.mockImplementation(async ({ gptId }: { gptId: string }) => ({
+      ok: true,
+      result: {
+        ok: true,
+        route: 'gaming',
+        mode: 'guide',
+        data: { response: 'Guide response', sources: [] }
+      },
+      _route: {
+        gptId,
+        module: 'ARCANOS:GAMING',
+        action: 'query',
+        route: 'gaming',
+        availableActions: ['query']
+      }
+    }));
+    const app = express();
+    app.use(express.json());
+    app.use(requestContext);
+    app.use('/gpt', gptRouter);
+
+    const response = await request(app)
+      .post(path)
+      .send({ action: 'query', payload: { mode: 'guide', prompt: 'Guide me.' } });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
+      result: { route: 'gaming' },
+      _route: { gptId: expectedGptId, module: 'ARCANOS:GAMING', route: 'gaming' }
     });
   });
 
@@ -777,20 +870,32 @@ describe('gpt router auth logging', () => {
     });
   });
 
-  it('returns structured gaming errors when explicit mode is missing', async () => {
-    mockRouteGptRequest.mockResolvedValue({
-      ok: false,
-      error: {
-        code: 'GAMEPLAY_MODE_REQUIRED',
-        message: "Gameplay requests require explicit mode 'guide', 'build', or 'meta'.",
-      },
-      _route: {
-        gptId: 'arcanos-gaming',
-        module: 'ARCANOS:GAMING',
-        route: 'gaming',
-      },
-    });
-
+  it.each([
+    [
+      'missing action',
+      { payload: { mode: 'guide', prompt: 'Give me a walkthrough.' } },
+      'GPT_ACTION_REQUIRED',
+      "Gaming requests require action 'query'."
+    ],
+    [
+      'missing payload',
+      { action: 'query', prompt: 'Give me a walkthrough.' },
+      'BAD_REQUEST',
+      'Gaming query requests require a payload object.'
+    ],
+    [
+      'invalid mode',
+      { action: 'query', payload: { mode: 'speedrun', prompt: 'Give me a walkthrough.' } },
+      'GAMEPLAY_MODE_REQUIRED',
+      "Gameplay requests require explicit mode 'guide', 'build', or 'meta'."
+    ],
+    [
+      'missing prompt',
+      { action: 'query', payload: { mode: 'guide' } },
+      'PROMPT_REQUIRED',
+      'query requires a non-empty prompt.'
+    ]
+  ])('rejects Gaming requests with %s before module dispatch', async (_caseName, body, code, message) => {
     const app = express();
     app.use(express.json());
     app.use(requestContext);
@@ -798,26 +903,29 @@ describe('gpt router auth logging', () => {
 
     const response = await request(app)
       .post('/gpt/arcanos-gaming')
-      .send({ prompt: 'Give me a walkthrough.' });
+      .send(body);
 
     expect(response.status).toBe(400);
+    expect(response.type).toBe('application/json');
     expect(response.body).toEqual(expect.objectContaining({
       ok: false,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
       gptId: 'arcanos-gaming',
       action: 'query',
       route: '/gpt/:gptId',
-      traceId: expect.any(String),
       _route: expect.objectContaining({
         gptId: 'arcanos-gaming',
-        module: 'ARCANOS:GAMING',
-        route: 'gaming',
-        traceId: expect.any(String),
+        route: 'gaming_validation',
+        requestId: response.headers['x-request-id'],
+        traceId: response.headers['x-trace-id']
       }),
       error: {
-        code: 'GAMEPLAY_MODE_REQUIRED',
-        message: "Gameplay requests require explicit mode 'guide', 'build', or 'meta'.",
-      },
+        code,
+        message
+      }
     }));
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
   it('rejects mismatched body-level gptId on the canonical route before dispatching', async () => {

--- a/tests/gpt-router-auth-logging.test.ts
+++ b/tests/gpt-router-auth-logging.test.ts
@@ -961,6 +961,92 @@ describe('gpt router auth logging', () => {
     expect(mockRouteGptRequest).not.toHaveBeenCalled();
   });
 
+  it('rejects an excessively nested Gaming payload with correlated JSON 400', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(requestContext);
+    app.use('/gpt', gptRouter);
+    const depth = 10_000;
+    const rawBody = `{"action":"query","payload":{"mode":"guide","game":"Palworld","prompt":"Guide me.","nested":${'{"value":'.repeat(depth)}null${'}'.repeat(depth)}}}`;
+
+    const response = await request(app)
+      .post('/gpt/arcanos-gaming')
+      .set('Content-Type', 'application/json')
+      .send(rawBody);
+
+    expect(response.status).toBe(400);
+    expect(response.type).toBe('application/json');
+    expect(response.body).toEqual(expect.objectContaining({
+      ok: false,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
+      error: {
+        code: 'BAD_REQUEST',
+        message: 'Gaming query request exceeds the supported structural limits.'
+      }
+    }));
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('rejects an excessively broad Gaming payload with correlated JSON 400', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(requestContext);
+    app.use('/gpt', gptRouter);
+
+    const response = await request(app)
+      .post('/gpt/arcanos-gaming')
+      .send({
+        action: 'query',
+        payload: {
+          mode: 'guide',
+          game: 'Palworld',
+          prompt: 'Guide me.',
+          nested: Array.from({ length: 4097 }, () => null)
+        }
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.type).toBe('application/json');
+    expect(response.body).toEqual(expect.objectContaining({
+      ok: false,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
+      error: {
+        code: 'BAD_REQUEST',
+        message: 'Gaming query request exceeds the supported structural limits.'
+      }
+    }));
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
+  it('rejects an excessively nested top-level Gaming field with correlated JSON 400', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(requestContext);
+    app.use('/gpt', gptRouter);
+    const depth = 10_000;
+    const rawBody = `{"action":"query","payload":{"mode":"guide","game":"Palworld","prompt":"Guide me."},"context":${'{"value":'.repeat(depth)}null${'}'.repeat(depth)}}`;
+
+    const response = await request(app)
+      .post('/gpt/arcanos-gaming')
+      .set('Content-Type', 'application/json')
+      .send(rawBody);
+
+    expect(response.status).toBe(400);
+    expect(response.type).toBe('application/json');
+    expect(response.body).toEqual(expect.objectContaining({
+      ok: false,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
+      error: {
+        code: 'BAD_REQUEST',
+        message: 'Gaming query request exceeds the supported structural limits.'
+      }
+    }));
+    expect(mockRouteGptRequest).not.toHaveBeenCalled();
+  });
+
   it('rejects mismatched body-level gptId on the canonical route before dispatching', async () => {
     const app = express();
     app.use(express.json());

--- a/tests/gptRouteTimeout.test.ts
+++ b/tests/gptRouteTimeout.test.ts
@@ -49,6 +49,12 @@ describe('resolveGptRouteHardTimeoutMs', () => {
     expect(resolveGptRouteHardTimeoutMs({ defaultMsOverride: 25_750 })).toBe(5_000);
   });
 
+  it('allows a bounded route-specific minimum to exceed a smaller generic env timeout', () => {
+    process.env.GPT_ROUTE_HARD_TIMEOUT_MS = '6000';
+
+    expect(resolveGptRouteHardTimeoutMs({ minimumMsOverride: 60_000 })).toBe(60_000);
+  });
+
   it('keeps the dag-execution timeout clamp unchanged', () => {
     process.env.GPT_ROUTE_DAG_EXECUTION_HARD_TIMEOUT_MS = '60000';
 

--- a/tests/openapi/custom-gpt-route.contract.test.ts
+++ b/tests/openapi/custom-gpt-route.contract.test.ts
@@ -57,5 +57,121 @@ describe('custom GPT route OpenAPI contract', () => {
       contract.components?.schemas?.GptRouteRequest?.properties?.payload?.description;
     expect(payloadDescription).toContain('ARCANOS Gaming');
     expect(payloadDescription).toContain('guide, build, or meta');
+
+    const requestSchema =
+      contract.paths?.['/gpt/{gptId}']?.post?.requestBody?.content?.['application/json']?.schema;
+    expect(requestSchema?.anyOf).toEqual([
+      { $ref: '#/components/schemas/GamingQueryRequest' },
+      { $ref: '#/components/schemas/GptRouteRequest' },
+    ]);
+
+    const gamingPayload = contract.components?.schemas?.GamingQueryPayload;
+    expect(gamingPayload?.required).toEqual(['mode', 'prompt']);
+    expect(gamingPayload?.properties?.mode?.enum).toEqual(['guide', 'build', 'meta']);
+    expect(Object.keys(gamingPayload?.properties ?? {})).toEqual(
+      expect.arrayContaining(['mode', 'game', 'prompt', 'url', 'urls', 'guideUrl', 'guideUrls'])
+    );
+    expect(gamingPayload?.properties?.url?.format).toBe('uri');
+    expect(gamingPayload?.properties?.urls?.items?.format).toBe('uri');
+    expect(gamingPayload?.properties?.guideUrl?.format).toBe('uri');
+    expect(gamingPayload?.properties?.guideUrls?.items?.format).toBe('uri');
+  });
+
+  it('binds the canonical production target and documents the public Gaming response envelope', () => {
+    const contract = JSON.parse(
+      readFileSync(join(process.cwd(), 'contracts/custom_gpt_route.openapi.v1.json'), 'utf8')
+    );
+
+    expect(contract.servers).toEqual([
+      {
+        url: 'https://acranos-production.up.railway.app',
+        description: 'Canonical ARCANOS production deployment',
+      },
+    ]);
+    expect(contract.security).toBeUndefined();
+    expect(contract.paths?.['/gpt/{gptId}']?.post?.security).toBeUndefined();
+    expect(JSON.stringify(contract.servers)).not.toContain('arcanos-v2-production');
+
+    const schemas = contract.components?.schemas;
+    expect(contract.info?.version).toBe('1.1.0');
+    expect(schemas?.GptRouteSuccessResponse?.anyOf).toEqual(
+      expect.arrayContaining([
+        { $ref: '#/components/schemas/GamingPublicResponse' },
+        { $ref: '#/components/schemas/GptRouteGenericResponse' },
+      ])
+    );
+    expect(schemas?.GamingPublicResponse?.required).toEqual([
+      'ok',
+      'requestId',
+      'traceId',
+      'result',
+      '_route',
+    ]);
+    expect(schemas?.GamingResult?.oneOf).toEqual([
+      { $ref: '#/components/schemas/GamingSuccessResult' },
+      { $ref: '#/components/schemas/GamingErrorResult' },
+    ]);
+    expect(schemas?.GamingResponseData?.required).toEqual(['response', 'sources']);
+    expect(schemas?.GamingResponseData?.properties?.sources?.items).toEqual({
+      $ref: '#/components/schemas/GamingSource',
+    });
+    expect(Object.keys(schemas?.GamingResponseData?.properties ?? {})).toEqual(
+      expect.arrayContaining([
+        'response',
+        'sources',
+        'fallbackReason',
+        'discoveryReason',
+        'discoveryFailureReason',
+      ])
+    );
+    expect(schemas?.GamingResponseData?.properties?.fallbackReason?.enum).toContain(
+      'CURRENT_EVIDENCE_UNAVAILABLE'
+    );
+    expect(schemas?.GamingResponseData?.properties?.discoveryFailureReason?.enum).toContain(
+      'DISCOVERY_PROVIDER_UNCONFIGURED'
+    );
+    expect(schemas?.GamingSource?.required).toEqual(['url']);
+    expect(Object.keys(schemas?.GamingSource?.properties ?? {})).toEqual(
+      expect.arrayContaining(['url', 'snippet', 'error'])
+    );
+    expect(schemas?.GamingRouteMeta?.allOf?.[1]?.required).toEqual(['requestId', 'traceId']);
+    expect(schemas?.GptRouteErrorResponse?.properties?.requestId).toEqual({
+      type: 'string',
+      minLength: 1,
+    });
+    expect(schemas?.GptRouteErrorResponse?.properties?.traceId).toEqual({
+      type: 'string',
+      minLength: 1,
+    });
+    expect(schemas?.GptRouteErrorResponse?.required).toEqual([
+      'ok',
+      'requestId',
+      'traceId',
+      'error',
+    ]);
+
+    const errorResponses = contract.paths?.['/gpt/{gptId}']?.post?.responses;
+    const errorExamples = [
+      ...Object.values(errorResponses?.['400']?.content?.['application/json']?.examples ?? {}),
+      ...Object.values(errorResponses?.['503']?.content?.['application/json']?.examples ?? {}),
+    ] as Array<{ value?: Record<string, unknown> }>;
+    expect(errorExamples).toHaveLength(8);
+    for (const example of errorExamples) {
+      expect(example.value).toEqual(expect.objectContaining({
+        ok: false,
+        requestId: 'req_example',
+        traceId: 'trace_example',
+      }));
+    }
+
+    const responses = contract.paths?.['/gpt/{gptId}']?.post?.responses;
+    expect(responses?.['400']?.content?.['application/json']?.schema).toEqual({
+      $ref: '#/components/schemas/GptRouteErrorResponse',
+    });
+    for (const status of ['500', '504']) {
+      expect(responses?.[status]?.content?.['application/json']?.schema).toEqual({
+        $ref: '#/components/schemas/GptRouteErrorResponse',
+      });
+    }
   });
 });

--- a/tests/openapi/custom-gpt-route.contract.test.ts
+++ b/tests/openapi/custom-gpt-route.contract.test.ts
@@ -1,7 +1,51 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+function collectLocalRefs(value: unknown, refs: string[] = []): string[] {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectLocalRefs(entry, refs);
+    }
+    return refs;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return refs;
+  }
+
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === '$ref' && typeof entry === 'string' && entry.startsWith('#/')) {
+      refs.push(entry);
+      continue;
+    }
+    collectLocalRefs(entry, refs);
+  }
+  return refs;
+}
+
+function resolveLocalRef(document: unknown, ref: string): unknown {
+  return ref.slice(2).split('/').reduce<unknown>((current, segment) => {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) {
+      return undefined;
+    }
+    const key = segment.replace(/~1/g, '/').replace(/~0/g, '~');
+    return (current as Record<string, unknown>)[key];
+  }, document);
+}
+
 describe('custom GPT route OpenAPI contract', () => {
+  it('resolves every local schema reference', () => {
+    const contract = JSON.parse(
+      readFileSync(join(process.cwd(), 'contracts/custom_gpt_route.openapi.v1.json'), 'utf8')
+    );
+
+    const localRefs = collectLocalRefs(contract);
+    expect(localRefs.length).toBeGreaterThan(0);
+    for (const ref of localRefs) {
+      expect(resolveLocalRef(contract, ref)).toBeDefined();
+    }
+  });
+
   it('documents no public GPT direct control actions while preserving safe DAG bridge examples', () => {
     const contract = JSON.parse(
       readFileSync(join(process.cwd(), 'contracts/custom_gpt_route.openapi.v1.json'), 'utf8')
@@ -97,9 +141,17 @@ describe('custom GPT route OpenAPI contract', () => {
     expect(schemas?.GptRouteSuccessResponse?.anyOf).toEqual(
       expect.arrayContaining([
         { $ref: '#/components/schemas/GamingPublicResponse' },
+        { $ref: '#/components/schemas/GptDiagnosticResponse' },
         { $ref: '#/components/schemas/GptRouteGenericResponse' },
       ])
     );
+    expect(schemas?.GptDiagnosticResponse?.required).toEqual([
+      'status',
+      'route',
+      'message',
+      'requestId',
+      'traceId',
+    ]);
     expect(schemas?.GamingPublicResponse?.required).toEqual([
       'ok',
       'requestId',

--- a/tests/query-finetune.route.test.ts
+++ b/tests/query-finetune.route.test.ts
@@ -109,7 +109,9 @@ describe('/query-finetune route', () => {
     expect(response.status).toBe(400);
     expect(response.body).toEqual({
       error: 'invalid request schema',
-      code: 400
+      code: 400,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id']
     });
   });
 });

--- a/tests/requestContext-security-logging.test.ts
+++ b/tests/requestContext-security-logging.test.ts
@@ -200,6 +200,34 @@ describe('requestContext security logging', () => {
     expect(JSON.stringify(response.body)).not.toMatch(/stack|payloadtoolarge|entity\.too\.large/i);
   });
 
+  it('masks structurally detected public GPT AppError messages', async () => {
+    const rawProviderMarker = 'provider-401-detail-must-not-escape';
+    const app = express();
+    app.use(requestContext);
+    app.use(express.json());
+    app.post('/gpt/arcanos-gaming', () => {
+      throw Object.assign(new Error(rawProviderMarker), { httpCode: 400 });
+    });
+    app.use(errorHandler);
+
+    const response = await request(app)
+      .post('/gpt/arcanos-gaming')
+      .send({ action: 'query' });
+
+    expect(response.status).toBe(400);
+    expect(response.type).toBe('application/json');
+    expect(response.body).toEqual({
+      ok: false,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
+      error: {
+        code: 'GPT_REQUEST_REJECTED',
+        message: 'The GPT request could not be accepted.'
+      }
+    });
+    expect(JSON.stringify(response.body)).not.toContain(rawProviderMarker);
+  });
+
   it('records self-healing signals for completed operational requests', async () => {
     const app = express();
     app.use(requestContext);

--- a/tests/requestContext-security-logging.test.ts
+++ b/tests/requestContext-security-logging.test.ts
@@ -46,6 +46,51 @@ describe('requestContext security logging', () => {
     consoleLogSpy.mockRestore();
   });
 
+  it('preserves bounded safe inbound correlation IDs', async () => {
+    const app = express();
+    app.use(requestContext);
+    app.get('/probe', (req, res) => {
+      res.status(200).json({ requestId: req.requestId, traceId: req.traceId });
+    });
+
+    const response = await request(app)
+      .get('/probe')
+      .set('x-request-id', 'req-client_123')
+      .set('x-trace-id', 'trace-client:123');
+
+    expect(response.body).toEqual({
+      requestId: 'req-client_123',
+      traceId: 'trace-client:123'
+    });
+    expect(response.headers['x-request-id']).toBe(response.body.requestId);
+    expect(response.headers['x-trace-id']).toBe(response.body.traceId);
+  });
+
+  it.each([
+    ['embedded whitespace', 'client supplied id'],
+    ['disallowed delimiter', 'client/id'],
+    ['oversized value', `client-${'x'.repeat(128)}`]
+  ])('regenerates %s correlation headers without echoing the raw value', async (_caseName, invalidId) => {
+    const app = express();
+    app.use(requestContext);
+    app.get('/probe', (req, res) => {
+      res.status(200).json({ requestId: req.requestId, traceId: req.traceId });
+    });
+
+    const response = await request(app)
+      .get('/probe')
+      .set('x-request-id', invalidId)
+      .set('x-trace-id', invalidId);
+
+    expect(response.body.requestId).toMatch(/^req_/);
+    expect(response.body.traceId).toMatch(/^trace_/);
+    expect(response.body.requestId).not.toBe(invalidId);
+    expect(response.body.traceId).not.toBe(invalidId);
+    expect(response.headers['x-request-id']).toBe(response.body.requestId);
+    expect(response.headers['x-trace-id']).toBe(response.body.traceId);
+    expect(consoleLogSpy.mock.calls.flat().join('\n')).not.toContain(invalidId);
+  });
+
   it('removes query parameters from request logs', async () => {
     const app = express();
     app.use(requestContext);

--- a/tests/requestContext-security-logging.test.ts
+++ b/tests/requestContext-security-logging.test.ts
@@ -91,7 +91,15 @@ describe('requestContext security logging', () => {
     });
     app.use(errorHandler);
 
-    await request(app).get('/boom?apiKey=topsecret');
+    const response = await request(app).get('/boom?apiKey=topsecret');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({
+      error: 'Internal Server Error',
+      code: 500,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id']
+    });
 
     const logs = collectStructuredLogs(consoleLogSpy.mock.calls);
     const requestFailed = logs.find((entry) => entry.event === 'request.failed');
@@ -118,8 +126,78 @@ describe('requestContext security logging', () => {
     expect(response.status).toBe(400);
     expect(response.body).toEqual({
       error: 'invalid request schema',
-      code: 400
+      code: 400,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id']
     });
+  });
+
+  it('returns malformed public GPT JSON as a bounded route error envelope', async () => {
+    const app = express();
+    let dispatched = false;
+    app.use(requestContext);
+    app.use(express.json());
+    app.post('/gpt/arcanos-gaming', (_req, res) => {
+      dispatched = true;
+      res.status(200).json({ ok: true });
+    });
+    app.use(errorHandler);
+
+    const response = await request(app)
+      .post('/gpt/arcanos-gaming')
+      .set('Content-Type', 'application/json')
+      .send('{"action":');
+
+    expect(response.status).toBe(400);
+    expect(response.type).toBe('application/json');
+    expect(response.body).toEqual({
+      ok: false,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
+      error: {
+        code: 'INVALID_JSON',
+        message: 'Request body must be valid JSON.'
+      }
+    });
+    expect(dispatched).toBe(false);
+    expect(JSON.stringify(response.body)).not.toMatch(/stack|syntaxerror|unexpected token/i);
+  });
+
+  it('returns oversized public GPT JSON as a bounded validation envelope', async () => {
+    const app = express();
+    let dispatched = false;
+    app.use(requestContext);
+    app.use(express.json({ limit: '128b' }));
+    app.post('/gpt/arcanos-gaming', (_req, res) => {
+      dispatched = true;
+      res.status(200).json({ ok: true });
+    });
+    app.use(errorHandler);
+
+    const response = await request(app)
+      .post('/gpt/arcanos-gaming')
+      .send({
+        action: 'query',
+        payload: {
+          mode: 'guide',
+          game: 'Elden Ring',
+          prompt: 'x'.repeat(256)
+        }
+      });
+
+    expect(response.status).toBe(400);
+    expect(response.type).toBe('application/json');
+    expect(response.body).toEqual({
+      ok: false,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
+      error: {
+        code: 'REQUEST_BODY_TOO_LARGE',
+        message: 'Request body exceeds the configured JSON size limit.'
+      }
+    });
+    expect(dispatched).toBe(false);
+    expect(JSON.stringify(response.body)).not.toMatch(/stack|payloadtoolarge|entity\.too\.large/i);
   });
 
   it('records self-healing signals for completed operational requests', async () => {

--- a/tests/transport-unsafe-execution-gate.test.ts
+++ b/tests/transport-unsafe-execution-gate.test.ts
@@ -230,4 +230,74 @@ describe('transport/http/middleware/unsafeExecutionGate', () => {
     });
     expect(JSON.stringify(response.json.mock.calls[0]?.[0])).not.toContain('PATTERN_INTEGRITY_FAILURE');
   });
+
+  it.each([
+    ['missing body', undefined, undefined, undefined, null, 'unknown', 'unknown'],
+    ['string body', 'not-json', ' ', ' ', null, 'unknown', 'unknown'],
+    ['array body', [], undefined, undefined, null, 'unknown', 'unknown'],
+    ['top-level build mode', { mode: 'BUILD' }, ' req-only ', undefined, 'build', 'req-only', 'req-only'],
+    ['primitive payload with meta mode', { payload: 'invalid', mode: 'meta' }, undefined, ' trace-only ', 'meta', 'trace-only', 'trace-only'],
+    ['array payload with invalid mode', { payload: [], mode: 'invalid' }, undefined, undefined, null, 'unknown', 'unknown'],
+    ['payload without mode', { payload: {} }, undefined, undefined, null, 'unknown', 'unknown']
+  ])('bounds unsafe Gaming alias requests with %s', (
+    _caseName,
+    body,
+    requestId,
+    traceId,
+    expectedMode,
+    expectedRequestId,
+    expectedTraceId
+  ) => {
+    const next = jest.fn();
+    const response = createResponse();
+    hasUnsafeBlockingConditionsMock.mockReturnValue(true);
+
+    unsafeExecutionGate({
+      method: 'POST',
+      path: '/gpt/gaming',
+      body,
+      requestId,
+      traceId
+    } as MockRequest as any, response as any, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.status).toHaveBeenCalledWith(200);
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      ok: true,
+      requestId: expectedRequestId,
+      traceId: expectedTraceId,
+      result: expect.objectContaining({
+        ok: false,
+        route: 'gaming',
+        mode: expectedMode
+      }),
+      _route: expect.objectContaining({
+        requestId: expectedRequestId,
+        traceId: expectedTraceId,
+        gptId: 'gaming'
+      })
+    }));
+  });
+
+  it('preserves available correlation IDs for blocked non-Gaming mutations', () => {
+    const next = jest.fn();
+    const response = createResponse();
+    hasUnsafeBlockingConditionsMock.mockReturnValue(true);
+
+    unsafeExecutionGate({
+      method: 'PUT',
+      path: '/mutate',
+      body: { action: 'write' },
+      requestId: ' req-generic '
+    } as MockRequest as any, response as any, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.status).toHaveBeenCalledWith(503);
+    expect(response.json).toHaveBeenCalledWith({
+      error: 'UNSAFE_TO_PROCEED',
+      conditions: ['PATTERN_INTEGRITY_FAILURE'],
+      requestId: 'req-generic',
+      traceId: 'req-generic'
+    });
+  });
 });

--- a/tests/transport-unsafe-execution-gate.test.ts
+++ b/tests/transport-unsafe-execution-gate.test.ts
@@ -17,6 +17,8 @@ type MockRequest = {
   method: string;
   path: string;
   body?: unknown;
+  requestId?: string;
+  traceId?: string;
   logger?: { info?: jest.Mock };
 };
 
@@ -186,5 +188,46 @@ describe('transport/http/middleware/unsafeExecutionGate', () => {
       error: 'UNSAFE_TO_PROCEED',
       conditions: ['PATTERN_INTEGRITY_FAILURE']
     });
+  });
+
+  it('contains an unsafe Gaming request in the public Gaming envelope', () => {
+    const next = jest.fn();
+    const response = createResponse();
+    hasUnsafeBlockingConditionsMock.mockReturnValue(true);
+
+    unsafeExecutionGate({
+      method: 'POST',
+      path: '/gpt/arcanos-gaming',
+      body: { action: 'query', payload: { mode: 'guide' } },
+      requestId: 'req-gaming-unsafe',
+      traceId: 'trace-gaming-unsafe'
+    } as MockRequest as any, response as any, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.status).toHaveBeenCalledWith(200);
+    expect(response.json).toHaveBeenCalledWith({
+      ok: true,
+      requestId: 'req-gaming-unsafe',
+      traceId: 'trace-gaming-unsafe',
+      result: {
+        ok: false,
+        route: 'gaming',
+        mode: 'guide',
+        error: {
+          code: 'UNSAFE_TO_PROCEED',
+          message: 'ARCANOS Gaming is temporarily unavailable because runtime integrity checks did not pass.'
+        }
+      },
+      _route: {
+        requestId: 'req-gaming-unsafe',
+        traceId: 'trace-gaming-unsafe',
+        gptId: 'arcanos-gaming',
+        module: 'ARCANOS:GAMING',
+        action: 'query',
+        route: 'gaming',
+        timestamp: expect.any(String)
+      }
+    });
+    expect(JSON.stringify(response.json.mock.calls[0]?.[0])).not.toContain('PATTERN_INTEGRITY_FAILURE');
   });
 });

--- a/tests/transport-unsafe-execution-gate.test.ts
+++ b/tests/transport-unsafe-execution-gate.test.ts
@@ -1,4 +1,7 @@
+import express from 'express';
+import request from 'supertest';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import requestContext from '../src/middleware/requestContext.js';
 
 const buildUnsafeToProceedPayloadMock = jest.fn(() => ({
   error: 'UNSAFE_TO_PROCEED',
@@ -198,7 +201,7 @@ describe('transport/http/middleware/unsafeExecutionGate', () => {
     unsafeExecutionGate({
       method: 'POST',
       path: '/gpt/arcanos-gaming',
-      body: { action: 'query', payload: { mode: 'guide' } },
+      body: { action: 'query', payload: { mode: 'guide', prompt: 'Guide me.' } },
       requestId: 'req-gaming-unsafe',
       traceId: 'trace-gaming-unsafe'
     } as MockRequest as any, response as any, next);
@@ -232,22 +235,39 @@ describe('transport/http/middleware/unsafeExecutionGate', () => {
   });
 
   it.each([
-    ['missing body', undefined, undefined, undefined, null, 'unknown', 'unknown'],
-    ['string body', 'not-json', ' ', ' ', null, 'unknown', 'unknown'],
-    ['array body', [], undefined, undefined, null, 'unknown', 'unknown'],
-    ['top-level build mode', { mode: 'BUILD' }, ' req-only ', undefined, 'build', 'req-only', 'req-only'],
-    ['primitive payload with meta mode', { payload: 'invalid', mode: 'meta' }, undefined, ' trace-only ', 'meta', 'trace-only', 'trace-only'],
-    ['array payload with invalid mode', { payload: [], mode: 'invalid' }, undefined, undefined, null, 'unknown', 'unknown'],
-    ['payload without mode', { payload: {} }, undefined, undefined, null, 'unknown', 'unknown']
-  ])('bounds unsafe Gaming alias requests with %s', (
-    _caseName,
-    body,
-    requestId,
-    traceId,
-    expectedMode,
-    expectedRequestId,
-    expectedTraceId
-  ) => {
+    ['trace ID only', { traceId: 'trace-only' }, 'trace-only', 'trace-only'],
+    ['request ID only', { requestId: 'request-only' }, 'request-only', 'request-only'],
+    ['no IDs', {}, 'unknown', 'unknown']
+  ])('keeps an unsafe Gaming response correlated with %s', (_caseName, ids, expectedRequestId, expectedTraceId) => {
+    const next = jest.fn();
+    const response = createResponse();
+    hasUnsafeBlockingConditionsMock.mockReturnValue(true);
+
+    unsafeExecutionGate({
+      method: 'POST',
+      path: '/gpt/arcanos-gaming',
+      body: { action: 'query', payload: { mode: 'guide', prompt: 'Guide me.' } },
+      ...ids
+    } as MockRequest as any, response as any, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.status).toHaveBeenCalledWith(200);
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      requestId: expectedRequestId,
+      traceId: expectedTraceId,
+      _route: expect.objectContaining({
+        requestId: expectedRequestId,
+        traceId: expectedTraceId
+      })
+    }));
+  });
+
+  it.each([
+    ['missing action', { payload: { mode: 'guide', prompt: 'Guide me.' } }, 'GPT_ACTION_REQUIRED'],
+    ['missing payload', { action: 'query', prompt: 'Guide me.' }, 'BAD_REQUEST'],
+    ['invalid mode', { action: 'query', payload: { mode: 'speedrun', prompt: 'Guide me.' } }, 'GAMEPLAY_MODE_REQUIRED'],
+    ['missing prompt', { action: 'query', payload: { mode: 'guide' } }, 'PROMPT_REQUIRED']
+  ])('keeps unsafe-state Gaming validation at HTTP 400 for %s', (_caseName, body, expectedCode) => {
     const next = jest.fn();
     const response = createResponse();
     hasUnsafeBlockingConditionsMock.mockReturnValue(true);
@@ -256,26 +276,148 @@ describe('transport/http/middleware/unsafeExecutionGate', () => {
       method: 'POST',
       path: '/gpt/gaming',
       body,
-      requestId,
-      traceId
+      requestId: 'req-invalid',
+      traceId: 'trace-invalid'
+    } as MockRequest as any, response as any, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.status).toHaveBeenCalledWith(400);
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      ok: false,
+      requestId: 'req-invalid',
+      traceId: 'trace-invalid',
+      error: expect.objectContaining({ code: expectedCode }),
+      _route: expect.objectContaining({
+        requestId: 'req-invalid',
+        traceId: 'trace-invalid',
+        gptId: 'gaming'
+      })
+    }));
+  });
+
+  it('validates the merged Gaming payload before returning an unsafe-state envelope', () => {
+    const next = jest.fn();
+    const response = createResponse();
+    hasUnsafeBlockingConditionsMock.mockReturnValue(true);
+
+    unsafeExecutionGate({
+      method: 'POST',
+      path: '/gpt/gaming/',
+      body: {
+        action: 'query',
+        mode: 'build',
+        payload: { prompt: 'Build help.' }
+      },
+      requestId: 'req-merged',
+      traceId: 'trace-merged'
     } as MockRequest as any, response as any, next);
 
     expect(next).not.toHaveBeenCalled();
     expect(response.status).toHaveBeenCalledWith(200);
     expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
-      ok: true,
-      requestId: expectedRequestId,
-      traceId: expectedTraceId,
-      result: expect.objectContaining({
-        ok: false,
-        route: 'gaming',
-        mode: expectedMode
-      }),
-      _route: expect.objectContaining({
-        requestId: expectedRequestId,
-        traceId: expectedTraceId,
-        gptId: 'gaming'
-      })
+      result: expect.objectContaining({ mode: 'build', error: expect.objectContaining({ code: 'UNSAFE_TO_PROCEED' }) }),
+      _route: expect.objectContaining({ gptId: 'gaming' })
+    }));
+  });
+
+  it('returns correlated JSON 400 before the unsafe response in real middleware order', async () => {
+    hasUnsafeBlockingConditionsMock.mockReturnValue(true);
+    const app = express();
+    app.use(requestContext);
+    app.use(express.json());
+    app.use(unsafeExecutionGate);
+    app.post('/gpt/arcanos-gaming', (_req, res) => res.status(200).json({ reachedRoute: true }));
+
+    const response = await request(app)
+      .post('/gpt/arcanos-gaming')
+      .send({ action: 'query', payload: { mode: 'speedrun', prompt: 'Guide me.' } });
+
+    expect(response.status).toBe(400);
+    expect(response.type).toBe('application/json');
+    expect(response.body).toEqual(expect.objectContaining({
+      ok: false,
+      requestId: response.headers['x-request-id'],
+      traceId: response.headers['x-trace-id'],
+      error: expect.objectContaining({ code: 'GAMEPLAY_MODE_REQUIRED' })
+    }));
+    expect(response.body.reachedRoute).toBeUndefined();
+  });
+
+  it.each([
+    ['operation alias', { body: { operation: 'query', payload: { mode: 'guide', prompt: 'Guide me.' } } }],
+    ['query parameter', { body: { payload: { mode: 'guide', prompt: 'Guide me.' } }, query: { action: 'query' } }],
+    ['action header', {
+      body: { payload: { mode: 'guide', prompt: 'Guide me.' } },
+      header: (name: string) => name === 'x-gpt-action' ? 'query' : undefined
+    }]
+  ])('recognizes the %s before unsafe-state validation', (_caseName, requestParts) => {
+    const next = jest.fn();
+    const response = createResponse();
+    hasUnsafeBlockingConditionsMock.mockReturnValue(true);
+
+    unsafeExecutionGate({
+      method: 'POST',
+      path: '/gpt/gaming',
+      requestId: 'req-alias',
+      traceId: 'trace-alias',
+      ...requestParts
+    } as MockRequest as any, response as any, next);
+
+    expect(response.status).toHaveBeenCalledWith(200);
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      result: expect.objectContaining({ error: expect.objectContaining({ code: 'UNSAFE_TO_PROCEED' }) })
+    }));
+  });
+
+  it.each([
+    ['query_and_wait', '/gpt/gaming'],
+    ['nonsense', '/gpt/arcanos-gaming'],
+    ['query', '/gpt/gaming//']
+  ])('does not reclassify unsafe %s at %s as a Gaming query', (action, path) => {
+    const next = jest.fn();
+    const response = createResponse();
+    hasUnsafeBlockingConditionsMock.mockReturnValue(true);
+
+    unsafeExecutionGate({
+      method: 'POST',
+      path,
+      body: { action, payload: { mode: 'guide', prompt: 'Guide me.' } },
+      requestId: 'req-generic-unsafe',
+      traceId: 'trace-generic-unsafe'
+    } as MockRequest as any, response as any, next);
+
+    expect(response.status).toHaveBeenCalledWith(503);
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      error: 'UNSAFE_TO_PROCEED',
+      requestId: 'req-generic-unsafe',
+      traceId: 'trace-generic-unsafe'
+    }));
+    expect(response.json).not.toHaveBeenCalledWith(expect.objectContaining({
+      result: expect.objectContaining({ route: 'gaming' })
+    }));
+  });
+
+  it.each([
+    ['/gpt/Gaming', 'gaming'],
+    ['/gpt/ARCANOS-GAMING/', 'arcanos-gaming']
+  ])('keeps normalized Gaming alias %s inside the public envelope', (path, expectedGptId) => {
+    const next = jest.fn();
+    const response = createResponse();
+    hasUnsafeBlockingConditionsMock.mockReturnValue(true);
+
+    unsafeExecutionGate({
+      method: 'POST',
+      path,
+      body: { action: 'query', payload: { mode: 'guide', prompt: 'Guide me.' } },
+      requestId: 'req-normalized',
+      traceId: 'trace-normalized'
+    } as MockRequest as any, response as any, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(response.status).toHaveBeenCalledWith(200);
+    expect(response.json).toHaveBeenCalledWith(expect.objectContaining({
+      result: expect.objectContaining({ route: 'gaming' }),
+      _route: expect.objectContaining({ gptId: expectedGptId })
     }));
   });
 


### PR DESCRIPTION
## Overview
Fixes the ARCANOS Gaming public action transport failure and hardens the complete public boundary. The observed `aiohttp.ClientResponseError` was reproduced against the retired `arcanos-v2-production.up.railway.app` target, which returns Railway fallback HTTP 404 JSON before ARCANOS routing.

## Root cause
- The action target was stale: the retired hostname returns `404 application/json`, `x-railway-fallback: true`, and `{"message":"Application not found"}` for every payload.
- The OpenAPI contract did not declare the canonical server.
- Latent boundary gaps could still turn parser, timeout, safety, dispatcher, retrieval, discovery, generation, and serialization failures into non-contract responses.

## Changes
- Binds the Custom GPT contract and registration workflow to `https://acranos-production.up.railway.app`.
- Documents `mode`, `game`, `prompt`, `url`, `urls`, `guideUrl`, and `guideUrls`.
- Adds top-level and route-level request/trace IDs and bounded JSON handling for malformed, oversized, timed-out, aborted, unsafe, truncated, and unexpected requests.
- Keeps controlled retrieval/discovery/provider/generation/integrity failures at HTTP 200 inside the Gaming envelope; reserves JSON 400 for malformed dispatcher input and JSON 500 for unexpected route defects.
- Contains Medium failures as safe source metadata and uses deterministic current-evidence fallback.
- Preserves source/citation alignment and bounds public source arrays.
- Distinguishes game versions from unrelated decimals, while accepting `Palworld 1.0`, parenthesized versions, and sentence-final version evidence.
- Scopes the generic fallback bypass to the two public Gaming IDs so other GPT routes retain prior behavior.

## Validation
- Exact-head GitHub `build-test`: 352 suites passed, 2 skipped; 2,812 tests passed, 4 skipped; 100% statements/branches/functions/lines.
- `npm run type-check`: passed, including layer/routing boundary checks.
- `npm run lint`: passed with 0 errors (92 existing warnings).
- `npm run build`: passed.
- `npm run validate:railway`: passed.
- `npm run guard:commit` and `npm run sync:check`: passed.

## Exact-head preview
- Commit: `626332096a7fff62f44c121562523d2fe9f6be00`
- Preview: https://arcanos-v2-arcanos-pr-1390.up.railway.app
- Railway API deployment: `78b5e6c3-01a9-4f77-a01c-f824fdb0e9c6` (`SUCCESS`)
- `/health` and `/healthz`: HTTP 200 JSON.
- Elden Ring no URL: HTTP 200 JSON, `result.ok:true`, 2 sources.
- Palworld no URL: HTTP 200 JSON, controlled `CURRENT_EVIDENCE_UNAVAILABLE` fallback.
- Palworld `url` and `guideUrls`: HTTP 200 JSON, safe Medium source-error metadata.
- All four calls passed `aiohttp.response.raise_for_status()`, had no redirects, and returned request/trace IDs.
- Malformed JSON: bounded HTTP 400 JSON with `INVALID_JSON` and both IDs.

## Production activation
The external Custom GPT builder state is not stored in this repository. After merge/deploy, re-import `https://acranos-production.up.railway.app/contracts/custom_gpt_route.openapi.v1.json` so the action stops calling the retired host.

## Rollback
- Full rollback: revert this PR (or commits `62633209`, `f7e5d6b3`, `45e3b107`, `06e126d8`, `92e8c8f5`, and `6d0b1540` in reverse order) and redeploy the prior artifact.
- Runtime-only rollback: retain `6d0b1540` so the retired hostname is not restored; revert the later runtime/test commits and redeploy.
- Trigger rollback on any new non-JSON response, missing correlation IDs, invalid source/citation mapping, health-check failure, or elevated Gaming 5xx rate.

## References
- Contract: `contracts/custom_gpt_route.openapi.v1.json`
- Docs: `docs/CUSTOM_GPTS.md`
- Public route: `POST /gpt/arcanos-gaming`
