### PR TITLE
feat(startup): keep web listener available during Redis outages

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -259,6 +259,12 @@ jobs:
           # reported against the MCP SDK, but this service does not expose MCP
           # resource templates and it builds a fresh HTTP server/transport pair
           # per request, so those code paths are not in use here.
+          # The 2026-07-21 Hono advisories require npm builds that are not yet
+          # published; their source tags omit required `dist` exports. ARCANOS
+          # uses none of the affected Hono static/AWS/JSX paths, so the policy
+          # script temporarily scopes those findings by advisory id and node.
+          # The high-severity fast-uri advisories are fixed by the pinned 3.1.4
+          # upstream tag rather than suppressed.
           # GHSA-w5hq-g745-h8pq is currently reported against `uuid` and
           # transitive `uuid` via `bullmq`; the audit-reported fixed uuid@14.0.0
           # is not published, this service does not call uuid directly, and

--- a/docs/RAILWAY_DEPLOYMENT.md
+++ b/docs/RAILWAY_DEPLOYMENT.md
@@ -35,6 +35,7 @@ Launcher behavior:
 - Web services start the compiled API runtime with `ARCANOS_PROCESS_KIND=web` and `RUN_WORKERS=false`.
 - Worker services expose a minimal health server and then start `dist/workers/jobRunner.js` with `ARCANOS_PROCESS_KIND=worker` and `RUN_WORKERS=true`.
 - The application keeps `/health`, `/healthz`, and `/readyz` available; Railway should probe `/health`.
+- The web listener binds before Redis initialization. `/health` and `/healthz` remain live during a Redis outage, while `/readyz` returns `503` until Redis reconnects; see `STARTUP_RESILIENCE.md`.
 - `Procfile` remains in the repository as a historical fallback artifact and must not be treated as the canonical Railway start path.
 
 Environment variables:

--- a/docs/STARTUP_RESILIENCE.md
+++ b/docs/STARTUP_RESILIENCE.md
@@ -1,0 +1,101 @@
+# Web startup and Redis resilience
+
+The web process treats HTTP liveness and dependency readiness as separate
+contracts. A temporary Redis outage must not prevent the process from binding
+its listener or exposing health information.
+
+## Startup sequence
+
+The production web entrypoint follows this order:
+
+1. Load and validate deterministic configuration and safety policy.
+2. Construct the Express application and register its routes.
+3. Bind the HTTP listener to `HOST` and `PORT`.
+4. Start the shared Redis lifecycle in the background.
+5. Prime self-heal telemetry without awaiting Redis.
+6. Initialize the remaining runtime dependencies.
+7. Start background application loops once, after the startup lifecycle is
+   ready.
+
+Only deterministic preflight or listener-binding failures remain fatal before
+the listener is available. Redis connection failures are represented as
+dependency state and are retried in-process.
+
+## State and endpoint contract
+
+| State | Listener | Redis | `/health` and `/healthz` | `/readyz` |
+| --- | --- | --- | --- | --- |
+| `STARTING` | Bound | Initializing | `200` | `503` |
+| `DEGRADED` | Bound | Unavailable | `200` | `503` |
+| `READY` | Bound | Connected and verified | `200` | `200` |
+
+Liveness responses contain only sanitized lifecycle metadata. Readiness reads
+the process-local lifecycle snapshot; it does not create a probe client or make
+a Redis command. Redis failures use stable codes such as
+`REDIS_INITIALIZING`, `REDIS_CONNECTION_REFUSED`, `REDIS_CONNECT_TIMEOUT`,
+`REDIS_AUTH_FAILED`, and `REDIS_DEPENDENCY_UNAVAILABLE`. Connection strings and
+raw provider errors are never part of the public lifecycle projection.
+
+## Redis lifecycle
+
+`src/platform/runtime/redisLifecycle.ts` owns one shared client for startup,
+self-heal telemetry, and runtime diagnostics, plus one serialized connection
+loop. Each connect and `PING` attempt is bounded to three seconds. Failed
+attempts use exponential backoff starting at 250 ms, capped at 30 seconds, with
+up to 250 ms of jitter. Recovery continues until shutdown; callers never need a
+process restart or redeploy.
+
+The same manager handles connection loss after readiness. Both socket errors
+and clean end events move the process to `DEGRADED`, invalidate access to the
+client, and start one reconnect loop. A successful reconnect moves the process
+back to `READY`. Repeated start calls and repeated disconnect events cannot
+create another client or overlapping retry loop.
+
+Specialized, pre-existing safety-v2 and incident kill-switch clients are not
+part of this lifecycle. They are lazily created by their own security features
+and do not participate in listener startup. Consolidating those clients would
+change fail-closed security behavior and is outside this startup-resilience
+change.
+
+Redis is optional in configurations where no Redis endpoint is present. In
+that case the Redis lifecycle reaches ready in unconfigured mode and does not
+open a client. Production configuration validation remains responsible for
+requiring the intended service reference.
+
+## Telemetry and runtime behavior
+
+Self-heal telemetry and shared runtime diagnostics use the lifecycle-owned
+ready client. They do not connect independently. Telemetry records created
+during an outage remain in memory, are merged with persisted state after Redis
+recovers, and are flushed without starting a second telemetry instance.
+Telemetry read or write failures are logged with stable error codes and never
+fail process startup.
+
+The root GPT job queue and dedicated Railway Worker are PostgreSQL-backed; Redis
+is not their durable job source of truth. The web Redis recovery path therefore
+does not start workers or queue consumers. This preserves the existing worker
+ownership boundary and prevents duplicate execution.
+
+## Shutdown
+
+Shutdown first marks readiness unavailable and stops accepting new requests.
+After active HTTP requests drain, it removes lifecycle subscriptions, cancels
+telemetry timers, aborts Redis retry timers and bounded attempts, closes the
+Redis client once, waits for in-flight runtime initialization, and closes the
+database. Late Redis events cannot restore readiness or start background
+runtime work after shutdown begins.
+
+## Local verification
+
+The focused regression suites are:
+
+```text
+tests/redis-startup-lifecycle.test.ts
+tests/server-startup-resilience.test.ts
+tests/startup-health-routes.test.ts
+tests/self-heal-telemetry-redis.test.ts
+tests/unified-health-redis.test.ts
+```
+
+They use fake clients and local HTTP requests only. They do not require a
+production credential or a live Redis service.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6040,9 +6040,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://codeload.github.com/fastify/fast-uri/tar.gz/refs/tags/v3.1.4",
+      "integrity": "sha512-w1d9PDFY3xOqTzTD9Nmyyfv1WQJ8lGtAQMbKVwwmACHqYjK3Wfh+Ko1HLqarlQZQr5rKoaVz4MvHAIj33Qzw0A==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -264,6 +264,7 @@
       "hono": "4.12.25"
     },
     "express-rate-limit": "https://codeload.github.com/express-rate-limit/express-rate-limit/tar.gz/refs/tags/v8.3.0",
+    "fast-uri": "https://codeload.github.com/fastify/fast-uri/tar.gz/refs/tags/v3.1.4",
     "ip-address": "10.1.1",
     "proxy-from-env": "https://codeload.github.com/Rob--W/proxy-from-env/tar.gz/refs/tags/v2.1.0",
     "express": {

--- a/scripts/check-npm-audit.js
+++ b/scripts/check-npm-audit.js
@@ -30,6 +30,12 @@ const vulnerabilities = report.vulnerabilities ?? {};
 // - brace-expansion (vendored minimatch -> brace-expansion): the patched
 //   5.0.6/5.0.7 releases are not yet published to npm and exposure is
 //   tooling-only. Retest and remove these entries when a patch is published.
+// - Hono (MCP SDK -> Hono): the patched @hono/node-server 2.0.5 and Hono
+//   4.12.27 npm builds are not published. Their source tags omit the compiled
+//   package exports, so consuming those archives would break runtime imports.
+//   ARCANOS mounts the SDK's Node/Web Standard streamable transport through
+//   Express and uses only @hono/node-server's root request listener; it does
+//   not use Hono static serving, AWS adapters, JSX, or CSS rendering.
 // Advisory IDs for every exception are deliberately source-scoped below, and
 // affected graphs are constrained where usage assumptions matter, so an
 // unexpected advisory or dependency path remains actionable.
@@ -63,6 +69,22 @@ const IGNORED_BRACE_EXPANSION_URLS = new Set([
 const IGNORED_BRACE_EXPANSION_NODES = new Set([
   'vendor/minimatch-9.0.7/node_modules/brace-expansion',
 ]);
+const IGNORED_HONO_NODE_SERVER_SOURCES = new Set([1124006]);
+const IGNORED_HONO_NODE_SERVER_URLS = new Set([
+  'https://github.com/advisories/GHSA-frvp-7c67-39w9',
+]);
+const IGNORED_HONO_SOURCES = new Set([1124005, 1124009, 1124010]);
+const IGNORED_HONO_URLS = new Set([
+  'https://github.com/advisories/GHSA-xgm2-5f3f-mvvc',
+  'https://github.com/advisories/GHSA-hvrm-45r6-mjfj',
+  'https://github.com/advisories/GHSA-w62v-xxxg-mg59',
+]);
+const IGNORED_HONO_NODE_SERVER_NODES = new Set([
+  'node_modules/@hono/node-server',
+]);
+const IGNORED_HONO_NODES = new Set(['node_modules/hono']);
+const IGNORED_MCP_SDK_NODES = new Set(['node_modules/@modelcontextprotocol/sdk']);
+const IGNORED_MCP_SDK_HONO_VIA = new Set(['@hono/node-server', 'hono']);
 
 function isIgnoredAxiosAdvisory(advisory) {
   if (!advisory || typeof advisory !== 'object') {
@@ -117,6 +139,41 @@ function isIgnoredBraceExpansionAdvisory(advisory) {
   );
 }
 
+function isIgnoredHonoNodeServerAdvisory(advisory) {
+  if (!advisory || typeof advisory !== 'object' || advisory.name !== '@hono/node-server') {
+    return false;
+  }
+
+  if (
+    typeof advisory.source === 'number' &&
+    IGNORED_HONO_NODE_SERVER_SOURCES.has(advisory.source)
+  ) {
+    return true;
+  }
+
+  return (
+    typeof advisory.url === 'string' &&
+    IGNORED_HONO_NODE_SERVER_URLS.has(advisory.url)
+  );
+}
+
+function isIgnoredHonoAdvisory(advisory) {
+  if (!advisory || typeof advisory !== 'object' || advisory.name !== 'hono') {
+    return false;
+  }
+
+  if (typeof advisory.source === 'number' && IGNORED_HONO_SOURCES.has(advisory.source)) {
+    return true;
+  }
+
+  return typeof advisory.url === 'string' && IGNORED_HONO_URLS.has(advisory.url);
+}
+
+function hasOnlyExpectedNodes(vulnerability, expectedNodes) {
+  const nodes = Array.isArray(vulnerability.nodes) ? vulnerability.nodes : [];
+  return nodes.length > 0 && nodes.every(node => expectedNodes.has(node));
+}
+
 function isIgnoredVulnerability(name, vulnerability) {
   if (!vulnerability || typeof vulnerability !== 'object') {
     return false;
@@ -151,6 +208,32 @@ function isIgnoredVulnerability(name, vulnerability) {
       via.every(isIgnoredBraceExpansionAdvisory) &&
       nodes.length > 0 &&
       nodes.every(node => IGNORED_BRACE_EXPANSION_NODES.has(node))
+    );
+  }
+
+  if (name === '@hono/node-server') {
+    return (
+      via.length > 0 &&
+      via.every(entry => entry === 'hono' || isIgnoredHonoNodeServerAdvisory(entry)) &&
+      hasOnlyExpectedNodes(vulnerability, IGNORED_HONO_NODE_SERVER_NODES)
+    );
+  }
+
+  if (name === 'hono') {
+    return (
+      via.length > 0 &&
+      via.every(isIgnoredHonoAdvisory) &&
+      hasOnlyExpectedNodes(vulnerability, IGNORED_HONO_NODES)
+    );
+  }
+
+  if (name === '@modelcontextprotocol/sdk') {
+    return (
+      via.length > 0 &&
+      via.every(
+        entry => typeof entry === 'string' && IGNORED_MCP_SDK_HONO_VIA.has(entry),
+      ) &&
+      hasOnlyExpectedNodes(vulnerability, IGNORED_MCP_SDK_NODES)
     );
   }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -21,6 +21,23 @@ import {
 
 const SERVICE_NAME = 'arcanos-backend';
 const SERVICE_VERSION = '1.0.0';
+const startedRuntimeApps = new WeakSet<Express>();
+
+/**
+ * Start background application runtime exactly once after startup readiness.
+ * Route construction stays side-effect free with respect to external
+ * dependencies, allowing the HTTP listener to bind before dependency recovery.
+ */
+export function startAppRuntimeOnce(app: Express): boolean {
+  if (startedRuntimeApps.has(app)) {
+    return false;
+  }
+
+  startedRuntimeApps.add(app);
+  startSelfHealingControlLoop(app);
+  void runtimeDiagnosticsService.logStartupSummary(app);
+  return true;
+}
 
 /**
  * Creates and configures the Express application.
@@ -178,8 +195,6 @@ export function createApp(): Express {
 
   setupDiagnostics(app);
   registerRoutes(app);
-  startSelfHealingControlLoop(app);
-  void runtimeDiagnosticsService.logStartupSummary(app);
 
   app.use(createFallbackMiddleware());
   app.use(errorHandler);

--- a/src/core/diagnostics.ts
+++ b/src/core/diagnostics.ts
@@ -10,6 +10,8 @@ import {
 } from '@services/runtimeDiagnosticsService.js';
 import { resolveErrorMessage } from '@core/lib/errors/index.js';
 import { getGptRegistrySnapshot } from '@platform/runtime/gptRouterConfig.js';
+import { getRedisLifecycleSnapshot } from '@platform/runtime/redisLifecycle.js';
+import { getStartupLifecycleSnapshot } from '@platform/runtime/startupLifecycle.js';
 import { withJsonResponseBytes } from '@shared/http/clientResponseGuards.js';
 import { sendBoundedJsonResponse } from '@shared/http/sendBoundedJsonResponse.js';
 
@@ -21,10 +23,43 @@ function hasConfiguredOpenAIKey(): boolean {
   return typeof key === 'string' && key.trim().length > 0;
 }
 
+function buildPublicStartupLifecycleSnapshot() {
+  const startup = getStartupLifecycleSnapshot();
+  const redis = getRedisLifecycleSnapshot();
+  const redisReady = redis.state === 'READY';
+  const redisCode = redisReady
+    ? null
+    : redis.state === 'STARTING'
+      ? 'REDIS_INITIALIZING'
+      : 'REDIS_DEPENDENCY_UNAVAILABLE';
+
+  return {
+    startup: {
+      phase: startup.phase,
+      ready: startup.ready,
+      listener_bound: startup.listenerBound,
+      runtime_initialized: startup.runtimeInitialized,
+      shutting_down: startup.shuttingDown,
+      changed_at: startup.changedAt
+    },
+    dependencies: {
+      redis: {
+        configured: redis.configured,
+        ready: redisReady,
+        status: redis.state.toLowerCase(),
+        code: redisCode,
+        attempt: redis.attempt,
+        retry_scheduled: redis.retryScheduled
+      }
+    }
+  };
+}
+
 export async function writePublicHealthResponse(req: Request, res: Response): Promise<void> {
   const baseSnapshot = runtimeDiagnosticsService.getHealthSnapshot();
   const { validation } = await getGptRegistrySnapshot();
   const status = validation.missingGptIds.length === 0 ? 'ok' : 'unhealthy';
+  const lifecycle = buildPublicStartupLifecycleSnapshot();
   const payload = withJsonResponseBytes({
     ...baseSnapshot,
     status,
@@ -36,6 +71,7 @@ export async function writePublicHealthResponse(req: Request, res: Response): Pr
       missing: validation.missingGptIds
     },
     openai_configured: hasConfiguredOpenAIKey(),
+    ...lifecycle,
   });
 
   req.logger?.info?.('health.response', {

--- a/src/core/startup.ts
+++ b/src/core/startup.ts
@@ -16,24 +16,14 @@ import { getQueryFinetuneAttemptLatencyBudgetDiagnostics } from "@config/queryFi
 import { getGptRegistrySnapshot } from '@platform/runtime/gptRouterConfig.js';
 
 /**
- * Runs startup checks including environment validation, database init,
- * OpenAI key validation, and schema verification.
+ * Run deterministic configuration and safety checks before opening the HTTP
+ * listener. No external dependency connection belongs in this phase.
  */
-export async function performStartup(): Promise<void> {
+export async function performStartupPreflight(): Promise<void> {
   // Railway-specific environment validation
   const railwayValidation = validateRailwayEnvironment();
   printValidationResults(railwayValidation);
   checkEphemeralFS();
-
-  //audit Assumption: Railway API config controls probe behavior
-  if (isRailwayApiConfigured()) {
-    const probeResult = await probeRailwayApi();
-    if (!probeResult.ok) {
-      logger.warn('⚠️ Railway management API probe failed - deployment automation features may be unavailable');
-    }
-  } else {
-    logger.info('Railway management API token not detected - skipping management API connectivity probe');
-  }
 
   const securityState = await initializeEnvironmentSecurity();
   logger.info('ARCANOS environment security', {
@@ -50,7 +40,7 @@ export async function performStartup(): Promise<void> {
   //audit Assumption: invalid env should halt startup
   if (!envValidation.isValid) {
     logger.error('Environment validation failed - exiting');
-    process.exit(1);
+    throw new Error('STARTUP_ENVIRONMENT_INVALID');
   }
 
   logger.info('🔥 ARCANOS STARTUP - Server boot sequence triggered');
@@ -77,32 +67,7 @@ export async function performStartup(): Promise<void> {
     });
   }
 
-  try {
-    const dbConnected = await initializeDatabase('server');
-    if (!dbConnected) {
-      logger.warn('⚠️ DB CHECK - Database not available - continuing with in-memory fallback');
-    } else {
-      try {
-        const hydratedEntries = await hydrateJudgedResponseFeedbackContext();
-        //audit Assumption: judged feedback hydration is best-effort and should not block startup; risk: missing historical context after restart; invariant: startup continues even when hydration fails; handling: informational logging with fallback catch below.
-        logger.info('🧠 Reinforcement judged feedback hydrated', { hydratedEntries });
-      } catch (hydrationError: unknown) {
-        logger.warn('⚠️ Reinforcement judged feedback hydration failed - continuing without persisted judgment context', {
-          error: resolveErrorMessage(hydrationError)
-        });
-      }
-    }
-  } catch (err: unknown) {
-    //audit Assumption: DB init errors should log and fallback
-    const errorMessage = resolveErrorMessage(err);
-    logger.error('❌ DB CHECK - Database initialization failed', { error: errorMessage });
-    logger.warn('⚠️ DB CHECK - Continuing with in-memory fallback');
-  }
-
-  await memoryStore.initialize();
-
   validateAPIKeyAtStartup(); // Always continue, but log warnings
-  await verifySchema();
   const gptRegistrySnapshot = await getGptRegistrySnapshot();
 
   logger.info('gpt.registry.startup', {
@@ -133,4 +98,55 @@ export async function performStartup(): Promise<void> {
     usedFallbackDefault: queryFinetuneAttemptLatencyBudgetDiagnostics.usedFallbackDefault
   });
   logger.info('✅ ARCANOS CONFIG - Configuration validation complete');
+}
+
+/**
+ * Initialize fallible external dependencies after the HTTP listener is bound.
+ * Each existing optional-dependency fallback remains intact so observability is
+ * not lost while a dependency is unavailable.
+ */
+export async function initializeRuntimeDependencies(): Promise<void> {
+  //audit Assumption: Railway API config controls probe behavior
+  if (isRailwayApiConfigured()) {
+    const probeResult = await probeRailwayApi();
+    if (!probeResult.ok) {
+      logger.warn('⚠️ Railway management API probe failed - deployment automation features may be unavailable');
+    }
+  } else {
+    logger.info('Railway management API token not detected - skipping management API connectivity probe');
+  }
+
+  try {
+    const dbConnected = await initializeDatabase('server');
+    if (!dbConnected) {
+      logger.warn('⚠️ DB CHECK - Database not available - continuing with in-memory fallback');
+    } else {
+      try {
+        const hydratedEntries = await hydrateJudgedResponseFeedbackContext();
+        //audit Assumption: judged feedback hydration is best-effort and should not block startup; risk: missing historical context after restart; invariant: startup continues even when hydration fails; handling: informational logging with fallback catch below.
+        logger.info('🧠 Reinforcement judged feedback hydrated', { hydratedEntries });
+      } catch (hydrationError: unknown) {
+        logger.warn('⚠️ Reinforcement judged feedback hydration failed - continuing without persisted judgment context', {
+          error: resolveErrorMessage(hydrationError)
+        });
+      }
+    }
+  } catch (err: unknown) {
+    //audit Assumption: DB init errors should log and fallback
+    const errorMessage = resolveErrorMessage(err);
+    logger.error('❌ DB CHECK - Database initialization failed', { error: errorMessage });
+    logger.warn('⚠️ DB CHECK - Continuing with in-memory fallback');
+  }
+
+  await memoryStore.initialize();
+  await verifySchema();
+}
+
+/**
+ * Compatibility entry point for non-server callers that still require the
+ * complete startup sequence.
+ */
+export async function performStartup(): Promise<void> {
+  await performStartupPreflight();
+  await initializeRuntimeDependencies();
 }

--- a/src/platform/resilience/unifiedHealth.ts
+++ b/src/platform/resilience/unifiedHealth.ts
@@ -16,21 +16,17 @@
  * @module unifiedHealth
  */
 
-import { Request, Response, NextFunction } from 'express';
-import { createClient } from 'redis';
+import { Request, Response } from 'express';
 import { aiLogger } from "@platform/logging/structuredLogging.js";
 import { recordTraceEvent } from "@platform/logging/telemetry.js";
-import { validateClientHealth, type HealthStatus as ClientHealthStatus } from '@arcanos/openai/unifiedClient';
+import { validateClientHealth } from '@arcanos/openai/unifiedClient';
 import { isOpenAIAdapterInitialized } from "@core/adapters/openai.adapter.js";
 import { getConfig } from "@platform/runtime/unifiedConfig.js";
 import { resolveConfiguredRedisConnection } from "@platform/runtime/redis.js";
-import { assessCoreServiceReadiness, HealthStatus as ServiceHealthStatus } from "@platform/resilience/healthChecks.js";
+import { getRedisLifecycleSnapshot } from "@platform/runtime/redisLifecycle.js";
+import { getStartupLifecycleSnapshot } from "@platform/runtime/startupLifecycle.js";
 import { resolveErrorMessage } from "@core/lib/errors/index.js";
 import { sendTimestampedStatus } from "@platform/resilience/serviceUnavailable.js";
-
-type RedisHealthClient = ReturnType<typeof createClient>;
-
-const REDIS_HEALTH_TIMEOUT_MS = 3_000;
 
 /**
  * Health check function type
@@ -45,6 +41,8 @@ export interface HealthCheckResult {
   healthy: boolean;
   /** Check name */
   name: string;
+  /** Stable machine-readable failure classification */
+  code?: string;
   /** Optional error message */
   error?: string;
   /** Optional metadata */
@@ -350,53 +348,6 @@ export function buildReadinessEndpoint(checks: HealthChecker[]): (req: Request, 
   };
 }
 
-async function withHealthCheckTimeout<T>(
-  operation: Promise<T>,
-  timeoutMs: number,
-  timeoutLabel: string
-): Promise<T> {
-  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timeoutHandle = setTimeout(() => {
-      reject(new Error(`${timeoutLabel} timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-
-    if (typeof timeoutHandle.unref === 'function') {
-      timeoutHandle.unref();
-    }
-  });
-
-  try {
-    return await Promise.race([operation, timeoutPromise]);
-  } finally {
-    if (timeoutHandle) {
-      clearTimeout(timeoutHandle);
-    }
-  }
-}
-
-async function closeRedisHealthClient(redisClient: RedisHealthClient): Promise<void> {
-  const disconnectableRedisClient = redisClient as RedisHealthClient & {
-    isOpen?: boolean;
-    disconnect?: () => Promise<void> | void;
-  };
-
-  try {
-    //audit Assumption: an open Redis health client should exit cleanly to avoid probe-driven socket leaks; failure risk: liveness/readiness checks accumulate idle connections; expected invariant: open clients are closed before the check returns; handling strategy: prefer `quit()` for open clients and fall back to `disconnect()` when needed.
-    if (disconnectableRedisClient.isOpen) {
-      await redisClient.quit();
-      return;
-    }
-
-    if (typeof disconnectableRedisClient.disconnect === 'function') {
-      await disconnectableRedisClient.disconnect();
-    }
-  } catch {
-    //audit Assumption: health probe cleanup is best-effort and must not mask the primary health result; failure risk: cleanup noise replaces the real dependency status; expected invariant: caller receives the original health outcome; handling strategy: swallow cleanup failures.
-  }
-}
-
 /**
  * Default health checks for common services
  */
@@ -472,20 +423,23 @@ export async function checkDatabaseHealth(): Promise<HealthCheckResult> {
  * Redis health check (if Redis is configured).
  *
  * Purpose:
- * - Verify that the app can establish a Redis connection and receive a `PONG`.
+ * - Project the long-lived Redis lifecycle into health/readiness responses.
  *
  * Inputs/outputs:
- * - Input: none; reads Redis configuration from runtime env via shared resolver.
+ * - Input: none; reads safe process-local lifecycle and configuration metadata.
  * - Output: health result with configuration and connectivity metadata.
  *
  * Edge case behavior:
  * - Returns healthy with `configured: false` when Redis is not configured for the deployment.
+ * - Never opens a Redis connection or exposes an underlying connection error.
  */
 export async function checkRedisHealth(): Promise<HealthCheckResult> {
   const redisConnection = resolveConfiguredRedisConnection();
+  const redisLifecycle = getRedisLifecycleSnapshot();
+  const configured = redisConnection.configured || redisLifecycle.configured;
 
   //audit Assumption: Redis is optional for some deployments, so missing configuration should not fail health by itself; failure risk: stateless or reduced-feature environments flap unhealthy without using Redis; expected invariant: unconfigured Redis reports healthy with explicit metadata; handling strategy: short-circuit with `configured: false`.
-  if (!redisConnection.configured || !redisConnection.url) {
+  if (!configured) {
     return {
       healthy: true,
       name: 'redis',
@@ -497,45 +451,8 @@ export async function checkRedisHealth(): Promise<HealthCheckResult> {
     };
   }
 
-  const redisHealthClient = createClient({
-    url: redisConnection.url,
-    socket: {
-      connectTimeout: REDIS_HEALTH_TIMEOUT_MS
-    }
-  });
-  redisHealthClient.on('error', () => {
-    //audit Assumption: probe-only redis clients can emit transient socket errors after the primary result is known; failure risk: unhandled error events crash the process; expected invariant: health checks never leave uncaught redis event handlers behind; handling strategy: attach a no-op listener and surface failures through awaited calls instead.
-  });
-
-  const redisPingStartedAtMs = Date.now();
-
-  try {
-    await withHealthCheckTimeout(
-      redisHealthClient.connect(),
-      REDIS_HEALTH_TIMEOUT_MS,
-      'Redis connect'
-    );
-    const redisPingResponse = await withHealthCheckTimeout(
-      redisHealthClient.ping(),
-      REDIS_HEALTH_TIMEOUT_MS,
-      'Redis ping'
-    );
-
-    //audit Assumption: a healthy Redis probe returns the canonical `PONG` response; failure risk: partial protocol failures look healthy; expected invariant: only `PONG` marks Redis healthy; handling strategy: treat any other reply as unhealthy.
-    if (redisPingResponse !== 'PONG') {
-      return {
-        healthy: false,
-        name: 'redis',
-        error: `Unexpected Redis ping response: ${redisPingResponse}`,
-        metadata: {
-          configured: true,
-          connected: true,
-          source: redisConnection.source,
-          latencyMs: Date.now() - redisPingStartedAtMs
-        }
-      };
-    }
-
+  //audit Assumption: the long-lived Redis lifecycle owns all connectivity and retry I/O; failure risk: readiness probes create duplicate clients and amplify an outage; expected invariant: health reads one synchronous sanitized snapshot; handling strategy: project lifecycle state without connecting or pinging.
+  if (redisLifecycle.state === 'READY') {
     return {
       healthy: true,
       name: 'redis',
@@ -543,23 +460,71 @@ export async function checkRedisHealth(): Promise<HealthCheckResult> {
         configured: true,
         connected: true,
         source: redisConnection.source,
-        latencyMs: Date.now() - redisPingStartedAtMs
+        state: redisLifecycle.state,
+        attempt: redisLifecycle.attempt,
+        recoveryCount: redisLifecycle.recoveryCount
       }
     };
-  } catch (error) {
-    return {
-      healthy: false,
-      name: 'redis',
-      error: resolveErrorMessage(error),
-      metadata: {
-        configured: true,
-        connected: false,
-        source: redisConnection.source
-      }
-    };
-  } finally {
-    await closeRedisHealthClient(redisHealthClient);
   }
+
+  const code = redisLifecycle.state === 'STARTING'
+    ? 'REDIS_INITIALIZING'
+    : 'REDIS_DEPENDENCY_UNAVAILABLE';
+
+  return {
+    healthy: false,
+    name: 'redis',
+    code,
+    error: code === 'REDIS_INITIALIZING'
+      ? 'Redis initialization is in progress.'
+      : 'Redis dependency is unavailable.',
+    metadata: {
+      configured: true,
+      connected: false,
+      source: redisConnection.source,
+      state: redisLifecycle.state,
+      attempt: redisLifecycle.attempt,
+      retryScheduled: redisLifecycle.retryScheduled,
+      code
+    }
+  };
+}
+
+/**
+ * Process startup readiness check.
+ *
+ * Purpose:
+ * - Keep `/readyz` unavailable until the listener, core runtime, and configured
+ *   Redis dependency have all reached the shared READY state.
+ *
+ * Edge case behavior:
+ * - Reads process-local state only and never performs dependency I/O.
+ */
+export function checkStartupReadiness(): HealthCheckResult {
+  const startup = getStartupLifecycleSnapshot();
+  const code = startup.phase === 'STARTING'
+    ? 'APPLICATION_STARTING'
+    : startup.phase === 'DEGRADED'
+      ? 'APPLICATION_DEGRADED'
+      : undefined;
+
+  return {
+    healthy: startup.ready,
+    name: 'startup',
+    ...(code ? {
+      code,
+      error: startup.phase === 'STARTING'
+        ? 'Application startup is in progress.'
+        : 'Application dependencies are degraded.'
+    } : {}),
+    metadata: {
+      phase: startup.phase,
+      listenerBound: startup.listenerBound,
+      runtimeInitialized: startup.runtimeInitialized,
+      shuttingDown: startup.shuttingDown,
+      changedAt: startup.changedAt
+    }
+  };
 }
 
 /**
@@ -593,5 +558,6 @@ export default {
   checkOpenAIHealth,
   checkDatabaseHealth,
   checkRedisHealth,
+  checkStartupReadiness,
   checkApplicationHealth
 };

--- a/src/platform/runtime/redisLifecycle.ts
+++ b/src/platform/runtime/redisLifecycle.ts
@@ -1,0 +1,578 @@
+import { createClient } from 'redis';
+import { logger } from '@platform/logging/structuredLogging.js';
+import { resolveConfiguredRedisConnection } from '@platform/runtime/redis.js';
+
+const REDIS_ATTEMPT_TIMEOUT_MS = 3_000;
+const REDIS_RETRY_BASE_DELAY_MS = 250;
+const REDIS_RETRY_MAX_DELAY_MS = 30_000;
+const REDIS_RETRY_JITTER_MS = 250;
+
+export type RedisLifecycleState = 'STARTING' | 'DEGRADED' | 'READY';
+
+export type RedisLifecycleErrorCode =
+  | 'REDIS_CONNECTION_REFUSED'
+  | 'REDIS_CONNECT_TIMEOUT'
+  | 'REDIS_AUTH_FAILED'
+  | 'REDIS_DNS_UNAVAILABLE'
+  | 'REDIS_CONNECTION_LOST'
+  | 'REDIS_UNAVAILABLE';
+
+export interface RedisLifecycleSnapshot {
+  state: RedisLifecycleState;
+  configured: boolean;
+  connected: boolean;
+  attempt: number;
+  recoveryCount: number;
+  retryScheduled: boolean;
+  lastTransitionAt: string;
+  lastReadyAt: string | null;
+  lastErrorCode: RedisLifecycleErrorCode | null;
+}
+
+export type RedisLifecycleClient = ReturnType<typeof createClient>;
+export type RedisLifecycleListener = (snapshot: RedisLifecycleSnapshot) => void;
+export type RedisLifecycleSleep = (delayMs: number, signal: AbortSignal) => Promise<void>;
+export type RedisLifecycleClientFactory = (
+  options: Parameters<typeof createClient>[0]
+) => RedisLifecycleClient;
+
+export interface RedisLifecycleManagerOptions {
+  clientFactory?: RedisLifecycleClientFactory;
+  sleep?: RedisLifecycleSleep;
+  random?: () => number;
+  now?: () => Date;
+}
+
+class RedisLifecycleAbortError extends Error {
+  constructor() {
+    super('Redis lifecycle operation aborted.');
+    this.name = 'RedisLifecycleAbortError';
+  }
+}
+
+class RedisLifecycleAttemptTimeoutError extends Error {
+  readonly code = 'REDIS_CONNECT_TIMEOUT';
+
+  constructor() {
+    super('Redis lifecycle connection attempt timed out.');
+    this.name = 'RedisLifecycleAttemptTimeoutError';
+  }
+}
+
+function defaultSleep(delayMs: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.reject(new RedisLifecycleAbortError());
+  }
+
+  return new Promise((resolve, reject) => {
+    const timeoutHandle = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, delayMs);
+    timeoutHandle.unref?.();
+
+    const onAbort = () => {
+      clearTimeout(timeoutHandle);
+      signal.removeEventListener('abort', onAbort);
+      reject(new RedisLifecycleAbortError());
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function normalizeErrorText(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message.toUpperCase();
+  }
+
+  return typeof error === 'string' ? error.toUpperCase() : '';
+}
+
+function normalizeErrorCode(error: unknown): string {
+  if (!error || typeof error !== 'object') {
+    return '';
+  }
+
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' ? code.trim().toUpperCase() : '';
+}
+
+function classifyRedisLifecycleError(error: unknown): RedisLifecycleErrorCode {
+  const code = normalizeErrorCode(error);
+  const message = normalizeErrorText(error);
+
+  if (code === 'WRONGPASS' || code === 'NOAUTH' || message.includes('WRONGPASS') || message.includes('NOAUTH')) {
+    return 'REDIS_AUTH_FAILED';
+  }
+
+  if (code === 'ECONNREFUSED' || message.includes('ECONNREFUSED')) {
+    return 'REDIS_CONNECTION_REFUSED';
+  }
+
+  if (
+    code === 'ETIMEDOUT'
+    || code === 'REDIS_CONNECT_TIMEOUT'
+    || message.includes('CONNECTION TIMEOUT')
+    || message.includes('TIMED OUT')
+  ) {
+    return 'REDIS_CONNECT_TIMEOUT';
+  }
+
+  if (code === 'ENOTFOUND' || code === 'EAI_AGAIN' || message.includes('ENOTFOUND') || message.includes('EAI_AGAIN')) {
+    return 'REDIS_DNS_UNAVAILABLE';
+  }
+
+  if (
+    code === 'ECONNRESET'
+    || code === 'EPIPE'
+    || message.includes('SOCKET CLOSED')
+    || message.includes('CONNECTION LOST')
+  ) {
+    return 'REDIS_CONNECTION_LOST';
+  }
+
+  return 'REDIS_UNAVAILABLE';
+}
+
+function cloneSnapshot(snapshot: RedisLifecycleSnapshot): RedisLifecycleSnapshot {
+  return { ...snapshot };
+}
+
+/**
+ * Own the shared startup/telemetry/diagnostics Redis connection without making
+ * listener startup wait for it.
+ *
+ * A single client is reused across bounded connect attempts. Reconnect scheduling is
+ * owned here so shutdown can abort every pending timer deterministically.
+ */
+export class RedisLifecycleManager {
+  private readonly clientFactory: RedisLifecycleClientFactory;
+  private readonly sleep: RedisLifecycleSleep;
+  private readonly random: () => number;
+  private readonly now: () => Date;
+  private readonly listeners = new Set<RedisLifecycleListener>();
+  private readonly abortController = new AbortController();
+  private client: RedisLifecycleClient | null = null;
+  private connectionLoop: Promise<void> | null = null;
+  private stopPromise: Promise<void> | null = null;
+  private started = false;
+  private stopping = false;
+  private consecutiveAttempts = 0;
+  private snapshot: RedisLifecycleSnapshot;
+
+  constructor(options: RedisLifecycleManagerOptions = {}) {
+    this.clientFactory = options.clientFactory ?? ((clientOptions) => createClient(clientOptions));
+    this.sleep = options.sleep ?? defaultSleep;
+    this.random = options.random ?? Math.random;
+    this.now = options.now ?? (() => new Date());
+    this.snapshot = {
+      state: 'STARTING',
+      configured: false,
+      connected: false,
+      attempt: 0,
+      recoveryCount: 0,
+      retryScheduled: false,
+      lastTransitionAt: this.now().toISOString(),
+      lastReadyAt: null,
+      lastErrorCode: null
+    };
+  }
+
+  /** Start connection recovery in the background. Repeated calls are no-ops. */
+  start(): void {
+    if (this.started || this.stopping) {
+      return;
+    }
+
+    this.started = true;
+    const redisConnection = resolveConfiguredRedisConnection();
+    if (!redisConnection.configured || !redisConnection.url) {
+      // Redis remains optional for local/stateless deployments. Production config
+      // validation is responsible for enforcing a required reference where needed.
+      this.updateSnapshot({
+        state: 'READY',
+        configured: false,
+        connected: false,
+        retryScheduled: false,
+        lastErrorCode: null
+      });
+      return;
+    }
+
+    this.updateSnapshot({
+      state: 'STARTING',
+      configured: true,
+      connected: false,
+      retryScheduled: false,
+      lastErrorCode: null
+    });
+
+    try {
+      const client = this.clientFactory({
+        url: redisConnection.url,
+        disableOfflineQueue: true,
+        socket: {
+          connectTimeout: REDIS_ATTEMPT_TIMEOUT_MS,
+          reconnectStrategy: false
+        }
+      });
+      this.client = client;
+      client.on('error', (error: Error) => {
+        this.handleClientError(client, error);
+      });
+      client.on('end', () => {
+        this.handleClientEnd(client);
+      });
+      this.ensureConnectionLoop(client);
+    } catch (error) {
+      const errorCode = classifyRedisLifecycleError(error);
+      this.updateSnapshot({
+        state: 'DEGRADED',
+        configured: true,
+        connected: false,
+        retryScheduled: false,
+        lastErrorCode: errorCode
+      });
+      logger.warn('redis.lifecycle.client_creation_failed', {
+        module: 'redis-lifecycle',
+        errorCode
+      });
+    }
+  }
+
+  /** Stop retries and close the current client. Repeated calls share one promise. */
+  async stop(): Promise<void> {
+    if (this.stopPromise) {
+      return this.stopPromise;
+    }
+
+    this.stopPromise = this.stopInternal();
+    return this.stopPromise;
+  }
+
+  /** Return the singleton client only while it is verified ready. */
+  getReadyClient(): RedisLifecycleClient | null {
+    const client = this.client;
+    if (
+      !client
+      || this.stopping
+      || this.snapshot.state !== 'READY'
+      || !this.snapshot.connected
+      || !client.isReady
+    ) {
+      return null;
+    }
+
+    return client;
+  }
+
+  /** Return an immutable, credential-free lifecycle projection. */
+  getSnapshot(): RedisLifecycleSnapshot {
+    return cloneSnapshot(this.snapshot);
+  }
+
+  /** Subscribe to lifecycle transitions and receive the current snapshot immediately. */
+  subscribe(listener: RedisLifecycleListener): () => void {
+    this.listeners.add(listener);
+    this.notifyListener(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  private ensureConnectionLoop(client: RedisLifecycleClient): void {
+    if (
+      this.connectionLoop
+      || this.stopping
+      || this.abortController.signal.aborted
+      || this.client !== client
+    ) {
+      return;
+    }
+
+    const loop = this.runConnectionLoop(client);
+    this.connectionLoop = loop;
+    void loop.finally(() => {
+      if (this.connectionLoop === loop) {
+        this.connectionLoop = null;
+      }
+      if (
+        !this.stopping
+        && !this.abortController.signal.aborted
+        && this.client === client
+        && this.snapshot.state === 'DEGRADED'
+      ) {
+        this.ensureConnectionLoop(client);
+      }
+    }).catch(() => {
+      // Every operational failure is represented by the sanitized lifecycle state.
+    });
+  }
+
+  private async runConnectionLoop(client: RedisLifecycleClient): Promise<void> {
+    while (!this.stopping && !this.abortController.signal.aborted && this.client === client) {
+      this.consecutiveAttempts += 1;
+      const attempt = this.consecutiveAttempts;
+      this.updateSnapshot({
+        attempt,
+        retryScheduled: false
+      });
+
+      try {
+        if (!client.isOpen) {
+          await this.runBoundedAttempt(client.connect(), client);
+        }
+
+        const pingResponse = await this.runBoundedAttempt(client.ping(), client);
+        if (pingResponse !== 'PONG') {
+          throw Object.assign(new Error('Unexpected Redis readiness response.'), {
+            code: 'REDIS_UNEXPECTED_RESPONSE'
+          });
+        }
+
+        if (this.stopping || this.abortController.signal.aborted || this.client !== client) {
+          return;
+        }
+
+        const recovered = this.snapshot.state === 'DEGRADED';
+        this.updateSnapshot({
+          state: 'READY',
+          configured: true,
+          connected: true,
+          retryScheduled: false,
+          recoveryCount: this.snapshot.recoveryCount + (recovered ? 1 : 0),
+          lastReadyAt: this.now().toISOString(),
+          lastErrorCode: null
+        });
+        this.consecutiveAttempts = 0;
+        logger.info('redis.lifecycle.ready', {
+          module: 'redis-lifecycle',
+          recovered,
+          attempt
+        });
+        return;
+      } catch (error) {
+        if (this.stopping || this.abortController.signal.aborted || error instanceof RedisLifecycleAbortError) {
+          return;
+        }
+
+        this.destroyClientConnection(client);
+        const errorCode = classifyRedisLifecycleError(error);
+        const retryDelayMs = this.calculateRetryDelay(attempt);
+        this.updateSnapshot({
+          state: 'DEGRADED',
+          configured: true,
+          connected: false,
+          retryScheduled: true,
+          lastErrorCode: errorCode
+        });
+        logger.warn('redis.lifecycle.retry_scheduled', {
+          module: 'redis-lifecycle',
+          errorCode,
+          attempt,
+          retryDelayMs
+        });
+
+        try {
+          await this.sleep(retryDelayMs, this.abortController.signal);
+        } catch (sleepError) {
+          if (sleepError instanceof RedisLifecycleAbortError || this.abortController.signal.aborted) {
+            return;
+          }
+          throw sleepError;
+        }
+      }
+    }
+  }
+
+  private async runBoundedAttempt<T>(
+    operation: Promise<T>,
+    client: RedisLifecycleClient
+  ): Promise<T> {
+    const attemptController = new AbortController();
+    const abortAttempt = () => attemptController.abort();
+    this.abortController.signal.addEventListener('abort', abortAttempt, { once: true });
+
+    const timeoutPromise = this.sleep(REDIS_ATTEMPT_TIMEOUT_MS, attemptController.signal)
+      .then<never>(() => {
+        if (this.client === client) {
+          this.destroyClientConnection(client);
+        }
+        throw new RedisLifecycleAttemptTimeoutError();
+      });
+
+    try {
+      return await Promise.race([operation, timeoutPromise]);
+    } finally {
+      attemptController.abort();
+      this.abortController.signal.removeEventListener('abort', abortAttempt);
+    }
+  }
+
+  private handleClientError(client: RedisLifecycleClient, error: unknown): void {
+    if (
+      this.stopping
+      || this.client !== client
+      || (this.connectionLoop !== null && this.snapshot.state !== 'READY')
+    ) {
+      return;
+    }
+
+    const errorCode = classifyRedisLifecycleError(error);
+    this.updateSnapshot({
+      state: 'DEGRADED',
+      configured: true,
+      connected: false,
+      retryScheduled: false,
+      lastErrorCode: errorCode
+    });
+    logger.warn('redis.lifecycle.connection_lost', {
+      module: 'redis-lifecycle',
+      errorCode
+    });
+    this.destroyClientConnection(client);
+    this.ensureConnectionLoop(client);
+  }
+
+  private handleClientEnd(client: RedisLifecycleClient): void {
+    if (
+      this.stopping
+      || this.client !== client
+      || this.snapshot.state !== 'READY'
+      || !this.snapshot.connected
+    ) {
+      return;
+    }
+
+    this.updateSnapshot({
+      state: 'DEGRADED',
+      configured: true,
+      connected: false,
+      retryScheduled: false,
+      lastErrorCode: 'REDIS_CONNECTION_LOST'
+    });
+    logger.warn('redis.lifecycle.connection_lost', {
+      module: 'redis-lifecycle',
+      errorCode: 'REDIS_CONNECTION_LOST'
+    });
+    this.ensureConnectionLoop(client);
+  }
+
+  private calculateRetryDelay(attempt: number): number {
+    const exponent = Math.max(0, Math.min(attempt - 1, 30));
+    const exponentialDelay = Math.min(
+      REDIS_RETRY_BASE_DELAY_MS * (2 ** exponent),
+      REDIS_RETRY_MAX_DELAY_MS
+    );
+    const boundedRandom = Math.max(0, Math.min(this.random(), 0.999999999));
+    const jitter = Math.floor(boundedRandom * REDIS_RETRY_JITTER_MS);
+    return Math.min(exponentialDelay + jitter, REDIS_RETRY_MAX_DELAY_MS);
+  }
+
+  private destroyClientConnection(client: RedisLifecycleClient): void {
+    if (this.client !== client || !client.isOpen) {
+      return;
+    }
+
+    try {
+      client.destroy();
+    } catch {
+      // Destruction is best-effort; the retry loop remains the source of truth.
+    }
+  }
+
+  private async stopInternal(): Promise<void> {
+    if (this.stopping) {
+      return;
+    }
+
+    this.stopping = true;
+    this.abortController.abort();
+    const client = this.client;
+    this.client = null;
+    const connectionLoop = this.connectionLoop;
+    this.updateSnapshot({
+      state: 'DEGRADED',
+      connected: false,
+      retryScheduled: false,
+      lastErrorCode: null
+    });
+
+    if (client?.isOpen) {
+      try {
+        if (client.isReady) {
+          await client.close();
+        } else {
+          client.destroy();
+        }
+      } catch {
+        try {
+          if (client.isOpen) {
+            client.destroy();
+          }
+        } catch {
+          // Redis shutdown remains best-effort under the server shutdown deadline.
+        }
+      }
+    }
+
+    if (connectionLoop) {
+      await connectionLoop.catch(() => undefined);
+    }
+
+    this.listeners.clear();
+  }
+
+  private updateSnapshot(update: Partial<RedisLifecycleSnapshot>): void {
+    const previousState = this.snapshot.state;
+    const nextState = update.state ?? previousState;
+    this.snapshot = {
+      ...this.snapshot,
+      ...update,
+      lastTransitionAt: nextState === previousState
+        ? this.snapshot.lastTransitionAt
+        : this.now().toISOString()
+    };
+    this.notifyListeners();
+  }
+
+  private notifyListeners(): void {
+    for (const listener of this.listeners) {
+      this.notifyListener(listener);
+    }
+  }
+
+  private notifyListener(listener: RedisLifecycleListener): void {
+    try {
+      listener(this.getSnapshot());
+    } catch {
+      logger.warn('redis.lifecycle.listener_failed', {
+        module: 'redis-lifecycle',
+        errorCode: 'REDIS_LIFECYCLE_LISTENER_FAILED'
+      });
+    }
+  }
+}
+
+const redisLifecycle = new RedisLifecycleManager();
+
+export function startRedisLifecycle(): void {
+  redisLifecycle.start();
+}
+
+export function stopRedisLifecycle(): Promise<void> {
+  return redisLifecycle.stop();
+}
+
+export function getReadyRedisClient(): RedisLifecycleClient | null {
+  return redisLifecycle.getReadyClient();
+}
+
+export function getRedisLifecycleSnapshot(): RedisLifecycleSnapshot {
+  return redisLifecycle.getSnapshot();
+}
+
+export function subscribeRedisLifecycle(listener: RedisLifecycleListener): () => void {
+  return redisLifecycle.subscribe(listener);
+}

--- a/src/platform/runtime/startupLifecycle.ts
+++ b/src/platform/runtime/startupLifecycle.ts
@@ -1,0 +1,200 @@
+/**
+ * Process-local web startup lifecycle state.
+ *
+ * The lifecycle is intentionally independent from dependency clients. Redis and
+ * the server bootstrap project their state here so health handlers can answer
+ * synchronously without opening new network connections.
+ */
+
+export type StartupLifecyclePhase = 'STARTING' | 'DEGRADED' | 'READY';
+
+export type StartupRedisStatus =
+  | 'not_started'
+  | 'connecting'
+  | 'ready'
+  | 'unavailable'
+  | 'stopped';
+
+export interface StartupRedisSnapshot {
+  configured: boolean;
+  status: StartupRedisStatus;
+  attempt: number;
+  lastErrorCode: string | null;
+}
+
+export interface StartupLifecycleSnapshot {
+  phase: StartupLifecyclePhase;
+  ready: boolean;
+  listenerBound: boolean;
+  runtimeInitialized: boolean;
+  runtimeErrorCode: string | null;
+  shuttingDown: boolean;
+  redis: StartupRedisSnapshot;
+  changedAt: string;
+}
+
+export interface StartupRedisLifecycleUpdate {
+  configured: boolean;
+  status: StartupRedisStatus;
+  attempt?: number;
+  lastErrorCode?: string | null;
+}
+
+type StartupLifecycleListener = (snapshot: StartupLifecycleSnapshot) => void;
+
+interface MutableStartupLifecycleState {
+  listenerBound: boolean;
+  runtimeInitialized: boolean;
+  runtimeErrorCode: string | null;
+  shuttingDown: boolean;
+  redis: StartupRedisSnapshot;
+  changedAt: string;
+}
+
+function createInitialState(): MutableStartupLifecycleState {
+  return {
+    listenerBound: false,
+    runtimeInitialized: false,
+    runtimeErrorCode: null,
+    shuttingDown: false,
+    redis: {
+      configured: false,
+      status: 'not_started',
+      attempt: 0,
+      lastErrorCode: null,
+    },
+    changedAt: new Date().toISOString(),
+  };
+}
+
+let state = createInitialState();
+const listeners = new Set<StartupLifecycleListener>();
+
+function derivePhase(current: MutableStartupLifecycleState): StartupLifecyclePhase {
+  if (
+    current.shuttingDown
+    || current.runtimeErrorCode !== null
+    || (
+      current.redis.status === 'unavailable'
+      || current.redis.status === 'stopped'
+    )
+  ) {
+    return 'DEGRADED';
+  }
+
+  if (
+    !current.listenerBound
+    || !current.runtimeInitialized
+    || current.redis.status !== 'ready'
+  ) {
+    return 'STARTING';
+  }
+
+  return 'READY';
+}
+
+function snapshotState(): StartupLifecycleSnapshot {
+  const phase = derivePhase(state);
+  return {
+    phase,
+    ready: phase === 'READY',
+    listenerBound: state.listenerBound,
+    runtimeInitialized: state.runtimeInitialized,
+    runtimeErrorCode: state.runtimeErrorCode,
+    shuttingDown: state.shuttingDown,
+    redis: { ...state.redis },
+    changedAt: state.changedAt,
+  };
+}
+
+function publish(): StartupLifecycleSnapshot {
+  state.changedAt = new Date().toISOString();
+  const snapshot = snapshotState();
+  for (const listener of listeners) {
+    try {
+      listener(snapshot);
+    } catch {
+      // Observers must never alter process startup.
+    }
+  }
+  return snapshot;
+}
+
+export function getStartupLifecycleSnapshot(): StartupLifecycleSnapshot {
+  return snapshotState();
+}
+
+export function subscribeStartupLifecycle(listener: StartupLifecycleListener): () => void {
+  listeners.add(listener);
+  listener(snapshotState());
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function markStartupListenerBound(): StartupLifecycleSnapshot {
+  if (!state.shuttingDown) {
+    state.listenerBound = true;
+  }
+  return publish();
+}
+
+export function markStartupRuntimeInitializing(): StartupLifecycleSnapshot {
+  if (!state.shuttingDown) {
+    state.runtimeInitialized = false;
+    state.runtimeErrorCode = null;
+  }
+  return publish();
+}
+
+export function markStartupRuntimeInitialized(): StartupLifecycleSnapshot {
+  if (!state.shuttingDown) {
+    state.runtimeInitialized = true;
+    state.runtimeErrorCode = null;
+  }
+  return publish();
+}
+
+export function markStartupRuntimeFailed(
+  errorCode = 'RUNTIME_INITIALIZATION_FAILED'
+): StartupLifecycleSnapshot {
+  if (!state.shuttingDown) {
+    state.runtimeInitialized = false;
+    state.runtimeErrorCode = errorCode;
+  }
+  return publish();
+}
+
+export function updateStartupRedisLifecycle(
+  redis: StartupRedisLifecycleUpdate
+): StartupLifecycleSnapshot {
+  if (state.shuttingDown) {
+    return snapshotState();
+  }
+
+  state.redis = {
+    configured: redis.configured,
+    status: redis.status,
+    attempt: Math.max(0, Math.trunc(redis.attempt ?? state.redis.attempt)),
+    lastErrorCode: redis.lastErrorCode ?? null,
+  };
+  return publish();
+}
+
+export function markStartupShutdown(): StartupLifecycleSnapshot {
+  if (!state.shuttingDown) {
+    state.shuttingDown = true;
+    if (state.redis.configured) {
+      state.redis.status = 'stopped';
+    }
+  }
+  return publish();
+}
+
+export function resetStartupLifecycleForTests(): void {
+  if (process.env.NODE_ENV !== 'test') {
+    return;
+  }
+  state = createInitialState();
+  listeners.clear();
+}

--- a/src/routes/ask/index.ts
+++ b/src/routes/ask/index.ts
@@ -451,9 +451,14 @@ async function buildSystemHealthProbeResponse(params: {
   const healthReport = runHealthCheck();
   const redisHealth = await checkRedisHealth();
   const overallStatus = healthReport.status === 'ok' && redisHealth.healthy ? 'ok' : 'degraded';
+  const redisStatus = redisHealth.healthy
+    ? 'ready'
+    : redisHealth.code === 'REDIS_INITIALIZING'
+      ? 'initializing'
+      : 'unavailable';
   const summary = redisHealth.healthy
     ? healthReport.summary
-    : `${healthReport.summary} | Redis: ${redisHealth.error || 'unhealthy'}`;
+    : `${healthReport.summary} | Redis dependency: ${redisStatus}`;
   const createdAt = Math.floor(Date.now() / 1000);
   const requestId = `health_${createdAt}`;
 

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -18,6 +18,7 @@ import {
   checkOpenAIHealth,
   checkDatabaseHealth,
   checkRedisHealth,
+  checkStartupReadiness,
   checkApplicationHealth
 } from "@platform/resilience/unifiedHealth.js";
 
@@ -39,7 +40,7 @@ router.get('/readyz', buildReadinessEndpoint([
   createHealthCheck('openai', checkOpenAIHealth, true),
   createHealthCheck('database', checkDatabaseHealth, true),
   createHealthCheck('redis', checkRedisHealth, true),
-  createHealthCheck('application', checkApplicationHealth, true)
+  createHealthCheck('startup', checkStartupReadiness, true)
 ]));
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,33 @@
 import 'dotenv/config';
 
 import type { Server } from 'node:http';
-import { app } from './app.js';
-import { performStartup } from './core/startup.js';
+import type { Express } from 'express';
+import {
+  initializeRuntimeDependencies,
+  performStartupPreflight,
+} from './core/startup.js';
 import { startSelfHealingLoop } from '@services/selfImprove/selfHealingLoop.js';
-import { primeSelfHealTelemetryPersistence } from '@services/selfImprove/selfHealTelemetry.js';
+import {
+  primeSelfHealTelemetryPersistence,
+  stopSelfHealTelemetryPersistence,
+} from '@services/selfImprove/selfHealTelemetry.js';
 import { close as closeDatabase } from '@core/db/index.js';
+import {
+  getRedisLifecycleSnapshot,
+  startRedisLifecycle,
+  stopRedisLifecycle,
+  subscribeRedisLifecycle,
+  type RedisLifecycleSnapshot,
+} from '@platform/runtime/redisLifecycle.js';
+import {
+  getStartupLifecycleSnapshot,
+  markStartupListenerBound,
+  markStartupRuntimeFailed,
+  markStartupRuntimeInitialized,
+  markStartupRuntimeInitializing,
+  markStartupShutdown,
+  updateStartupRedisLifecycle,
+} from '@platform/runtime/startupLifecycle.js';
 
 const DEFAULT_PORT = 3000;
 const DEFAULT_LOCAL_HOST = '127.0.0.1';
@@ -14,6 +36,12 @@ const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
 
 let httpServer: Server | null = null;
 let shutdownStarted = false;
+let fullRuntimeStarted = false;
+let unsubscribeRedisLifecycle: (() => void) | null = null;
+let runtimeInitializationPromise: Promise<void> | null = null;
+let activeStopTelemetryPersistence: () => Promise<void> = stopSelfHealTelemetryPersistence;
+let activeStopRedisLifecycle: () => Promise<void> = stopRedisLifecycle;
+let activeCloseDatabase: () => Promise<void> = closeDatabase;
 
 interface StartupDeploymentSummary {
   serviceName: string;
@@ -25,6 +53,27 @@ interface StartupDeploymentSummary {
 interface ListenerConfig {
   port: number;
   host: string;
+}
+
+interface AppRuntimeModule {
+  app: Express;
+  startAppRuntimeOnce: (app: Express) => boolean;
+}
+
+export interface StartServerOptions {
+  app?: Express;
+  startAppRuntimeOnce?: (app: Express) => boolean;
+  performPreflight?: () => Promise<void>;
+  initializeDependencies?: () => Promise<void>;
+  startRedis?: () => void;
+  stopRedis?: () => Promise<void>;
+  primeTelemetry?: () => Promise<void>;
+  stopTelemetry?: () => Promise<void>;
+  getRedisSnapshot?: () => RedisLifecycleSnapshot;
+  subscribeRedis?: (listener: (snapshot: RedisLifecycleSnapshot) => void) => () => void;
+  startSelfHealing?: typeof startSelfHealingLoop;
+  closeDatabase?: () => Promise<void>;
+  registerSignalHandlers?: boolean;
 }
 
 function parsePositiveInteger(value: string | undefined, fallback: number): number {
@@ -118,15 +167,22 @@ function closeHttpServer(server: Server): Promise<void> {
 }
 
 async function closeResources(): Promise<void> {
-  await closeDatabase();
+  unsubscribeRedisLifecycle?.();
+  unsubscribeRedisLifecycle = null;
+  await activeStopTelemetryPersistence();
+  await activeStopRedisLifecycle();
+  await runtimeInitializationPromise?.catch(() => undefined);
+  await activeCloseDatabase();
 }
 
-async function shutdown(signal: NodeJS.Signals): Promise<void> {
+/** Gracefully stop the listener and its dependency lifecycle exactly once. */
+export async function shutdownServer(signal: NodeJS.Signals): Promise<void> {
   if (shutdownStarted) {
     return;
   }
 
   shutdownStarted = true;
+  markStartupShutdown();
   const shutdownTimeoutMs = resolveShutdownTimeoutMs();
   console.log(`[SHUTDOWN] Received ${signal}; closing HTTP server and resources.`);
 
@@ -154,32 +210,158 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   }
 }
 
-/**
- * Starts the ARCANOS HTTP server after startup preflight.
- *
- * Purpose: Ensure startup initialization (including DB init) runs before serving traffic.
- * Inputs/Outputs: Uses process environment; starts Express listener on configured port.
- * Edge cases: Throws if startup preflight fails unexpectedly.
- */
-async function startServer(): Promise<void> {
-  const listenerConfig = resolveListenerConfig();
-  await performStartup();
-  await primeSelfHealTelemetryPersistence();
+function projectRedisLifecycle(snapshot: RedisLifecycleSnapshot): void {
+  const status = snapshot.state === 'READY'
+    ? 'ready'
+    : snapshot.state === 'DEGRADED'
+      ? 'unavailable'
+      : snapshot.configured
+        ? 'connecting'
+        : 'not_started';
 
-  httpServer = app.listen(listenerConfig.port, listenerConfig.host, () => {
-    const selfHealLoopStatus = startSelfHealingLoop();
-    const startupDeploymentSummary = resolveStartupDeploymentSummary();
-    console.log(
-      `ARCANOS running on ${listenerConfig.host}:${listenerConfig.port} | service=${startupDeploymentSummary.serviceName} | deployment=${startupDeploymentSummary.deploymentId} | git=${startupDeploymentSummary.gitCommit} | branch=${startupDeploymentSummary.gitBranch} | workerHelperRoutes=enabled | askWorkerTools=enabled | selfHealLoop=${selfHealLoopStatus.loopRunning ? 'enabled' : 'disabled'} | selfHealIntervalMs=${selfHealLoopStatus.intervalMs}`
-    );
+  updateStartupRedisLifecycle({
+    configured: snapshot.configured,
+    status,
+    attempt: snapshot.attempt,
+    lastErrorCode: snapshot.lastErrorCode,
   });
-
-  process.once('SIGTERM', () => void shutdown('SIGTERM'));
-  process.once('SIGINT', () => void shutdown('SIGINT'));
 }
 
-startServer().catch((error) => {
-  //audit assumption: startup failures should fail fast; risk: serving partially initialized state; invariant: process exits on unrecoverable startup error; handling: log and terminate.
-  console.error('[STARTUP] Fatal startup failure:', error);
-  process.exit(1);
-});
+function listenForReady(app: Express, listenerConfig: ListenerConfig): Promise<Server> {
+  return new Promise((resolve, reject) => {
+    let server: Server;
+    try {
+      server = app.listen(listenerConfig.port, listenerConfig.host);
+      httpServer = server;
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    const onError = (error: Error) => {
+      server.removeListener('listening', onListening);
+      if (httpServer === server) {
+        httpServer = null;
+      }
+      reject(error);
+    };
+    const onListening = () => {
+      server.removeListener('error', onError);
+      resolve(server);
+    };
+
+    server.once('error', onError);
+    server.once('listening', onListening);
+  });
+}
+
+async function loadAppRuntime(options: StartServerOptions): Promise<AppRuntimeModule> {
+  if (options.app && options.startAppRuntimeOnce) {
+    return {
+      app: options.app,
+      startAppRuntimeOnce: options.startAppRuntimeOnce,
+    };
+  }
+
+  const appRuntime = await import('./app.js');
+  return {
+    app: options.app ?? appRuntime.app,
+    startAppRuntimeOnce: options.startAppRuntimeOnce ?? appRuntime.startAppRuntimeOnce,
+  };
+}
+
+/**
+ * Start the ARCANOS HTTP listener before fallible dependency initialization.
+ *
+ * Purpose: keep liveness and readiness observable while Redis or another
+ * external dependency recovers.
+ * Inputs/Outputs: uses process environment by default; accepts injectable
+ * lifecycle seams for deterministic tests; resolves once the listener binds.
+ * Edge cases: deterministic preflight or listener failures still reject and
+ * remain fatal to the production entrypoint.
+ */
+export async function startServer(options: StartServerOptions = {}): Promise<Server> {
+  if (httpServer) {
+    throw new Error('SERVER_ALREADY_STARTED');
+  }
+
+  const listenerConfig = resolveListenerConfig();
+  const runPreflight = options.performPreflight ?? performStartupPreflight;
+  const initializeDependencies = options.initializeDependencies ?? initializeRuntimeDependencies;
+  const startRedis = options.startRedis ?? startRedisLifecycle;
+  const getRedisSnapshot = options.getRedisSnapshot ?? getRedisLifecycleSnapshot;
+  const subscribeRedis = options.subscribeRedis ?? subscribeRedisLifecycle;
+  const startSelfHealing = options.startSelfHealing ?? startSelfHealingLoop;
+
+  await runPreflight();
+  const appRuntime = await loadAppRuntime(options);
+  activeStopRedisLifecycle = options.stopRedis ?? stopRedisLifecycle;
+  activeStopTelemetryPersistence = options.stopTelemetry ?? stopSelfHealTelemetryPersistence;
+  activeCloseDatabase = options.closeDatabase ?? closeDatabase;
+
+  if (options.registerSignalHandlers !== false) {
+    process.once('SIGTERM', () => void shutdownServer('SIGTERM'));
+    process.once('SIGINT', () => void shutdownServer('SIGINT'));
+  }
+
+  const server = await listenForReady(appRuntime.app, listenerConfig);
+  markStartupListenerBound();
+  const startupDeploymentSummary = resolveStartupDeploymentSummary();
+  console.log(
+    `[STARTUP] HTTP listener bound on ${listenerConfig.host}:${listenerConfig.port} | service=${startupDeploymentSummary.serviceName} | deployment=${startupDeploymentSummary.deploymentId} | git=${startupDeploymentSummary.gitCommit} | branch=${startupDeploymentSummary.gitBranch}`
+  );
+
+  const startFullRuntimeIfReady = () => {
+    const lifecycle = getStartupLifecycleSnapshot();
+    if (!lifecycle.ready || lifecycle.shuttingDown || fullRuntimeStarted) {
+      return;
+    }
+
+    // Set the guard before any side effect so a partial failure can never
+    // duplicate background loops on a later Redis transition.
+    fullRuntimeStarted = true;
+    try {
+      appRuntime.startAppRuntimeOnce(appRuntime.app);
+      const selfHealLoopStatus = startSelfHealing();
+      console.log(
+        `ARCANOS running on ${listenerConfig.host}:${listenerConfig.port} | service=${startupDeploymentSummary.serviceName} | deployment=${startupDeploymentSummary.deploymentId} | git=${startupDeploymentSummary.gitCommit} | branch=${startupDeploymentSummary.gitBranch} | workerHelperRoutes=enabled | askWorkerTools=enabled | selfHealLoop=${selfHealLoopStatus.loopRunning ? 'enabled' : 'disabled'} | selfHealIntervalMs=${selfHealLoopStatus.intervalMs}`
+      );
+    } catch (error) {
+      markStartupRuntimeFailed('FULL_RUNTIME_START_FAILED');
+      console.error('[STARTUP] Full runtime initialization failed', {
+        errorType: error instanceof Error ? error.name : 'Error',
+      });
+    }
+  };
+
+  unsubscribeRedisLifecycle = subscribeRedis((snapshot) => {
+    projectRedisLifecycle(snapshot);
+    startFullRuntimeIfReady();
+  });
+
+  // Project once even when a test double does not immediately invoke its
+  // subscriber, then begin Redis recovery without awaiting it.
+  projectRedisLifecycle(getRedisSnapshot());
+  startRedis();
+  void (options.primeTelemetry ?? primeSelfHealTelemetryPersistence)().catch((error: unknown) => {
+    console.warn('[STARTUP] Self-heal telemetry priming deferred', {
+      errorType: error instanceof Error ? error.name : 'Error',
+    });
+  });
+  markStartupRuntimeInitializing();
+
+  runtimeInitializationPromise = initializeDependencies()
+    .then(() => {
+      markStartupRuntimeInitialized();
+      startFullRuntimeIfReady();
+    })
+    .catch((error: unknown) => {
+      markStartupRuntimeFailed();
+      console.error('[STARTUP] Runtime dependency initialization failed', {
+        errorType: error instanceof Error ? error.name : 'Error',
+      });
+    });
+  void runtimeInitializationPromise;
+
+  return server;
+}

--- a/src/services/gptAccessGateway.ts
+++ b/src/services/gptAccessGateway.ts
@@ -29,6 +29,8 @@ import { planAutonomousWorkerJob } from '@services/workerAutonomyService.js';
 import { buildSafetySelfHealSnapshot } from '@services/selfHealRuntimeInspectionService.js';
 import { getJobEventTimeline } from '@services/jobEventTimelineService.js';
 import { getWorkerRuntimeStatus } from '@platform/runtime/workerConfig.js';
+import { getRedisLifecycleSnapshot } from '@platform/runtime/redisLifecycle.js';
+import { getStartupLifecycleSnapshot } from '@platform/runtime/startupLifecycle.js';
 import { getNaturalLanguageDispatchRuntimeStatus } from '@dispatcher/naturalLanguage/planner.js';
 import { DISPATCH_UTTERANCE_MAX_LENGTH } from '@dispatcher/naturalLanguage/types.js';
 export { GPT_ACCESS_SCOPES, type GptAccessScope } from '@services/gptAccessScopes.js';
@@ -636,13 +638,40 @@ export function isGptAccessScopeAllowed(scope: GptAccessScope): boolean {
 }
 
 export function buildGptAccessHealthPayload() {
+  const startup = getStartupLifecycleSnapshot();
+  const redis = getRedisLifecycleSnapshot();
+  const redisReady = redis.state === 'READY';
+  const redisCode = redisReady
+    ? null
+    : redis.state === 'STARTING'
+      ? 'REDIS_INITIALIZING'
+      : 'REDIS_DEPENDENCY_UNAVAILABLE';
+
   return {
     ok: true,
+    status: startup.phase === 'READY'
+      ? 'healthy'
+      : startup.phase === 'STARTING'
+        ? 'starting'
+        : 'degraded',
     service: 'arcanos-gpt-access',
     time: new Date().toISOString(),
     authRequired: true,
     version: SERVICE_VERSION,
-    nlDispatch: getNaturalLanguageDispatchRuntimeStatus()
+    nlDispatch: getNaturalLanguageDispatchRuntimeStatus(),
+    startup: {
+      phase: startup.phase,
+      ready: startup.ready
+    },
+    dependencies: {
+      redis: {
+        configured: redis.configured,
+        ready: redisReady,
+        status: redis.state.toLowerCase(),
+        code: redisCode,
+        retryScheduled: redis.retryScheduled
+      }
+    }
   };
 }
 

--- a/src/services/runtimeDiagnosticsService.ts
+++ b/src/services/runtimeDiagnosticsService.ts
@@ -1,12 +1,14 @@
 import type { Application } from 'express';
-import { createClient } from 'redis';
 import { getEnv, getEnvNumber } from '@platform/runtime/env.js';
 import { logger } from '@platform/logging/structuredLogging.js';
 import { resolveErrorMessage } from '@core/lib/errors/index.js';
 import { getGptModuleMap } from '@platform/runtime/gptRouterConfig.js';
+import {
+  getReadyRedisClient,
+  type RedisLifecycleClient
+} from '@platform/runtime/redisLifecycle.js';
 import { loadModuleDefinitions, type LoadedModule } from './moduleLoader.js';
 import { getActiveRouteTable } from './runtimeRouteTableService.js';
-import { resolveConfiguredRedisConnection } from '@platform/runtime/redis.js';
 import type { AIDegradedResponseMetadata, AITimeoutKind } from '@shared/http/aiDegradedHeaders.js';
 
 type ModuleStatus =
@@ -138,7 +140,7 @@ interface MetricsSnapshot {
   topErrorRoutes: DiagnosticsRouteErrorSnapshot[];
 }
 
-type RuntimeDiagnosticsRedisClient = ReturnType<typeof createClient>;
+type RuntimeDiagnosticsRedisClient = RedisLifecycleClient;
 
 const RECENT_LATENCY_LIMIT = Math.max(10, getEnvNumber('DIAGNOSTICS_RECENT_LATENCY_LIMIT', 50));
 const RECENT_REQUEST_LIMIT = Math.max(25, getEnvNumber('DIAGNOSTICS_RECENT_REQUEST_LIMIT', 250));
@@ -489,14 +491,12 @@ class RuntimeDiagnosticsService {
 }
 
 class RuntimeDiagnosticsRedisStore {
-  private clientPromise: Promise<RuntimeDiagnosticsRedisClient | null> | null = null;
-
   async recordRequestCompletion(
     statusCode: number,
     latencyMs: number,
     metadata: AIDegradedResponseMetadata = {}
   ): Promise<void> {
-    const redisClient = await this.getClient();
+    const redisClient = this.getClient();
     if (!redisClient) {
       return;
     }
@@ -511,16 +511,16 @@ class RuntimeDiagnosticsRedisStore {
       redisCommandBatch.lPush(this.key('recent_latency_ms'), String(latencyMs));
       redisCommandBatch.lTrim(this.key('recent_latency_ms'), 0, RECENT_LATENCY_LIMIT - 1);
       await redisCommandBatch.exec();
-    } catch (error) {
+    } catch {
       logger.warn('diagnostics.shared_metrics.write_failed', {
         module: 'runtime-diagnostics',
-        error: resolveErrorMessage(error)
+        errorCode: 'REDIS_DEPENDENCY_UNAVAILABLE'
       });
     }
   }
 
   async getSnapshot(): Promise<MetricsSnapshot | null> {
-    const redisClient = await this.getClient();
+    const redisClient = this.getClient();
     if (!redisClient) {
       return null;
     }
@@ -569,17 +569,17 @@ class RuntimeDiagnosticsRedisStore {
           : 'DATA NOT EXPOSED: recent_latency_ms',
         topErrorRoutes: []
       };
-    } catch (error) {
+    } catch {
       logger.warn('diagnostics.shared_metrics.read_failed', {
         module: 'runtime-diagnostics',
-        error: resolveErrorMessage(error)
+        errorCode: 'REDIS_DEPENDENCY_UNAVAILABLE'
       });
       return null;
     }
   }
 
   async reset(): Promise<void> {
-    const redisClient = await this.getClient();
+    const redisClient = this.getClient();
     if (!redisClient) {
       return;
     }
@@ -591,49 +591,20 @@ class RuntimeDiagnosticsRedisStore {
         this.key('latency_total_ms'),
         this.key('recent_latency_ms')
       ]);
-    } catch (error) {
+    } catch {
       logger.warn('diagnostics.shared_metrics.reset_failed', {
         module: 'runtime-diagnostics',
-        error: resolveErrorMessage(error)
+        errorCode: 'REDIS_DEPENDENCY_UNAVAILABLE'
       });
     }
   }
 
-  private async getClient(): Promise<RuntimeDiagnosticsRedisClient | null> {
+  private getClient(): RuntimeDiagnosticsRedisClient | null {
     if (!REDIS_SHARED_METRICS_ENABLED) {
       return null;
     }
 
-    if (!this.clientPromise) {
-      this.clientPromise = this.createClient();
-    }
-
-    return this.clientPromise;
-  }
-
-  private async createClient(): Promise<RuntimeDiagnosticsRedisClient | null> {
-    const redisConnection = resolveConfiguredRedisConnection();
-    if (!redisConnection.configured || !redisConnection.url) {
-      return null;
-    }
-
-    try {
-      const redisClient = createClient({ url: redisConnection.url });
-      redisClient.on('error', (error) => {
-        logger.warn('diagnostics.shared_metrics.redis_error', {
-          module: 'runtime-diagnostics',
-          error: resolveErrorMessage(error)
-        });
-      });
-      await redisClient.connect();
-      return redisClient;
-    } catch (error) {
-      logger.warn('diagnostics.shared_metrics.unavailable', {
-        module: 'runtime-diagnostics',
-        error: resolveErrorMessage(error)
-      });
-      return null;
-    }
+    return getReadyRedisClient();
   }
 
   private key(suffix: string): string {

--- a/src/services/selfImprove/selfHealTelemetry.ts
+++ b/src/services/selfImprove/selfHealTelemetry.ts
@@ -1,9 +1,15 @@
 import fs from 'fs';
 import path from 'path';
-import { createClient } from 'redis';
 import { resolveErrorMessage } from '@core/lib/errors/index.js';
+import { logger } from '@platform/logging/structuredLogging.js';
 import { getEnv } from '@platform/runtime/env.js';
 import { resolveConfiguredRedisConnection } from '@platform/runtime/redis.js';
+import {
+  getReadyRedisClient,
+  subscribeRedisLifecycle,
+  type RedisLifecycleClient,
+  type RedisLifecycleSnapshot
+} from '@platform/runtime/redisLifecycle.js';
 import { readJsonFileSafely } from '@shared/jsonFileUtils.js';
 
 const SELF_HEAL_EVENT_KINDS = [
@@ -154,9 +160,13 @@ interface PersistedSelfHealTelemetryState {
 }
 
 let pendingPersistenceTimeout: NodeJS.Timeout | null = null;
-let redisClientPromise: Promise<SelfHealTelemetryRedisClient | null> | null = null;
-
-type SelfHealTelemetryRedisClient = ReturnType<typeof createClient>;
+let redisHydrationRetryTimeout: NodeJS.Timeout | null = null;
+let redisHydrationPromise: Promise<void> | null = null;
+let redisLifecycleUnsubscribe: (() => void) | null = null;
+let redisPersistenceDirty = false;
+let redisPersistenceStopping = false;
+let redisPersistenceGeneration = 0;
+let handledRedisReadyAt: string | null = null;
 
 function isPathWithin(basePath: string, candidatePath: string): boolean {
   const resolvedBasePath = path.resolve(basePath);
@@ -485,6 +495,47 @@ function applyPersistedState(
   state.persistence.lastSavedAt = persistedState.storedAt ?? state.persistence.lastSavedAt;
 }
 
+function applyLastEventReference(state: SelfHealTelemetryState, event: SelfHealEvent): void {
+  if (event.kind === 'trigger') {
+    state.lastTrigger = event;
+  } else if (event.kind === 'attempt') {
+    state.lastAttempt = event;
+  } else if (event.kind === 'success') {
+    state.lastSuccess = event;
+  } else if (event.kind === 'failure') {
+    state.lastFailure = event;
+  } else if (event.kind === 'fallback') {
+    state.lastFallback = event;
+  }
+}
+
+function applyPersistedStateWithoutLosingLocalEvents(
+  state: SelfHealTelemetryState,
+  persistedState: PersistedSelfHealTelemetryState | null,
+  loadedAt: string
+): void {
+  const localEvents = state.recentEvents.map((event) => cloneEvent(event)!);
+  applyPersistedState(state, persistedState, loadedAt);
+
+  if (!persistedState) {
+    return;
+  }
+
+  for (const localEvent of localEvents) {
+    const mergedEvent = {
+      ...localEvent,
+      id: `self_heal_event_${state.nextSequence}`
+    };
+    state.nextSequence += 1;
+    state.recentEvents.push(mergedEvent);
+    applyLastEventReference(state, mergedEvent);
+  }
+
+  if (state.recentEvents.length > MAX_RECENT_EVENTS) {
+    state.recentEvents.splice(0, state.recentEvents.length - MAX_RECENT_EVENTS);
+  }
+}
+
 function hydrateStateFromPersistence(state: SelfHealTelemetryState): void {
   if (state.hydrated) {
     return;
@@ -499,53 +550,35 @@ function hydrateStateFromPersistence(state: SelfHealTelemetryState): void {
   applyPersistedState(state, loadPersistedStateFromFile(target), new Date().toISOString());
 }
 
-async function getRedisClient(): Promise<SelfHealTelemetryRedisClient | null> {
-  const redisConnection = resolveConfiguredRedisConnection();
-  if (!redisConnection.configured || !redisConnection.url) {
-    return null;
-  }
-
-  if (!redisClientPromise) {
-    redisClientPromise = (async () => {
-      try {
-        const redisClient = createClient({ url: redisConnection.url });
-        redisClient.on('error', (error) => {
-          console.warn(`[SELF-HEAL][TELEMETRY] redis error: ${resolveErrorMessage(error)}`);
-        });
-        await redisClient.connect();
-        return redisClient;
-      } catch (error) {
-        console.warn(`[SELF-HEAL][TELEMETRY] redis unavailable: ${resolveErrorMessage(error)}`);
-        return null;
-      }
-    })();
-  }
-
-  return redisClientPromise;
+interface RedisPersistenceLoadResult {
+  ok: boolean;
+  state: PersistedSelfHealTelemetryState | null;
 }
 
 async function loadPersistedStateFromRedis(
+  redisClient: RedisLifecycleClient,
   target: SelfHealTelemetryPersistenceTarget
-): Promise<PersistedSelfHealTelemetryState | null> {
+): Promise<RedisPersistenceLoadResult> {
   if (!target.redisKey) {
-    return null;
-  }
-
-  const redisClient = await getRedisClient();
-  if (!redisClient) {
-    return null;
+    return { ok: true, state: null };
   }
 
   try {
     const persistedStateRaw = await redisClient.get(target.redisKey);
     if (!persistedStateRaw) {
-      return null;
+      return { ok: true, state: null };
     }
 
-    return normalizePersistedState(JSON.parse(persistedStateRaw));
-  } catch (error) {
-    console.warn(`[SELF-HEAL][TELEMETRY] redis read failed: ${resolveErrorMessage(error)}`);
-    return null;
+    return {
+      ok: true,
+      state: normalizePersistedState(JSON.parse(persistedStateRaw))
+    };
+  } catch {
+    logger.warn('self_heal.telemetry.redis_read_failed', {
+      module: 'self-heal-telemetry',
+      errorCode: 'REDIS_DEPENDENCY_UNAVAILABLE'
+    });
+    return { ok: false, state: null };
   }
 }
 
@@ -575,20 +608,41 @@ async function persistStateToRedis(
     return;
   }
 
-  const redisClient = await getRedisClient();
-  if (!redisClient) {
-    state.persistence.lastSaveError = 'Redis client unavailable';
+  if (!state.hydrated) {
+    redisPersistenceDirty = true;
+    state.persistence.lastSaveError = 'REDIS_TELEMETRY_NOT_HYDRATED';
+    return;
+  }
+
+  const redisClient = getReadyRedisClient();
+  if (!redisClient || redisPersistenceStopping) {
+    redisPersistenceDirty = true;
+    state.persistence.lastSaveError = 'REDIS_DEPENDENCY_UNAVAILABLE';
     return;
   }
 
   const persistedState = buildPersistedState(state);
   try {
     await redisClient.set(target.redisKey, JSON.stringify(persistedState));
+    if (getReadyRedisClient() !== redisClient) {
+      redisPersistenceDirty = true;
+      state.persistence.lastSaveError = 'REDIS_DEPENDENCY_UNAVAILABLE';
+      scheduleRedisHydrationRetry();
+      return;
+    }
+
+    redisPersistenceDirty = false;
+    clearRedisHydrationRetry();
     state.persistence.lastSavedAt = persistedState.storedAt;
     state.persistence.lastSaveError = null;
-  } catch (error) {
-    state.persistence.lastSaveError = resolveErrorMessage(error);
-    console.warn(`[SELF-HEAL][TELEMETRY] redis write failed: ${state.persistence.lastSaveError}`);
+  } catch {
+    redisPersistenceDirty = true;
+    state.persistence.lastSaveError = 'REDIS_DEPENDENCY_UNAVAILABLE';
+    scheduleRedisHydrationRetry();
+    logger.warn('self_heal.telemetry.redis_write_failed', {
+      module: 'self-heal-telemetry',
+      errorCode: 'REDIS_DEPENDENCY_UNAVAILABLE'
+    });
   }
 }
 
@@ -863,21 +917,158 @@ export function buildCompactSelfHealSummary(snapshot: SelfHealTelemetrySnapshot)
   };
 }
 
+function clearRedisHydrationRetry(): void {
+  if (!redisHydrationRetryTimeout) {
+    return;
+  }
+
+  clearTimeout(redisHydrationRetryTimeout);
+  redisHydrationRetryTimeout = null;
+}
+
+function scheduleRedisHydrationRetry(): void {
+  if (redisPersistenceStopping || redisHydrationRetryTimeout) {
+    return;
+  }
+
+  redisHydrationRetryTimeout = setTimeout(() => {
+    redisHydrationRetryTimeout = null;
+    const lifecycleSnapshot = getReadyRedisClient();
+    if (lifecycleSnapshot) {
+      void hydrateRedisTelemetryPersistence();
+    }
+  }, 1_000);
+  redisHydrationRetryTimeout.unref?.();
+}
+
+async function hydrateRedisTelemetryPersistence(): Promise<void> {
+  if (redisPersistenceStopping) {
+    return;
+  }
+
+  const state = getOrCreateMutableState();
+  if (state.hydrated) {
+    if (redisPersistenceDirty) {
+      await persistStateToRedis(state, resolvePersistenceTarget());
+    }
+    return;
+  }
+
+  if (redisHydrationPromise) {
+    return redisHydrationPromise;
+  }
+
+  const redisClient = getReadyRedisClient();
+  const target = resolvePersistenceTarget();
+  if (!redisClient || target.mode !== 'redis') {
+    state.persistence.lastSaveError = 'REDIS_DEPENDENCY_UNAVAILABLE';
+    redisPersistenceDirty = true;
+    return;
+  }
+
+  const generation = redisPersistenceGeneration;
+  const hydration = (async () => {
+    const result = await loadPersistedStateFromRedis(redisClient, target);
+    if (
+      !result.ok
+      || redisPersistenceStopping
+      || generation !== redisPersistenceGeneration
+      || getReadyRedisClient() !== redisClient
+    ) {
+      state.persistence.lastSaveError = 'REDIS_DEPENDENCY_UNAVAILABLE';
+      redisPersistenceDirty = true;
+      scheduleRedisHydrationRetry();
+      return;
+    }
+
+    const hadLocalEvents = state.recentEvents.length > 0;
+    applyPersistedStateWithoutLosingLocalEvents(
+      state,
+      result.state,
+      new Date().toISOString()
+    );
+    state.hydrated = true;
+    state.persistence.lastSaveError = null;
+    clearRedisHydrationRetry();
+
+    if (hadLocalEvents || redisPersistenceDirty) {
+      redisPersistenceDirty = true;
+      await persistStateToRedis(state, target);
+    }
+  })();
+  redisHydrationPromise = hydration;
+
+  try {
+    await hydration;
+  } finally {
+    if (redisHydrationPromise === hydration) {
+      redisHydrationPromise = null;
+    }
+  }
+}
+
+function handleRedisLifecycleSnapshot(snapshot: RedisLifecycleSnapshot): void {
+  if (redisPersistenceStopping || resolvePersistenceTarget().mode !== 'redis') {
+    return;
+  }
+
+  const state = getOrCreateMutableState();
+  if (snapshot.state !== 'READY' || !snapshot.connected) {
+    redisPersistenceDirty = true;
+    state.persistence.lastSaveError = 'REDIS_DEPENDENCY_UNAVAILABLE';
+    return;
+  }
+
+  if (snapshot.lastReadyAt && handledRedisReadyAt === snapshot.lastReadyAt) {
+    return;
+  }
+
+  handledRedisReadyAt = snapshot.lastReadyAt;
+  void hydrateRedisTelemetryPersistence();
+}
+
+function ensureRedisLifecycleSubscription(): void {
+  if (redisLifecycleUnsubscribe || redisPersistenceStopping) {
+    return;
+  }
+
+  redisLifecycleUnsubscribe = subscribeRedisLifecycle(handleRedisLifecycleSnapshot);
+}
+
 export async function primeSelfHealTelemetryPersistence(): Promise<void> {
   const state = getOrCreateMutableState();
+  const target = resolvePersistenceTarget();
+
+  if (target.mode === 'redis') {
+    ensureRedisLifecycleSubscription();
+    void hydrateRedisTelemetryPersistence();
+    return;
+  }
+
   if (state.hydrated) {
     return;
   }
 
-  const target = resolvePersistenceTarget();
   state.hydrated = true;
+  applyPersistedState(state, loadPersistedStateFromFile(target), new Date().toISOString());
+}
 
-  if (target.mode === 'redis') {
-    applyPersistedState(state, await loadPersistedStateFromRedis(target), new Date().toISOString());
+/** Stop telemetry retry/debounce work without waiting on an unavailable Redis dependency. */
+export async function stopSelfHealTelemetryPersistence(): Promise<void> {
+  if (redisPersistenceStopping) {
     return;
   }
 
-  applyPersistedState(state, loadPersistedStateFromFile(target), new Date().toISOString());
+  redisPersistenceStopping = true;
+  redisPersistenceGeneration += 1;
+  redisLifecycleUnsubscribe?.();
+  redisLifecycleUnsubscribe = null;
+  clearRedisHydrationRetry();
+
+  if (pendingPersistenceTimeout) {
+    clearTimeout(pendingPersistenceTimeout);
+    pendingPersistenceTimeout = null;
+  }
 }
 
 export function resetSelfHealTelemetryForTests(options: { clearPersistence?: boolean } = {}): void {
@@ -889,6 +1080,15 @@ export function resetSelfHealTelemetryForTests(options: { clearPersistence?: boo
     clearTimeout(pendingPersistenceTimeout);
     pendingPersistenceTimeout = null;
   }
+
+  clearRedisHydrationRetry();
+  redisLifecycleUnsubscribe?.();
+  redisLifecycleUnsubscribe = null;
+  redisPersistenceGeneration += 1;
+  redisHydrationPromise = null;
+  redisPersistenceDirty = false;
+  redisPersistenceStopping = false;
+  handledRedisReadyAt = null;
 
   const runtime = globalThis as SelfHealTelemetryGlobal;
   runtime[GLOBAL_KEY] = createInitialState();

--- a/src/services/selfImprove/selfHealTelemetry.ts
+++ b/src/services/selfImprove/selfHealTelemetry.ts
@@ -995,7 +995,15 @@ async function hydrateRedisTelemetryPersistence(): Promise<void> {
       redisPersistenceDirty = true;
       await persistStateToRedis(state, target);
     }
-  })();
+  })().catch(() => {
+    state.persistence.lastSaveError = 'REDIS_DEPENDENCY_UNAVAILABLE';
+    redisPersistenceDirty = true;
+    scheduleRedisHydrationRetry();
+    logger.warn('self_heal.telemetry.redis_hydration_failed', {
+      module: 'self-heal-telemetry',
+      errorCode: 'REDIS_DEPENDENCY_UNAVAILABLE'
+    });
+  });
   redisHydrationPromise = hydration;
 
   try {

--- a/src/start-server.ts
+++ b/src/start-server.ts
@@ -2,6 +2,8 @@ import { startServer } from './server.js';
 
 startServer().catch((error) => {
   //audit assumption: startup failures should fail fast; risk: serving partially initialized state; invariant: process exits on unrecoverable startup error; handling: log and terminate.
-  console.error('[STARTUP] Fatal startup failure:', error);
+  console.error('[STARTUP] Fatal startup failure:', {
+    errorType: error instanceof Error ? error.name : 'Error',
+  });
   process.exit(1);
 });

--- a/src/start-server.ts
+++ b/src/start-server.ts
@@ -1,1 +1,7 @@
-import './server.js';
+import { startServer } from './server.js';
+
+startServer().catch((error) => {
+  //audit assumption: startup failures should fail fast; risk: serving partially initialized state; invariant: process exits on unrecoverable startup error; handling: log and terminate.
+  console.error('[STARTUP] Fatal startup failure:', error);
+  process.exit(1);
+});

--- a/tests/check-npm-audit-policy.test.ts
+++ b/tests/check-npm-audit-policy.test.ts
@@ -51,7 +51,7 @@ function parseStdout(result: { stdout: string; stderr: string }) {
 
 function advisory(
   name: string,
-  severity: 'high' | 'critical',
+  severity: 'moderate' | 'high' | 'critical',
   source: number,
   ghsa: string,
   nodes = [`node_modules/${name}`],
@@ -220,5 +220,126 @@ describe('npm audit policy', () => {
 
     expect(result.status).toBe(1);
     expect(parseStdout(result).actionable[0].name).toBe('brace-expansion');
+  });
+
+  it('retains source- and node-scoped exceptions for the unpublished Hono builds', () => {
+    const hono = advisory('hono', 'moderate', 1_124_005, 'GHSA-xgm2-5f3f-mvvc');
+    hono.via.push(
+      {
+        name: 'hono',
+        source: 1_124_009,
+        url: 'https://github.com/advisories/GHSA-hvrm-45r6-mjfj',
+      },
+      {
+        name: 'hono',
+        source: 1_124_010,
+        url: 'https://github.com/advisories/GHSA-w62v-xxxg-mg59',
+      },
+    );
+
+    const honoNodeServer = advisory(
+      '@hono/node-server',
+      'moderate',
+      1_124_006,
+      'GHSA-frvp-7c67-39w9',
+    );
+    honoNodeServer.via.push('hono');
+
+    const result = runAuditPolicy({
+      '@hono/node-server': honoNodeServer,
+      hono,
+      '@modelcontextprotocol/sdk': {
+        severity: 'moderate',
+        via: ['@hono/node-server', 'hono'],
+        nodes: ['node_modules/@modelcontextprotocol/sdk'],
+        fixAvailable: false,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(parseStdout(result).ignored.map((entry: { name: string }) => entry.name)).toEqual(
+      expect.arrayContaining(['@hono/node-server', 'hono', '@modelcontextprotocol/sdk']),
+    );
+  });
+
+  it('does not suppress an unexpected Hono advisory', () => {
+    const result = runAuditPolicy({
+      hono: advisory('hono', 'moderate', 9_999_995, 'GHSA-neww-hono-sory'),
+    });
+
+    expect(result.status).toBe(1);
+    expect(parseStdout(result).actionable[0].name).toBe('hono');
+  });
+
+  it('does not suppress a mixed known and unexpected node-server advisory set', () => {
+    const nodeServer = advisory(
+      '@hono/node-server',
+      'moderate',
+      1_124_006,
+      'GHSA-frvp-7c67-39w9',
+    );
+    nodeServer.via.push({
+      name: '@hono/node-server',
+      source: 9_999_994,
+      url: 'https://github.com/advisories/GHSA-neww-node-sory',
+    });
+    const result = runAuditPolicy({ '@hono/node-server': nodeServer });
+
+    expect(result.status).toBe(1);
+    expect(parseStdout(result).actionable[0].name).toBe('@hono/node-server');
+  });
+
+  it('does not suppress an approved node-server advisory on a new dependency path', () => {
+    const result = runAuditPolicy({
+      '@hono/node-server': advisory(
+        '@hono/node-server',
+        'moderate',
+        1_124_006,
+        'GHSA-frvp-7c67-39w9',
+        ['node_modules/unexpected-package/node_modules/@hono/node-server'],
+      ),
+    });
+
+    expect(result.status).toBe(1);
+    expect(parseStdout(result).actionable[0].name).toBe('@hono/node-server');
+  });
+
+  it('does not suppress an approved Hono advisory on a new dependency path', () => {
+    const result = runAuditPolicy({
+      hono: advisory('hono', 'moderate', 1_124_005, 'GHSA-xgm2-5f3f-mvvc', [
+        'node_modules/unexpected-package/node_modules/hono',
+      ]),
+    });
+
+    expect(result.status).toBe(1);
+    expect(parseStdout(result).actionable[0].name).toBe('hono');
+  });
+
+  it('does not suppress a new vulnerability propagated through the MCP SDK', () => {
+    const result = runAuditPolicy({
+      '@modelcontextprotocol/sdk': {
+        severity: 'high',
+        via: ['unexpected-package'],
+        nodes: ['node_modules/@modelcontextprotocol/sdk'],
+        fixAvailable: false,
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(parseStdout(result).actionable[0].name).toBe('@modelcontextprotocol/sdk');
+  });
+
+  it('does not suppress the approved MCP Hono graph on a new SDK node', () => {
+    const result = runAuditPolicy({
+      '@modelcontextprotocol/sdk': {
+        severity: 'moderate',
+        via: ['@hono/node-server', 'hono'],
+        nodes: ['node_modules/unexpected-package/node_modules/@modelcontextprotocol/sdk'],
+        fixAvailable: false,
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(parseStdout(result).actionable[0].name).toBe('@modelcontextprotocol/sdk');
   });
 });

--- a/tests/redis-startup-lifecycle.test.ts
+++ b/tests/redis-startup-lifecycle.test.ts
@@ -1,0 +1,463 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import {
+  RedisLifecycleManager,
+  type RedisLifecycleClient,
+  type RedisLifecycleClientFactory,
+  type RedisLifecycleSleep
+} from '../src/platform/runtime/redisLifecycle.js';
+
+type RedisEventListener = (...args: unknown[]) => void;
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function redisError(code: string, message: string): Error & { code: string } {
+  return Object.assign(new Error(message), { code });
+}
+
+class FakeRedisClient {
+  isOpen = false;
+  isReady = false;
+  private readonly listeners = new Map<string, Set<RedisEventListener>>();
+  private connectBehaviors: Array<() => Promise<void>> = [];
+
+  readonly connect = jest.fn(async () => {
+    this.isOpen = true;
+    const behavior = this.connectBehaviors.shift();
+    try {
+      await (behavior?.() ?? Promise.resolve());
+      if (this.isOpen) {
+        this.isReady = true;
+      }
+    } catch (error) {
+      this.isOpen = false;
+      this.isReady = false;
+      throw error;
+    }
+  });
+
+  readonly ping = jest.fn(async () => 'PONG');
+
+  readonly close = jest.fn(async () => {
+    this.isOpen = false;
+    this.isReady = false;
+  });
+
+  readonly destroy = jest.fn(() => {
+    this.isOpen = false;
+    this.isReady = false;
+  });
+
+  readonly on = jest.fn((event: string, listener: RedisEventListener) => {
+    const eventListeners = this.listeners.get(event) ?? new Set<RedisEventListener>();
+    eventListeners.add(listener);
+    this.listeners.set(event, eventListeners);
+    return this;
+  });
+
+  queueConnect(...behaviors: Array<() => Promise<void>>): void {
+    this.connectBehaviors.push(...behaviors);
+  }
+
+  emit(event: string, ...args: unknown[]): void {
+    for (const listener of this.listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+}
+
+interface ManualSleepCall {
+  delayMs: number;
+  signal: AbortSignal;
+  settled: boolean;
+  resolve: () => void;
+  reject: (reason?: unknown) => void;
+}
+
+function createManualSleep(): {
+  sleep: RedisLifecycleSleep;
+  calls: ManualSleepCall[];
+  resolveNext: (delayMs: number) => void;
+} {
+  const calls: ManualSleepCall[] = [];
+  const sleep: RedisLifecycleSleep = (delayMs, signal) => new Promise<void>((resolve, reject) => {
+    const call: ManualSleepCall = {
+      delayMs,
+      signal,
+      settled: false,
+      resolve: () => {
+        if (call.settled) {
+          return;
+        }
+        call.settled = true;
+        signal.removeEventListener('abort', onAbort);
+        resolve();
+      },
+      reject
+    };
+    const onAbort = () => {
+      if (call.settled) {
+        return;
+      }
+      call.settled = true;
+      signal.removeEventListener('abort', onAbort);
+      reject(new Error('sleep aborted'));
+    };
+
+    calls.push(call);
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+
+  return {
+    sleep,
+    calls,
+    resolveNext(delayMs: number): void {
+      const call = calls.find((candidate) => !candidate.settled && candidate.delayMs === delayMs);
+      if (!call) {
+        throw new Error(`No pending ${delayMs}ms sleep.`);
+      }
+      call.resolve();
+    }
+  };
+}
+
+async function flushAsyncWork(iterations = 8): Promise<void> {
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    await Promise.resolve();
+  }
+}
+
+const REDIS_ENV_NAMES = [
+  'REDIS_URL',
+  'REDISHOST',
+  'REDIS_HOST',
+  'REDISPORT',
+  'REDIS_PORT',
+  'REDISUSER',
+  'REDIS_USER',
+  'REDISPASSWORD',
+  'REDIS_PASSWORD'
+] as const;
+
+const originalRedisEnvironment = Object.fromEntries(
+  REDIS_ENV_NAMES.map((name) => [name, process.env[name]])
+) as Record<(typeof REDIS_ENV_NAMES)[number], string | undefined>;
+
+describe('RedisLifecycleManager', () => {
+  const managers: RedisLifecycleManager[] = [];
+
+  function createManager(
+    client: FakeRedisClient,
+    options: {
+      sleep?: RedisLifecycleSleep;
+      random?: () => number;
+    } = {}
+  ): { manager: RedisLifecycleManager; clientFactory: jest.Mock } {
+    const clientFactory = jest.fn(() => client as unknown as RedisLifecycleClient);
+    const manager = new RedisLifecycleManager({
+      clientFactory: clientFactory as unknown as RedisLifecycleClientFactory,
+      sleep: options.sleep,
+      random: options.random ?? (() => 0),
+      now: () => new Date('2026-07-21T12:00:00.000Z')
+    });
+    managers.push(manager);
+    return { manager, clientFactory };
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    for (const name of REDIS_ENV_NAMES) {
+      delete process.env[name];
+    }
+    process.env.REDIS_URL = 'redis://lifecycle.invalid:6379';
+  });
+
+  afterEach(async () => {
+    await Promise.all(managers.splice(0).map((manager) => manager.stop()));
+    jest.useRealTimers();
+    for (const name of REDIS_ENV_NAMES) {
+      const originalValue = originalRedisEnvironment[name];
+      if (originalValue === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = originalValue;
+      }
+    }
+  });
+
+  it('classifies connection refusal and keeps a retry scheduled', async () => {
+    const client = new FakeRedisClient();
+    client.queueConnect(async () => {
+      throw redisError('ECONNREFUSED', 'connect ECONNREFUSED');
+    });
+    const { manager } = createManager(client);
+
+    manager.start();
+    await flushAsyncWork();
+
+    expect(manager.getSnapshot()).toEqual(expect.objectContaining({
+      state: 'DEGRADED',
+      configured: true,
+      connected: false,
+      attempt: 1,
+      retryScheduled: true,
+      lastErrorCode: 'REDIS_CONNECTION_REFUSED'
+    }));
+    expect(manager.getReadyClient()).toBeNull();
+  });
+
+  it('bounds a stalled connect attempt and destroys its socket before retrying', async () => {
+    const client = new FakeRedisClient();
+    client.queueConnect(() => new Promise<void>(() => undefined));
+    const { manager } = createManager(client);
+
+    manager.start();
+    await jest.advanceTimersByTimeAsync(3_000);
+
+    expect(client.destroy).toHaveBeenCalledTimes(1);
+    expect(manager.getSnapshot()).toEqual(expect.objectContaining({
+      state: 'DEGRADED',
+      connected: false,
+      retryScheduled: true,
+      lastErrorCode: 'REDIS_CONNECT_TIMEOUT'
+    }));
+  });
+
+  it('classifies authentication failures without retaining the raw error', async () => {
+    const client = new FakeRedisClient();
+    client.queueConnect(async () => {
+      throw redisError('WRONGPASS', 'WRONGPASS invalid username-password pair');
+    });
+    const { manager } = createManager(client);
+
+    manager.start();
+    await flushAsyncWork();
+
+    const snapshot = manager.getSnapshot();
+    expect(snapshot.lastErrorCode).toBe('REDIS_AUTH_FAILED');
+    expect(JSON.stringify(snapshot)).not.toContain('username-password');
+    expect(JSON.stringify(snapshot)).not.toContain('lifecycle.invalid');
+  });
+
+  it('recovers automatically when Redis returns after startup', async () => {
+    const client = new FakeRedisClient();
+    client.queueConnect(
+      async () => {
+        throw redisError('ECONNREFUSED', 'connect ECONNREFUSED');
+      },
+      async () => undefined
+    );
+    const { manager } = createManager(client);
+
+    manager.start();
+    await flushAsyncWork();
+    expect(manager.getSnapshot().state).toBe('DEGRADED');
+
+    await jest.advanceTimersByTimeAsync(250);
+
+    expect(client.connect).toHaveBeenCalledTimes(2);
+    expect(client.ping).toHaveBeenCalledTimes(1);
+    expect(manager.getSnapshot()).toEqual(expect.objectContaining({
+      state: 'READY',
+      connected: true,
+      retryScheduled: false,
+      recoveryCount: 1,
+      lastErrorCode: null
+    }));
+    expect(manager.getReadyClient()).toBe(client);
+  });
+
+  it('serializes reconnect work while Redis is flapping', async () => {
+    const reconnect = createDeferred<void>();
+    const client = new FakeRedisClient();
+    client.queueConnect(async () => undefined, () => reconnect.promise);
+    const { manager, clientFactory } = createManager(client);
+
+    manager.start();
+    await flushAsyncWork();
+    expect(manager.getSnapshot().state).toBe('READY');
+
+    client.emit('error', redisError('ECONNRESET', 'connection lost'));
+    client.emit('error', redisError('ECONNRESET', 'connection lost again'));
+    client.emit('error', redisError('ECONNRESET', 'connection lost again'));
+    await flushAsyncWork();
+
+    expect(manager.getSnapshot().state).toBe('DEGRADED');
+    expect(client.connect).toHaveBeenCalledTimes(2);
+    expect(clientFactory).toHaveBeenCalledTimes(1);
+
+    reconnect.resolve(undefined);
+    await flushAsyncWork();
+
+    expect(manager.getSnapshot()).toEqual(expect.objectContaining({
+      state: 'READY',
+      connected: true,
+      recoveryCount: 1
+    }));
+    expect(client.connect).toHaveBeenCalledTimes(2);
+  });
+
+  it('reconnects after a clean Redis disconnect event', async () => {
+    const client = new FakeRedisClient();
+    client.queueConnect(async () => undefined, async () => undefined);
+    const { manager } = createManager(client);
+
+    manager.start();
+    await flushAsyncWork();
+    expect(manager.getSnapshot().state).toBe('READY');
+
+    client.isOpen = false;
+    client.isReady = false;
+    client.emit('end');
+    await flushAsyncWork();
+
+    expect(client.connect).toHaveBeenCalledTimes(2);
+    expect(manager.getSnapshot()).toEqual(expect.objectContaining({
+      state: 'READY',
+      connected: true,
+      recoveryCount: 1
+    }));
+  });
+
+  it('starts once and creates one client across repeated start calls', async () => {
+    const client = new FakeRedisClient();
+    const { manager, clientFactory } = createManager(client);
+
+    manager.start();
+    manager.start();
+    manager.start();
+    await flushAsyncWork();
+
+    expect(clientFactory).toHaveBeenCalledTimes(1);
+    expect(client.connect).toHaveBeenCalledTimes(1);
+    expect(client.ping).toHaveBeenCalledTimes(1);
+    expect(manager.getSnapshot().state).toBe('READY');
+  });
+
+  it('uses exponential backoff with bounded deterministic jitter and keeps retrying', async () => {
+    const manualSleep = createManualSleep();
+    const client = new FakeRedisClient();
+    client.queueConnect(
+      async () => { throw redisError('ECONNREFUSED', 'refused 1'); },
+      async () => { throw redisError('ECONNREFUSED', 'refused 2'); },
+      async () => { throw redisError('ECONNREFUSED', 'refused 3'); },
+      async () => { throw redisError('ECONNREFUSED', 'refused 4'); },
+      async () => undefined
+    );
+    const { manager } = createManager(client, {
+      sleep: manualSleep.sleep,
+      random: () => 0.5
+    });
+
+    manager.start();
+    await flushAsyncWork();
+
+    for (const delayMs of [375, 625, 1_125, 2_125]) {
+      expect(manualSleep.calls.some((call) => !call.settled && call.delayMs === delayMs)).toBe(true);
+      manualSleep.resolveNext(delayMs);
+      await flushAsyncWork();
+    }
+
+    expect(client.connect).toHaveBeenCalledTimes(5);
+    expect(manager.getSnapshot()).toEqual(expect.objectContaining({
+      state: 'READY',
+      connected: true,
+      recoveryCount: 1
+    }));
+  });
+
+  it('cancels a scheduled retry and does not reconnect after shutdown', async () => {
+    const client = new FakeRedisClient();
+    client.queueConnect(async () => {
+      throw redisError('ECONNREFUSED', 'connect ECONNREFUSED');
+    });
+    const { manager } = createManager(client);
+
+    manager.start();
+    await flushAsyncWork();
+    expect(manager.getSnapshot().retryScheduled).toBe(true);
+
+    await manager.stop();
+    await jest.advanceTimersByTimeAsync(60_000);
+
+    expect(client.connect).toHaveBeenCalledTimes(1);
+    expect(manager.getSnapshot()).toEqual(expect.objectContaining({
+      state: 'DEGRADED',
+      connected: false,
+      retryScheduled: false
+    }));
+  });
+
+  it('cancels a pending connection attempt during shutdown and ignores late completion', async () => {
+    const pendingConnect = createDeferred<void>();
+    const client = new FakeRedisClient();
+    client.queueConnect(() => pendingConnect.promise);
+    const { manager } = createManager(client);
+
+    manager.start();
+    await flushAsyncWork();
+    expect(client.connect).toHaveBeenCalledTimes(1);
+
+    await manager.stop();
+    pendingConnect.resolve(undefined);
+    await flushAsyncWork();
+
+    expect(client.destroy).toHaveBeenCalledTimes(1);
+    expect(client.ping).not.toHaveBeenCalled();
+    expect(manager.getReadyClient()).toBeNull();
+    expect(manager.getSnapshot()).toEqual(expect.objectContaining({
+      state: 'DEGRADED',
+      connected: false,
+      retryScheduled: false
+    }));
+  });
+
+  it('ignores stale client events after shutdown', async () => {
+    const client = new FakeRedisClient();
+    const { manager } = createManager(client);
+
+    manager.start();
+    await flushAsyncWork();
+    await manager.stop();
+    const snapshotAfterStop = manager.getSnapshot();
+
+    client.emit('error', redisError('ECONNRESET', 'late connection loss'));
+    client.emit('end');
+    await flushAsyncWork();
+
+    expect(manager.getSnapshot()).toEqual(snapshotAfterStop);
+    expect(client.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes a ready client cleanly exactly once', async () => {
+    const client = new FakeRedisClient();
+    const { manager } = createManager(client);
+
+    manager.start();
+    await flushAsyncWork();
+    expect(manager.getSnapshot().state).toBe('READY');
+
+    await manager.stop();
+    await manager.stop();
+
+    expect(client.close).toHaveBeenCalledTimes(1);
+    expect(client.destroy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/self-heal-telemetry-redis.test.ts
+++ b/tests/self-heal-telemetry-redis.test.ts
@@ -16,6 +16,7 @@ interface TelemetryRedisHarness {
   subscribeMock: jest.Mock;
   unsubscribeMock: jest.Mock;
   getReadyClientMock: jest.Mock;
+  loggerWarnMock: jest.Mock;
 }
 
 function lifecycleSnapshot(
@@ -100,6 +101,7 @@ async function loadTelemetryRedisHarness(
     set: jest.fn(async () => 'OK')
   };
   const getReadyClientMock = jest.fn(() => readyClient);
+  const loggerWarnMock = jest.fn();
   const subscribeMock = jest.fn((listener: (snapshot: RedisLifecycleSnapshot) => void) => {
     lifecycleListeners.add(listener);
     listener(initialSnapshot);
@@ -129,7 +131,7 @@ async function loadTelemetryRedisHarness(
     },
     logger: {
       info: jest.fn(),
-      warn: jest.fn(),
+      warn: loggerWarnMock,
       error: jest.fn(),
       debug: jest.fn(),
       child: jest.fn(() => ({
@@ -157,7 +159,8 @@ async function loadTelemetryRedisHarness(
     },
     subscribeMock,
     unsubscribeMock,
-    getReadyClientMock
+    getReadyClientMock,
+    loggerWarnMock
   };
 }
 
@@ -320,5 +323,49 @@ describe('self-heal telemetry Redis lifecycle integration', () => {
 
     expect(harness.client.get).toHaveBeenCalledTimes(1);
     expect(harness.client.set).not.toHaveBeenCalled();
+  });
+
+  it('contains unexpected hydration failures and retries with sanitized telemetry', async () => {
+    jest.useFakeTimers();
+    const harness = await loadTelemetryRedisHarness();
+    loadedModules.push(harness.moduleUnderTest);
+    harness.client.get.mockResolvedValue(null);
+    harness.setReadyClient(harness.client);
+    const secretSentinel = 'redis://user:secret@telemetry.invalid:6379';
+    const toISOStringSpy = jest.spyOn(Date.prototype, 'toISOString')
+      .mockImplementationOnce(() => {
+        throw new Error(secretSentinel);
+      });
+
+    try {
+      await harness.moduleUnderTest.primeSelfHealTelemetryPersistence();
+      harness.emitLifecycle(lifecycleSnapshot('READY'));
+      await flushAsyncWork();
+
+      expect(harness.client.get).toHaveBeenCalledTimes(1);
+      expect(harness.moduleUnderTest.buildSelfHealTelemetrySnapshot({
+        enabled: true,
+        active: false
+      }).persistence.lastSaveError).toBe('REDIS_DEPENDENCY_UNAVAILABLE');
+      expect(harness.loggerWarnMock).toHaveBeenCalledWith(
+        'self_heal.telemetry.redis_hydration_failed',
+        {
+          module: 'self-heal-telemetry',
+          errorCode: 'REDIS_DEPENDENCY_UNAVAILABLE'
+        }
+      );
+      expect(JSON.stringify(harness.loggerWarnMock.mock.calls)).not.toContain(secretSentinel);
+
+      await jest.advanceTimersByTimeAsync(1_000);
+      await flushAsyncWork();
+
+      expect(harness.client.get).toHaveBeenCalledTimes(2);
+      expect(harness.moduleUnderTest.buildSelfHealTelemetrySnapshot({
+        enabled: true,
+        active: false
+      }).persistence.lastSaveError).toBeNull();
+    } finally {
+      toISOStringSpy.mockRestore();
+    }
   });
 });

--- a/tests/self-heal-telemetry-redis.test.ts
+++ b/tests/self-heal-telemetry-redis.test.ts
@@ -1,0 +1,324 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+type SelfHealTelemetryModule = typeof import('../src/services/selfImprove/selfHealTelemetry.js');
+type RedisLifecycleSnapshot = import('../src/platform/runtime/redisLifecycle.js').RedisLifecycleSnapshot;
+
+interface FakeRedisTelemetryClient {
+  get: jest.Mock;
+  set: jest.Mock;
+}
+
+interface TelemetryRedisHarness {
+  moduleUnderTest: SelfHealTelemetryModule;
+  client: FakeRedisTelemetryClient;
+  setReadyClient: (client: FakeRedisTelemetryClient | null) => void;
+  emitLifecycle: (snapshot: RedisLifecycleSnapshot) => void;
+  subscribeMock: jest.Mock;
+  unsubscribeMock: jest.Mock;
+  getReadyClientMock: jest.Mock;
+}
+
+function lifecycleSnapshot(
+  state: RedisLifecycleSnapshot['state'],
+  overrides: Partial<RedisLifecycleSnapshot> = {}
+): RedisLifecycleSnapshot {
+  return {
+    state,
+    configured: true,
+    connected: state === 'READY',
+    attempt: state === 'STARTING' ? 0 : 1,
+    recoveryCount: 0,
+    retryScheduled: state === 'DEGRADED',
+    lastTransitionAt: '2026-07-21T12:00:00.000Z',
+    lastReadyAt: state === 'READY' ? '2026-07-21T12:00:00.000Z' : null,
+    lastErrorCode: state === 'DEGRADED' ? 'REDIS_CONNECTION_REFUSED' : null,
+    ...overrides
+  };
+}
+
+function persistedEvent(params: {
+  id: string;
+  timestamp: string;
+  kind: 'success' | 'failure';
+  reason: string;
+}) {
+  return {
+    id: params.id,
+    timestamp: params.timestamp,
+    kind: params.kind,
+    type: params.kind,
+    source: 'persisted-self-heal',
+    trigger: 'startup',
+    reason: params.reason,
+    actionTaken: null,
+    healedComponent: 'redis',
+    payload: null,
+    details: null,
+    correlationId: null,
+    requestId: null,
+    traceId: null
+  };
+}
+
+function persistedStateJson(): string {
+  const success = persistedEvent({
+    id: 'persisted_event_1',
+    timestamp: '2026-07-21T11:59:00.000Z',
+    kind: 'success',
+    reason: 'persisted recovery event'
+  });
+  return JSON.stringify({
+    version: 1,
+    storedAt: '2026-07-21T11:59:01.000Z',
+    nextSequence: 2,
+    recentEvents: [success],
+    lastTrigger: null,
+    lastAttempt: null,
+    lastSuccess: success,
+    lastFailure: null,
+    lastFallback: null
+  });
+}
+
+async function flushAsyncWork(iterations = 12): Promise<void> {
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    await Promise.resolve();
+  }
+}
+
+async function loadTelemetryRedisHarness(
+  initialSnapshot: RedisLifecycleSnapshot = lifecycleSnapshot('STARTING')
+): Promise<TelemetryRedisHarness> {
+  jest.resetModules();
+  Reflect.deleteProperty(globalThis, '__ARCANOS_SELF_HEAL_TELEMETRY__');
+
+  const lifecycleListeners = new Set<(snapshot: RedisLifecycleSnapshot) => void>();
+  const unsubscribeMock = jest.fn();
+  let readyClient: FakeRedisTelemetryClient | null = null;
+  const client: FakeRedisTelemetryClient = {
+    get: jest.fn(async () => null),
+    set: jest.fn(async () => 'OK')
+  };
+  const getReadyClientMock = jest.fn(() => readyClient);
+  const subscribeMock = jest.fn((listener: (snapshot: RedisLifecycleSnapshot) => void) => {
+    lifecycleListeners.add(listener);
+    listener(initialSnapshot);
+    return () => {
+      lifecycleListeners.delete(listener);
+      unsubscribeMock();
+    };
+  });
+
+  jest.unstable_mockModule('@platform/runtime/redisLifecycle.js', () => ({
+    getReadyRedisClient: getReadyClientMock,
+    subscribeRedisLifecycle: subscribeMock
+  }));
+  jest.unstable_mockModule('@platform/runtime/redis.js', () => ({
+    resolveConfiguredRedisConnection: jest.fn(() => ({
+      configured: true,
+      source: 'REDIS_URL',
+      url: 'redis://telemetry.invalid:6379'
+    }))
+  }));
+  jest.unstable_mockModule('@platform/logging/structuredLogging.js', () => ({
+    aiLogger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn()
+    },
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      child: jest.fn(() => ({
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn()
+      }))
+    }
+  }));
+
+  const moduleUnderTest = await import('../src/services/selfImprove/selfHealTelemetry.js');
+  moduleUnderTest.resetSelfHealTelemetryForTests();
+
+  return {
+    moduleUnderTest,
+    client,
+    setReadyClient(nextClient): void {
+      readyClient = nextClient;
+    },
+    emitLifecycle(snapshot): void {
+      for (const listener of lifecycleListeners) {
+        listener(snapshot);
+      }
+    },
+    subscribeMock,
+    unsubscribeMock,
+    getReadyClientMock
+  };
+}
+
+const TELEMETRY_ENV_NAMES = [
+  'NODE_ENV',
+  'REDIS_URL',
+  'SELF_HEAL_TELEMETRY_FILE',
+  'RAILWAY_VOLUME_MOUNT_PATH',
+  'RAILWAY_SERVICE_NAME',
+  'RAILWAY_ENVIRONMENT'
+] as const;
+
+const originalTelemetryEnvironment = Object.fromEntries(
+  TELEMETRY_ENV_NAMES.map((name) => [name, process.env[name]])
+) as Record<(typeof TELEMETRY_ENV_NAMES)[number], string | undefined>;
+
+describe('self-heal telemetry Redis lifecycle integration', () => {
+  const loadedModules: SelfHealTelemetryModule[] = [];
+  let consoleLogSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.REDIS_URL = 'redis://telemetry.invalid:6379';
+    process.env.RAILWAY_SERVICE_NAME = 'ARCANOS V2';
+    process.env.RAILWAY_ENVIRONMENT = 'production';
+    delete process.env.SELF_HEAL_TELEMETRY_FILE;
+    delete process.env.RAILWAY_VOLUME_MOUNT_PATH;
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(async () => {
+    for (const telemetryModule of loadedModules.splice(0)) {
+      await telemetryModule.stopSelfHealTelemetryPersistence();
+      telemetryModule.resetSelfHealTelemetryForTests();
+    }
+    jest.useRealTimers();
+    consoleLogSpy.mockRestore();
+    for (const name of TELEMETRY_ENV_NAMES) {
+      const originalValue = originalTelemetryEnvironment[name];
+      if (originalValue === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = originalValue;
+      }
+    }
+  });
+
+  it('returns immediately while Redis is absent, then merges and flushes local outage events once', async () => {
+    const harness = await loadTelemetryRedisHarness();
+    loadedModules.push(harness.moduleUnderTest);
+    harness.client.get.mockResolvedValue(persistedStateJson());
+
+    await expect(harness.moduleUnderTest.primeSelfHealTelemetryPersistence()).resolves.toBeUndefined();
+
+    expect(harness.subscribeMock).toHaveBeenCalledTimes(1);
+    expect(harness.client.get).not.toHaveBeenCalled();
+    harness.moduleUnderTest.recordSelfHealEvent({
+      kind: 'failure',
+      source: 'startup',
+      trigger: 'redis.outage',
+      reason: 'local outage event',
+      healedComponent: 'redis',
+      timestamp: '2026-07-21T12:00:00.000Z'
+    });
+    expect(harness.moduleUnderTest.buildSelfHealTelemetrySnapshot({
+      enabled: true,
+      active: false
+    }).recentEvents.map((event) => event.reason)).toEqual(['local outage event']);
+
+    harness.setReadyClient(harness.client);
+    harness.emitLifecycle(lifecycleSnapshot('READY'));
+    await flushAsyncWork();
+
+    expect(harness.client.get).toHaveBeenCalledTimes(1);
+    expect(harness.client.set).toHaveBeenCalledTimes(1);
+    const snapshot = harness.moduleUnderTest.buildSelfHealTelemetrySnapshot({
+      enabled: true,
+      active: false
+    });
+    expect(snapshot.recentEvents.map((event) => event.reason)).toEqual([
+      'persisted recovery event',
+      'local outage event'
+    ]);
+    expect(snapshot.lastSuccess?.reason).toBe('persisted recovery event');
+    expect(snapshot.lastFailure?.reason).toBe('local outage event');
+    expect(snapshot.persistence).toEqual(expect.objectContaining({
+      mode: 'redis',
+      durable: true,
+      restoredFromDisk: true,
+      lastSaveError: null
+    }));
+
+    const flushedState = JSON.parse(String(harness.client.set.mock.calls[0]?.[1]));
+    expect(flushedState.recentEvents.map((event: { reason: string }) => event.reason)).toEqual([
+      'persisted recovery event',
+      'local outage event'
+    ]);
+  });
+
+  it('deduplicates subscriptions and hydration across repeated READY notifications and flapping', async () => {
+    const harness = await loadTelemetryRedisHarness(lifecycleSnapshot('READY'));
+    loadedModules.push(harness.moduleUnderTest);
+    harness.client.get.mockResolvedValue(null);
+    harness.setReadyClient(harness.client);
+
+    await harness.moduleUnderTest.primeSelfHealTelemetryPersistence();
+    await harness.moduleUnderTest.primeSelfHealTelemetryPersistence();
+    await harness.moduleUnderTest.primeSelfHealTelemetryPersistence();
+    await flushAsyncWork();
+
+    expect(harness.subscribeMock).toHaveBeenCalledTimes(1);
+    expect(harness.client.get).toHaveBeenCalledTimes(1);
+    expect(harness.client.set).not.toHaveBeenCalled();
+
+    harness.emitLifecycle(lifecycleSnapshot('READY'));
+    harness.emitLifecycle(lifecycleSnapshot('READY'));
+    await flushAsyncWork();
+    expect(harness.client.get).toHaveBeenCalledTimes(1);
+    expect(harness.client.set).not.toHaveBeenCalled();
+
+    harness.setReadyClient(null);
+    harness.emitLifecycle(lifecycleSnapshot('DEGRADED'));
+    harness.setReadyClient(harness.client);
+    harness.emitLifecycle(lifecycleSnapshot('READY', {
+      recoveryCount: 1,
+      lastReadyAt: '2026-07-21T12:01:00.000Z'
+    }));
+    harness.emitLifecycle(lifecycleSnapshot('READY', {
+      recoveryCount: 1,
+      lastReadyAt: '2026-07-21T12:01:00.000Z'
+    }));
+    await flushAsyncWork();
+
+    expect(harness.subscribeMock).toHaveBeenCalledTimes(1);
+    expect(harness.client.get).toHaveBeenCalledTimes(1);
+    expect(harness.client.set).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels hydration retries and lifecycle notifications when stopped', async () => {
+    jest.useFakeTimers();
+    const harness = await loadTelemetryRedisHarness();
+    loadedModules.push(harness.moduleUnderTest);
+    harness.client.get.mockRejectedValue(new Error('Redis read unavailable'));
+
+    await harness.moduleUnderTest.primeSelfHealTelemetryPersistence();
+    harness.setReadyClient(harness.client);
+    harness.emitLifecycle(lifecycleSnapshot('READY'));
+    await flushAsyncWork();
+    expect(harness.client.get).toHaveBeenCalledTimes(1);
+
+    await harness.moduleUnderTest.stopSelfHealTelemetryPersistence();
+    expect(harness.unsubscribeMock).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(5_000);
+    harness.emitLifecycle(lifecycleSnapshot('READY', {
+      recoveryCount: 1,
+      lastReadyAt: '2026-07-21T12:01:00.000Z'
+    }));
+    await flushAsyncWork();
+
+    expect(harness.client.get).toHaveBeenCalledTimes(1);
+    expect(harness.client.set).not.toHaveBeenCalled();
+  });
+});

--- a/tests/server-startup-resilience.test.ts
+++ b/tests/server-startup-resilience.test.ts
@@ -455,3 +455,38 @@ describe('startup lifecycle transitions', () => {
     }));
   });
 });
+
+describe('server entrypoint failure handling', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('logs only a sanitized error type before exiting', async () => {
+    jest.resetModules();
+    const secretSentinel = 'redis://user:secret@startup.invalid:6379';
+    const startServer = jest.fn(async () => {
+      throw new Error(secretSentinel);
+    });
+    jest.unstable_mockModule('../src/server.js', () => ({ startServer }));
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+    try {
+      await import('../src/start-server.js');
+      await flushAsyncWork();
+
+      expect(startServer).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[STARTUP] Fatal startup failure:',
+        { errorType: 'Error' }
+      );
+      expect(JSON.stringify(consoleErrorSpy.mock.calls)).not.toContain(secretSentinel);
+      expect(exitSpy).toHaveBeenCalledTimes(1);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    }
+  });
+});

--- a/tests/server-startup-resilience.test.ts
+++ b/tests/server-startup-resilience.test.ts
@@ -1,0 +1,457 @@
+import { EventEmitter } from 'node:events';
+import type { Server } from 'node:http';
+import type { Express } from 'express';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { RedisLifecycleSnapshot } from '../src/platform/runtime/redisLifecycle.js';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+class FakeHttpServer extends EventEmitter {
+  readonly close = jest.fn((callback?: (error?: Error) => void) => {
+    callback?.();
+    return this;
+  });
+
+  readonly closeIdleConnections = jest.fn();
+  readonly closeAllConnections = jest.fn();
+}
+
+function buildFakeApp(sequence: string[]): {
+  app: Express;
+  server: FakeHttpServer;
+  listenMock: jest.Mock;
+} {
+  const server = new FakeHttpServer();
+  const listenMock = jest.fn(() => {
+    sequence.push('listener.bind');
+    queueMicrotask(() => server.emit('listening'));
+    return server as unknown as Server;
+  });
+  const app = {
+    listen: listenMock
+  } as unknown as Express;
+
+  return { app, server, listenMock };
+}
+
+function redisSnapshot(
+  state: RedisLifecycleSnapshot['state'],
+  overrides: Partial<RedisLifecycleSnapshot> = {}
+): RedisLifecycleSnapshot {
+  return {
+    state,
+    configured: true,
+    connected: state === 'READY',
+    attempt: state === 'STARTING' ? 0 : 1,
+    recoveryCount: 0,
+    retryScheduled: state === 'DEGRADED',
+    lastTransitionAt: '2026-07-21T12:00:00.000Z',
+    lastReadyAt: state === 'READY' ? '2026-07-21T12:00:00.000Z' : null,
+    lastErrorCode: state === 'DEGRADED' ? 'REDIS_CONNECTION_REFUSED' : null,
+    ...overrides
+  };
+}
+
+async function flushAsyncWork(iterations = 10): Promise<void> {
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    await Promise.resolve();
+  }
+}
+
+describe('web server startup resilience', () => {
+  const originalPort = process.env.PORT;
+  const originalHost = process.env.HOST;
+  const originalNodeEnv = process.env.NODE_ENV;
+  let consoleLogSpy: ReturnType<typeof jest.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof jest.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.PORT = '32123';
+    process.env.HOST = '127.0.0.1';
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    if (originalPort === undefined) {
+      delete process.env.PORT;
+    } else {
+      process.env.PORT = originalPort;
+    }
+    if (originalHost === undefined) {
+      delete process.env.HOST;
+    } else {
+      process.env.HOST = originalHost;
+    }
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it('binds before deferred dependencies and Redis, then starts the full runtime once', async () => {
+    jest.resetModules();
+    const serverModule = await import('../src/server.js');
+    const startupLifecycle = await import('../src/platform/runtime/startupLifecycle.js');
+    startupLifecycle.resetStartupLifecycleForTests();
+
+    const sequence: string[] = [];
+    const dependencies = createDeferred<void>();
+    const { app, server, listenMock } = buildFakeApp(sequence);
+    let lifecycleListener: ((snapshot: RedisLifecycleSnapshot) => void) | null = null;
+    const performPreflight = jest.fn(async () => {
+      sequence.push('preflight');
+    });
+    const initializeDependencies = jest.fn(() => {
+      sequence.push('dependencies.start');
+      return dependencies.promise;
+    });
+    const startRedis = jest.fn(() => {
+      sequence.push('redis.start');
+    });
+    const startAppRuntimeOnce = jest.fn(() => {
+      sequence.push('runtime.start');
+      return true;
+    });
+    const startSelfHealing = jest.fn(() => ({
+      loopRunning: true,
+      intervalMs: 30_000
+    }));
+    const subscribeRedis = jest.fn((listener: (snapshot: RedisLifecycleSnapshot) => void) => {
+      lifecycleListener = listener;
+      return jest.fn();
+    });
+
+    const startedServer = await serverModule.startServer({
+      app,
+      startAppRuntimeOnce,
+      performPreflight,
+      initializeDependencies,
+      startRedis,
+      stopRedis: jest.fn(async () => undefined),
+      primeTelemetry: jest.fn(async () => undefined),
+      stopTelemetry: jest.fn(async () => undefined),
+      getRedisSnapshot: () => redisSnapshot('STARTING'),
+      subscribeRedis,
+      startSelfHealing: startSelfHealing as never,
+      closeDatabase: jest.fn(async () => undefined),
+      registerSignalHandlers: false
+    });
+
+    expect(startedServer).toBe(server);
+    expect(listenMock).toHaveBeenCalledWith(32123, '127.0.0.1');
+    expect(sequence.indexOf('listener.bind')).toBeLessThan(sequence.indexOf('redis.start'));
+    expect(sequence.indexOf('listener.bind')).toBeLessThan(sequence.indexOf('dependencies.start'));
+    expect(startAppRuntimeOnce).not.toHaveBeenCalled();
+    expect(startSelfHealing).not.toHaveBeenCalled();
+    expect(startupLifecycle.getStartupLifecycleSnapshot()).toEqual(expect.objectContaining({
+      phase: 'STARTING',
+      ready: false,
+      listenerBound: true,
+      runtimeInitialized: false,
+      redis: expect.objectContaining({ status: 'connecting' })
+    }));
+
+    dependencies.resolve(undefined);
+    await flushAsyncWork();
+
+    expect(startupLifecycle.getStartupLifecycleSnapshot()).toEqual(expect.objectContaining({
+      phase: 'STARTING',
+      ready: false,
+      listenerBound: true,
+      runtimeInitialized: true
+    }));
+    expect(startAppRuntimeOnce).not.toHaveBeenCalled();
+
+    expect(lifecycleListener).not.toBeNull();
+    lifecycleListener?.(redisSnapshot('READY'));
+    await flushAsyncWork();
+
+    expect(startupLifecycle.getStartupLifecycleSnapshot()).toEqual(expect.objectContaining({
+      phase: 'READY',
+      ready: true,
+      runtimeInitialized: true,
+      redis: expect.objectContaining({ status: 'ready' })
+    }));
+    expect(startAppRuntimeOnce).toHaveBeenCalledTimes(1);
+    expect(startSelfHealing).toHaveBeenCalledTimes(1);
+
+    lifecycleListener?.(redisSnapshot('DEGRADED'));
+    lifecycleListener?.(redisSnapshot('READY', { recoveryCount: 1 }));
+    await flushAsyncWork();
+
+    expect(startupLifecycle.getStartupLifecycleSnapshot().phase).toBe('READY');
+    expect(startAppRuntimeOnce).toHaveBeenCalledTimes(1);
+    expect(startSelfHealing).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the bound listener observable when deferred runtime initialization fails', async () => {
+    jest.resetModules();
+    const serverModule = await import('../src/server.js');
+    const startupLifecycle = await import('../src/platform/runtime/startupLifecycle.js');
+    startupLifecycle.resetStartupLifecycleForTests();
+
+    const sequence: string[] = [];
+    const { app, server } = buildFakeApp(sequence);
+    let lifecycleListener: ((snapshot: RedisLifecycleSnapshot) => void) | null = null;
+    const startAppRuntimeOnce = jest.fn(() => true);
+    const startSelfHealing = jest.fn(() => ({
+      loopRunning: false,
+      intervalMs: 30_000
+    }));
+
+    const startedServer = await serverModule.startServer({
+      app,
+      startAppRuntimeOnce,
+      performPreflight: jest.fn(async () => undefined),
+      initializeDependencies: jest.fn(async () => {
+        throw new Error('telemetry initialization failed');
+      }),
+      startRedis: jest.fn(),
+      stopRedis: jest.fn(async () => undefined),
+      primeTelemetry: jest.fn(async () => undefined),
+      stopTelemetry: jest.fn(async () => undefined),
+      getRedisSnapshot: () => redisSnapshot('READY'),
+      subscribeRedis: (listener) => {
+        lifecycleListener = listener;
+        return jest.fn();
+      },
+      startSelfHealing: startSelfHealing as never,
+      closeDatabase: jest.fn(async () => undefined),
+      registerSignalHandlers: false
+    });
+    await flushAsyncWork();
+
+    expect(startedServer).toBe(server);
+    expect(startupLifecycle.getStartupLifecycleSnapshot()).toEqual(expect.objectContaining({
+      phase: 'DEGRADED',
+      ready: false,
+      listenerBound: true,
+      runtimeInitialized: false,
+      runtimeErrorCode: 'RUNTIME_INITIALIZATION_FAILED'
+    }));
+    expect(startAppRuntimeOnce).not.toHaveBeenCalled();
+    expect(startSelfHealing).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[STARTUP] Runtime dependency initialization failed',
+      { errorType: 'Error' }
+    );
+
+    lifecycleListener?.(redisSnapshot('DEGRADED'));
+    await flushAsyncWork();
+    expect(startupLifecycle.getStartupLifecycleSnapshot().phase).toBe('DEGRADED');
+  });
+
+  it('keeps startup progressing when telemetry priming fails', async () => {
+    jest.resetModules();
+    const serverModule = await import('../src/server.js');
+    const startupLifecycle = await import('../src/platform/runtime/startupLifecycle.js');
+    startupLifecycle.resetStartupLifecycleForTests();
+
+    const sequence: string[] = [];
+    const { app, server } = buildFakeApp(sequence);
+    let lifecycleListener: ((snapshot: RedisLifecycleSnapshot) => void) | null = null;
+    const startAppRuntimeOnce = jest.fn(() => true);
+    const startSelfHealing = jest.fn(() => ({
+      loopRunning: true,
+      intervalMs: 30_000
+    }));
+    const primeTelemetry = jest.fn(async () => {
+      throw new Error('telemetry persistence failed');
+    });
+
+    const startedServer = await serverModule.startServer({
+      app,
+      startAppRuntimeOnce,
+      performPreflight: jest.fn(async () => undefined),
+      initializeDependencies: jest.fn(async () => undefined),
+      startRedis: jest.fn(),
+      stopRedis: jest.fn(async () => undefined),
+      primeTelemetry,
+      stopTelemetry: jest.fn(async () => undefined),
+      getRedisSnapshot: () => redisSnapshot('STARTING'),
+      subscribeRedis: (listener) => {
+        lifecycleListener = listener;
+        return jest.fn();
+      },
+      startSelfHealing: startSelfHealing as never,
+      closeDatabase: jest.fn(async () => undefined),
+      registerSignalHandlers: false
+    });
+    await flushAsyncWork();
+
+    expect(startedServer).toBe(server);
+    expect(primeTelemetry).toHaveBeenCalledTimes(1);
+    expect(startupLifecycle.getStartupLifecycleSnapshot()).toEqual(expect.objectContaining({
+      phase: 'STARTING',
+      listenerBound: true,
+      runtimeInitialized: true,
+      runtimeErrorCode: null
+    }));
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      '[STARTUP] Self-heal telemetry priming deferred',
+      { errorType: 'Error' }
+    );
+
+    lifecycleListener?.(redisSnapshot('READY'));
+    await flushAsyncWork();
+
+    expect(startupLifecycle.getStartupLifecycleSnapshot().phase).toBe('READY');
+    expect(startAppRuntimeOnce).toHaveBeenCalledTimes(1);
+    expect(startSelfHealing).toHaveBeenCalledTimes(1);
+  });
+
+  it('drains the listener before cancelling dependency work and closes each resource once', async () => {
+    jest.resetModules();
+    const serverModule = await import('../src/server.js');
+    const startupLifecycle = await import('../src/platform/runtime/startupLifecycle.js');
+    startupLifecycle.resetStartupLifecycleForTests();
+
+    const sequence: string[] = [];
+    const { app, server } = buildFakeApp(sequence);
+    const unsubscribe = jest.fn(() => sequence.push('redis.unsubscribe'));
+    const stopTelemetry = jest.fn(async () => {
+      sequence.push('telemetry.stop');
+    });
+    const stopRedis = jest.fn(async () => {
+      sequence.push('redis.stop');
+    });
+    const closeDatabase = jest.fn(async () => {
+      sequence.push('database.close');
+    });
+    server.close.mockImplementation((callback?: (error?: Error) => void) => {
+      sequence.push('listener.drain');
+      callback?.();
+      return server;
+    });
+    server.closeIdleConnections.mockImplementation(() => {
+      sequence.push('listener.stop_accepting');
+    });
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+    try {
+      await serverModule.startServer({
+        app,
+        startAppRuntimeOnce: jest.fn(() => true),
+        performPreflight: jest.fn(async () => undefined),
+        initializeDependencies: jest.fn(async () => undefined),
+        startRedis: jest.fn(),
+        stopRedis,
+        primeTelemetry: jest.fn(async () => undefined),
+        stopTelemetry,
+        getRedisSnapshot: () => redisSnapshot('READY'),
+        subscribeRedis: (listener) => {
+          listener(redisSnapshot('READY'));
+          return unsubscribe;
+        },
+        startSelfHealing: jest.fn(() => ({
+          loopRunning: true,
+          intervalMs: 30_000
+        })) as never,
+        closeDatabase,
+        registerSignalHandlers: false
+      });
+      await flushAsyncWork();
+
+      await serverModule.shutdownServer('SIGTERM');
+
+      expect(sequence).toEqual(expect.arrayContaining([
+        'listener.stop_accepting',
+        'listener.drain',
+        'redis.unsubscribe',
+        'telemetry.stop',
+        'redis.stop',
+        'database.close'
+      ]));
+      expect(sequence.indexOf('listener.stop_accepting')).toBeLessThan(sequence.indexOf('listener.drain'));
+      expect(sequence.indexOf('listener.drain')).toBeLessThan(sequence.indexOf('redis.unsubscribe'));
+      expect(sequence.indexOf('redis.unsubscribe')).toBeLessThan(sequence.indexOf('telemetry.stop'));
+      expect(sequence.indexOf('telemetry.stop')).toBeLessThan(sequence.indexOf('redis.stop'));
+      expect(sequence.indexOf('redis.stop')).toBeLessThan(sequence.indexOf('database.close'));
+      expect(stopTelemetry).toHaveBeenCalledTimes(1);
+      expect(stopRedis).toHaveBeenCalledTimes(1);
+      expect(closeDatabase).toHaveBeenCalledTimes(1);
+      expect(exitSpy).toHaveBeenCalledWith(0);
+      expect(startupLifecycle.getStartupLifecycleSnapshot()).toEqual(expect.objectContaining({
+        phase: 'DEGRADED',
+        ready: false,
+        shuttingDown: true
+      }));
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+});
+
+describe('startup lifecycle transitions', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('moves STARTING to DEGRADED to READY and refuses recovery after shutdown', async () => {
+    jest.resetModules();
+    const lifecycle = await import('../src/platform/runtime/startupLifecycle.js');
+    lifecycle.resetStartupLifecycleForTests();
+
+    expect(lifecycle.getStartupLifecycleSnapshot().phase).toBe('STARTING');
+    lifecycle.markStartupListenerBound();
+    lifecycle.markStartupRuntimeInitialized();
+    lifecycle.updateStartupRedisLifecycle({
+      configured: true,
+      status: 'unavailable',
+      attempt: 1,
+      lastErrorCode: 'REDIS_CONNECTION_REFUSED'
+    });
+    expect(lifecycle.getStartupLifecycleSnapshot()).toEqual(expect.objectContaining({
+      phase: 'DEGRADED',
+      ready: false
+    }));
+
+    lifecycle.updateStartupRedisLifecycle({
+      configured: true,
+      status: 'ready',
+      attempt: 2,
+      lastErrorCode: null
+    });
+    expect(lifecycle.getStartupLifecycleSnapshot()).toEqual(expect.objectContaining({
+      phase: 'READY',
+      ready: true
+    }));
+
+    lifecycle.markStartupShutdown();
+    lifecycle.updateStartupRedisLifecycle({
+      configured: true,
+      status: 'ready',
+      attempt: 3,
+      lastErrorCode: null
+    });
+    expect(lifecycle.getStartupLifecycleSnapshot()).toEqual(expect.objectContaining({
+      phase: 'DEGRADED',
+      ready: false,
+      shuttingDown: true,
+      redis: expect.objectContaining({ status: 'stopped' })
+    }));
+  });
+});

--- a/tests/startup-health-routes.test.ts
+++ b/tests/startup-health-routes.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { RedisLifecycleSnapshot } from '../src/platform/runtime/redisLifecycle.js';
+import type { StartupLifecycleSnapshot } from '../src/platform/runtime/startupLifecycle.js';
+
+const request = (await import('supertest')).default;
+const CURRENT_GPT_ROUTER_HASH = '8bf52c870195f165b17397ca16e87361fa401553fa10f86ebdbcc857a4fbba58';
+
+function redisSnapshot(
+  state: RedisLifecycleSnapshot['state'],
+  overrides: Partial<RedisLifecycleSnapshot> = {}
+): RedisLifecycleSnapshot {
+  return {
+    state,
+    configured: true,
+    connected: state === 'READY',
+    attempt: state === 'STARTING' ? 0 : 1,
+    recoveryCount: 0,
+    retryScheduled: state === 'DEGRADED',
+    lastTransitionAt: '2026-07-21T12:00:00.000Z',
+    lastReadyAt: state === 'READY' ? '2026-07-21T12:00:00.000Z' : null,
+    lastErrorCode: state === 'DEGRADED' ? 'REDIS_CONNECTION_REFUSED' : null,
+    ...overrides
+  };
+}
+
+function startupSnapshot(
+  phase: StartupLifecycleSnapshot['phase'],
+  overrides: Partial<StartupLifecycleSnapshot> = {}
+): StartupLifecycleSnapshot {
+  return {
+    phase,
+    ready: phase === 'READY',
+    listenerBound: true,
+    runtimeInitialized: phase !== 'STARTING',
+    runtimeErrorCode: null,
+    shuttingDown: false,
+    redis: {
+      configured: true,
+      status: phase === 'READY'
+        ? 'ready'
+        : phase === 'DEGRADED'
+          ? 'unavailable'
+          : 'connecting',
+      attempt: phase === 'STARTING' ? 0 : 1,
+      lastErrorCode: phase === 'DEGRADED' ? 'REDIS_CONNECTION_REFUSED' : null
+    },
+    changedAt: '2026-07-21T12:00:00.000Z',
+    ...overrides
+  };
+}
+
+interface AppHealthHarness {
+  app: import('express').Express;
+  createClientMock: jest.Mock;
+  setRedisSnapshot: (snapshot: RedisLifecycleSnapshot) => void;
+  setStartupSnapshot: (snapshot: StartupLifecycleSnapshot) => void;
+}
+
+async function buildAppHealthHarness(): Promise<AppHealthHarness> {
+  jest.resetModules();
+  let currentRedisSnapshot = redisSnapshot('STARTING');
+  let currentStartupSnapshot = startupSnapshot('STARTING');
+  const createClientMock = jest.fn(() => {
+    throw new Error('Health probes must not create a Redis client.');
+  });
+
+  jest.unstable_mockModule('redis', () => ({
+    createClient: createClientMock
+  }));
+  jest.unstable_mockModule('@platform/runtime/redisLifecycle.js', () => ({
+    RedisLifecycleManager: class {},
+    getRedisLifecycleSnapshot: jest.fn(() => ({ ...currentRedisSnapshot })),
+    getReadyRedisClient: jest.fn(() => null),
+    startRedisLifecycle: jest.fn(),
+    stopRedisLifecycle: jest.fn(async () => undefined),
+    subscribeRedisLifecycle: jest.fn(() => jest.fn())
+  }));
+  jest.unstable_mockModule('@platform/runtime/startupLifecycle.js', () => ({
+    getStartupLifecycleSnapshot: jest.fn(() => ({
+      ...currentStartupSnapshot,
+      redis: { ...currentStartupSnapshot.redis }
+    })),
+    subscribeStartupLifecycle: jest.fn(() => jest.fn()),
+    markStartupListenerBound: jest.fn(),
+    markStartupRuntimeInitializing: jest.fn(),
+    markStartupRuntimeInitialized: jest.fn(),
+    markStartupRuntimeFailed: jest.fn(),
+    markStartupShutdown: jest.fn(),
+    updateStartupRedisLifecycle: jest.fn(),
+    resetStartupLifecycleForTests: jest.fn()
+  }));
+
+  const { createApp } = await import('../src/app.js');
+  const app = createApp();
+  createClientMock.mockClear();
+
+  return {
+    app,
+    createClientMock,
+    setRedisSnapshot(snapshot): void {
+      currentRedisSnapshot = snapshot;
+    },
+    setStartupSnapshot(snapshot): void {
+      currentStartupSnapshot = snapshot;
+    }
+  };
+}
+
+const HEALTH_ENV_NAMES = [
+  'NODE_ENV',
+  'OPENAI_API_KEY',
+  'DATABASE_URL',
+  'REDIS_URL',
+  'ARCANOS_GPT_ACCESS_TOKEN',
+  'ARCANOS_GPT_ACCESS_SCOPES',
+  'DIAGNOSTICS_SHARED_METRICS',
+  'SAFETY_EXPECTED_HASH_GPT_ROUTER_CONFIG',
+  'RUN_WORKERS',
+  'DISABLE_EXTERNAL_CALLS'
+] as const;
+
+const originalHealthEnvironment = Object.fromEntries(
+  HEALTH_ENV_NAMES.map((name) => [name, process.env[name]])
+) as Record<(typeof HEALTH_ENV_NAMES)[number], string | undefined>;
+
+describe('actual Express startup health route ordering', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+    process.env.OPENAI_API_KEY = 'test-openai-api-key';
+    // Keep an explicit blank sentinel so env.ts cannot backfill a developer
+    // DATABASE_URL from .env when this isolated module graph is loaded.
+    process.env.DATABASE_URL = '';
+    process.env.REDIS_URL = 'redis://health.invalid:6379';
+    process.env.ARCANOS_GPT_ACCESS_TOKEN = 'test-startup-health-token';
+    process.env.ARCANOS_GPT_ACCESS_SCOPES = 'diagnostics.read';
+    process.env.DIAGNOSTICS_SHARED_METRICS = 'false';
+    process.env.SAFETY_EXPECTED_HASH_GPT_ROUTER_CONFIG = CURRENT_GPT_ROUTER_HASH;
+    process.env.RUN_WORKERS = 'false';
+    process.env.DISABLE_EXTERNAL_CALLS = 'true';
+  });
+
+  afterEach(() => {
+    for (const name of HEALTH_ENV_NAMES) {
+      const originalValue = originalHealthEnvironment[name];
+      if (originalValue === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = originalValue;
+      }
+    }
+  });
+
+  it('keeps liveness public while readiness tracks STARTING, DEGRADED, and READY', async () => {
+    const harness = await buildAppHealthHarness();
+
+    const startingHealth = await request(harness.app).get('/health');
+    const startingHealthz = await request(harness.app).get('/healthz');
+    const startingReady = await request(harness.app).get('/readyz');
+
+    expect(startingHealth.status).toBe(200);
+    expect(startingHealth.body).toEqual(expect.objectContaining({
+      status: 'ok',
+      startup: expect.objectContaining({
+        phase: 'STARTING',
+        ready: false,
+        listener_bound: true
+      }),
+      dependencies: {
+        redis: expect.objectContaining({
+          ready: false,
+          status: 'starting',
+          code: 'REDIS_INITIALIZING'
+        })
+      }
+    }));
+    expect(startingHealthz.status).toBe(200);
+    expect(startingHealthz.body.startup).toEqual(expect.objectContaining({
+      phase: 'STARTING',
+      ready: false
+    }));
+    expect(startingReady.status).toBe(503);
+    expect(startingReady.body).toEqual(expect.objectContaining({
+      ready: false,
+      status: 'unhealthy'
+    }));
+    expect(startingReady.body.checks).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'redis', code: 'REDIS_INITIALIZING', healthy: false }),
+      expect.objectContaining({ name: 'startup', code: 'APPLICATION_STARTING', healthy: false })
+    ]));
+
+    harness.setRedisSnapshot(redisSnapshot('DEGRADED'));
+    harness.setStartupSnapshot(startupSnapshot('DEGRADED'));
+    const degradedHealth = await request(harness.app).get('/health');
+    const degradedHealthz = await request(harness.app).get('/healthz');
+    const degradedReady = await request(harness.app).get('/readyz');
+
+    expect(degradedHealth.status).toBe(200);
+    expect(degradedHealth.body).toEqual(expect.objectContaining({
+      startup: expect.objectContaining({ phase: 'DEGRADED', ready: false }),
+      dependencies: {
+        redis: expect.objectContaining({
+          ready: false,
+          status: 'degraded',
+          code: 'REDIS_DEPENDENCY_UNAVAILABLE',
+          retry_scheduled: true
+        })
+      }
+    }));
+    expect(degradedHealthz.status).toBe(200);
+    expect(degradedHealthz.body.startup.phase).toBe('DEGRADED');
+    expect(degradedReady.status).toBe(503);
+    expect(degradedReady.body.checks).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: 'redis',
+        code: 'REDIS_DEPENDENCY_UNAVAILABLE',
+        healthy: false
+      }),
+      expect.objectContaining({
+        name: 'startup',
+        code: 'APPLICATION_DEGRADED',
+        healthy: false
+      })
+    ]));
+
+    harness.setRedisSnapshot(redisSnapshot('READY', { recoveryCount: 1 }));
+    harness.setStartupSnapshot(startupSnapshot('READY'));
+    const readyHealth = await request(harness.app).get('/health');
+    const readyHealthz = await request(harness.app).get('/healthz');
+    const readyResponse = await request(harness.app).get('/readyz');
+
+    expect(readyHealth.status).toBe(200);
+    expect(readyHealth.body.startup).toEqual(expect.objectContaining({
+      phase: 'READY',
+      ready: true
+    }));
+    expect(readyHealthz.status).toBe(200);
+    expect(readyHealthz.body.startup.phase).toBe('READY');
+    expect(readyResponse.status).toBe(200);
+    expect(readyResponse.body).toEqual(expect.objectContaining({
+      ready: true,
+      status: 'healthy'
+    }));
+
+    expect(harness.createClientMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps GPT Access health responsive with sanitized startup and Redis state', async () => {
+    const harness = await buildAppHealthHarness();
+    const authorize = () => request(harness.app)
+      .get('/gpt-access/health')
+      .set('Authorization', 'Bearer test-startup-health-token')
+      .expect('content-type', /json/u);
+
+    const starting = await authorize();
+    expect(starting.status).toBe(200);
+    expect(starting.body).toEqual(expect.objectContaining({
+      ok: true,
+      status: 'starting',
+      startup: { phase: 'STARTING', ready: false },
+      dependencies: {
+        redis: expect.objectContaining({
+          ready: false,
+          status: 'starting',
+          code: 'REDIS_INITIALIZING'
+        })
+      }
+    }));
+
+    harness.setRedisSnapshot(redisSnapshot('DEGRADED'));
+    harness.setStartupSnapshot(startupSnapshot('DEGRADED'));
+    const degraded = await authorize();
+    expect(degraded.status).toBe(200);
+    expect(degraded.body).toEqual(expect.objectContaining({
+      ok: true,
+      status: 'degraded',
+      startup: { phase: 'DEGRADED', ready: false },
+      dependencies: {
+        redis: expect.objectContaining({
+          ready: false,
+          status: 'degraded',
+          code: 'REDIS_DEPENDENCY_UNAVAILABLE',
+          retryScheduled: true
+        })
+      }
+    }));
+    expect(JSON.stringify(degraded.body)).not.toContain('REDIS_CONNECTION_REFUSED');
+
+    harness.setRedisSnapshot(redisSnapshot('READY', { recoveryCount: 1 }));
+    harness.setStartupSnapshot(startupSnapshot('READY'));
+    const ready = await authorize();
+    expect(ready.status).toBe(200);
+    expect(ready.body).toEqual(expect.objectContaining({
+      ok: true,
+      status: 'healthy',
+      startup: { phase: 'READY', ready: true },
+      dependencies: {
+        redis: expect.objectContaining({
+          ready: true,
+          status: 'ready',
+          code: null,
+          retryScheduled: false
+        })
+      }
+    }));
+    expect(harness.createClientMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unified-health-redis.test.ts
+++ b/tests/unified-health-redis.test.ts
@@ -1,69 +1,79 @@
 import { describe, expect, it, jest } from '@jest/globals';
 
 type UnifiedHealthModule = typeof import('../src/platform/resilience/unifiedHealth.js');
+type RedisLifecycleSnapshot = import('../src/platform/runtime/redisLifecycle.js').RedisLifecycleSnapshot;
+type StartupLifecycleSnapshot = import('../src/platform/runtime/startupLifecycle.js').StartupLifecycleSnapshot;
 
-interface UnifiedHealthRedisHarnessOptions {
+interface UnifiedHealthHarnessOptions {
   redisResolution?: {
     configured: boolean;
     source: 'REDIS_URL' | 'discrete' | 'none';
     url?: string;
   };
-  redis?: {
-    connectError?: Error;
-    pingError?: Error;
-    pingResponse?: string;
-  };
+  redisLifecycle?: Partial<RedisLifecycleSnapshot>;
+  startupLifecycle?: Partial<StartupLifecycleSnapshot>;
 }
 
-interface UnifiedHealthRedisHarness {
+interface UnifiedHealthHarness {
   moduleUnderTest: UnifiedHealthModule;
   createClientMock: jest.Mock;
-  redisConnectMock: jest.Mock;
-  redisPingMock: jest.Mock;
-  redisQuitMock: jest.Mock;
-  redisDisconnectMock: jest.Mock;
+  getRedisLifecycleSnapshotMock: jest.Mock;
+  getStartupLifecycleSnapshotMock: jest.Mock;
 }
 
-/**
- * Load unified health helpers with isolated Redis mocks.
- *
- * Purpose:
- * - Keep Redis health probe tests deterministic without real network I/O.
- *
- * Inputs/outputs:
- * - Input: harness options for Redis configuration and client behavior.
- * - Output: imported module plus Redis mock spies.
- *
- * Edge case behavior:
- * - Defaults to a healthy `PONG` round trip when no Redis failures are requested.
- */
-async function loadUnifiedHealthRedisHarness(
-  options: UnifiedHealthRedisHarnessOptions = {}
-): Promise<UnifiedHealthRedisHarness> {
+const DEFAULT_REDIS_LIFECYCLE: RedisLifecycleSnapshot = {
+  state: 'STARTING',
+  configured: true,
+  connected: false,
+  attempt: 1,
+  recoveryCount: 0,
+  retryScheduled: false,
+  lastTransitionAt: '2026-07-21T12:00:00.000Z',
+  lastReadyAt: null,
+  lastErrorCode: null
+};
+
+const DEFAULT_STARTUP_LIFECYCLE: StartupLifecycleSnapshot = {
+  phase: 'STARTING',
+  ready: false,
+  listenerBound: true,
+  runtimeInitialized: false,
+  runtimeErrorCode: null,
+  shuttingDown: false,
+  redis: {
+    configured: true,
+    status: 'connecting',
+    attempt: 1,
+    lastErrorCode: null
+  },
+  changedAt: '2026-07-21T12:00:00.000Z'
+};
+
+/** Load unified health with process-local lifecycle projections and no Redis I/O. */
+async function loadUnifiedHealthHarness(
+  options: UnifiedHealthHarnessOptions = {}
+): Promise<UnifiedHealthHarness> {
   jest.resetModules();
 
-  const redisConnectMock = jest.fn(async () => {
-    if (options.redis?.connectError) {
-      throw options.redis.connectError;
+  const redisLifecycle = {
+    ...DEFAULT_REDIS_LIFECYCLE,
+    ...options.redisLifecycle
+  };
+  const startupLifecycle = {
+    ...DEFAULT_STARTUP_LIFECYCLE,
+    ...options.startupLifecycle,
+    redis: {
+      ...DEFAULT_STARTUP_LIFECYCLE.redis,
+      ...options.startupLifecycle?.redis
     }
+  };
+  const createClientMock = jest.fn(() => {
+    throw new Error('Health checks must not create Redis clients.');
   });
-  const redisPingMock = jest.fn(async () => {
-    if (options.redis?.pingError) {
-      throw options.redis.pingError;
-    }
-
-    return options.redis?.pingResponse ?? 'PONG';
-  });
-  const redisQuitMock = jest.fn(async () => {});
-  const redisDisconnectMock = jest.fn(async () => {});
-
-  const createClientMock = jest.fn(() => ({
-    on: jest.fn(),
-    connect: redisConnectMock,
-    ping: redisPingMock,
-    quit: redisQuitMock,
-    disconnect: redisDisconnectMock,
-    isOpen: true
+  const getRedisLifecycleSnapshotMock = jest.fn(() => ({ ...redisLifecycle }));
+  const getStartupLifecycleSnapshotMock = jest.fn(() => ({
+    ...startupLifecycle,
+    redis: { ...startupLifecycle.redis }
   }));
 
   jest.unstable_mockModule('redis', () => ({
@@ -74,9 +84,15 @@ async function loadUnifiedHealthRedisHarness(
       options.redisResolution ?? {
         configured: true,
         source: 'REDIS_URL',
-        url: 'redis://localhost:6379'
+        url: 'redis://configured.invalid:6379'
       }
     ))
+  }));
+  jest.unstable_mockModule('@platform/runtime/redisLifecycle.js', () => ({
+    getRedisLifecycleSnapshot: getRedisLifecycleSnapshotMock
+  }));
+  jest.unstable_mockModule('@platform/runtime/startupLifecycle.js', () => ({
+    getStartupLifecycleSnapshot: getStartupLifecycleSnapshotMock
   }));
   jest.unstable_mockModule('@platform/logging/structuredLogging.js', () => ({
     aiLogger: {
@@ -122,25 +138,27 @@ async function loadUnifiedHealthRedisHarness(
   return {
     moduleUnderTest,
     createClientMock,
-    redisConnectMock,
-    redisPingMock,
-    redisQuitMock,
-    redisDisconnectMock
+    getRedisLifecycleSnapshotMock,
+    getStartupLifecycleSnapshotMock
   };
 }
 
-describe('platform/resilience/unifiedHealth redis checks', () => {
-  it('reports healthy and unconfigured when Redis is not configured', async () => {
-    const harness = await loadUnifiedHealthRedisHarness({
+describe('platform/resilience/unifiedHealth Redis lifecycle checks', () => {
+  it('reports healthy and optional without opening a client when Redis is unconfigured', async () => {
+    const harness = await loadUnifiedHealthHarness({
       redisResolution: {
         configured: false,
         source: 'none'
+      },
+      redisLifecycle: {
+        state: 'READY',
+        configured: false,
+        connected: false,
+        attempt: 0
       }
     });
 
-    const result = await harness.moduleUnderTest.checkRedisHealth();
-
-    expect(result).toEqual({
+    await expect(harness.moduleUnderTest.checkRedisHealth()).resolves.toEqual({
       healthy: true,
       name: 'redis',
       metadata: {
@@ -152,56 +170,154 @@ describe('platform/resilience/unifiedHealth redis checks', () => {
     expect(harness.createClientMock).not.toHaveBeenCalled();
   });
 
-  it('reports healthy when Redis connect and ping succeed', async () => {
-    const harness = await loadUnifiedHealthRedisHarness({
+  it('projects READY from the long-lived lifecycle without connect or ping I/O', async () => {
+    const harness = await loadUnifiedHealthHarness({
       redisResolution: {
         configured: true,
         source: 'discrete',
-        url: 'redis://redis.internal:6379'
-      }
-    });
-
-    const result = await harness.moduleUnderTest.checkRedisHealth();
-
-    expect(harness.createClientMock).toHaveBeenCalledWith(expect.objectContaining({
-      url: 'redis://redis.internal:6379'
-    }));
-    expect(harness.redisConnectMock).toHaveBeenCalledTimes(1);
-    expect(harness.redisPingMock).toHaveBeenCalledTimes(1);
-    expect(harness.redisQuitMock).toHaveBeenCalledTimes(1);
-    expect(result.healthy).toBe(true);
-    expect(result.metadata).toEqual(expect.objectContaining({
-      configured: true,
-      connected: true,
-      source: 'discrete'
-    }));
-  });
-
-  it('reports unhealthy when Redis ping fails', async () => {
-    const harness = await loadUnifiedHealthRedisHarness({
-      redisResolution: {
-        configured: true,
-        source: 'REDIS_URL',
-        url: 'redis://localhost:6379'
+        url: 'redis://configured.invalid:6379'
       },
-      redis: {
-        pingError: new Error('redis ping failed')
+      redisLifecycle: {
+        state: 'READY',
+        configured: true,
+        connected: true,
+        attempt: 2,
+        recoveryCount: 1,
+        retryScheduled: false,
+        lastReadyAt: '2026-07-21T12:01:00.000Z'
       }
     });
 
     const result = await harness.moduleUnderTest.checkRedisHealth();
 
     expect(result).toEqual({
-      healthy: false,
+      healthy: true,
       name: 'redis',
-      error: 'redis ping failed',
       metadata: {
         configured: true,
-        connected: false,
-        source: 'REDIS_URL'
+        connected: true,
+        source: 'discrete',
+        state: 'READY',
+        attempt: 2,
+        recoveryCount: 1
       }
     });
-    expect(harness.redisQuitMock).toHaveBeenCalledTimes(1);
-    expect(harness.redisDisconnectMock).not.toHaveBeenCalled();
+    expect(harness.getRedisLifecycleSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(harness.createClientMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a stable initializing error while the lifecycle is STARTING', async () => {
+    const harness = await loadUnifiedHealthHarness({
+      redisLifecycle: {
+        state: 'STARTING',
+        configured: true,
+        connected: false,
+        attempt: 1,
+        retryScheduled: false
+      }
+    });
+
+    const result = await harness.moduleUnderTest.checkRedisHealth();
+
+    expect(result).toEqual(expect.objectContaining({
+      healthy: false,
+      name: 'redis',
+      code: 'REDIS_INITIALIZING',
+      error: 'Redis initialization is in progress.',
+      metadata: expect.objectContaining({
+        configured: true,
+        connected: false,
+        state: 'STARTING',
+        code: 'REDIS_INITIALIZING'
+      })
+    }));
+    expect(JSON.stringify(result)).not.toContain('configured.invalid');
+    expect(harness.createClientMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a stable dependency error without exposing the underlying Redis failure', async () => {
+    const harness = await loadUnifiedHealthHarness({
+      redisLifecycle: {
+        state: 'DEGRADED',
+        configured: true,
+        connected: false,
+        attempt: 4,
+        retryScheduled: true,
+        lastErrorCode: 'REDIS_AUTH_FAILED'
+      }
+    });
+
+    const result = await harness.moduleUnderTest.checkRedisHealth();
+    const serialized = JSON.stringify(result);
+
+    expect(result).toEqual(expect.objectContaining({
+      healthy: false,
+      name: 'redis',
+      code: 'REDIS_DEPENDENCY_UNAVAILABLE',
+      error: 'Redis dependency is unavailable.',
+      metadata: expect.objectContaining({
+        state: 'DEGRADED',
+        attempt: 4,
+        retryScheduled: true,
+        code: 'REDIS_DEPENDENCY_UNAVAILABLE'
+      })
+    }));
+    expect(serialized).not.toContain('WRONGPASS');
+    expect(serialized).not.toContain('REDIS_AUTH_FAILED');
+    expect(serialized).not.toContain('configured.invalid');
+    expect(harness.createClientMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('platform/resilience/unifiedHealth startup readiness', () => {
+  it.each([
+    ['STARTING', 'APPLICATION_STARTING'],
+    ['DEGRADED', 'APPLICATION_DEGRADED']
+  ] as const)('reports %s as not ready with a stable code', async (phase, code) => {
+    const harness = await loadUnifiedHealthHarness({
+      startupLifecycle: {
+        phase,
+        ready: false,
+        runtimeInitialized: phase === 'DEGRADED',
+        runtimeErrorCode: phase === 'DEGRADED' ? 'RUNTIME_INITIALIZATION_FAILED' : null
+      }
+    });
+
+    expect(harness.moduleUnderTest.checkStartupReadiness()).toEqual(expect.objectContaining({
+      healthy: false,
+      name: 'startup',
+      code,
+      metadata: expect.objectContaining({ phase })
+    }));
+    expect(harness.getStartupLifecycleSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports READY only after the shared startup lifecycle is ready', async () => {
+    const harness = await loadUnifiedHealthHarness({
+      startupLifecycle: {
+        phase: 'READY',
+        ready: true,
+        listenerBound: true,
+        runtimeInitialized: true,
+        redis: {
+          configured: true,
+          status: 'ready',
+          attempt: 2,
+          lastErrorCode: null
+        }
+      }
+    });
+
+    expect(harness.moduleUnderTest.checkStartupReadiness()).toEqual({
+      healthy: true,
+      name: 'startup',
+      metadata: {
+        phase: 'READY',
+        listenerBound: true,
+        runtimeInitialized: true,
+        shuttingDown: false,
+        changedAt: '2026-07-21T12:00:00.000Z'
+      }
+    });
   });
 });


### PR DESCRIPTION
## Overview

Keep the ARCANOS web listener observable during temporary Redis outages. The production incident was caused by pre-listener telemetry priming waiting on unavailable Redis, which prevented the listener from binding and left Railway with zero healthy replicas.

This change binds HTTP first, reports liveness independently from readiness, reconnects Redis in the background, and starts the full runtime exactly once after dependencies recover.

## Root cause

```text
Redis unavailable
→ pre-listener telemetry priming blocked startup
→ HTTP listener never bound
→ Railway had zero healthy replicas
→ GPT Access returned 502
```

## Prerequisites

- [x] Branch is up to date with target base branch
- [x] Scope is limited to a single coherent startup-resilience change, with separately documented dependency-audit remediation

## Implementation

- Add a shared Redis lifecycle with bounded attempts, exponential backoff, jitter, cancellation, and indefinite recovery.
- Add explicit `STARTING`, `DEGRADED`, and `READY` startup states.
- Bind the listener before Redis, telemetry, schema verification, and background runtime initialization.
- Keep `/health` and `/healthz` live while `/readyz` reports 503 until Redis is ready.
- Make telemetry hydration and persistence non-blocking and recoverable.
- Prevent duplicate Redis loops, telemetry subscriptions, runtime initialization, and shutdown work.
- Return sanitized dependency status without stack traces.
- Document startup, recovery, and shutdown behavior.

## Validation

- [x] `npm run type-check`
- [x] `npm run lint` — 0 errors; 86 pre-existing warnings
- [x] Current-head CI `npm test` — 439 suites passed, 4 intentionally skipped; 4,716 tests passed, 8 intentionally skipped
- [x] `npm run build`
- [x] `npm run validate:railway`
- [x] `npm run guard:commit`
- [x] `npm run test:integration` — 84 active tests passed; 3 intentionally skipped
- [x] Focused startup-resilience tests — 31/31 passed
- [x] Related GPT Access, telemetry, diagnostics, parser, and self-heal tests — 154/154 passed
- [x] GitHub deployment-readiness and aggregate completion gates passed

## Configuration

- [x] No environment-variable changes
- [x] No new variables or secret changes
- [x] No Railway configuration changes
- [x] No database schema or migration changes

## Local behavior

- [x] Backend startup and health-route behavior tested
- [x] Changed endpoints and lifecycle transitions tested locally
- [x] Compiled server bound successfully with Redis pointed at a closed loopback port
- [x] During that outage, `/health` returned 200 and `/readyz` returned 503 with a sanitized dependency code

## Railway preview validation

The canonical bot-created `Arcanos-pr-1403` environment had no application services, so the final end-to-end test used the separately isolated `pr1403-active-redis-20260722` preview.

- Preview URL at validation time: [pr1403-web-active](https://pr1403-web-active-pr1403-active-redis-20260722.up.railway.app)
- The validation target was created from a clean checkout at final PR head `a16af15c73f17ab4fa694a899facdf804de6eec5`. Railway did not emit a Git `commitHash` for the CLI-uploaded deployment, so source correlation uses the clean checkout, deployment message, and resulting image identity rather than platform Git-SHA attestation.
- The isolated topology included PostgreSQL, Redis, one web process, one worker process, and a private synthetic provider. The worker was explicitly limited to `WORKER_COUNT=1`; runtime evidence showed one worker, one task listener, and one database job-runner listener.
- Baseline web, worker, Redis, queue, GPT Access, runtime, self-heal, and readiness checks were healthy before fault injection.
- Redis deployment `fc83b268-7dbd-485b-a5f7-17931a392ad9` was stopped exactly once. The existing web process remained observable: `/health` and `/healthz` returned 200, `/readyz` returned 503 with `REDIS_DEPENDENCY_UNAVAILABLE`, GPT Access health/status remained available in a degraded state, and 30 concurrent probes produced zero 502 responses or transport failures.
- Web deployment `8d4b4b53-19e7-4cea-b083-c30e2c93b6f7` was cold-restarted exactly once while Redis remained stopped. Its deployment ID, instance ID, and image digest remained unchanged. The listener bound before Redis recovery, liveness remained 200, readiness remained 503, and Redis retry delays progressed to the configured 30-second cap without a crash loop, duplicate listener, duplicate runtime initialization, or resource exhaustion.
- The same Redis deployment was then restarted exactly once. The unchanged web instance recovered automatically in approximately 29 seconds, transitioned from degraded to ready without another web restart or redeploy, emitted one Redis-ready recovery event, and started the full runtime exactly once.
- Post-recovery verification returned 200 for all 24 bounded health and diagnostic probes. Queue and self-heal checks recovered, deep diagnostics reported no risks or recommended actions, and one bounded `arcanos-core` advisory job was accepted and completed once with no retries or duplicate execution.
- Final queue state was two completed jobs with zero pending, running, failed, delayed, stalled, retry, or dead-letter jobs. CPU and memory metrics showed no busy loop or resource exhaustion during the fault and recovery window.
- No production service or configuration was changed. The preview remains available for review and has not been remotely torn down.

## Deploy (Railway)

- [ ] No deploy impact
- [x] Backward-compatible deploy
- [x] Rollback is configuration- and schema-safe because this PR changes neither; reverting restores the prior startup lifecycle
- [x] No production deployment was performed by this PR work

Post-deploy verification should require `/health`, `/readyz`, GPT Access health, runtime status, worker status, queue inspection, self-heal status, and one bounded advisory job.

## Known limitations and follow-ups

- Railway did not provide Git-SHA attestation for the CLI-uploaded preview image. Final-head provenance is supported by the clean checkout, deployment message, and image digest, but not by a platform-origin `commitHash`.
- Preview Redis is volume-less. The test proves transient dependency-loss recovery, but not Redis data persistence across instance or volume loss; persistence-parity work requires a separately reviewed volume-backed topology and reference cutover.
- Preview PostgreSQL used private-network TLS with certificate verification disabled, so trusted-CA parity with production was not established in this preview.
- Private-provider isolation was verified operationally through private-only routing, no public domain or upstream provider, and a synthetic credential. The repository’s preview-isolation guard was not active because it currently supports loopback/native-preview modes rather than this manual private-service topology.
- Deterministic Redis clients remain appropriate for unit coverage of authentication failure, timeouts, cancellation, and flapping; the full listener-first outage and automatic-recovery path was additionally exercised against the live preview Redis service.
- Pre-existing fail-closed safety-v2 and incident kill-switch Redis clients remain intentionally separate.
- The job queue is PostgreSQL-backed; no Redis queue consumer exists or was added.
- Current-head CI is green; its 4 skipped suites and 8 skipped tests are intentional.
- Temporary Hono advisory exceptions are scoped to exact advisory IDs and installed paths and require review by **2026-07-28**.

Independent startup-resilience review: **PASS WITH LIMITATIONS**. The limitations are infrastructure/provenance parity follow-ups; the functional startup-resilience contract passed with no blocker.

Final PR-readiness review: **MERGE READY**, with no code or functional validation blockers.

## References

- Production source baseline: `01e800d68c4453a6e516129480cbe734bffe6ecf`
- Current PR head: `a16af15c73f17ab4fa694a899facdf804de6eec5`
- Docs updated:
  - `docs/STARTUP_RESILIENCE.md`
  - `docs/RAILWAY_DEPLOYMENT.md`
- Primary tests:
  - `tests/redis-startup-lifecycle.test.ts`
  - `tests/server-startup-resilience.test.ts`
  - `tests/startup-health-routes.test.ts`
  - `tests/self-heal-telemetry-redis.test.ts`
  - `tests/unified-health-redis.test.ts`

## CI and review follow-up

The initial PR run exposed advisory-feed drift that also affected the unchanged base branch.

- Pinned transitive `fast-uri` to upstream `3.1.4`, clearing both high-severity findings and the derived Ajv finding.
- Kept the working published Hono builds because the patched source-tag archives omit required `dist` exports.
- Added temporary Hono exceptions scoped to exact advisory IDs and installed node paths.
- Added negative policy tests proving new advisories, mixed advisory sets, and unexpected dependency paths still fail.
- Live npm audit policy: zero actionable findings.
- Audit-policy suite: 31/31 passed.
- License compliance: passed.
- Python dependency audit: no known vulnerabilities.
- Independent security review: passed with no blockers.
- Copilot review findings were addressed: fatal startup logs no longer expose raw errors, and unexpected telemetry hydration failures are contained, safely classified, and retried.
- Both Copilot review threads have evidence-backed replies and are resolved.

Follow-up commits:

- `e19dc88e` — dependency audit remediation
- `a16af15c` — Copilot review remediation

