### PR TITLE
docs: harden documentation governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,16 @@
+# Default owner and current repository maintainer.
 * @pbjustin
-daemon-python/ @pbjustin
-.github/workflows/ @pbjustin
+
+# Maintained documentation, policy, and documentation-backed configuration.
+/docs/ @pbjustin
+/README.md @pbjustin
+/CONTRIBUTING.md @pbjustin
+/CHANGELOG.md @pbjustin
+/DEPRECATION.md @pbjustin
+/SECURITY.md @pbjustin
+/.env.example @pbjustin
+/daemon-python/README.md @pbjustin
+
+# Runtime-specific and automation-sensitive paths.
+/daemon-python/ @pbjustin
+/.github/workflows/ @pbjustin

--- a/.github/workflows/auto-update-documentation.yml
+++ b/.github/workflows/auto-update-documentation.yml
@@ -1,85 +1,105 @@
-name: Auto-Update Documentation
+name: Analyze Documentation Updates
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [main]
+    # A human-applied documentation-only patch must not start another analysis
+    # run. Mixed code-and-documentation commits still run.
+    paths-ignore:
+      - '**/*.md'
+      - 'backend-index.json'
+      - 'cli-agent-index.json'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-documentation-${{ github.repository }}
+  cancel-in-progress: true
+
 env:
-  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
   NODE_VERSION: '20.19.0'
 
 jobs:
-  update-docs:
+  analyze:
+    name: Analyze and validate documentation proposal
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    env:
-      ARCANOS_GPT_ACCESS_BASE_URL: ${{ format('{0}://localhost:{1}', 'http', '8080') }}
-      ARCANOS_GPT_ACCESS_SCOPES: >-
-        runtime.read,workers.read,queue.read,jobs.create,jobs.result,
-        logs.read_sanitized,db.explain_approved,mcp.approved_readonly,
-        diagnostics.read
+    timeout-minutes: 25
     permissions:
-      contents: write
-      actions: write
-      pull-requests: write
+      contents: read
 
     steps:
-      - name: 📥 Checkout Repository
+      - name: Checkout source commit
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
-      - name: 🧰 Set up Node.js
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: npm
 
-      - name: 📦 Install Dependencies
+      - name: Install dependencies
         run: npm ci
 
-      - name: 🔧 Install Required Tools
-        run: |
-          # Install jq for JSON processing
-          sudo apt-get update && sudo apt-get install -y jq
-
-      - name: 🔨 Build Project
+      - name: Build project
         run: npm run build
 
-      - name: 📝 Run Documentation Update
+      - name: Verify clean analysis baseline
+        run: git diff --exit-code HEAD --
+
+      - name: Run documentation analysis
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || 'sk-mock-for-ci-testing' }}
+          ARCANOS_GPT_ACCESS_TOKEN: ${{ secrets.ARCANOS_GPT_ACCESS_TOKEN || 'ci-gpt-access-token-for-local-workflow-only' }}
+          ARCANOS_GPT_ACCESS_BASE_URL: http://localhost:8080
+          ARCANOS_GPT_ACCESS_SCOPES: >-
+            runtime.read,workers.read,queue.read,jobs.create,jobs.result,
+            logs.read_sanitized,db.explain_approved,mcp.approved_readonly,
+            diagnostics.read
         run: |
-          echo "📝 Starting AI-powered documentation update..."
+          set -euo pipefail
+
           export PORT=8080
           export NODE_ENV=production
-          export OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY || 'sk-mock-for-ci-testing' }}"
-          export ARCANOS_GPT_ACCESS_TOKEN="${{ secrets.ARCANOS_GPT_ACCESS_TOKEN || 'ci-gpt-access-token-for-local-workflow-only' }}"
-          CI_API_KEY="${OPENAI_API_KEY}"
-          DOCS_STRICT_FLAG="--strict"
+          # The client bearer is localhost-only and deliberately distinct from
+          # the provider credential used by the backend.
+          export CI_API_KEY="ci-local-documentation-client"
+
+          DOCS_MODE=--strict
           if [ "$OPENAI_API_KEY" = "sk-mock-for-ci-testing" ]; then
-            echo "OPENAI_API_KEY secret is unavailable; running documentation generation in allow-partial validation mode."
-            DOCS_STRICT_FLAG="--allow-partial"
+            echo "OPENAI_API_KEY is unavailable; running allow-partial analysis without applying degraded output."
+            DOCS_MODE=--allow-partial
           fi
-          
-          # Start ARCANOS backend for documentation analysis
+
           npm start &
           SERVER_PID=$!
-          trap 'kill $SERVER_PID || true' EXIT
-          
-          # Wait for server to be ready
-          sleep 15
-          
-          # Test server is responding
-          curl -f http://localhost:8080/health || {
-            echo "Server failed to start properly"
+          trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+
+          SERVER_READY=false
+          for attempt in {1..30}; do
+            if curl --fail --silent --show-error http://localhost:8080/health >/dev/null; then
+              SERVER_READY=true
+              break
+            fi
+
+            if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+              echo "::error::The documentation analysis server exited before becoming healthy."
+              exit 1
+            fi
+
+            sleep 1
+          done
+
+          if [ "$SERVER_READY" != "true" ]; then
+            echo "::error::The documentation analysis server did not become healthy within 30 seconds."
             exit 1
-          }
-          
-          echo "✅ ARCANOS backend is running"
-          
-          # Generate documentation through narrow async ARCANOS jobs.
-          # The script polls /jobs/:id/result and fails on degraded pipeline fallback output.
+          fi
+
           node scripts/generate-docs-update.js \
             --base-url http://localhost:8080 \
             --gpt-id arcanos-core \
@@ -88,244 +108,211 @@ jobs:
             --timeout-ms 120000 \
             --poll-interval-ms 1000 \
             --concurrency 2 \
-            $DOCS_STRICT_FLAG
-          
-          # Stop the server
-          kill $SERVER_PID || true
+            "$DOCS_MODE"
+
+          kill "$SERVER_PID" 2>/dev/null || true
           trap - EXIT
-          
-          echo "📊 Documentation analysis completed"
 
-      - name: 📄 Process Documentation Updates
+      - name: Apply bounded tracked-document updates
         id: process_updates
+        env:
+          MAX_UPDATE_FILES: '1'
+          MAX_FILE_BYTES: '262144'
+          MAX_TOTAL_BYTES: '1048576'
         run: |
-          if [ ! -f doc_analysis.json ]; then
-            echo "No analysis results found"
-            echo "has_updates=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          
-          echo "📋 Processing documentation updates..."
-          
-          # Check if we have a valid JSON response
-          if ! jq empty doc_analysis.json 2>/dev/null; then
-            echo "Invalid JSON response from documentation analysis"
-            echo "Analysis response:"
-            cat doc_analysis.json
-            echo "has_updates=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          
-          # Extract updates from the response
-          # Handle both direct JSON format and nested response field
-          ANALYSIS_OK=$(jq -r '.ok // .response.ok // false' doc_analysis.json 2>/dev/null || echo "false")
-          if [ "$ANALYSIS_OK" != "true" ]; then
-            echo "Documentation analysis completed with failures; artifacts were uploaded, so skipping file updates."
-            echo "has_updates=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
+          node --input-type=module <<'NODE'
+          import { execFileSync } from 'node:child_process';
+          import { readFileSync, writeFileSync } from 'node:fs';
+          import path from 'node:path';
 
-          UPDATES=$(jq -r '.updates // .response.updates // empty' doc_analysis.json 2>/dev/null || echo "[]")
-          
-          if [ "$UPDATES" = "[]" ] || [ "$UPDATES" = "null" ] || [ -z "$UPDATES" ]; then
-            echo "No documentation updates needed"
-            echo "has_updates=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          
-          echo "Found documentation updates to apply"
-          echo "$UPDATES" > updates.json
-          
-          # Apply updates
-          HAS_CHANGES=false
-          UPDATE_COUNT=0
-          
-          # Create temporary file to track changes
-          echo "false" > /tmp/has_changes
-          echo "0" > /tmp/update_count
-          
-          # Process each update
-          echo "$UPDATES" | jq -c '.[]' | while read -r update; do
-            FILE=$(echo "$update" | jq -r '.file')
-            CONTENT=$(echo "$update" | jq -r '.content')
-            REASON=$(echo "$update" | jq -r '.reason')
-            
-            if [ "$FILE" != "null" ] && [ "$CONTENT" != "null" ] && [ "$FILE" != "" ]; then
-              echo "📝 Processing update for $FILE: $REASON"
-              
-              # Validate file path (basic security check)
-              if [[ "$FILE" == ../* ]] || [[ "$FILE" == */../* ]]; then
-                echo "  ⚠️ Skipping $FILE - path traversal detected"
-                continue
-              fi
-              
-              # Create directory if it doesn't exist
-              mkdir -p "$(dirname "$FILE")"
-              
-              # Back up existing file if it exists
-              if [ -f "$FILE" ]; then
-                cp "$FILE" "$FILE.bak" 2>/dev/null || true
-              fi
-              
-              # Write updated content (decode any escaped newlines)
-              echo -e "$CONTENT" > "$FILE"
-              
-              # Verify the file was created/updated
-              if [ ! -f "$FILE" ]; then
-                echo "  ❌ Failed to create $FILE"
-                # Restore backup if it exists
-                if [ -f "$FILE.bak" ]; then
-                  mv "$FILE.bak" "$FILE"
-                fi
-                continue
-              fi
-              
-              # Check if file was actually changed
-              if [ -f "$FILE.bak" ] && cmp -s "$FILE" "$FILE.bak"; then
-                echo "  ℹ️  No changes needed for $FILE"
-                rm -f "$FILE.bak"
-              else
-                echo "  ✅ Updated $FILE"
-                rm -f "$FILE.bak"
-                # Update counters
-                CURRENT_COUNT=$(cat /tmp/update_count)
-                echo "$((CURRENT_COUNT + 1))" > /tmp/update_count
-                echo "true" > /tmp/has_changes
-              fi
-            else
-              echo "  ⚠️ Skipping invalid update entry: FILE='$FILE' CONTENT_LENGTH=$(echo "$CONTENT" | wc -c)"
-            fi
-          done
-          
-          # Read final values
-          HAS_CHANGES=$(cat /tmp/has_changes)
-          UPDATE_COUNT=$(cat /tmp/update_count)
-          
-          echo "Processed $UPDATE_COUNT file updates"
-          
-          if [ "$HAS_CHANGES" = "true" ]; then
-            echo "has_updates=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_updates=false" >> $GITHUB_OUTPUT
-          fi
-          
-          # Cleanup temporary files
-          rm -f /tmp/has_changes /tmp/update_count
+          const outputPath = process.env.GITHUB_OUTPUT;
+          const setOutput = (name, value) => {
+            writeFileSync(outputPath, `${name}=${value}\n`, { encoding: 'utf8', flag: 'a' });
+          };
 
-      - name: 📊 Generate Update Summary
-        if: steps.process_updates.outputs.has_updates == 'true'
-        run: |
-          echo "## 📝 Documentation Update Summary" > update_summary.md
-          echo "" >> update_summary.md
-          echo "**Timestamp:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> update_summary.md
-          echo "**Triggered by:** ${{ github.event_name }}" >> update_summary.md
-          echo "**Commit:** ${{ github.sha }}" >> update_summary.md
-          echo "" >> update_summary.md
-          
-          # Add summary from analysis
-          if [ -f doc_analysis.json ]; then
-            SUMMARY=$(jq -r '.summary // .response.summary // "Documentation updates applied based on current codebase state"' doc_analysis.json)
-            echo "**Analysis Summary:** $SUMMARY" >> update_summary.md
-            echo "" >> update_summary.md
-          fi
-          
-          echo "### Changed Files" >> update_summary.md
-          echo "" >> update_summary.md
-          
-          # List changed files
-          git diff --name-only | while read -r file; do
-            echo "- \`$file\`" >> update_summary.md
-          done
-          
-          echo "" >> update_summary.md
-          echo "### CLEAR 2.0 Standards Applied" >> update_summary.md
-          echo "" >> update_summary.md
-          echo "- **Clarity**: Documentation updated with precise, unambiguous language" >> update_summary.md
-          echo "- **Leverage**: Key project strengths and unique features highlighted" >> update_summary.md
-          echo "- **Efficiency**: Removed redundant or outdated information" >> update_summary.md
-          echo "- **Alignment**: Documentation synchronized with current codebase state" >> update_summary.md
-          echo "- **Resilience**: Verified procedures and comprehensive error handling documented" >> update_summary.md
-
-      - name: 🚀 Commit and Push Changes
-        if: steps.process_updates.outputs.has_updates == 'true'
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          
-          # Show what files have changed
-          echo "📊 Files changed:"
-          git status --porcelain
-          
-          # Check if there are actually changes to commit
-          if git diff --quiet && git diff --cached --quiet; then
-            echo "No changes to commit after processing"
-            exit 0
-          fi
-          
-          # Add changed files
-          git add .
-          
-          # Show final diff summary
-          echo "📋 Changes summary:"
-          git diff --cached --stat
-          
-          # Commit with detailed message
-          git commit -m "🤖 Auto-update documentation from codebase scan
-
-          Automated documentation update performed by ARCANOS AI system.
-          
-          Changes applied based on:
-          - Current codebase analysis
-          - API endpoint verification  
-          - Environment variable audit
-          - Package.json script validation
-          - CLEAR 2.0 documentation standards
-          
-          Trigger: ${{ github.event_name }}
-          Commit: ${{ github.sha }}
-          Timestamp: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" || {
-            echo "Commit failed - may be no actual changes"
-            exit 0
+          if (!outputPath) {
+            throw new Error('GITHUB_OUTPUT is unavailable.');
           }
-          
-          # Push changes with retry logic
-          for i in {1..3}; do
-            if git push; then
-              echo "✅ Successfully pushed changes to repository"
-              break
-            else
-              if [ $i -lt 3 ]; then
-                echo "Push attempt $i failed, retrying..."
-                sleep 5
-                # Pull any concurrent changes
-                git pull --rebase origin ${{ github.ref_name }} || true
-              else
-                echo "❌ Push failed after 3 attempts"
-                echo "This may be due to concurrent changes or permission issues"
-                exit 1
-              fi
-            fi
-          done
 
-      - name: 📤 Upload Documentation Artifacts
+          let payload;
+          try {
+            payload = JSON.parse(readFileSync('doc_analysis.json', 'utf8'));
+          } catch (error) {
+            throw new Error(`Documentation analysis did not produce valid JSON: ${error.message}`);
+          }
+
+          const analysis = payload?.response ?? payload;
+          if (analysis?.ok !== true) {
+            console.log('Documentation analysis was partial or unsuccessful; no proposal will be created.');
+            setOutput('has_updates', 'false');
+            setOutput('update_count', '0');
+            process.exit(0);
+          }
+
+          const updates = analysis?.updates ?? [];
+          if (!Array.isArray(updates)) {
+            throw new Error('Documentation analysis returned a non-array updates value.');
+          }
+
+          if (updates.length === 0) {
+            console.log('Documentation analysis found no updates.');
+            setOutput('has_updates', 'false');
+            setOutput('update_count', '0');
+            process.exit(0);
+          }
+
+          const maxFiles = Number(process.env.MAX_UPDATE_FILES);
+          const maxFileBytes = Number(process.env.MAX_FILE_BYTES);
+          const maxTotalBytes = Number(process.env.MAX_TOTAL_BYTES);
+
+          if (updates.length > maxFiles) {
+            throw new Error(`Refusing ${updates.length} updates; the limit is ${maxFiles}.`);
+          }
+
+          // The current generator has one dedicated, maintained output. Expanding
+          // this allowlist requires a reviewed workflow change.
+          const allowedDocuments = new Set([
+            'docs/GPT_ASYNC_DOCUMENTATION_WORKFLOW.md',
+          ]);
+
+          function isAllowedDocument(file) {
+            if (
+              typeof file !== 'string'
+              || file.length === 0
+              || file.includes('\\')
+              || file.includes('\0')
+              || path.posix.isAbsolute(file)
+              || path.posix.normalize(file) !== file
+              || !file.endsWith('.md')
+            ) {
+              return false;
+            }
+
+            return allowedDocuments.has(file);
+          }
+
+          const seenFiles = new Set();
+          let totalBytes = 0;
+
+          for (const [index, update] of updates.entries()) {
+            const file = update?.file;
+            const content = update?.content;
+
+            if (!isAllowedDocument(file)) {
+              throw new Error(`Update ${index + 1} targets a disallowed documentation path: ${String(file)}`);
+            }
+            if (seenFiles.has(file)) {
+              throw new Error(`Documentation analysis returned duplicate updates for ${file}.`);
+            }
+            if (typeof content !== 'string' || content.includes('\0')) {
+              throw new Error(`Update ${index + 1} has invalid text content.`);
+            }
+
+            try {
+              execFileSync('git', ['ls-files', '--error-unmatch', '--', file], { stdio: 'ignore' });
+            } catch {
+              throw new Error(`Update ${index + 1} targets an untracked document: ${file}`);
+            }
+
+            const fileBytes = Buffer.byteLength(content, 'utf8');
+            if (fileBytes > maxFileBytes) {
+              throw new Error(`${file} exceeds the ${maxFileBytes}-byte per-file limit.`);
+            }
+
+            totalBytes += fileBytes;
+            if (totalBytes > maxTotalBytes) {
+              throw new Error(`Documentation updates exceed the ${maxTotalBytes}-byte total limit.`);
+            }
+
+            seenFiles.add(file);
+          }
+
+          for (const update of updates) {
+            const normalizedContent = update.content.endsWith('\n')
+              ? update.content
+              : `${update.content}\n`;
+            writeFileSync(update.file, normalizedContent, 'utf8');
+          }
+
+          const changedFiles = execFileSync(
+            'git',
+            ['diff', '--name-only', '-z', 'HEAD', '--'],
+            { encoding: 'utf8' },
+          ).split('\0').filter(Boolean);
+
+          const unexpectedFiles = changedFiles.filter((file) => !seenFiles.has(file));
+          if (unexpectedFiles.length > 0) {
+            throw new Error(
+              `Refusing tracked side effects outside the documentation allowlist: ${unexpectedFiles.join(', ')}`,
+            );
+          }
+
+          console.log(`Applied ${changedFiles.length} changed tracked-document update(s).`);
+          setOutput('has_updates', changedFiles.length > 0 ? 'true' : 'false');
+          setOutput('update_count', String(changedFiles.length));
+          NODE
+
+      - name: Validate proposed documentation
+        if: steps.process_updates.outputs.has_updates == 'true'
+        run: |
+          set -euo pipefail
+
+          ALLOWED_DOCUMENT=docs/GPT_ASYNC_DOCUMENTATION_WORKFLOW.md
+          mapfile -d '' TRACKED_CHANGES < <(git diff --name-only -z HEAD --)
+          if [ "${#TRACKED_CHANGES[@]}" -ne 1 ] || [ "${TRACKED_CHANGES[0]}" != "$ALLOWED_DOCUMENT" ]; then
+            echo "::error::Tracked diff does not exactly match the documentation allowlist."
+            printf 'Tracked change: %s\n' "${TRACKED_CHANGES[@]}"
+            exit 1
+          fi
+
+          git diff --check HEAD -- "$ALLOWED_DOCUMENT"
+          node scripts/check-documentation.mjs
+
+          PATCH_BYTES=$(git diff HEAD --binary -- "$ALLOWED_DOCUMENT" | wc -c)
+          if [ "$PATCH_BYTES" -gt 1048576 ]; then
+            echo "::error::Documentation patch is larger than the 1 MiB artifact limit."
+            exit 1
+          fi
+
+          git diff HEAD --binary --full-index -- "$ALLOWED_DOCUMENT" > documentation-update.patch
+
+          {
+            echo "## Documentation update proposal"
+            echo
+            echo "- Source commit: \`${GITHUB_SHA}\`"
+            echo "- Changed tracked documents: ${{ steps.process_updates.outputs.update_count }}"
+            echo
+            echo "### Changed files"
+            echo
+            printf -- '- `%s`\n' "$ALLOWED_DOCUMENT"
+          } > update_summary.md
+
+      - name: Upload analysis artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: documentation-analysis-${{ github.run_id }}
+          name: documentation-analysis-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             doc_analysis.json
+            documentation-update.patch
             update_summary.md
-            updates.json
+          if-no-files-found: warn
           retention-days: 7
 
-      - name: ✅ Documentation Update Complete
+      - name: Report analysis result
+        if: always()
         run: |
-          if [ "${{ steps.process_updates.outputs.has_updates }}" = "true" ]; then
-            echo "🎉 Documentation update completed successfully!"
-            echo "Updated files have been committed and pushed."
+          if [ "${{ job.status }}" != "success" ]; then
+            MESSAGE="Documentation analysis or validation failed. Review the job logs and available analysis artifact."
+          elif [ "${{ steps.process_updates.outputs.has_updates }}" = "true" ]; then
+            MESSAGE="A validated documentation patch is available in the documentation-analysis-${{ github.run_id }}-${{ github.run_attempt }} artifact. Download and review it, then apply it on a human-authored branch and open a pull request."
           else
-            echo "✅ Documentation is already up to date with current codebase."
+            MESSAGE="No validated documentation changes were proposed."
           fi
-          
-          echo ""
-          echo "📊 Analysis artifacts available in workflow artifacts"
+
+          echo "$MESSAGE"
+          {
+            echo "## Documentation analysis"
+            echo
+            echo "$MESSAGE"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -10,17 +10,23 @@ permissions:
 
 jobs:
   documentation-audit:
-    name: 📋 Documentation Integrity Check
+    # Keep this name stable: branch protection requires this exact context.
+    name: docs:check
     runs-on: ubuntu-latest
     
     steps:
       - name: 📥 Checkout Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
         
       - name: 🔧 Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20.19.0'
+
+      - name: 🧪 Test Documentation Link Checker
+        run: npm run docs:links:test
           
       - name: 🔍 Run Documentation Audit
         id: audit

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -1,0 +1,97 @@
+name: Documentation Link Audit
+
+on:
+  schedule:
+    - cron: '17 13 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: documentation-link-audit
+  cancel-in-progress: false
+
+jobs:
+  documentation-links:
+    name: Documentation link integrity
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.19.0'
+
+      - name: Check maintained documentation links
+        id: audit
+        shell: bash
+        run: |
+          set +e
+          npm run docs:links -- --json-report "$RUNNER_TEMP/documentation-link-report.json" \
+            | tee "$RUNNER_TEMP/documentation-link-audit.txt"
+          AUDIT_EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+          echo "exit-code=$AUDIT_EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+      - name: Write job summary
+        if: always()
+        shell: bash
+        run: |
+          node --input-type=module <<'NODE'
+          import { appendFileSync, existsSync, readFileSync } from 'node:fs';
+
+          const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+          const reportPath = `${process.env.RUNNER_TEMP}/documentation-link-report.json`;
+          let summary = '## Documentation link audit\n\n';
+
+          if (!existsSync(reportPath)) {
+            summary += 'The audit did not produce a report. Review the job log for the startup failure.\n';
+          } else {
+            const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+            summary += [
+              '| Measure | Result |',
+              '| --- | ---: |',
+              `| Maintained Markdown files | ${report.filesScanned} |`,
+              `| Local targets passed | ${report.local.passed} |`,
+              `| Local targets failed | ${report.local.failed} |`,
+              `| External URLs passed | ${report.external.passed} |`,
+              `| External URLs failed | ${report.external.failed} |`,
+              `| External URL warnings | ${report.external.warnings} |`,
+              '',
+              report.errors === 0
+                ? 'No definitive broken links were found.'
+                : `${report.errors} definitive link failure(s) were found.`,
+              '',
+              'Transient network responses and access-restricted URLs are reported as warnings. '
+                + 'The complete redacted report is attached to this run.',
+              '',
+            ].join('\n');
+          }
+
+          appendFileSync(summaryPath, summary, 'utf8');
+          NODE
+
+      - name: Upload redacted audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation-link-audit-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/documentation-link-audit.txt
+            ${{ runner.temp }}/documentation-link-report.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Fail on definitive link issues
+        if: always() && steps.audit.outputs.exit-code != '0'
+        shell: bash
+        run: |
+          echo "::error::Documentation link audit found a definitive failure or could not complete."
+          exit 1

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -10,12 +10,15 @@ This repository uses GitHub Actions workflows in `.github/workflows/` for build/
 
 ## Setup
 Core workflows to review first:
-- `.github/workflows/ci-cd.yml`
-- `.github/workflows/pr-ci.yml`
-- `.github/workflows/doc-audit.yml`
-- `.github/workflows/arcanos-release.yml`
-- `.github/workflows/arcanos-deploy.yml`
-- `.github/workflows/railway-auto-deploy.yml`
+
+- [CI/CD pipeline](../.github/workflows/ci-cd.yml)
+- [PR CI](../.github/workflows/pr-ci.yml)
+- [Documentation audit](../.github/workflows/doc-audit.yml)
+- [Documentation update analysis](../.github/workflows/auto-update-documentation.yml)
+- [Documentation link audit](../.github/workflows/documentation-links.yml)
+- [Release](../.github/workflows/arcanos-release.yml)
+- [Arcanos deployment](../.github/workflows/arcanos-deploy.yml)
+- [Railway automatic deployment](../.github/workflows/railway-auto-deploy.yml)
 
 ## Configuration
 Common secrets referenced in workflows:
@@ -28,6 +31,18 @@ Environment separation guidance:
 - Keep production and development secrets separate in both Railway and GitHub.
 - Restrict deployment-triggering workflows to protected branches.
 
+Documentation automation boundaries:
+
+- The `docs:check` job in `.github/workflows/doc-audit.yml` is the stable
+  documentation-integrity status context required on `main`.
+- `.github/workflows/auto-update-documentation.yml` is report-only. It has
+  `contents: read`, validates bounded output for its single maintained target,
+  and uploads a patch for human review. It never commits, pushes, or opens a
+  pull request.
+- `.github/workflows/documentation-links.yml` runs a read-only external-link
+  audit every Monday at 13:17 UTC and on manual dispatch. It writes only a job
+  summary and a redacted workflow artifact.
+
 ## Run locally
 Pre-CI local validation:
 ```bash
@@ -35,6 +50,8 @@ npm run type-check
 npm run lint
 npm test
 npm run build
+npm run docs:check
+npm run docs:links -- --local-only
 npm run validate:railway
 ```
 
@@ -44,16 +61,21 @@ Deployment workflows are repository-specific; verify current trigger and require
 ## Troubleshooting
 - Workflow fails on missing secret: add the secret in GitHub settings or disable that job.
 - Deployment job fails after build passes: validate Railway auth token and service linkage.
-- Docs audit fails: run `./scripts/doc_audit.sh` locally.
+- Docs audit fails: run `npm run docs:check` locally.
+- Scheduled link audit fails: run `npm run docs:links`; treat access-restricted
+  or transient results as warnings and repair definitive failures.
 
 ## References
-- `../.github/workflows/ci-cd.yml`
-- `../.github/workflows/pr-ci.yml`
-- `../.github/workflows/doc-audit.yml`
-- `../.github/workflows/arcanos-deploy.yml`
-- `../.github/workflows/railway-auto-deploy.yml`
-- `../railway.json`
-- `RAILWAY_DEPLOYMENT.md`
+
+- [CI/CD pipeline](../.github/workflows/ci-cd.yml)
+- [PR CI](../.github/workflows/pr-ci.yml)
+- [Documentation audit](../.github/workflows/doc-audit.yml)
+- [Documentation update analysis](../.github/workflows/auto-update-documentation.yml)
+- [Documentation link audit](../.github/workflows/documentation-links.yml)
+- [Arcanos deployment](../.github/workflows/arcanos-deploy.yml)
+- [Railway automatic deployment](../.github/workflows/railway-auto-deploy.yml)
+- [Railway configuration](../railway.json)
+- [Railway deployment guide](RAILWAY_DEPLOYMENT.md)
 
 ## Workflow and npm script alignment
 - Ensure that any npm scripts referenced in `.github/workflows/ci-cd.yml` (for example, `npm run audit:sdk-compliance`) are defined in `package.json`, or update the workflow to remove or replace them.

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -24,22 +24,43 @@ New durable facts should go into an existing canonical owner. Avoid creating a
 one-off refactor, migration, review, or status document when the information
 belongs in a maintained guide, changelog entry, test, or dated audit record.
 
-## Canonical owners
+## Canonical ownership and review schedule
 
-| Change | Documentation owner |
-| --- | --- |
-| Routes, endpoints, and response contracts | [API.md](API.md) |
-| Architecture and routing boundaries | [ARCHITECTURE.md](ARCHITECTURE.md) |
-| Environment variables | [CONFIGURATION.md](CONFIGURATION.md) and [../.env.example](../.env.example) |
-| Local setup and startup | [RUN_LOCAL.md](RUN_LOCAL.md) |
-| Railway build, start, health, and rollback behavior | [RAILWAY_DEPLOYMENT.md](RAILWAY_DEPLOYMENT.md) |
-| OpenAI construction, Responses, tools, and streaming | [OPENAI_RESPONSES_TOOLS.md](OPENAI_RESPONSES_TOOLS.md) |
-| Workspace packages and exports | [WORKSPACE_PACKAGES.md](WORKSPACE_PACKAGES.md) |
-| Public protocol and schema changes | [SCHEMA_PROTOCOL_GUIDE.md](SCHEMA_PROTOCOL_GUIDE.md) |
-| Database and migrations | [DATABASE_MIGRATIONS.md](DATABASE_MIGRATIONS.md) |
-| Python daemon behavior | [../daemon-python/README.md](../daemon-python/README.md) |
-| TypeScript CLI behavior | [CLI_OVERVIEW.md](CLI_OVERVIEW.md) |
-| Release-facing changes | [../CHANGELOG.md](../CHANGELOG.md) |
+The accountable reviewer for maintained documentation is
+[@pbjustin](https://github.com/pbjustin). The owner is responsible for making
+sure a review happens and for approving material changes; other contributors
+may still author and review documentation. [CODEOWNERS](../.github/CODEOWNERS)
+routes documentation changes to that reviewer. Branch protection determines
+whether the routed review is required.
+
+An affected document must be reviewed in the same pull request as a behavior,
+contract, dependency, or workflow change. The maximum interval below is a
+backstop for drift when no triggering change is noticed, not permission to
+postpone a known update. A review may result in no text change, but should
+verify the guide against current source, tests, executable configuration, and
+required CI. The repository-wide review completed on 2026-07-23 is the initial
+baseline for the intervals below. A later content commit or pull request that
+explicitly records a no-change review resets the interval for the named
+document; formatting-only edits do not.
+
+| Surface | Canonical document or record | Review trigger | Maximum interval |
+| --- | --- | --- | --- |
+| Routes, endpoints, and response contracts | [API.md](API.md) | Route, middleware, request, response, or authentication change | 90 days |
+| Architecture and routing boundaries | [ARCHITECTURE.md](ARCHITECTURE.md) | Component, dependency, execution-boundary, or routing change | 90 days |
+| CI and delivery | [CI_CD.md](CI_CD.md) | Required check, workflow, release, or environment-boundary change | 90 days |
+| Environment variables | [CONFIGURATION.md](CONFIGURATION.md) and [../.env.example](../.env.example) | Variable, default, validation, or secret-handling change | 90 days |
+| Local setup and diagnosis | [RUN_LOCAL.md](RUN_LOCAL.md) and [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Install, build, startup, developer-tool, or recurring-failure change | 90 days |
+| Railway build and operations | [RAILWAY_DEPLOYMENT.md](RAILWAY_DEPLOYMENT.md) | Build, launcher, health, topology, deploy, or rollback change; after a relevant incident | 90 days |
+| Runtime resilience | [STARTUP_RESILIENCE.md](STARTUP_RESILIENCE.md), [REDIS_RESILIENCE_RUNBOOK.md](REDIS_RESILIENCE_RUNBOOK.md), and [SOLO_OPERATOR_RUNTIME_GUIDE.md](SOLO_OPERATOR_RUNTIME_GUIDE.md) | Dependency lifecycle, recovery, monitoring, authentication, or operator-workflow change; after a relevant incident | 90 days |
+| OpenAI construction and tools | [OPENAI_RESPONSES_TOOLS.md](OPENAI_RESPONSES_TOOLS.md) | SDK, model, adapter, tool, streaming, retry, or retention change | 90 days |
+| Workspace packages and exports | [WORKSPACE_PACKAGES.md](WORKSPACE_PACKAGES.md) | Workspace, export-map, package API, or shared-helper change | 90 days |
+| Public protocol and schemas | [SCHEMA_PROTOCOL_GUIDE.md](SCHEMA_PROTOCOL_GUIDE.md) | Command, schema, catalog, validator, or TypeScript-Python contract change | 90 days |
+| Database and migrations | [DATABASE_MIGRATIONS.md](DATABASE_MIGRATIONS.md) | Schema, migration, repository, initialization, or validation change | 90 days |
+| GPT access and memory | [gpt-access-gateway.md](gpt-access-gateway.md) and [MEMORY_BACKEND_USAGE.md](MEMORY_BACKEND_USAGE.md) | Gateway, scope, confirmation, persistence, retrieval, or authorization-boundary change | 90 days |
+| TypeScript CLI behavior | [CLI_OVERVIEW.md](CLI_OVERVIEW.md) | Command, flag, transport, output, or packaging change | 90 days |
+| Python daemon behavior | [../daemon-python/README.md](../daemon-python/README.md) | Command, daemon API, protocol consumer, install, or packaging change | 90 days |
+| Documentation governance and navigation | This document and [README.md](README.md) | Canonical-owner, lifecycle, naming, generated-index, or checker change | 180 days |
+| Release-facing changes | [../CHANGELOG.md](../CHANGELOG.md) | Every release or user-visible compatibility change | Every release |
 
 Security contracts, GPT-OSS validators, and migration-local READMEs may have
 additional fixed-path requirements. Check nearby tests and validation scripts
@@ -59,9 +80,43 @@ generated indexes as substitutes for correcting source organization.
 
 ## Historical evidence
 
-Tracked files under [audits/](audits/) are dated evidence. Preserve them when
-tests, approvals, incident review, or migration history depend on their exact
-content. They are not part of the active reading path.
+Canonical and companion guides describe current supported behavior. Test
+results, approval records, proposals, incident timelines, point-in-time
+topology, and migration observations are historical evidence even when they
+were produced during work on a canonical guide. Put the durable conclusion or
+current procedure in the canonical guide and keep the supporting snapshot
+under [audits/](audits/). Do not turn a maintained guide into a chronological
+evidence log.
+
+Use this layout for new tracked documentation evidence sets:
+
+```text
+docs/audits/<topic>/YYYY-MM-DD/<optional-scope>/
+```
+
+- Use lower-kebab-case for `<topic>`, `<optional-scope>`, and artifact names.
+- Use the UTC capture or incident-start date. Put the date in the directory,
+  not every filename.
+- For incidents, use `docs/audits/incidents/YYYY-MM-DD/<incident-slug>/`.
+- A single small artifact may live directly in the dated directory. Give a
+  multi-file evidence set a `README.md` that identifies its historical
+  lifecycle, purpose, capture boundary, validation status, relevant canonical
+  guide, and whether any included action was merely proposed or actually
+  authorized and executed.
+- Keep machine-readable results in stable formats such as JSON or CSV and
+  redact credentials, tokens, personal data, and sensitive payloads before
+  tracking them.
+- If a test or validator consumes an evidence path, treat it as docs-as-contract
+  and update the consumer in the same change.
+- Machine-enforced evidence stores with an existing contract, such as
+  `governance/evidence_packs/`, remain at that contract-defined path.
+
+Existing evidence directories are grandfathered: do not move them solely to
+match this convention. Apply the layout to new evidence sets, and normalize an
+old set only when a scoped change already requires moving it and all inbound
+references can be updated. Tracked historical evidence should otherwise remain
+immutable; add a new dated artifact or an explicitly identified correction
+instead of silently rewriting a captured result.
 
 Untracked audit artifacts belong to their creator until explicitly brought into
 scope. Do not rewrite or delete them as incidental documentation cleanup.
@@ -101,6 +156,20 @@ documentation index. The legacy Bash entry point delegates to the same check:
 ```bash
 ./scripts/doc_audit.sh
 ```
+
+Validate maintained-document links locally without network access:
+
+```bash
+npm run docs:links -- --local-only
+```
+
+The read-only [Documentation Link Audit](../.github/workflows/documentation-links.yml)
+runs every Monday at 13:17 UTC and on manual dispatch. It checks external links
+with bounded concurrency, redirects, retries, and timeouts, then uploads a
+redacted JSON report. Definitive broken links fail the scheduled run;
+access-restricted or transient network results remain warnings. Historical
+evidence under `docs/audits/` is excluded because it is an immutable snapshot,
+not maintained navigation.
 
 Use real Markdown links for navigation. Backticked paths are appropriate for
 copyable source locations and commands, but they are not substitutes for links

--- a/governance/README.md
+++ b/governance/README.md
@@ -29,6 +29,13 @@ Protect `main` in GitHub with:
 
 1. pull requests required before merging;
 2. at least one approving review; and
-3. required status checks for the `build-test` job from the `PR CI` workflow and the `require-approval` job from the `Require Human Approval (Self-Improve)` workflow.
+3. required status checks for the `build-test` job from the `PR CI`
+   workflow, the `require-approval` job from the `Require Human Approval
+   (Self-Improve)` workflow, and the `docs:check` job from the `Documentation
+   Audit` workflow.
 
-Optionally require Code Owner review. To establish ownership, copy `templates/CODEOWNERS.example` to `.github/CODEOWNERS` and replace its placeholder handles. The approval workflow is label-driven, so the same gate can be applied to another pull request by adding a covered label.
+The active [CODEOWNERS](../.github/CODEOWNERS) file routes repository,
+documentation, daemon, and workflow changes to the current maintainer.
+Optionally require Code Owner review through branch protection. The approval
+workflow is label-driven, so the same gate can be applied to another pull
+request by adding a covered label.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "type-check": "npm run check:boundaries && npm run check:cef-layer-access && npm run check:routing-boundaries && npm run build:packages && tsc --noEmit",
     "reindex": "node scripts/reindex-codebase.js",
     "docs:check": "node scripts/check-documentation.mjs",
+    "docs:links": "node scripts/check-documentation-links.mjs",
+    "docs:links:test": "node --test scripts/check-documentation-links.test.mjs",
     "lint": "eslint src tests packages workers arcanos-ai-runtime",
     "lint:fix": "eslint src tests packages workers arcanos-ai-runtime --fix",
     "assistants-sync": "npx ts-node scripts/assistants-sync.ts",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,6 +22,8 @@ Automation-token flows require the backend's `ARCANOS_AUTOMATION_SECRET`.
 ## Run locally
 Common scripts:
 - `npm run docs:check` (cross-platform documentation audit)
+- `npm run docs:links -- --local-only` (maintained-document links without network access)
+- `npm run docs:links` (bounded external-link audit; network access required)
 - `./scripts/doc_audit.sh` (Bash compatibility wrapper)
 - `node scripts/validate-railway-compatibility.js`
 - `node scripts/check-railway-timeout-regressions.js --since 30m --lines 400`

--- a/scripts/check-documentation-links.mjs
+++ b/scripts/check-documentation-links.mjs
@@ -1,0 +1,1628 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { lookup } from 'node:dns/promises';
+import {
+  existsSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import { isIP } from 'node:net';
+import {
+  dirname,
+  extname,
+  isAbsolute,
+  relative,
+  resolve,
+} from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = realpathSync(process.cwd());
+const maintainedMarkdownExclusions = [
+  'docs/audits/',
+];
+const defaultOptions = {
+  concurrency: 8,
+  jsonReport: '',
+  localOnly: false,
+  requestTimeoutMs: 10_000,
+  retries: 2,
+};
+const externalRequestHeaders = {
+  Accept: 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.1',
+  Connection: 'close',
+  'User-Agent': 'Arcanos-Documentation-Link-Audit/1.0',
+};
+const permanentFailureReasons = new Set([
+  'CERT_HAS_EXPIRED',
+  'CERT_NOT_YET_VALID',
+  'DEPTH_ZERO_SELF_SIGNED_CERT',
+  'EAI_NONAME',
+  'EBADNAME',
+  'ENODATA',
+  'ENOTFOUND',
+  'ERR_INVALID_URL',
+  'ERR_UNESCAPED_CHARACTERS',
+  'ERR_TLS_CERT_ALTNAME_INVALID',
+  'ERR_TLS_CERT_SIGNATURE_ALGORITHM_UNSUPPORTED',
+  'SELF_SIGNED_CERT_IN_CHAIN',
+  'UNABLE_TO_GET_ISSUER_CERT',
+  'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+  'embedded-credentials',
+  'private-host',
+  'too-many-redirects',
+  'unsupported-protocol',
+]);
+
+function usage() {
+  process.stdout.write(`Usage: node scripts/check-documentation-links.mjs [options]
+
+Options:
+  --local-only          Validate local files and anchors without network requests
+  --concurrency <n>     Maximum simultaneous external checks (default: 8)
+  --timeout-ms <n>      Per-request timeout in milliseconds (default: 10000)
+  --retries <n>         Retries for transient external failures (default: 2)
+  --json-report <path>  Write a machine-readable report
+  --help                Show this help
+`);
+}
+
+function integerOption(name, rawValue, minimum, maximum) {
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return parsed;
+}
+
+function parseArguments(argv) {
+  const options = { ...defaultOptions };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const [name, inlineValue] = argument.split('=', 2);
+    const nextValue = () => {
+      if (inlineValue !== undefined) {
+        return inlineValue;
+      }
+      index += 1;
+      if (index >= argv.length) {
+        throw new Error(`${name} requires a value`);
+      }
+      return argv[index];
+    };
+
+    switch (name) {
+      case '--concurrency':
+        options.concurrency = integerOption(name, nextValue(), 1, 32);
+        break;
+      case '--help':
+        usage();
+        process.exit(0);
+        break;
+      case '--json-report':
+        options.jsonReport = nextValue();
+        break;
+      case '--local-only':
+        options.localOnly = true;
+        break;
+      case '--retries':
+        options.retries = integerOption(name, nextValue(), 0, 5);
+        break;
+      case '--timeout-ms':
+        options.requestTimeoutMs = integerOption(name, nextValue(), 1_000, 60_000);
+        break;
+      default:
+        throw new Error(`Unknown option: ${name}`);
+    }
+  }
+
+  return options;
+}
+
+function trackedMarkdownFiles(root = repositoryRoot) {
+  const result = spawnSync(
+    'git',
+    ['ls-files', '-z', '--', '*.md'],
+    { cwd: root, encoding: 'utf8' },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || 'git ls-files failed');
+  }
+
+  return result.stdout
+    .split('\0')
+    .filter(Boolean)
+    .map((path) => path.replaceAll('\\', '/'))
+    .filter((path) => (
+      !maintainedMarkdownExclusions.some((prefix) => path.startsWith(prefix))
+      && existsSync(resolve(root, path))
+    ));
+}
+
+function maskRange(characters, start, end) {
+  for (let index = start; index < end; index += 1) {
+    if (characters[index] !== '\r' && characters[index] !== '\n') {
+      characters[index] = ' ';
+    }
+  }
+}
+
+function sourceLines(source) {
+  const lines = [];
+  let start = 0;
+
+  while (start < source.length) {
+    let end = source.indexOf('\n', start);
+    if (end < 0) {
+      end = source.length;
+    } else {
+      end += 1;
+    }
+    const contentEnd = source[end - 1] === '\n'
+      ? end - (source[end - 2] === '\r' ? 2 : 1)
+      : end;
+    lines.push({
+      content: source.slice(start, contentEnd),
+      contentEnd,
+      end,
+      start,
+    });
+    start = end;
+  }
+
+  return lines;
+}
+
+function maskMarkdownBlocks(source) {
+  const characters = source.split('');
+
+  for (let start = source.indexOf('<!--'); start >= 0;) {
+    const closing = source.indexOf('-->', start + 4);
+    const end = closing < 0 ? source.length : closing + 3;
+    maskRange(characters, start, end);
+    start = source.indexOf('<!--', end);
+  }
+
+  let activeFence = null;
+  let activeIndentedCode = false;
+  let paragraphOpen = false;
+  for (const line of sourceLines(characters.join(''))) {
+    const containerContent = line.content.replace(
+      /^(?: {0,3}>[ \t]?)+/u,
+      '',
+    );
+    if (activeFence) {
+      maskRange(characters, line.start, line.end);
+      const closing = containerContent.match(/^ {0,3}(`+|~+)[ \t]*$/u);
+      if (
+        closing
+        && closing[1][0] === activeFence.marker
+        && closing[1].length >= activeFence.length
+      ) {
+        activeFence = null;
+      }
+      continue;
+    }
+
+    const blank = /^[\t ]*$/u.test(containerContent);
+    const indentation = indentationColumns(containerContent);
+    if (activeIndentedCode) {
+      if (blank || indentation >= 4) {
+        maskRange(characters, line.start, line.end);
+        continue;
+      }
+      activeIndentedCode = false;
+    }
+
+    const opening = containerContent.match(/^ {0,3}(`{3,}|~{3,})(.*)$/u);
+    if (opening && !(opening[1][0] === '`' && opening[2].includes('`'))) {
+      activeFence = {
+        length: opening[1].length,
+        marker: opening[1][0],
+      };
+      maskRange(characters, line.start, line.end);
+      paragraphOpen = false;
+      continue;
+    }
+
+    if (blank) {
+      paragraphOpen = false;
+      continue;
+    }
+
+    if (indentation >= 4 && !paragraphOpen) {
+      activeIndentedCode = true;
+      maskRange(characters, line.start, line.end);
+      continue;
+    }
+
+    const leaf = containerContent.slice(indentationCharacterCount(
+      containerContent,
+      Math.min(indentation, 3),
+    ));
+    if (
+      /^#{1,6}(?:[ \t]+|$)/u.test(leaf)
+      || /^(?:=+|-+)[ \t]*$/u.test(leaf)
+      || /^(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/u.test(leaf)
+    ) {
+      paragraphOpen = false;
+    } else {
+      paragraphOpen = true;
+    }
+  }
+
+  return characters.join('');
+}
+
+function indentationColumns(value) {
+  let columns = 0;
+  for (const character of value) {
+    if (character === ' ') {
+      columns += 1;
+    } else if (character === '\t') {
+      columns += 4 - (columns % 4);
+    } else {
+      break;
+    }
+  }
+  return columns;
+}
+
+function indentationCharacterCount(value, maximumColumns) {
+  let columns = 0;
+  let index = 0;
+  while (index < value.length && columns < maximumColumns) {
+    if (value[index] === ' ') {
+      columns += 1;
+    } else if (value[index] === '\t') {
+      columns += 4 - (columns % 4);
+    } else {
+      break;
+    }
+    index += 1;
+  }
+  return index;
+}
+
+function maskNonLinkMarkdown(source) {
+  const characters = maskMarkdownBlocks(source).split('');
+  const masked = characters.join('');
+
+  for (let index = 0; index < masked.length;) {
+    if (masked[index] !== '`') {
+      index += 1;
+      continue;
+    }
+
+    let openingEnd = index + 1;
+    while (masked[openingEnd] === '`') {
+      openingEnd += 1;
+    }
+    const delimiterLength = openingEnd - index;
+    let cursor = openingEnd;
+    let closingEnd = -1;
+
+    while (cursor < masked.length) {
+      const nextTick = masked.indexOf('`', cursor);
+      if (nextTick < 0) {
+        break;
+      }
+      let runEnd = nextTick + 1;
+      while (masked[runEnd] === '`') {
+        runEnd += 1;
+      }
+      if (runEnd - nextTick === delimiterLength) {
+        closingEnd = runEnd;
+        break;
+      }
+      cursor = runEnd;
+    }
+
+    if (closingEnd < 0) {
+      index = openingEnd;
+      continue;
+    }
+    maskRange(characters, index, closingEnd);
+    index = closingEnd;
+  }
+
+  return characters.join('');
+}
+
+function lineStartOffsets(source) {
+  const offsets = [0];
+  for (let index = 0; index < source.length; index += 1) {
+    if (source.charCodeAt(index) === 10) {
+      offsets.push(index + 1);
+    }
+  }
+  return offsets;
+}
+
+function lineNumberAt(offsets, index) {
+  let low = 0;
+  let high = offsets.length;
+  while (low < high) {
+    const middle = low + Math.floor((high - low) / 2);
+    if (offsets[middle] <= index) {
+      low = middle + 1;
+    } else {
+      high = middle;
+    }
+  }
+  return low;
+}
+
+function isEscaped(source, index) {
+  let backslashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && source[cursor] === '\\'; cursor -= 1) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
+}
+
+function decodeHtmlEntities(value) {
+  return value.replace(
+    /&(?:#(\d+)|#x([\da-f]+)|amp|apos|gt|lt|quot);/giu,
+    (entity, decimal, hexadecimal) => {
+      if (decimal) {
+        return String.fromCodePoint(Number.parseInt(decimal, 10));
+      }
+      if (hexadecimal) {
+        return String.fromCodePoint(Number.parseInt(hexadecimal, 16));
+      }
+      return {
+        '&amp;': '&',
+        '&apos;': "'",
+        '&gt;': '>',
+        '&lt;': '<',
+        '&quot;': '"',
+      }[entity.toLocaleLowerCase('en-US')] ?? entity;
+    },
+  );
+}
+
+function unescapeMarkdown(value) {
+  return decodeHtmlEntities(
+    value.replace(/\\([!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/gu, '$1'),
+  );
+}
+
+function normalizedMarkdownTarget(rawTarget) {
+  return unescapeMarkdown(rawTarget.trim());
+}
+
+function findClosingBracket(source, openingIndex) {
+  let depth = 0;
+  for (let index = openingIndex; index < source.length; index += 1) {
+    if (isEscaped(source, index)) {
+      continue;
+    }
+    if (source[index] === '[') {
+      depth += 1;
+    } else if (source[index] === ']') {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  return -1;
+}
+
+function skipMarkdownWhitespace(source, start) {
+  let index = start;
+  while (/[\t\n\r ]/u.test(source[index] ?? '')) {
+    index += 1;
+  }
+  return index;
+}
+
+function parseLinkTitleAndClose(source, start) {
+  let index = skipMarkdownWhitespace(source, start);
+  if (source[index] === ')') {
+    return index;
+  }
+
+  const opener = source[index];
+  const closer = opener === '(' ? ')' : opener;
+  if (!['"', "'", '('].includes(opener)) {
+    return -1;
+  }
+  index += 1;
+
+  for (; index < source.length; index += 1) {
+    if (source[index] === '\n' && source[index + 1] === '\n') {
+      return -1;
+    }
+    if (source[index] === closer && !isEscaped(source, index)) {
+      const closingParenthesis = skipMarkdownWhitespace(source, index + 1);
+      return source[closingParenthesis] === ')' ? closingParenthesis : -1;
+    }
+  }
+  return -1;
+}
+
+function parseInlineDestination(source, openingParenthesis) {
+  let index = skipMarkdownWhitespace(source, openingParenthesis + 1);
+  let target = '';
+  let targetEnd = index;
+  let targetStart = index;
+
+  if (source[index] === '<') {
+    targetStart = index + 1;
+    index += 1;
+    let foundClosingBracket = false;
+    for (; index < source.length; index += 1) {
+      if (source[index] === '\n' || source[index] === '\r') {
+        return null;
+      }
+      if (source[index] === '>' && !isEscaped(source, index)) {
+        targetEnd = index;
+        target = source.slice(targetStart, index);
+        index += 1;
+        foundClosingBracket = true;
+        break;
+      }
+    }
+    if (!foundClosingBracket) {
+      return null;
+    }
+  } else {
+    targetStart = index;
+    let parenthesisDepth = 0;
+
+    for (; index < source.length; index += 1) {
+      const character = source[index];
+      if (isEscaped(source, index)) {
+        continue;
+      }
+      if (character === '(') {
+        parenthesisDepth += 1;
+        continue;
+      }
+      if (character === ')') {
+        if (parenthesisDepth === 0) {
+          targetEnd = index;
+          target = source.slice(targetStart, index);
+          return {
+            closingIndex: index,
+            target,
+            targetEnd,
+            targetStart,
+          };
+        }
+        parenthesisDepth -= 1;
+        continue;
+      }
+      if (/[\t\n\r ]/u.test(character) && parenthesisDepth === 0) {
+        targetEnd = index;
+        target = source.slice(targetStart, index);
+        break;
+      }
+      if (character === '<') {
+        return null;
+      }
+    }
+  }
+
+  const closingIndex = parseLinkTitleAndClose(source, index);
+  if (closingIndex < 0) {
+    return null;
+  }
+  return {
+    closingIndex,
+    target,
+    targetEnd,
+    targetStart,
+  };
+}
+
+function parseReferenceDestination(source, start, end) {
+  let index = start;
+  while (index < end && /[\t ]/u.test(source[index])) {
+    index += 1;
+  }
+
+  if (source[index] === '<') {
+    const targetStart = index + 1;
+    for (index += 1; index < end; index += 1) {
+      if (source[index] === '>' && !isEscaped(source, index)) {
+        return {
+          target: source.slice(targetStart, index),
+          targetEnd: index,
+          targetStart,
+        };
+      }
+    }
+    return null;
+  }
+
+  const targetStart = index;
+  let parenthesisDepth = 0;
+  for (; index < end; index += 1) {
+    const character = source[index];
+    if (isEscaped(source, index)) {
+      continue;
+    }
+    if (character === '(') {
+      parenthesisDepth += 1;
+    } else if (character === ')' && parenthesisDepth > 0) {
+      parenthesisDepth -= 1;
+    } else if (/[\t ]/u.test(character) && parenthesisDepth === 0) {
+      break;
+    }
+  }
+  if (index === targetStart) {
+    return null;
+  }
+  return {
+    target: source.slice(targetStart, index),
+    targetEnd: index,
+    targetStart,
+  };
+}
+
+function findHtmlTagEnd(source, start, allowNewlines = false) {
+  let quote = '';
+  for (let index = start + 1; index < source.length; index += 1) {
+    const character = source[index];
+    if (quote) {
+      if (character === quote) {
+        quote = '';
+      }
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === '>') {
+      return index;
+    } else if (!allowNewlines && (character === '\n' || character === '\r')) {
+      return -1;
+    }
+  }
+  return -1;
+}
+
+function extractLinks(source, relativePath) {
+  const masked = maskNonLinkMarkdown(source);
+  const lineOffsets = lineStartOffsets(masked);
+  const links = [];
+  const seenRanges = new Set();
+  const addLink = (rawTarget, index, targetStart, targetEnd) => {
+    if (rawTarget === null || rawTarget === undefined) {
+      return;
+    }
+    const target = normalizedMarkdownTarget(rawTarget);
+    const line = lineNumberAt(lineOffsets, index);
+    const key = `${targetStart}:${targetEnd}`;
+    if (!seenRanges.has(key)) {
+      seenRanges.add(key);
+      links.push({
+        file: relativePath,
+        line,
+        target,
+        targetEnd,
+        targetStart,
+      });
+    }
+  };
+
+  for (let index = 0; index < masked.length; index += 1) {
+    const openingBracket = masked[index] === '!'
+      && masked[index + 1] === '['
+      && !isEscaped(masked, index)
+      ? index + 1
+      : index;
+    if (masked[openingBracket] !== '[' || isEscaped(masked, openingBracket)) {
+      continue;
+    }
+    const closingBracket = findClosingBracket(masked, openingBracket);
+    if (closingBracket < 0 || masked[closingBracket + 1] !== '(') {
+      continue;
+    }
+    const parsed = parseInlineDestination(masked, closingBracket + 1);
+    if (parsed) {
+      addLink(
+        parsed.target,
+        index,
+        parsed.targetStart,
+        parsed.targetEnd,
+      );
+    }
+  }
+
+  const lines = sourceLines(masked);
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex];
+    const indentation = line.content.match(/^ {0,3}/u)?.[0].length ?? 0;
+    const openingBracket = line.start + indentation;
+    if (masked[openingBracket] !== '[') {
+      continue;
+    }
+    const closingBracket = findClosingBracket(masked, openingBracket);
+    if (
+      closingBracket < 0
+      || closingBracket >= line.contentEnd
+      || masked[closingBracket + 1] !== ':'
+    ) {
+      continue;
+    }
+    let destinationStart = closingBracket + 2;
+    let destinationEnd = line.contentEnd;
+    if (
+      /^[\t ]*$/u.test(masked.slice(destinationStart, destinationEnd))
+      && lines[lineIndex + 1]
+    ) {
+      const continuation = lines[lineIndex + 1];
+      const continuationIndent = continuation.content.match(/^ {0,3}/u)?.[0].length ?? 0;
+      destinationStart = continuation.start + continuationIndent;
+      destinationEnd = continuation.contentEnd;
+    }
+    const parsed = parseReferenceDestination(
+      masked,
+      destinationStart,
+      destinationEnd,
+    );
+    if (parsed) {
+      addLink(
+        parsed.target,
+        openingBracket,
+        parsed.targetStart,
+        parsed.targetEnd,
+      );
+    }
+  }
+
+  for (let index = masked.indexOf('<'); index >= 0;) {
+    const isHtmlTag = /^<(?:a|area|img|source)\b/iu.test(masked.slice(index));
+    const isAutolink = (
+      /^<[a-z][a-z\d+.-]{0,31}:/iu.test(masked.slice(index))
+      || /^<[\w.!#$%&'*+/=?^`{|}~-]+@/u.test(masked.slice(index))
+    );
+    if (!isHtmlTag && !isAutolink) {
+      index = masked.indexOf('<', index + 1);
+      continue;
+    }
+
+    const tagEnd = findHtmlTagEnd(masked, index, isHtmlTag);
+    if (tagEnd < 0) {
+      index = masked.indexOf('<', index + 1);
+      continue;
+    }
+
+    const tag = masked.slice(index, tagEnd + 1);
+    const autolink = tag.match(
+      /^<([a-z][a-z\d+.-]{0,31}:[^\s<>]*)>$/iu,
+    );
+    if (autolink) {
+      addLink(autolink[1], index, index + 1, tagEnd);
+    } else if (/^<[\w.!#$%&'*+/=?^`{|}~-]+@[^<>\s]+>$/u.test(tag)) {
+      addLink(`mailto:${tag.slice(1, -1)}`, index, index + 1, tagEnd);
+    } else if (isHtmlTag) {
+      const attributes = tag.matchAll(
+        /(?:^|[\t\n\r ])(?:href|src)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/gimu,
+      );
+      for (const match of attributes) {
+        const rawTarget = match[1] ?? match[2] ?? match[3];
+        const attributeStart = index + (match.index ?? 0);
+        const valueOffset = match[0].lastIndexOf(rawTarget);
+        const targetStart = attributeStart + valueOffset;
+        addLink(
+          rawTarget,
+          attributeStart,
+          targetStart,
+          targetStart + rawTarget.length,
+        );
+      }
+    }
+    index = masked.indexOf('<', tagEnd + 1);
+  }
+
+  for (const match of masked.matchAll(/\bhttps?:\/\//giu)) {
+    const start = match.index ?? 0;
+    let index = start;
+    let parenthesisDepth = 0;
+    while (index < masked.length) {
+      const character = masked[index];
+      if (/[\s<>"'`]/u.test(character)) {
+        break;
+      }
+      if (character === '(') {
+        parenthesisDepth += 1;
+      } else if (character === ')') {
+        if (parenthesisDepth === 0) {
+          break;
+        }
+        parenthesisDepth -= 1;
+      }
+      index += 1;
+    }
+    const target = masked
+      .slice(start, index)
+      .replace(/[\].,;:!?]+$/u, '');
+    addLink(target, start, start, start + target.length);
+  }
+
+  return links
+    .sort((left, right) => (
+      left.targetStart - right.targetStart
+      || left.targetEnd - right.targetEnd
+    ))
+    .map(({
+      targetEnd: _targetEnd,
+      targetStart: _targetStart,
+      ...link
+    }) => link);
+}
+
+function decoded(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function localTargetParts(target) {
+  const hashIndex = target.indexOf('#');
+  const queryIndex = target.indexOf('?');
+  const indexes = [hashIndex, queryIndex].filter((index) => index >= 0);
+  const pathEnd = indexes.length > 0 ? Math.min(...indexes) : target.length;
+  const fragment = hashIndex >= 0
+    ? target.slice(hashIndex + 1, queryIndex > hashIndex ? queryIndex : undefined)
+    : '';
+
+  return {
+    fragment: decoded(fragment),
+    path: decoded(target.slice(0, pathEnd)),
+  };
+}
+
+function githubHeadingSlug(rawHeading) {
+  return decodeHtmlEntities(rawHeading)
+    .normalize('NFKC')
+    .replace(/<[^>]+>/gu, '')
+    .replace(/!\[([^\]]*)\]\([^)]*\)/gu, '$1')
+    .replace(/\[([^\]]+)\]\([^)]*\)/gu, '$1')
+    .replace(/[`*_~]/gu, '')
+    .trim()
+    .toLocaleLowerCase('en-US')
+    .replace(/[^\p{L}\p{N}\s_-]/gu, '')
+    .replace(/\s+/gu, '-');
+}
+
+function allocateHeadingSlugs(headings) {
+  const anchors = new Set();
+  const nextSuffixes = new Map();
+
+  for (const heading of headings) {
+    const baseSlug = githubHeadingSlug(heading);
+    if (!baseSlug) {
+      continue;
+    }
+
+    let slug = baseSlug;
+    if (anchors.has(slug)) {
+      let suffix = nextSuffixes.get(baseSlug) ?? 1;
+      do {
+        slug = `${baseSlug}-${suffix}`;
+        suffix += 1;
+      } while (anchors.has(slug));
+      nextSuffixes.set(baseSlug, suffix);
+    } else {
+      nextSuffixes.set(baseSlug, 1);
+    }
+    anchors.add(slug);
+  }
+
+  return anchors;
+}
+
+function markdownAnchorsFromSource(rawSource) {
+  const source = maskMarkdownBlocks(rawSource)
+    .replace(/`+([^`\r\n]*)`+/gu, '$1');
+  const headings = [];
+  const indexedHeadings = [];
+
+  for (const match of source.matchAll(/^ {0,3}#{1,6}[ \t]+(.+?)[ \t]*#*[ \t]*$/gmu)) {
+    indexedHeadings.push({ index: match.index ?? 0, text: match[1] });
+  }
+
+  const lines = sourceLines(source);
+  for (let index = 0; index < lines.length - 1; index += 1) {
+    if (
+      lines[index].content.trim()
+      && /^ {0,3}(?:=+|-+)[ \t]*$/u.test(lines[index + 1].content)
+    ) {
+      indexedHeadings.push({
+        index: lines[index].start,
+        text: lines[index].content.trim(),
+      });
+    }
+  }
+
+  indexedHeadings.sort((left, right) => left.index - right.index);
+  headings.push(...indexedHeadings.map(({ text }) => text));
+  const anchors = allocateHeadingSlugs(headings);
+
+  for (const match of source.matchAll(/\b(?:id|name)\s*=\s*["']([^"']+)["']/giu)) {
+    anchors.add(decoded(match[1]));
+  }
+  return anchors;
+}
+
+const anchorCache = new Map();
+
+function markdownAnchors(absolutePath) {
+  if (!anchorCache.has(absolutePath)) {
+    anchorCache.set(
+      absolutePath,
+      markdownAnchorsFromSource(readFileSync(absolutePath, 'utf8')),
+    );
+  }
+  return anchorCache.get(absolutePath);
+}
+
+function pathInsideRepository(absolutePath, root = repositoryRoot) {
+  const relativePath = relative(root, absolutePath);
+  return relativePath === ''
+    || (
+      !isAbsolute(relativePath)
+      &&
+      relativePath !== '..'
+      && !relativePath.startsWith(`..\\`)
+      && !relativePath.startsWith('../')
+    );
+}
+
+function localIssue(link, message, kind = 'local') {
+  return {
+    ...link,
+    kind,
+    message,
+    severity: 'error',
+  };
+}
+
+function validateLocalLink(link, root = repositoryRoot) {
+  const rootRealPath = realpathSync(root);
+  const { fragment, path } = localTargetParts(link.target);
+  const sourcePath = resolve(rootRealPath, link.file);
+  if (!existsSync(sourcePath)) {
+    return localIssue(link, 'source document does not exist');
+  }
+
+  const sourceRealPath = realpathSync(sourcePath);
+  if (!pathInsideRepository(sourceRealPath, rootRealPath)) {
+    return localIssue(link, 'source document escapes the repository');
+  }
+
+  const targetPath = path
+    ? resolve(dirname(sourcePath), path)
+    : sourcePath;
+  if (!pathInsideRepository(targetPath, rootRealPath)) {
+    return localIssue(link, 'target escapes the repository');
+  }
+  if (!existsSync(targetPath)) {
+    return localIssue(link, 'target does not exist');
+  }
+
+  const targetRealPath = realpathSync(targetPath);
+  if (!pathInsideRepository(targetRealPath, rootRealPath)) {
+    return localIssue(link, 'target escapes the repository');
+  }
+
+  if (
+    fragment
+    && !statSync(targetRealPath).isDirectory()
+    && extname(targetPath).toLocaleLowerCase('en-US') === '.md'
+    && !markdownAnchors(targetRealPath).has(fragment)
+  ) {
+    return localIssue(link, `Markdown anchor not found: #${fragment}`, 'anchor');
+  }
+
+  return null;
+}
+
+function isExternalUrl(target) {
+  return /^https?:\/\//iu.test(target);
+}
+
+function shouldSkipTarget(target) {
+  return (
+    target.startsWith('/')
+    || target.startsWith('//')
+    || /^[a-z][a-z0-9+.-]*:/iu.test(target)
+  );
+}
+
+function redactedUrl(rawUrl) {
+  try {
+    const url = new URL(rawUrl);
+    const queryMarker = url.search ? '?<redacted>' : '';
+    return `${url.protocol}//${url.host}${url.pathname}${queryMarker}`;
+  } catch {
+    return '<invalid URL>';
+  }
+}
+
+function redactedLocalTarget(target) {
+  const queryIndex = target.indexOf('?');
+  if (queryIndex < 0) {
+    return target;
+  }
+  const fragmentIndex = target.indexOf('#', queryIndex);
+  return `${target.slice(0, queryIndex)}?<redacted>${
+    fragmentIndex >= 0 ? target.slice(fragmentIndex) : ''
+  }`;
+}
+
+function redactedErrorMessage(error) {
+  const message = error instanceof Error ? error.message : 'unknown error';
+  return message
+    .replace(/https?:\/\/[^\s]+/giu, (url) => redactedUrl(url))
+    .replace(
+      /\b(api[_-]?key|password|secret|token)=([^\s&]+)/giu,
+      '$1=<redacted>',
+    );
+}
+
+function parseIpv4(address) {
+  const octets = address.split('.');
+  if (
+    octets.length !== 4
+    || octets.some((octet) => !/^(?:0|[1-9]\d{0,2})$/u.test(octet))
+  ) {
+    return null;
+  }
+  const numbers = octets.map(Number);
+  if (numbers.some((octet) => octet > 255)) {
+    return null;
+  }
+  return numbers.reduce((value, octet) => ((value * 256) + octet) >>> 0, 0);
+}
+
+function ipv4InCidr(addressValue, baseAddress, prefixLength) {
+  const baseValue = parseIpv4(baseAddress);
+  const mask = prefixLength === 0
+    ? 0
+    : (0xffffffff << (32 - prefixLength)) >>> 0;
+  return (addressValue & mask) === (baseValue & mask);
+}
+
+const specialIpv4Ranges = [
+  ['0.0.0.0', 8],
+  ['10.0.0.0', 8],
+  ['100.64.0.0', 10],
+  ['127.0.0.0', 8],
+  ['169.254.0.0', 16],
+  ['172.16.0.0', 12],
+  ['192.0.0.0', 24],
+  ['192.0.2.0', 24],
+  ['192.31.196.0', 24],
+  ['192.52.193.0', 24],
+  ['192.88.99.0', 24],
+  ['192.168.0.0', 16],
+  ['192.175.48.0', 24],
+  ['198.18.0.0', 15],
+  ['198.51.100.0', 24],
+  ['203.0.113.0', 24],
+  ['224.0.0.0', 4],
+  ['240.0.0.0', 4],
+];
+
+function parseIpv6(address) {
+  let normalized = address.toLocaleLowerCase('en-US');
+  const ipv4Separator = normalized.lastIndexOf(':');
+  if (normalized.includes('.') && ipv4Separator >= 0) {
+    const ipv4Value = parseIpv4(normalized.slice(ipv4Separator + 1));
+    if (ipv4Value === null) {
+      return null;
+    }
+    normalized = `${normalized.slice(0, ipv4Separator)}:${
+      (ipv4Value >>> 16).toString(16)
+    }:${(ipv4Value & 0xffff).toString(16)}`;
+  }
+
+  const halves = normalized.split('::');
+  if (halves.length > 2) {
+    return null;
+  }
+  const left = halves[0] ? halves[0].split(':') : [];
+  const right = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  const missing = 8 - left.length - right.length;
+  if (
+    missing < 0
+    || (halves.length === 1 && missing !== 0)
+    || (halves.length === 2 && missing < 1)
+  ) {
+    return null;
+  }
+  const groups = [...left, ...Array(missing).fill('0'), ...right];
+  if (
+    groups.length !== 8
+    || groups.some((group) => !/^[\da-f]{1,4}$/u.test(group))
+  ) {
+    return null;
+  }
+  return groups.reduce(
+    (value, group) => (value << 16n) | BigInt(Number.parseInt(group, 16)),
+    0n,
+  );
+}
+
+function ipv6InCidr(addressValue, baseAddress, prefixLength) {
+  const baseValue = parseIpv6(baseAddress);
+  const shift = BigInt(128 - prefixLength);
+  return (addressValue >> shift) === (baseValue >> shift);
+}
+
+const specialIpv6Ranges = [
+  ['::', 96],
+  ['::1', 128],
+  ['::ffff:0:0', 96],
+  ['64:ff9b::', 96],
+  ['64:ff9b:1::', 48],
+  ['100::', 64],
+  ['2001::', 23],
+  ['2001:db8::', 32],
+  ['2002::', 16],
+  ['2620:4f:8000::', 48],
+  ['3fff::', 20],
+  ['5f00::', 16],
+  ['fc00::', 7],
+  ['fe80::', 10],
+  ['fec0::', 10],
+  ['ff00::', 8],
+];
+
+function isPublicIp(address) {
+  const version = isIP(address);
+  if (version === 4) {
+    const value = parseIpv4(address);
+    return value !== null && !specialIpv4Ranges.some(
+      ([baseAddress, prefixLength]) => ipv4InCidr(value, baseAddress, prefixLength),
+    );
+  }
+  if (version === 6) {
+    const value = parseIpv6(address);
+    return value !== null
+      && ipv6InCidr(value, '2000::', 3)
+      && !specialIpv6Ranges.some(
+        ([baseAddress, prefixLength]) => ipv6InCidr(value, baseAddress, prefixLength),
+      );
+  }
+  return false;
+}
+
+function policyError(message, code = '') {
+  const error = new Error(message);
+  if (code) {
+    error.code = code;
+  }
+  return error;
+}
+
+function normalizedHostname(url) {
+  return url.hostname
+    .replace(/^\[(.*)\]$/u, '$1')
+    .replace(/\.$/u, '')
+    .toLocaleLowerCase('en-US');
+}
+
+function assertPublicHttpUrl(url) {
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw policyError('unsupported-protocol');
+  }
+  if (url.username || url.password) {
+    throw policyError('embedded-credentials');
+  }
+
+  const hostname = normalizedHostname(url);
+  if (
+    !hostname
+    || hostname === 'localhost'
+    || hostname.endsWith('.localhost')
+  ) {
+    throw policyError('private-host');
+  }
+  if (isIP(hostname) && !isPublicIp(hostname)) {
+    throw policyError('private-host');
+  }
+  return hostname;
+}
+
+function createPinnedLookup(resolver = lookup) {
+  return (hostname, rawOptions, callback) => {
+    const options = typeof rawOptions === 'number'
+      ? { family: rawOptions }
+      : (rawOptions ?? {});
+
+    Promise.resolve(resolver(hostname, { all: true, verbatim: true }))
+      .then((resolvedAddresses) => {
+        const addresses = Array.isArray(resolvedAddresses)
+          ? resolvedAddresses
+          : [resolvedAddresses];
+        if (
+          addresses.length === 0
+          || addresses.some(({ address, family }) => (
+            isIP(address) !== Number(family)
+            || !isPublicIp(address)
+          ))
+        ) {
+          callback(policyError('private-host', 'ERR_NON_PUBLIC_ADDRESS'));
+          return;
+        }
+
+        const requestedFamily = Number(options.family) || 0;
+        const candidates = addresses
+          .filter(({ family }) => !requestedFamily || family === requestedFamily)
+          .map(({ address, family }) => ({ address, family: Number(family) }));
+        if (candidates.length === 0) {
+          callback(policyError('name resolution returned no usable address', 'ENOTFOUND'));
+          return;
+        }
+
+        if (options.all) {
+          callback(null, candidates);
+        } else {
+          callback(null, candidates[0].address, candidates[0].family);
+        }
+      })
+      .catch((error) => {
+        callback(error instanceof Error ? error : policyError('name resolution failed'));
+      });
+  };
+}
+
+function requestHttpStatus(
+  url,
+  requestTimeoutMs,
+  method,
+  {
+    requestImplementation,
+    resolver = lookup,
+  } = {},
+) {
+  const hostname = assertPublicHttpUrl(url);
+  const directIp = isIP(hostname) !== 0;
+  const transportRequest = requestImplementation
+    ?? (url.protocol === 'https:' ? httpsRequest : httpRequest);
+
+  return new Promise((resolveRequest, rejectRequest) => {
+    let request;
+    let settled = false;
+    const finish = (callback, value) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      callback(value);
+    };
+    const timeout = setTimeout(() => {
+      const error = policyError('request-timeout');
+      error.name = 'TimeoutError';
+      if (request) {
+        request.destroy(error);
+      } else {
+        finish(rejectRequest, error);
+      }
+    }, requestTimeoutMs);
+
+    try {
+      request = transportRequest(
+        {
+          agent: false,
+          headers: externalRequestHeaders,
+          hostname,
+          lookup: directIp ? undefined : createPinnedLookup(resolver),
+          method,
+          path: `${url.pathname}${url.search}`,
+          port: url.port || undefined,
+          protocol: url.protocol,
+          ...(url.protocol === 'https:' && !directIp ? { servername: hostname } : {}),
+        },
+        (response) => {
+          const location = Array.isArray(response.headers.location)
+            ? response.headers.location[0]
+            : response.headers.location;
+          if (response.statusCode === undefined) {
+            finish(rejectRequest, policyError('request-failed'));
+            response.destroy();
+            return;
+          }
+          const result = {
+            location,
+            status: response.statusCode,
+          };
+          finish(resolveRequest, result);
+          response.resume();
+          response.destroy();
+        },
+      );
+      request.once('error', (error) => {
+        finish(rejectRequest, error);
+      });
+      request.end();
+    } catch (error) {
+      finish(rejectRequest, error);
+    }
+  });
+}
+
+async function fetchWithRedirects(
+  rawUrl,
+  requestTimeoutMs,
+  method,
+  dependencies,
+) {
+  let currentUrl = new URL(rawUrl);
+  currentUrl.hash = '';
+
+  for (let redirects = 0; redirects <= 5; redirects += 1) {
+    assertPublicHttpUrl(currentUrl);
+    const response = await requestHttpStatus(
+      currentUrl,
+      requestTimeoutMs,
+      method,
+      dependencies,
+    );
+
+    if (response.status < 300 || response.status >= 400) {
+      return response.status;
+    }
+    if (!response.location) {
+      return response.status;
+    }
+    if (redirects === 5) {
+      throw policyError('too-many-redirects');
+    }
+    currentUrl = new URL(response.location, currentUrl);
+    currentUrl.hash = '';
+  }
+
+  throw policyError('too-many-redirects');
+}
+
+function transientStatus(status) {
+  return status === 408
+    || status === 425
+    || status === 429
+    || status >= 500;
+}
+
+function delay(milliseconds) {
+  return new Promise((resolveDelay) => {
+    setTimeout(resolveDelay, milliseconds);
+  });
+}
+
+function requestFailureReason(error) {
+  if (!(error instanceof Error)) {
+    return 'request-failed';
+  }
+  if (permanentFailureReasons.has(error.message) || error.message === 'request-timeout') {
+    return error.message;
+  }
+
+  const cause = 'cause' in error ? error.cause : undefined;
+  if (
+    cause instanceof Error
+    && (
+      permanentFailureReasons.has(cause.message)
+      || cause.message === 'request-timeout'
+    )
+  ) {
+    return cause.message;
+  }
+  const directCode = 'code' in error && typeof error.code === 'string'
+    ? error.code
+    : '';
+  const causeCode = (
+    cause
+    && typeof cause === 'object'
+    && 'code' in cause
+    && typeof cause.code === 'string'
+  )
+    ? cause.code
+    : '';
+  const code = directCode || causeCode;
+
+  return /^[A-Z][A-Z0-9_]*$/u.test(code)
+    ? code
+    : (error.name === 'TimeoutError' ? 'request-timeout' : 'request-failed');
+}
+
+function permanentRequestFailure(reason) {
+  return permanentFailureReasons.has(reason);
+}
+
+async function checkExternalUrl(rawUrl, options) {
+  let lastStatus = 0;
+  let lastErrorCode = '';
+  const requester = options.requester ?? fetchWithRedirects;
+
+  for (let attempt = 0; attempt <= options.retries; attempt += 1) {
+    try {
+      let status = await requester(rawUrl, options.requestTimeoutMs, 'HEAD');
+      if (
+        (
+          status >= 400
+          && status < 500
+          && ![408, 425, 429].includes(status)
+        )
+        || status === 501
+      ) {
+        status = await requester(rawUrl, options.requestTimeoutMs, 'GET');
+      }
+      lastStatus = status;
+
+      if (status >= 200 && status < 400) {
+        return { outcome: 'passed', status };
+      }
+      if ([401, 403, 407].includes(status)) {
+        return { outcome: 'warning', reason: 'access restricted', status };
+      }
+      if (!transientStatus(status) || attempt === options.retries) {
+        return {
+          outcome: transientStatus(status) ? 'warning' : 'failed',
+          reason: transientStatus(status) ? 'transient HTTP response' : 'broken HTTP response',
+          status,
+        };
+      }
+    } catch (error) {
+      lastErrorCode = requestFailureReason(error);
+      if (lastErrorCode === 'private-host') {
+        return { outcome: 'warning', reason: 'non-public URL was not requested' };
+      }
+      if (permanentRequestFailure(lastErrorCode)) {
+        return { outcome: 'failed', reason: lastErrorCode };
+      }
+      if (attempt === options.retries) {
+        return { outcome: 'warning', reason: lastErrorCode };
+      }
+    }
+
+    await delay(250 * (attempt + 1));
+  }
+
+  return {
+    outcome: 'warning',
+    reason: lastErrorCode || 'transient HTTP response',
+    status: lastStatus || undefined,
+  };
+}
+
+async function concurrentMap(items, concurrency, mapper) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(items[index], index);
+    }
+  }
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(concurrency, items.length) },
+      () => worker(),
+    ),
+  );
+  return results;
+}
+
+function reportIssue(issue) {
+  const prefix = issue.severity === 'error' ? 'FAIL' : 'WARN';
+  const target = issue.kind === 'external'
+    ? redactedUrl(issue.target)
+    : redactedLocalTarget(issue.target);
+  const status = issue.status ? ` (HTTP ${issue.status})` : '';
+  process.stdout.write(
+    `${prefix}: ${issue.file}:${issue.line} ${target} - ${issue.message}${status}\n`,
+  );
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const files = trackedMarkdownFiles();
+  const links = files.flatMap((file) => (
+    extractLinks(readFileSync(resolve(repositoryRoot, file), 'utf8'), file)
+  ));
+  const issues = [];
+  let localChecked = 0;
+  let skipped = 0;
+  const externalReferences = new Map();
+
+  for (const link of links) {
+    if (isExternalUrl(link.target)) {
+      let normalizedUrl;
+      try {
+        const parsed = new URL(link.target);
+        parsed.hash = '';
+        normalizedUrl = parsed.toString();
+      } catch {
+        issues.push({
+          ...link,
+          kind: 'external',
+          message: 'invalid HTTP URL',
+          severity: 'error',
+        });
+        continue;
+      }
+
+      const references = externalReferences.get(normalizedUrl) ?? [];
+      references.push(link);
+      externalReferences.set(normalizedUrl, references);
+      continue;
+    }
+
+    if (shouldSkipTarget(link.target)) {
+      skipped += 1;
+      continue;
+    }
+
+    localChecked += 1;
+    const issue = validateLocalLink(link);
+    if (issue) {
+      issues.push(issue);
+    }
+  }
+
+  const externalEntries = [...externalReferences.entries()];
+  let externalResults = [];
+  if (!options.localOnly) {
+    externalResults = await concurrentMap(
+      externalEntries,
+      options.concurrency,
+      async ([url, references]) => ({
+        references,
+        result: await checkExternalUrl(url, options),
+        url,
+      }),
+    );
+
+    for (const { references, result, url } of externalResults) {
+      if (result.outcome === 'passed') {
+        continue;
+      }
+      for (const reference of references) {
+        issues.push({
+          ...reference,
+          kind: 'external',
+          message: result.reason ?? result.outcome,
+          severity: result.outcome === 'failed' ? 'error' : 'warning',
+          status: result.status,
+          target: url,
+        });
+      }
+    }
+  }
+
+  const errors = issues.filter(({ severity }) => severity === 'error');
+  const warnings = issues.filter(({ severity }) => severity === 'warning');
+  for (const issue of issues) {
+    reportIssue(issue);
+  }
+
+  const externalPassed = externalResults.filter(
+    ({ result }) => result.outcome === 'passed',
+  ).length;
+  const externalFailed = externalResults.filter(
+    ({ result }) => result.outcome === 'failed',
+  ).length;
+  const externalWarnings = externalResults.filter(
+    ({ result }) => result.outcome === 'warning',
+  ).length;
+  const localFailures = errors.filter(
+    ({ kind }) => kind === 'local' || kind === 'anchor',
+  ).length;
+  const summary = {
+    errors: errors.length,
+    external: {
+      checked: externalResults.length,
+      failed: externalFailed,
+      passed: externalPassed,
+      warnings: externalWarnings,
+    },
+    filesScanned: files.length,
+    generatedAt: new Date().toISOString(),
+    linksFound: links.length,
+    local: {
+      checked: localChecked,
+      failed: localFailures,
+      passed: localChecked - localFailures,
+    },
+    mode: options.localOnly ? 'local-only' : 'local-and-external',
+    skipped,
+    uniqueExternalUrls: externalEntries.length,
+    warnings: warnings.length,
+  };
+
+  process.stdout.write('\nDocumentation link audit\n');
+  process.stdout.write(`Maintained Markdown files: ${summary.filesScanned}\n`);
+  process.stdout.write(`Links found: ${summary.linksFound}\n`);
+  process.stdout.write(
+    `Local targets: ${summary.local.passed} passed, ${summary.local.failed} failed\n`,
+  );
+  if (options.localOnly) {
+    process.stdout.write(
+      `External URLs: ${summary.uniqueExternalUrls} discovered, network checks skipped\n`,
+    );
+  } else {
+    process.stdout.write(
+      `External URLs: ${summary.external.passed} passed, `
+      + `${summary.external.failed} failed, ${summary.external.warnings} warnings\n`,
+    );
+  }
+  process.stdout.write(`Skipped routes and non-HTTP schemes: ${summary.skipped}\n`);
+  process.stdout.write(`Result: ${summary.errors === 0 ? 'PASS' : 'FAIL'}\n`);
+
+  if (options.jsonReport) {
+    const reportPath = resolve(repositoryRoot, options.jsonReport);
+    const sanitizedIssues = issues.map((issue) => ({
+      file: issue.file,
+      kind: issue.kind,
+      line: issue.line,
+      message: issue.message,
+      severity: issue.severity,
+      ...(issue.status ? { status: issue.status } : {}),
+      target: issue.kind === 'external'
+        ? redactedUrl(issue.target)
+        : redactedLocalTarget(issue.target),
+    }));
+    writeFileSync(
+      reportPath,
+      `${JSON.stringify({ ...summary, issues: sanitizedIssues }, null, 2)}\n`,
+      'utf8',
+    );
+  }
+
+  process.exitCode = summary.errors === 0 ? 0 : 1;
+  return summary;
+}
+
+const isCliExecution = process.argv[1]
+  && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (isCliExecution) {
+  main().catch((error) => {
+    process.stderr.write(
+      `Documentation link audit failed to run: ${redactedErrorMessage(error)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}
+
+export {
+  allocateHeadingSlugs,
+  assertPublicHttpUrl,
+  checkExternalUrl,
+  createPinnedLookup,
+  extractLinks,
+  fetchWithRedirects,
+  githubHeadingSlug,
+  isPublicIp,
+  main,
+  markdownAnchorsFromSource,
+  maskMarkdownBlocks,
+  maskNonLinkMarkdown,
+  parseArguments,
+  pathInsideRepository,
+  permanentRequestFailure,
+  redactedLocalTarget,
+  redactedErrorMessage,
+  redactedUrl,
+  requestFailureReason,
+  requestHttpStatus,
+  validateLocalLink,
+};

--- a/scripts/check-documentation-links.test.mjs
+++ b/scripts/check-documentation-links.test.mjs
@@ -1,0 +1,506 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import {
+  allocateHeadingSlugs,
+  assertPublicHttpUrl,
+  checkExternalUrl,
+  createPinnedLookup,
+  extractLinks,
+  fetchWithRedirects,
+  isPublicIp,
+  markdownAnchorsFromSource,
+  pathInsideRepository,
+  permanentRequestFailure,
+  redactedErrorMessage,
+  redactedLocalTarget,
+  redactedUrl,
+  requestFailureReason,
+  requestHttpStatus,
+  validateLocalLink,
+} from './check-documentation-links.mjs';
+
+function callLookup(lookupImplementation, hostname, options = {}) {
+  return new Promise((resolve, reject) => {
+    lookupImplementation(hostname, options, (error, address, family) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve({ address, family });
+      }
+    });
+  });
+}
+
+test('extractLinks handles Markdown and HTML links without reading code', () => {
+  const source = [
+    '[balanced](docs/file_(one).md "title")',
+    String.raw`[escaped](docs/file\(two\).md)`,
+    '[![diagram](images/diagram(one).png)](guide.md#part)',
+    '[reference][ref]',
+    '[ref]: reference(target).md "Reference title"',
+    '<https://example.com/path?q=secret>',
+    '<img src="images/a(b).png" alt="example">',
+    '<a',
+    '  href="multiline.html">',
+    '  multiline',
+    '</a>',
+    '😀 before a longer fence',
+    '````javascript',
+    '[fenced](missing-fenced.md)',
+    '`````',
+    '',
+    '> ~~~~',
+    '> [quoted fence](missing-quoted.md)',
+    '> ~~~~~',
+    '',
+    '    [indented](missing-indented.md)',
+    '`[inline](missing-inline.md)`',
+  ].join('\n');
+
+  const links = extractLinks(source, 'docs/example.md');
+  assert.deepEqual(
+    links.map(({ target }) => target),
+    [
+      'docs/file_(one).md',
+      'docs/file(two).md',
+      'images/diagram(one).png',
+      'guide.md#part',
+      'reference(target).md',
+      'https://example.com/path?q=secret',
+      'images/a(b).png',
+      'multiline.html',
+    ],
+  );
+  assert.equal(links.some(({ target }) => target.includes('missing-')), false);
+});
+
+test('extractLinks preserves authored occurrences and block semantics', () => {
+  const source = [
+    'paragraph',
+    '    [paragraph continuation](paragraph.md)',
+    '- list item',
+    '    [list continuation](list.md)',
+    '',
+    '    [root code](missing-root-code.md)',
+    '',
+    '[repeat](same.md) and [repeat](same.md)',
+    '[empty]()',
+    '[reference]:',
+    '  continued.md "title"',
+    '[use][reference]',
+    '<person@example.com>',
+    '<a data-href="ignored.html" href=kept.html>kept</a>',
+    '<source srcset="ignored.png 2x" src="media.png">',
+    '````',
+    '```',
+    '[short fence](missing-short-fence.md)',
+    '`````',
+    '[after fence](after.md)',
+    '````',
+    '[unclosed](missing-unclosed.md)',
+  ].join('\n');
+
+  assert.deepEqual(
+    extractLinks(source, 'fixtures.md').map(({ target }) => target),
+    [
+      'paragraph.md',
+      'list.md',
+      'same.md',
+      'same.md',
+      '',
+      'continued.md',
+      'mailto:person@example.com',
+      'kept.html',
+      'media.png',
+      'after.md',
+    ],
+  );
+});
+
+test('inline code uses exact backtick runs and unmatched runs remain text', () => {
+  const source = [
+    '`` [ignored](missing.md) ` still code `` [kept](kept.md)',
+    '` unmatched [also kept](also-kept.md)',
+  ].join('\n');
+  assert.deepEqual(
+    extractLinks(source, 'inline-code.md').map(({ target }) => target),
+    ['kept.md', 'also-kept.md'],
+  );
+});
+
+test('link line numbers use the indexed source offsets', () => {
+  const links = extractLinks(
+    '[first](first.md)\nplain text\n[third](third.md)\n',
+    'line-numbers.md',
+  );
+  assert.deepEqual(
+    links.map(({ line, target }) => ({ line, target })),
+    [
+      { line: 1, target: 'first.md' },
+      { line: 3, target: 'third.md' },
+    ],
+  );
+});
+
+test('GitHub-style heading allocation avoids explicit suffix collisions', () => {
+  assert.deepEqual(
+    [...allocateHeadingSlugs(['Foo', 'Foo-1', 'Foo', 'Foo-1'])],
+    ['foo', 'foo-1', 'foo-2', 'foo-1-1'],
+  );
+  assert.deepEqual(
+    [...markdownAnchorsFromSource('# Bar\n# Bar\n# Bar-1\n')],
+    ['bar', 'bar-1', 'bar-1-1'],
+  );
+});
+
+test('IP policy permits globally routable addresses and rejects special ranges', () => {
+  assert.equal(isPublicIp('8.8.8.8'), true);
+  assert.equal(isPublicIp('2606:4700:4700::1111'), true);
+
+  for (const address of [
+    '0.0.0.0',
+    '10.1.2.3',
+    '100.64.1.1',
+    '127.0.0.1',
+    '169.254.169.254',
+    '192.0.2.1',
+    '198.51.100.1',
+    '224.0.0.1',
+    '::',
+    '::1',
+    '::ffff:8.8.8.8',
+    '2001:db8::1',
+    '3fff::1',
+    'fc00::1',
+    'fe80::1',
+    'ff02::1',
+    '4000::1',
+  ]) {
+    assert.equal(isPublicIp(address), false, address);
+  }
+});
+
+test('permanent request failures are classified and returned without retry', async () => {
+  const nestedError = new Error('fetch failed', {
+    cause: Object.assign(new Error('DNS failed'), { code: 'ENOTFOUND' }),
+  });
+  assert.equal(requestFailureReason(nestedError), 'ENOTFOUND');
+  assert.equal(permanentRequestFailure('ENOTFOUND'), true);
+  assert.equal(permanentRequestFailure('ERR_INVALID_URL'), true);
+  assert.equal(permanentRequestFailure('ECONNRESET'), false);
+
+  let requests = 0;
+  const result = await checkExternalUrl('https://example.com', {
+    requestTimeoutMs: 1_000,
+    requester: async () => {
+      requests += 1;
+      throw nestedError;
+    },
+    retries: 3,
+  });
+  assert.deepEqual(result, { outcome: 'failed', reason: 'ENOTFOUND' });
+  assert.equal(requests, 1);
+
+  const wrappedPolicyError = new Error('request wrapper', {
+    cause: new Error('private-host'),
+  });
+  assert.equal(requestFailureReason(wrappedPolicyError), 'private-host');
+});
+
+test('HEAD rejection falls back to one headers-only GET', async () => {
+  const methods = [];
+  const result = await checkExternalUrl('https://example.com', {
+    requestTimeoutMs: 1_000,
+    requester: async (_url, _timeout, method) => {
+      methods.push(method);
+      return method === 'HEAD' ? 405 : 204;
+    },
+    retries: 2,
+  });
+  assert.deepEqual(methods, ['HEAD', 'GET']);
+  assert.deepEqual(result, { outcome: 'passed', status: 204 });
+});
+
+test('reported URL forms redact credentials, query values, and fragments', () => {
+  const external = redactedUrl(
+    'https://user:password@example.com/path?filter=hidden-value#private-fragment',
+  );
+  assert.equal(external, 'https://example.com/path?<redacted>');
+  assert.doesNotMatch(external, /user|password|hidden-value|private-fragment/u);
+
+  const local = redactedLocalTarget('guide.md?filter=hidden-value#safe-anchor');
+  assert.equal(local, 'guide.md?<redacted>#safe-anchor');
+  assert.doesNotMatch(local, /hidden-value/u);
+
+  const errorMessage = redactedErrorMessage(
+    new Error(
+      'request https://user:password@example.com/path?filter=hidden-value#fragment failed',
+    ),
+  );
+  assert.doesNotMatch(errorMessage, /user|password|hidden-value|fragment/u);
+});
+
+test('local validation follows real paths and rejects a symlink escape', (context) => {
+  const temporaryRoot = mkdtempSync(join(tmpdir(), 'arcanos-doc-links-'));
+  const repository = join(temporaryRoot, 'repository');
+  const documentation = join(repository, 'docs');
+  const outside = join(temporaryRoot, 'outside');
+
+  try {
+    mkdirSync(documentation, { recursive: true });
+    mkdirSync(outside, { recursive: true });
+    writeFileSync(join(documentation, 'source.md'), '# Source\n', 'utf8');
+    writeFileSync(join(outside, 'target.md'), '# Target\n', 'utf8');
+    try {
+      symlinkSync(
+        outside,
+        join(documentation, 'escape'),
+        process.platform === 'win32' ? 'junction' : 'dir',
+      );
+    } catch (error) {
+      if (error?.code === 'EPERM') {
+        context.skip('creating symlinks is not permitted in this environment');
+        return;
+      }
+      throw error;
+    }
+
+    const issue = validateLocalLink(
+      {
+        file: 'docs/source.md',
+        line: 1,
+        target: 'escape/target.md',
+      },
+      repository,
+    );
+    assert.equal(issue?.message, 'target escapes the repository');
+  } finally {
+    rmSync(temporaryRoot, { force: true, recursive: true });
+  }
+});
+
+test('repository containment rejects absolute relative results and encoded Windows roots', (context) => {
+  if (process.platform !== 'win32') {
+    context.skip('Windows drive and UNC containment regression');
+    return;
+  }
+
+  assert.equal(pathInsideRepository('D:\\outside', 'C:\\repository'), false);
+  assert.equal(
+    pathInsideRepository('\\\\server\\share\\target.md', 'C:\\repository'),
+    false,
+  );
+
+  const temporaryRoot = mkdtempSync(join(tmpdir(), 'arcanos-doc-links-'));
+  const documentation = join(temporaryRoot, 'docs');
+  try {
+    mkdirSync(documentation, { recursive: true });
+    writeFileSync(join(documentation, 'source.md'), '# Source\n', 'utf8');
+
+    for (const target of [
+      '%44:%5Coutside%5Ctarget.md',
+      '%5C%5Cserver%5Cshare%5Ctarget.md',
+    ]) {
+      const issue = validateLocalLink(
+        {
+          file: 'docs/source.md',
+          line: 1,
+          target,
+        },
+        temporaryRoot,
+      );
+      assert.equal(issue?.message, 'target escapes the repository');
+    }
+  } finally {
+    rmSync(temporaryRoot, { force: true, recursive: true });
+  }
+});
+
+test('pinned lookup rejects mixed answers and returns validated addresses', async () => {
+  const publicLookup = createPinnedLookup(async (hostname, options) => {
+    assert.equal(hostname, 'example.com');
+    assert.deepEqual(options, { all: true, verbatim: true });
+    return [{ address: '93.184.216.34', family: 4 }];
+  });
+  assert.deepEqual(
+    await callLookup(publicLookup, 'example.com'),
+    { address: '93.184.216.34', family: 4 },
+  );
+  assert.deepEqual(
+    await callLookup(publicLookup, 'example.com', { all: true }),
+    {
+      address: [{ address: '93.184.216.34', family: 4 }],
+      family: undefined,
+    },
+  );
+
+  const mixedLookup = createPinnedLookup(async () => [
+    { address: '93.184.216.34', family: 4 },
+    { address: '127.0.0.1', family: 4 },
+  ]);
+  await assert.rejects(
+    callLookup(mixedLookup, 'example.com'),
+    (error) => error.message === 'private-host',
+  );
+
+  const mismatchedFamilyLookup = createPinnedLookup(async () => [
+    { address: '93.184.216.34', family: 6 },
+  ]);
+  await assert.rejects(
+    callLookup(mismatchedFamilyLookup, 'example.com'),
+    (error) => error.message === 'private-host',
+  );
+});
+
+test('direct private addresses and private redirect targets are never requested', async () => {
+  assert.throws(
+    () => assertPublicHttpUrl(new URL('http://127.0.0.1/private')),
+    (error) => error.message === 'private-host',
+  );
+
+  let requests = 0;
+  const requestImplementation = (_options, onResponse) => {
+    const request = new EventEmitter();
+    request.end = () => {
+      requests += 1;
+      onResponse({
+        destroy() {},
+        headers: { location: 'http://[::1]/private' },
+        resume() {},
+        statusCode: 302,
+      });
+    };
+    request.destroy = (error) => request.emit('error', error);
+    return request;
+  };
+  await assert.rejects(
+    fetchWithRedirects(
+      'https://example.com/start',
+      1_000,
+      'HEAD',
+      {
+        requestImplementation,
+        resolver: async () => [{ address: '93.184.216.34', family: 4 }],
+      },
+    ),
+    (error) => error.message === 'private-host',
+  );
+  assert.equal(requests, 1);
+});
+
+test('malformed redirect locations fail definitively without retry', async () => {
+  let requests = 0;
+  const requestImplementation = (_options, onResponse) => {
+    const request = new EventEmitter();
+    request.end = () => {
+      requests += 1;
+      onResponse({
+        destroy() {},
+        headers: { location: 'http://[' },
+        resume() {},
+        statusCode: 302,
+      });
+    };
+    request.destroy = (error) => request.emit('error', error);
+    return request;
+  };
+  const result = await checkExternalUrl('https://example.com/start', {
+    requestTimeoutMs: 1_000,
+    requester: (rawUrl, requestTimeoutMs, method) => fetchWithRedirects(
+      rawUrl,
+      requestTimeoutMs,
+      method,
+      {
+        requestImplementation,
+        resolver: async () => [{ address: '93.184.216.34', family: 4 }],
+      },
+    ),
+    retries: 3,
+  });
+
+  assert.deepEqual(result, { outcome: 'failed', reason: 'ERR_INVALID_URL' });
+  assert.equal(requests, 1);
+});
+
+test('HTTP requests resolve at connect time through the pinned lookup', async () => {
+  let resolverCalls = 0;
+  let capturedOptions;
+  const resolver = async () => {
+    resolverCalls += 1;
+    return [{ address: '93.184.216.34', family: 4 }];
+  };
+  const requestImplementation = (options, onResponse) => {
+    capturedOptions = options;
+    const request = new EventEmitter();
+    request.end = () => {
+      options.lookup(options.hostname, {}, (error, address, family) => {
+        assert.ifError(error);
+        assert.equal(address, '93.184.216.34');
+        assert.equal(family, 4);
+        onResponse({
+          destroy() {},
+          headers: {},
+          resume() {},
+          statusCode: 204,
+        });
+      });
+    };
+    request.destroy = (error) => request.emit('error', error);
+    return request;
+  };
+
+  assert.equal(resolverCalls, 0);
+  const result = await requestHttpStatus(
+    new URL('https://example.com:8443/docs?view=summary'),
+    1_000,
+    'HEAD',
+    { requestImplementation, resolver },
+  );
+  assert.deepEqual(result, { location: undefined, status: 204 });
+  assert.equal(resolverCalls, 1);
+  assert.equal(capturedOptions.agent, false);
+  assert.equal(capturedOptions.headers.Connection, 'close');
+  assert.equal(capturedOptions.hostname, 'example.com');
+  assert.equal(capturedOptions.path, '/docs?view=summary');
+  assert.equal(capturedOptions.port, '8443');
+  assert.equal(capturedOptions.servername, 'example.com');
+});
+
+test('one request timeout includes DNS and prevents a later connection', async () => {
+  let connections = 0;
+  const requestImplementation = (options) => {
+    const request = new EventEmitter();
+    request.end = () => {
+      options.lookup(options.hostname, {}, () => {
+        connections += 1;
+      });
+    };
+    request.destroy = (error) => request.emit('error', error);
+    return request;
+  };
+
+  await assert.rejects(
+    requestHttpStatus(
+      new URL('https://example.com'),
+      20,
+      'HEAD',
+      {
+        requestImplementation,
+        resolver: () => new Promise(() => {}),
+      },
+    ),
+    (error) => error.message === 'request-timeout',
+  );
+  assert.equal(connections, 0);
+});

--- a/tests/pr-preview-workflow-safety.test.js
+++ b/tests/pr-preview-workflow-safety.test.js
@@ -14,7 +14,7 @@ const providerBearingPrJobs = [
   },
   {
     path: '.github/workflows/auto-update-documentation.yml',
-    job: 'update-docs',
+    job: 'analyze',
     expectedGate: "if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'",
   },
 ];


### PR DESCRIPTION
## Overview
Establish active documentation ownership and review cadence, standardize dated evidence placement, replace the documentation updater's direct-to-`main` writes with a read-only report artifact, and add a hardened weekly external-link audit. The existing documentation gate now exposes a stable `docs:check` job suitable for branch protection.

## Prerequisites
- [x] Branch is up to date with target base branch
- [x] Scope is limited to a single coherent change

## Setup
Validation run before requesting review:
- [ ] `npm run type-check` (not applicable: no TypeScript/runtime changes)
- [x] `npm run lint` (0 errors; 84 existing warnings)
- [ ] `npm test` (the complete suite runs in CI; focused local checks are listed below)
- [ ] `npm run build` (no application/build changes; the complete build runs in CI)
- [ ] `npm run validate:railway` (not deploy-affecting; Railway compatibility runs in CI)

Additional validation:
- [x] Node 20.19 link-checker tests: 16/16 passed
- [x] Provider-workflow safety contract: 5/5 passed
- [x] Documentation audit: 264/264 passed
- [x] Local links: 139/139 passed
- [x] External links: 24/24 passed with zero warnings
- [x] All changed workflow YAML parsed successfully
- [x] `bash -n scripts/doc_audit.sh`
- [x] `git diff --check`
- [x] Two independent final reviews found no merge blockers
- [x] Copilot efficiency feedback addressed with indexed line offsets and a regression test

## Configuration
Configuration and secrets changes:
- [x] No env changes
- [ ] `.env.example` updated for new vars (no new vars)
- [ ] Railway variable changes documented (none)
- [x] Security-sensitive changes reviewed

The analyzer uses a fixed localhost-only CI bearer instead of forwarding `OPENAI_API_KEY`, has `contents: read`, disables checkout credential persistence, validates a hard allowlist and complete tracked diff, and can only upload a report artifact.

## Run locally
Manual verification performed:
- [ ] Backend startup and `/healthz` check (not needed for documentation-only validation)
- [x] Changed endpoints/scripts tested locally
- [ ] Confirmation-gated routes tested (not applicable)

Commands:
```text
npm run docs:links:test
npm run docs:links -- --local-only
npm run docs:links
npm run docs:check
node scripts/run-jest.mjs --testPathPatterns=pr-preview-workflow-safety --coverage=false
npm run lint
```

## Deploy (Railway)
Deployment notes:
- [x] No deploy impact
- [x] Backward-compatible deploy
- [x] Rollback is a normal PR revert; no data or environment migration exists

## Troubleshooting
Known risks / follow-ups:
- [x] Optional follow-up listed below

Optional supply-chain hardening: pin third-party GitHub Actions to immutable commit SHAs repository-wide. This PR retains the repository's current major-tag convention.

After this PR merges and the new job passes on the resulting `main` SHA, configure classic branch protection to require the exact `docs:check` context from the GitHub Actions app.

## References
- Related issue(s): None
- Docs updated: `.github/CODEOWNERS`, `docs/CI_CD.md`, `docs/DOCUMENTATION.md`, `governance/README.md`, `scripts/README.md`
- Automation updated: `.github/workflows/auto-update-documentation.yml`, `.github/workflows/doc-audit.yml`, `.github/workflows/documentation-links.yml`, `tests/pr-preview-workflow-safety.test.js`
- Evidence: local validation above; commit `3ff6c380fee46dc995e98846d1a69aa034cc4d38`
