### PR TITLE
Restore paired Railway auto promotion

### DIFF
--- a/.github/workflows/railway-auto-deploy.yml
+++ b/.github/workflows/railway-auto-deploy.yml
@@ -19,9 +19,9 @@ on:
 
 env:
   # Keep one explicit repository-owned state. "none" restores normal automatic
-  # promotion only after the coordinated rollout is verified in every writer.
+  # promotion after the coordinated rollout has been verified in every writer.
   # Missing, blank, or malformed values fail closed in the policy job.
-  ARCANOS_COORDINATED_DAG_WRITER_ROLLOUT_HOLD: '20260727-dag-snapshot-generation-v1'
+  ARCANOS_COORDINATED_DAG_WRITER_ROLLOUT_HOLD: 'none'
 
 permissions:
   contents: read
@@ -81,7 +81,7 @@ jobs:
       && github.event.workflow_run.head_repository.full_name == github.repository
       && github.event.workflow_run.head_sha == github.sha))
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 130
     concurrency:
       group: railway-auto-deploy-production
       cancel-in-progress: false
@@ -89,7 +89,8 @@ jobs:
       DEPLOY_REF: ${{ github.sha }}
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
-      RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
+      RAILWAY_WEB_SERVICE_ID: ${{ vars.RAILWAY_WEB_SERVICE_ID }}
+      RAILWAY_WORKER_SERVICE_ID: ${{ vars.RAILWAY_WORKER_SERVICE_ID }}
       RAILWAY_ENVIRONMENT_NAME: ${{ vars.RAILWAY_ENVIRONMENT_NAME }}
 
     steps:
@@ -161,123 +162,195 @@ jobs:
           echo "${bin_dir}" >> "${GITHUB_PATH}"
 
       - name: Validate deploy configuration
-        id: deploy_config
         env:
           RAILWAY_PROJECT_TOKEN_CONFIGURED: ${{ secrets.RAILWAY_PRODUCTION_PROJECT_TOKEN != '' }}
         run: |
           set -euo pipefail
           missing_fields=()
 
-          # //audit Assumption: repo-connected Railway deploys may already handle production promotion; failure risk: this workflow fails red on every main push when optional GitHub-side Railway credentials are intentionally unset; expected invariant: workflow_run auto-deploy only executes when all Railway credentials are configured; handling strategy: record missing configuration and skip auto mode cleanly while preserving manual-dispatch failures.
           if [ "${RAILWAY_PROJECT_TOKEN_CONFIGURED}" != "true" ]; then
             missing_fields+=("RAILWAY_PRODUCTION_PROJECT_TOKEN")
           fi
 
-          # //audit Assumption: project and service identifiers are required only for GitHub-driven Railway CLI deploys; failure risk: redundant automation path blocks branch protection even though Railway repo deploy already shipped; expected invariant: missing identifiers are surfaced explicitly; handling strategy: aggregate missing identifiers into one decision output.
           if [ -z "${RAILWAY_PROJECT_ID:-}" ]; then
             missing_fields+=("RAILWAY_PROJECT_ID")
           fi
 
-          if [ -z "${RAILWAY_SERVICE_ID:-}" ]; then
-            missing_fields+=("RAILWAY_SERVICE_ID")
+          if [ -z "${RAILWAY_WEB_SERVICE_ID:-}" ]; then
+            missing_fields+=("RAILWAY_WEB_SERVICE_ID")
+          fi
+
+          if [ -z "${RAILWAY_WORKER_SERVICE_ID:-}" ]; then
+            missing_fields+=("RAILWAY_WORKER_SERVICE_ID")
           fi
 
           if [ -z "${RAILWAY_ENVIRONMENT_NAME:-}" ]; then
-            echo "RAILWAY_ENVIRONMENT_NAME not set; defaulting to production"
-            echo "RAILWAY_ENVIRONMENT_NAME=production" >> "$GITHUB_ENV"
+            missing_fields+=("RAILWAY_ENVIRONMENT_NAME")
           fi
 
-          if [ "${#missing_fields[@]}" -eq 0 ]; then
-            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
-            echo "missing_fields=" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [ "${#missing_fields[@]}" -ne 0 ]; then
+            missing_fields_csv="$(IFS=,; printf '%s' "${missing_fields[*]}")"
+            echo "Paired Railway production promotion is not configured. Missing: ${missing_fields_csv}"
+            exit 1
           fi
 
-          missing_fields_csv="$(IFS=,; printf '%s' "${missing_fields[*]}")"
-          echo "should_deploy=false" >> "$GITHUB_OUTPUT"
-          echo "missing_fields=${missing_fields_csv}" >> "$GITHUB_OUTPUT"
-          echo "GitHub-side Railway deploy is not configured. Missing: ${missing_fields_csv}"
+          uuid_pattern='^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+          if [[ ! "${RAILWAY_PROJECT_ID}" =~ ${uuid_pattern} ]]; then
+            echo "RAILWAY_PROJECT_ID_INVALID"
+            exit 1
+          fi
+          if [[ ! "${RAILWAY_WEB_SERVICE_ID}" =~ ${uuid_pattern} ]]; then
+            echo "RAILWAY_WEB_SERVICE_ID_INVALID"
+            exit 1
+          fi
+          if [[ ! "${RAILWAY_WORKER_SERVICE_ID}" =~ ${uuid_pattern} ]]; then
+            echo "RAILWAY_WORKER_SERVICE_ID_INVALID"
+            exit 1
+          fi
+          if [ "${RAILWAY_WEB_SERVICE_ID}" = "${RAILWAY_WORKER_SERVICE_ID}" ]; then
+            echo "RAILWAY_PAIRED_SERVICE_IDS_NOT_DISTINCT"
+            exit 1
+          fi
 
-      - name: Fail manual deploy when Railway credentials are missing
-        if: github.event_name == 'workflow_dispatch' && steps.deploy_config.outputs.should_deploy != 'true'
-        run: |
-          set -euo pipefail
-          echo "Manual Railway deploy requested but configuration is incomplete: ${{ steps.deploy_config.outputs.missing_fields }}"
-          exit 1
+      - name: Validate Railway compatibility
+        run: node scripts/validate-railway-compatibility.js
 
-      - name: Skip auto deploy when Railway credentials are missing
-        if: github.event_name == 'workflow_run' && steps.deploy_config.outputs.should_deploy != 'true'
-        run: |
-          set -euo pipefail
-          echo "Skipping GitHub-driven Railway deploy; Railway repo deploy remains the active path."
-          echo "Missing configuration: ${{ steps.deploy_config.outputs.missing_fields }}"
-
-      - name: Verify Railway deploy access
-        if: steps.deploy_config.outputs.should_deploy == 'true'
-        env:
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_PROJECT_TOKEN }}
-        run: |
-          set -euo pipefail
-          # //audit Assumption: GitHub Actions may use a project-scoped Railway token instead of a user-scoped account token; failure risk: `railway whoami` rejects valid deploy credentials and blocks automated deploys; expected invariant: the configured token can read project-scoped service state before deploy; handling strategy: probe service variables with the target service/environment pair.
-          node scripts/railway-auto-deploy-observer.mjs variables \
-            --service "${RAILWAY_SERVICE_ID}" \
-            --environment "${RAILWAY_ENVIRONMENT_NAME}" > /dev/null
-
-      - name: Deploy to Railway
-        if: steps.deploy_config.outputs.should_deploy == 'true'
+      - name: Verify paired Railway targets
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_PROJECT_TOKEN }}
         run: |
           set -euo pipefail
 
-          deployment_id="$(node scripts/railway-auto-deploy-observer.mjs enqueue \
+          baseline_worker_deployment_id="$(node scripts/railway-auto-deploy-observer.mjs active-id \
+            --service "${RAILWAY_WORKER_SERVICE_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT_NAME}")"
+          baseline_web_deployment_id="$(node scripts/railway-auto-deploy-observer.mjs active-id \
+            --service "${RAILWAY_WEB_SERVICE_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT_NAME}")"
+
+          worker_evidence="$(node scripts/railway-auto-deploy-observer.mjs variables \
+            --service "${RAILWAY_WORKER_SERVICE_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT_NAME}" \
+            | env -u RAILWAY_TOKEN RAILWAY_SERVICE_ID="${RAILWAY_WORKER_SERVICE_ID}" \
+              node scripts/verify-railway-readiness-activation.mjs)"
+          case "${worker_evidence}" in
+            'role=worker readiness=ready evidence=direct'|'role=worker readiness=ready evidence=platform') ;;
+            *) echo "RAILWAY_WORKER_TARGET_ROLE_MISMATCH"; exit 1 ;;
+          esac
+
+          web_evidence="$(node scripts/railway-auto-deploy-observer.mjs variables \
+            --service "${RAILWAY_WEB_SERVICE_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT_NAME}" \
+            | env -u RAILWAY_TOKEN RAILWAY_SERVICE_ID="${RAILWAY_WEB_SERVICE_ID}" \
+              node scripts/verify-railway-readiness-activation.mjs)"
+          if [ "${web_evidence}" != 'role=web readiness=ready evidence=direct' ]; then
+            echo "RAILWAY_WEB_TARGET_ROLE_MISMATCH"
+            exit 1
+          fi
+
+          echo "BASELINE_WORKER_DEPLOYMENT_ID=${baseline_worker_deployment_id}" >> "$GITHUB_ENV"
+          echo "BASELINE_WEB_DEPLOYMENT_ID=${baseline_web_deployment_id}" >> "$GITHUB_ENV"
+          echo "Paired target preflight passed: worker_baseline=${baseline_worker_deployment_id} web_baseline=${baseline_web_deployment_id}."
+
+      - name: Deploy and verify Railway worker
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_PROJECT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          worker_deployment_id="$(node scripts/railway-auto-deploy-observer.mjs enqueue \
             --project "${RAILWAY_PROJECT_ID}" \
-            --service "${RAILWAY_SERVICE_ID}" \
+            --service "${RAILWAY_WORKER_SERVICE_ID}" \
             --environment "${RAILWAY_ENVIRONMENT_NAME}" \
             --deploy-ref "${DEPLOY_REF}")"
 
-          echo "DEPLOYMENT_ID=${deployment_id}" >> "$GITHUB_ENV"
-          echo "Queued exact Railway deployment ${deployment_id} for ${DEPLOY_REF}."
+          echo "WORKER_DEPLOYMENT_ID=${worker_deployment_id}" >> "$GITHUB_ENV"
+          echo "Queued exact Railway worker deployment ${worker_deployment_id} for ${DEPLOY_REF}."
 
-      - name: Wait for deployment success
-        if: steps.deploy_config.outputs.should_deploy == 'true'
+          node scripts/railway-auto-deploy-observer.mjs wait \
+            --deployment-id "${worker_deployment_id}" \
+            --service "${RAILWAY_WORKER_SERVICE_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT_NAME}"
+
+          node scripts/railway-auto-deploy-observer.mjs verify-active \
+            --deployment-id "${worker_deployment_id}" \
+            --service "${RAILWAY_WORKER_SERVICE_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT_NAME}"
+
+          worker_evidence="$(node scripts/railway-auto-deploy-observer.mjs variables \
+            --service "${RAILWAY_WORKER_SERVICE_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT_NAME}" \
+            | env -u RAILWAY_TOKEN RAILWAY_SERVICE_ID="${RAILWAY_WORKER_SERVICE_ID}" \
+              node scripts/verify-railway-readiness-activation.mjs)"
+          case "${worker_evidence}" in
+            'role=worker readiness=ready evidence=direct'|'role=worker readiness=ready evidence=platform') ;;
+            *) echo "RAILWAY_WORKER_TARGET_ROLE_MISMATCH"; exit 1 ;;
+          esac
+
+          node scripts/railway-auto-deploy-observer.mjs verify-active \
+            --deployment-id "${worker_deployment_id}" \
+            --service "${RAILWAY_WORKER_SERVICE_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT_NAME}"
+
+          echo "role=worker deployment_id=${worker_deployment_id} status=SUCCESS tracked_healthcheck=/readyz tracked_drainingSeconds=60 effective_settings_readback=required"
+
+      - name: Deploy and verify Railway web pair
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_PROJECT_TOKEN }}
         run: |
           set -euo pipefail
 
-          node scripts/railway-auto-deploy-observer.mjs wait \
-            --deployment-id "${DEPLOYMENT_ID}" \
-            --service "${RAILWAY_SERVICE_ID}" \
-            --environment "${RAILWAY_ENVIRONMENT_NAME}"
-
-          # Railway reports SUCCESS only after the configured deployment
-          # healthcheck returns 200. Static validation binds that platform
-          # observation to the repository-owned /readyz and 60-second drain
-          # contract. Public roles receive an immediate bounded direct request;
-          # a private worker retains the platform activation result rather than
-          # acquiring a public domain solely for this check.
-          env -u RAILWAY_TOKEN node scripts/validate-railway-compatibility.js
-
-          node scripts/railway-auto-deploy-observer.mjs verify-active \
-            --deployment-id "${DEPLOYMENT_ID}" \
-            --service "${RAILWAY_SERVICE_ID}" \
-            --environment "${RAILWAY_ENVIRONMENT_NAME}"
-
-          node scripts/railway-auto-deploy-observer.mjs variables \
-            --service "${RAILWAY_SERVICE_ID}" \
+          web_deployment_id="$(node scripts/railway-auto-deploy-observer.mjs enqueue \
+            --project "${RAILWAY_PROJECT_ID}" \
+            --service "${RAILWAY_WEB_SERVICE_ID}" \
             --environment "${RAILWAY_ENVIRONMENT_NAME}" \
-            | env -u RAILWAY_TOKEN node scripts/verify-railway-readiness-activation.mjs
+            --deploy-ref "${DEPLOY_REF}")"
 
-          node scripts/railway-auto-deploy-observer.mjs verify-active \
-            --deployment-id "${DEPLOYMENT_ID}" \
-            --service "${RAILWAY_SERVICE_ID}" \
+          echo "WEB_DEPLOYMENT_ID=${web_deployment_id}" >> "$GITHUB_ENV"
+          echo "Queued exact Railway web deployment ${web_deployment_id} for ${DEPLOY_REF}."
+
+          node scripts/railway-auto-deploy-observer.mjs wait \
+            --deployment-id "${web_deployment_id}" \
+            --service "${RAILWAY_WEB_SERVICE_ID}" \
             --environment "${RAILWAY_ENVIRONMENT_NAME}"
 
-          echo "deployment_id=${DEPLOYMENT_ID} status=SUCCESS tracked_healthcheck=/readyz tracked_drainingSeconds=60 effective_settings_readback=required"
+          node scripts/railway-auto-deploy-observer.mjs verify-active \
+            --deployment-id "${web_deployment_id}" \
+            --service "${RAILWAY_WEB_SERVICE_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT_NAME}"
 
-      - name: Post-deploy watchdog/budget regression check
-        if: steps.deploy_config.outputs.should_deploy == 'true'
+          web_evidence="$(node scripts/railway-auto-deploy-observer.mjs variables \
+            --service "${RAILWAY_WEB_SERVICE_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT_NAME}" \
+            | env -u RAILWAY_TOKEN RAILWAY_SERVICE_ID="${RAILWAY_WEB_SERVICE_ID}" \
+              node scripts/verify-railway-readiness-activation.mjs)"
+          if [ "${web_evidence}" != 'role=web readiness=ready evidence=direct' ]; then
+            echo "RAILWAY_WEB_TARGET_ROLE_MISMATCH"
+            exit 1
+          fi
+
+          worker_evidence="$(node scripts/railway-auto-deploy-observer.mjs variables \
+            --service "${RAILWAY_WORKER_SERVICE_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT_NAME}" \
+            | env -u RAILWAY_TOKEN RAILWAY_SERVICE_ID="${RAILWAY_WORKER_SERVICE_ID}" \
+              node scripts/verify-railway-readiness-activation.mjs)"
+          case "${worker_evidence}" in
+            'role=worker readiness=ready evidence=direct'|'role=worker readiness=ready evidence=platform') ;;
+            *) echo "RAILWAY_WORKER_TARGET_ROLE_MISMATCH"; exit 1 ;;
+          esac
+
+          node scripts/railway-auto-deploy-observer.mjs verify-active \
+            --deployment-id "${web_deployment_id}" \
+            --service "${RAILWAY_WEB_SERVICE_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT_NAME}"
+          node scripts/railway-auto-deploy-observer.mjs verify-active \
+            --deployment-id "${WORKER_DEPLOYMENT_ID}" \
+            --service "${RAILWAY_WORKER_SERVICE_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT_NAME}"
+
+          echo "pair_status=SUCCESS worker_deployment_id=${WORKER_DEPLOYMENT_ID} web_deployment_id=${web_deployment_id} tracked_healthcheck=/readyz tracked_drainingSeconds=60 effective_settings_readback=required"
+
+      - name: Post-deploy web watchdog/budget regression check
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_PROJECT_TOKEN }}
         run: |
@@ -286,5 +359,5 @@ jobs:
             --since 15m \
             --lines 500 \
             --fail-on-budget-abort \
-            --service "${RAILWAY_SERVICE_ID}" \
+            --service "${RAILWAY_WEB_SERVICE_ID}" \
             --environment "${RAILWAY_ENVIRONMENT_NAME}"

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -367,21 +367,35 @@ environment. Checkout credential persistence and a
 single-maintainer-compatible protected-environment topology remain separate
 defense-in-depth and repository-settings decisions.
 
-The production deployment job has a 60-minute GitHub Actions timeout and uses
+The production deployment job has a 130-minute GitHub Actions timeout and uses
 the `railway-auto-deploy-production` concurrency group without cancelling a
 run that has already started. A newer run therefore waits while the active run
 continues observing any remote deployment it created. GitHub may still
 coalesce older runs that have not started.
 
-The deployment job captures the exact deployment ID returned by its own
-detached upload and observes deployment history for that ID only. The upload
-has a 10-minute command timeout; observation uses a 45-minute elapsed-time
-budget with ten-second polling. Each Railway status or variable read also has
-an explicit timeout and output cap. That exact deployment must reach Railway
-`SUCCESS`, after which the job runs
-`node scripts/validate-railway-compatibility.js`, confirms the same deployment
-remains the active successful and non-stopped deployment, and reads the exact
-service's resolved Railway identity and role.
+The deployment job requires `RAILWAY_PROJECT_ID`,
+`RAILWAY_ENVIRONMENT_NAME`, and explicit, distinct
+`RAILWAY_WEB_SERVICE_ID` and `RAILWAY_WORKER_SERVICE_ID` repository variables.
+Missing credentials or any identifier fails the promotion; there is no green
+automatic skip and no implicit `production` environment default.
+Static Railway compatibility validation runs before the first remote mutation.
+The token preflight captures the exact active successful deployment ID for
+both roles, then reads each service's resolved identity and role. It requires a
+direct current web readiness response; a public worker also receives a direct
+request, while a private worker retains current Railway active-`SUCCESS`
+platform evidence rather than being made public solely for CI.
+Swapped or duplicated targets fail before upload.
+
+Promotion is one worker-first pair in a single job. The workflow uploads the
+exact default-branch SHA to the worker, observes only the returned worker
+deployment ID, and completes its activation checks before uploading that same
+SHA to the web service. Each upload has a 10-minute command timeout; each
+exact-deployment observation uses a 45-minute elapsed-time budget with
+ten-second polling. Every Railway status or variable read also has an explicit
+timeout and output cap. After web activation, both new deployment IDs must
+still be the active successful and non-stopped deployment for their exact
+service.
+
 For a public web or worker role it then makes a bounded, no-redirect
 `GET /readyz` request and requires the exact role response plus
 `Cache-Control: no-store`. A private worker retains Railway's platform
@@ -393,29 +407,32 @@ one-time activation checks; they do not replace continuous monitoring, exact
 web/worker effective-settings readback, or a measured drain rehearsal before
 production promotion.
 
-The detached upload is a remote mutation that can outlive the GitHub runner.
-An upload timeout before an ID is returned, a manual workflow cancellation,
-runner loss, or a deployment that remains nonterminal beyond the 45-minute
-observer budget requires operator reconciliation against the exact project,
-environment, service, and revision. The workflow does not call `railway down`
-because that command does not safely target the captured in-flight deployment.
-Post-deploy log retrieval is limited to 30 seconds and 4 MiB and fails closed
-if either bound is exceeded.
+Each detached upload is a remote mutation that can outlive the GitHub runner.
+The pair is coordinated but not provider-atomic. An upload timeout before an ID
+is returned, a manual workflow cancellation, runner loss, worker success
+followed by web failure, or a deployment that remains nonterminal beyond the
+45-minute observer budget requires operator reconciliation against the logged
+baseline/attempt deployment IDs, exact project, environment, service, and
+revision. The workflow does not guess a prior revision, call generic
+`railway redeploy`, or automatically roll application code across a potentially
+incompatible schema. Post-deploy web log retrieval is limited to 30 seconds and
+4 MiB and fails closed if either bound is exceeded.
 
-The active `20260727-dag-snapshot-generation-v1` hold protects the coordinated
-DAG snapshot-generation migration. A deliberate `workflow_dispatch` may pass it
-only when the operator types
+The historical `20260727-dag-snapshot-generation-v1` hold protected the
+coordinated DAG snapshot-generation migration. That rollout is complete and
+the tracked marker is now the exact inactive sentinel `none`, so successful
+default-branch CI admits normal paired promotion. If that hold is reactivated,
+a deliberate `workflow_dispatch` may pass it only when the operator types
 `DAG WRITERS DRAINED: 20260727-dag-snapshot-generation-v1` exactly. That phrase
 is an operator attestation, not a drain command: separately confirm the approved
 revision, project, environment, database, every DAG-writing service, and the
 actual stopped/drained state before dispatch.
 
-This GitHub policy does not control Railway-native GitHub auto-deploy. Keep that
-trigger disabled on every production writer for the entire coordinated rollout;
-for the current topology, independently verify `ARCANOS V2` and
-`ARCANOS Worker`. Re-enable native triggers only after every writer is on the
-accepted revision and the reviewed `none` follow-up has restored normal
-repository promotion.
+This GitHub policy does not control Railway-native GitHub auto-deploy. Keep
+native triggers disabled for both `ARCANOS V2` and `ARCANOS Worker` while this
+paired workflow is the canonical production path. Enabling either native
+trigger would create an independent single-service deployment that can bypass
+the pair's ordering, exact-ID observation, and shared concurrency lock.
 
 Keep the hold active during rollout and any rollback decision. After the schema
 and compatible revision are verified on every DAG writer, no old writer can
@@ -425,7 +442,8 @@ guard remains in place for future coordinated migrations, while the `none`
 state preserves the workflow's normal automatic deployment behavior.
 
 ## Troubleshooting
-- Workflow fails on missing secret: add the secret in GitHub settings or disable that job.
+- Workflow fails on missing secret or paired target: restore the exact scoped
+  secret and repository variables; do not convert the failure into a green skip.
 - Deployment job fails after build passes: validate Railway auth token and service linkage.
 - Automatic Railway deploy is skipped with
   `automatic_promotion_blocked`: inspect the active coordinated-writer hold and

--- a/docs/DATABASE_MIGRATIONS.md
+++ b/docs/DATABASE_MIGRATIONS.md
@@ -304,22 +304,21 @@ apply the migration and compatible code together, and do not allow an older
 binary to run concurrently. Likewise, attempt rollback only after all writers
 are stopped or confirmed compatible with the rolled-back schema.
 
-The repository-level Railway fail-safe for this rollout is the
+The repository-level Railway fail-safe used for this completed rollout was the
 `20260727-dag-snapshot-generation-v1` value of
 `ARCANOS_COORDINATED_DAG_WRITER_ROLLOUT_HOLD` in
 `.github/workflows/railway-auto-deploy.yml`. With that hold active, successful
-`main` CI cannot automatically start the Railway deployment job. A deliberate
-manual dispatch requires the exact typed attestation
+`main` CI could not automatically start the Railway deployment job. A
+deliberate manual dispatch required the exact typed attestation
 `DAG WRITERS DRAINED: 20260727-dag-snapshot-generation-v1`; the workflow does
-not perform or verify the drain itself and deploys only its one configured
-service.
+not perform or verify the drain itself.
 
-Keep the hold active until the migration and compatible revision are verified
-on every DAG-writing process, all older replicas are gone, and post-deploy
-health is accepted. Keep it active through any rollback. Then set the marker to
-the exact sentinel `none` in a reviewed follow-up commit to restore normal
-automatic promotion. Deleting, blanking, or malforming the marker fails closed
-instead of silently lifting the hold.
+That rollout is now verified and the marker is the exact sentinel `none`, which
+restores normal worker-first web/worker pair promotion. For a future
+incompatible writer migration, set a reviewed non-`none` hold before the change
+reaches `main`, keep it active through rollout and any rollback, and return to
+`none` only after every writer is compatible and healthy. Deleting, blanking,
+or malforming the marker fails closed instead of silently lifting the hold.
 
 `migrations/20260727_dag_run_snapshot_generation_v1.rollback.sql` verifies
 the complete installed column and validated constraint before destructive

--- a/docs/RAILWAY_DEPLOYMENT.md
+++ b/docs/RAILWAY_DEPLOYMENT.md
@@ -194,14 +194,16 @@ A separately approved local runtime check must use a deliberately isolated effec
 
 ## Deploy (Railway)
 
-The tracked `.github/workflows/railway-auto-deploy.yml` can deploy one configured
-service after successful CI on `main` or by manual dispatch. It skips automatic
-CLI deployment when its Railway credentials or identifiers are absent.
-Repository-connected Railway deployment and current web/worker service coverage
-are environment-dependent and must be confirmed separately.
+The tracked `.github/workflows/railway-auto-deploy.yml` promotes one explicit
+web/worker pair after successful CI on `main` or by manual dispatch. It requires
+`RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT_NAME`, and distinct
+`RAILWAY_WEB_SERVICE_ID` and `RAILWAY_WORKER_SERVICE_ID` repository variables.
+Missing credentials or identifiers fail the promotion; there is no green skip
+or implicit environment default. Railway-native GitHub triggers remain disabled
+so an independent single-service deploy cannot bypass the pair.
 
 Successful CI means the aggregate verifier observed the exact required job set
-with every result equal to `success`, including the seven-suite PostgreSQL job.
+with every result equal to `success`, including the eight-suite PostgreSQL job.
 It is not proof of current production topology, deployed revision, live database
 schema, writer compatibility, or drain readiness; those remain separately
 verified promotion conditions.
@@ -223,50 +225,58 @@ protected GitHub environment/approval topology are separate defense-in-depth
 and repository-settings decisions, not guarantees provided by these workflow
 controls.
 
-The production job is limited to 60 minutes and serializes through the
+The production job is limited to 130 minutes and serializes through the
 `railway-auto-deploy-production` concurrency group without cancelling a run
 that has already started. A newer run waits while the active observer finishes;
 GitHub may still coalesce older runs that remain pending.
 
-The workflow captures the exact deployment ID returned by its own detached
-upload and observes deployment history for that ID only. Upload is bounded to
-10 minutes, exact-deployment observation to 45 elapsed minutes with ten-second
-polling, and every Railway status or variable subprocess has an explicit
-timeout and output cap. After that deployment reaches Railway `SUCCESS`, the
-workflow reruns the static Railway validator and rereads the same
-service/environment status, requiring that exact deployment to remain the
-active successful and non-stopped deployment. It also reads the exact target's
-resolved identity, rejects identity or live drain-variable drift, and makes a
-bounded, no-redirect `/readyz` request when that role has a public domain. A
-private worker retains Railway's first-200 activation result instead of being
-exposed solely for the workflow. Post-deploy log retrieval is limited to 30
-seconds and 4 MiB. This is one-time activation evidence, not continuous health
-monitoring or effective provider-setting readback.
+Static Railway compatibility validation runs before any remote mutation. The
+token preflight then captures both exact active successful baseline deployment
+IDs and validates the resolved identity and expected role for each target. It
+requires a direct current web readiness response; a private worker retains
+current Railway active-`SUCCESS` platform evidence instead of acquiring a
+public domain solely for this check. Promotion deploys and verifies the worker
+first, then uploads the same exact SHA to the web service. Worker-first ordering avoids
+a new web producer activating against an old queue consumer; ordinary releases
+must still preserve old/new interoperability, while incompatible migrations use
+the separate rollout hold and stopped/drained procedure.
 
-The detached upload remains a remote mutation. If upload times out before an ID
-is returned, the workflow is manually cancelled, the runner is lost, or an
-exact deployment remains nonterminal past the observer budget, it may continue
-remotely without the remaining activation checks. Reconcile that residual
-manually against the exact project, environment, service, and revision. The
-workflow intentionally does not call `railway down`, which cannot safely
-contain the captured in-flight deployment by exact ID.
+Each upload is bounded to 10 minutes, each exact-deployment observation to 45
+elapsed minutes with ten-second polling, and every Railway status or variable
+subprocess has an explicit timeout and output cap. Each returned ID must reach
+Railway `SUCCESS`, remain the active successful and non-stopped deployment, and
+pass exact identity/role/readiness checks. After web activation the workflow
+re-verifies both new deployment IDs together. A private worker retains
+Railway's first-200 activation result instead of being exposed solely for the
+workflow. Post-deploy web log retrieval is limited to 30 seconds and 4 MiB.
+This is one-time activation evidence, not continuous health monitoring or
+effective provider-setting readback.
+
+Each detached upload remains a remote mutation, and the pair is coordinated
+rather than provider-atomic. If upload times out before an ID is returned, the
+workflow is manually cancelled, the runner is lost, worker promotion succeeds
+but web promotion fails, or an exact deployment remains nonterminal past the
+observer budget, it may continue remotely without the remaining activation
+checks. Reconcile that residual manually against the logged baseline/attempt
+IDs and exact project, environment, service, and revision. The workflow does
+not guess a prior revision, use generic `railway redeploy`, or automatically
+roll application code across a potentially incompatible schema.
 
 The workflow also runs a repository-owned coordinated-writer policy before the
-production deployment job can enter its concurrency group. While
-`ARCANOS_COORDINATED_DAG_WRITER_ROLLOUT_HOLD` contains the active
+production deployment job can enter its concurrency group. The completed DAG
+snapshot-generation rollout now uses the inactive `none` sentinel, which admits
+normal paired promotion. If
+`ARCANOS_COORDINATED_DAG_WRITER_ROLLOUT_HOLD` is changed back to the active
 `20260727-dag-snapshot-generation-v1` ID, automatic `workflow_run` promotion is
-skipped without starting or cancelling a deployment. A manual dispatch fails
-unless the operator types the exact confirmation
+skipped without starting or cancelling a deployment. A manual dispatch then
+fails unless the operator types the exact confirmation
 `DAG WRITERS DRAINED: 20260727-dag-snapshot-generation-v1`.
 
 The repository policy cannot suppress Railway's separate GitHub-source
-auto-deploy trigger. Before a coordinated migration reaches `main`, disable
-native auto-deploy on every production DAG writer and verify the setting from
-each service. For the current topology, that means both `ARCANOS V2` and
-`ARCANOS Worker` must show **Auto deploy is disabled** while their running
-deployments remain unchanged. Re-enable those triggers only after the
-coordinated revision is accepted on every writer and the reviewed `none`
-follow-up has restored the normal repository policy.
+auto-deploy trigger. Keep native auto-deploy disabled on both `ARCANOS V2` and
+`ARCANOS Worker` while the GitHub paired workflow is canonical. Enabling either
+trigger would permit a source push to bypass worker-first ordering, exact-ID
+observation, and the shared production concurrency lock.
 
 The typed phrase does not stop a process, apply a migration, validate a target,
 or authorize production work. Before using it:
@@ -279,8 +289,8 @@ or authorize production work. Before using it:
 4. Drain or stop every writer and verify that an older binary cannot restart.
 5. Confirm the compatible revision and migration are the approved rollout pair.
 6. Dispatch the workflow only for the approved revision. The workflow deploys
-   one configured `RAILWAY_SERVICE_ID`; coordinate every other writer through
-   its separately approved mechanism.
+   the explicitly configured worker first and web second; inventory and
+   coordinate any additional writer through its separately approved mechanism.
 7. Verify the installed schema, exact revision on every writer, absence of old
    replicas, deployment health, and bounded application diagnostics.
 
@@ -360,8 +370,15 @@ The `railway:probe:fast-path` and `railway:probe:async` scripts are live operati
 
 Rollback:
 1. Treat rollback as a state-changing production operation and satisfy the approval gate.
-2. In the confirmed target's deployment history, identify the last known-good deployment.
-3. Redeploy only the approved version, then observe the targeted health and deployment status.
+2. For a paired-promotion failure, first decide whether the approved recovery
+   is to forward-complete the web role onto the verified worker revision or to
+   restore the worker's captured baseline. Confirm schema compatibility and any
+   coordinated-writer hold before either action; do not guess from `HEAD^` or
+   use a generic latest-deployment redeploy as a substitute.
+3. In each confirmed target's deployment history, identify the exact approved
+   deployment for that recovery decision.
+4. Redeploy only those approved versions, then repeat exact web/worker role,
+   readiness, active-deployment, and shared-revision verification.
 
 ## Troubleshooting
 - Build fails: run `npm ci --include=dev --no-audit --no-fund && npm run build` locally first.

--- a/scripts/railway-auto-deploy-observer.mjs
+++ b/scripts/railway-auto-deploy-observer.mjs
@@ -415,6 +415,45 @@ export async function verifyActiveDeployment(
 }
 
 /**
+ * Return the exact active successful deployment ID for pre-deploy evidence.
+ */
+export async function readActiveDeploymentId(
+  { serviceId, environmentName },
+  { runCommand = runBoundedRailwayCommand } = {},
+) {
+  const target = validateTarget({ serviceId, environmentName });
+  const output = await runCommand(
+    [
+      'service',
+      'status',
+      '--service',
+      target.serviceId,
+      '--environment',
+      target.environmentName,
+      '--json',
+    ],
+    RAILWAY_COMMAND_LIMITS.serviceStatus,
+  );
+  const response = parseJsonObject(
+    output,
+    'RAILWAY_BASELINE_ACTIVATION_EVIDENCE_MISMATCH',
+  );
+
+  if (response.status !== 'SUCCESS' || response.stopped !== false) {
+    throw safeError('RAILWAY_BASELINE_ACTIVATION_EVIDENCE_MISMATCH');
+  }
+
+  try {
+    return requireUuid(
+      response.deploymentId,
+      'RAILWAY_BASELINE_ACTIVATION_EVIDENCE_MISMATCH',
+    );
+  } catch {
+    throw safeError('RAILWAY_BASELINE_ACTIVATION_EVIDENCE_MISMATCH');
+  }
+}
+
+/**
  * Read bounded variable JSON for the exact service and environment.
  */
 export async function readRailwayVariables(
@@ -509,6 +548,16 @@ export async function main(argv = process.argv.slice(2)) {
       '--environment',
     ]);
     await verifyActiveDeployment(options);
+    return;
+  }
+
+  if (mode === 'active-id') {
+    const options = parseCliOptions(args, [
+      '--service',
+      '--environment',
+    ]);
+    const deploymentId = await readActiveDeploymentId(options);
+    process.stdout.write(`${deploymentId}\n`);
     return;
   }
 

--- a/tests/railway-auto-deploy-observer.test.js
+++ b/tests/railway-auto-deploy-observer.test.js
@@ -5,6 +5,7 @@ import {
   RAILWAY_COMMAND_LIMITS,
   classifyDeploymentStatus,
   enqueueDeployment,
+  readActiveDeploymentId,
   readRailwayVariables,
   runBoundedRailwayCommand,
   verifyActiveDeployment,
@@ -340,6 +341,73 @@ describe('Railway exact-deployment observation', () => {
 });
 
 describe('Railway bounded activation evidence', () => {
+  it('captures the exact active successful deployment before mutation', async () => {
+    const runCommand = jest.fn(async () =>
+      JSON.stringify({
+        deploymentId: DEPLOYMENT_ID,
+        status: 'SUCCESS',
+        stopped: false,
+      }),
+    );
+
+    await expect(
+      readActiveDeploymentId(target, { runCommand }),
+    ).resolves.toBe(DEPLOYMENT_ID);
+    expect(runCommand).toHaveBeenCalledWith(
+      [
+        'service',
+        'status',
+        '--service',
+        SERVICE_ID,
+        '--environment',
+        ENVIRONMENT_NAME,
+        '--json',
+      ],
+      RAILWAY_COMMAND_LIMITS.serviceStatus,
+    );
+  });
+
+  it.each([
+    [
+      'invalid deployment ID',
+      JSON.stringify({
+        deploymentId: 'latest',
+        status: 'SUCCESS',
+        stopped: false,
+      }),
+    ],
+    [
+      'non-success state',
+      JSON.stringify({
+        deploymentId: DEPLOYMENT_ID,
+        status: 'DEPLOYING',
+        stopped: false,
+      }),
+    ],
+    [
+      'stopped deployment',
+      JSON.stringify({
+        deploymentId: DEPLOYMENT_ID,
+        status: 'SUCCESS',
+        stopped: true,
+      }),
+    ],
+    [
+      'missing stopped evidence',
+      JSON.stringify({
+        deploymentId: DEPLOYMENT_ID,
+        status: 'SUCCESS',
+      }),
+    ],
+    ['malformed JSON', '{'],
+  ])('rejects %s baseline evidence', async (_label, output) => {
+    await expect(
+      readActiveDeploymentId(target, {
+        runCommand: async () => output,
+      }),
+    ).rejects.toThrow('RAILWAY_BASELINE_ACTIVATION_EVIDENCE_MISMATCH');
+  });
+
   it('requires the exact deployment to remain the active SUCCESS', async () => {
     const runCommand = jest.fn(async () =>
       JSON.stringify({

--- a/tests/railway-auto-deploy-supply-chain.test.js
+++ b/tests/railway-auto-deploy-supply-chain.test.js
@@ -13,39 +13,39 @@ const RAILWAY_CLI_ARCHIVE_SHA256 =
 const RAILWAY_PROJECT_TOKEN_SECRET =
   '${{ secrets.RAILWAY_PRODUCTION_PROJECT_TOKEN }}';
 const RAILWAY_TOKEN_STEPS = [
-  'Verify Railway deploy access',
-  'Deploy to Railway',
-  'Wait for deployment success',
-  'Post-deploy watchdog/budget regression check',
+  'Verify paired Railway targets',
+  'Deploy and verify Railway worker',
+  'Deploy and verify Railway web pair',
+  'Post-deploy web watchdog/budget regression check',
 ];
 // Freeze the complete security-critical step bodies and checked-in executors
 // so appended behavior cannot inherit the project token without review.
 const INSTALL_STEP_RUN_SHA256 =
   '6eab131a43da49cf62f45780558cb138190c5e3566cd430d36a0713abef6c509';
 const DEPLOYMENT_OBSERVER_SOURCE_SHA256 =
-  '6a75386ce311ff2ef340ccab1fa1528ed1ad676de5172fd9fa34cde8d40fe626';
+  '333aa034eb78d49ad20a769703b9fda8dc3c7a94d0671365859cccf1938ce2a7';
 const TIMEOUT_WATCHDOG_SOURCE_SHA256 =
   '717a6cda82721d2eb53d6099f462c8738212785e288fbebc3d6855d222bd11e4';
 const READINESS_VERIFIER_SOURCE_SHA256 =
   'd17d5ae7e421728d2523f55da699226f9c3532e53f1745f01ad444768c211b66';
 const TOKEN_STEP_RUN_SHA256 = {
-  'Verify Railway deploy access':
-    '5594ef732d5aa25c48c5eee8f15c83e1aa2fdad33058074a301cb0cba2668868',
-  'Deploy to Railway':
-    '1a65dde7985f4786070584891d58f29a2280dd139fe81e2b4b36828cf3403c2d',
-  'Wait for deployment success':
-    '24996df67931a7a165387514cd6bc1f6d527ab108815b028ec2bcbb982e79dce',
-  'Post-deploy watchdog/budget regression check':
-    '74c9d80317bdfa3de7c1cb5e4083013a0f116646388fe5d1c8455142f81ed674',
+  'Verify paired Railway targets':
+    '025b924c1cb5203d7e46e872ea9339098b321d8f6e0b9d07cdf4f6ab2b50f755',
+  'Deploy and verify Railway worker':
+    'c201922bfc44f403375254ba14395d12f1569a08a3aed357a956308391354103',
+  'Deploy and verify Railway web pair':
+    '53603cd9ee0d5cf6781e544624dfb786d4d002b1cf2b6be347846be0ce87dc78',
+  'Post-deploy web watchdog/budget regression check':
+    '0b3aa83aede25811a0a0a99eedd7e61ea4b5554f8f14c26368a7961ce62f3c96',
 };
 const TOKEN_STEP_REQUIRED_COMMAND = {
-  'Verify Railway deploy access':
-    'node scripts/railway-auto-deploy-observer.mjs variables',
-  'Deploy to Railway':
+  'Verify paired Railway targets':
+    'node scripts/railway-auto-deploy-observer.mjs active-id',
+  'Deploy and verify Railway worker':
     'node scripts/railway-auto-deploy-observer.mjs enqueue',
-  'Wait for deployment success':
-    'node scripts/railway-auto-deploy-observer.mjs wait',
-  'Post-deploy watchdog/budget regression check':
+  'Deploy and verify Railway web pair':
+    'node scripts/railway-auto-deploy-observer.mjs enqueue',
+  'Post-deploy web watchdog/budget regression check':
     'node scripts/check-railway-timeout-regressions.js',
 };
 
@@ -196,7 +196,7 @@ describe('Railway auto-deploy supply-chain containment', () => {
     );
   });
 
-  it('exposes one project token only to the four Railway CLI steps', () => {
+  it('exposes one project token only to the four paired Railway steps', () => {
     const deployJob = job('deploy-production');
     const deploySteps = deployJob.steps ?? [];
     const validationStep = namedStep(
@@ -243,25 +243,22 @@ describe('Railway auto-deploy supply-chain containment', () => {
     expect(
       namedStep(
         'deploy-production',
-        'Post-deploy watchdog/budget regression check',
+        'Post-deploy web watchdog/budget regression check',
       ).run,
     ).toContain('node scripts/check-railway-timeout-regressions.js');
     expect(
       namedStep(
         'deploy-production',
-        'Post-deploy watchdog/budget regression check',
+        'Post-deploy web watchdog/budget regression check',
       ).run,
     ).not.toContain('npm run');
 
-    const waitScript = namedStep(
+    const workerScript = namedStep(
       'deploy-production',
-      'Wait for deployment success',
+      'Deploy and verify Railway worker',
     ).run;
-    expect(waitScript).toContain(
-      'env -u RAILWAY_TOKEN node scripts/validate-railway-compatibility.js',
-    );
-    expect(waitScript).toContain(
-      '| env -u RAILWAY_TOKEN node scripts/verify-railway-readiness-activation.mjs',
+    expect(workerScript).toContain(
+      '| env -u RAILWAY_TOKEN RAILWAY_SERVICE_ID="${RAILWAY_WORKER_SERVICE_ID}"',
     );
   });
 });

--- a/tests/railway-coordinated-rollout-guard.test.js
+++ b/tests/railway-coordinated-rollout-guard.test.js
@@ -152,7 +152,7 @@ describe('Railway coordinated DAG writer rollout policy', () => {
 
   it('wires the repository hold through a preflight job before deploy concurrency', () => {
     expect(workflow.env?.ARCANOS_COORDINATED_DAG_WRITER_ROLLOUT_HOLD).toBe(
-      ACTIVE_HOLD,
+      INACTIVE_ROLLOUT_HOLD,
     );
     expect(Object.keys(workflow.jobs ?? {})).toEqual([
       'rollout-policy',
@@ -188,7 +188,7 @@ describe('Railway coordinated DAG writer rollout policy', () => {
       group: 'railway-auto-deploy-production',
       'cancel-in-progress': false,
     });
-    expect(deployJob['timeout-minutes']).toBe(60);
+    expect(deployJob['timeout-minutes']).toBe(130);
   });
 
   it('runs privileged promotion only from trusted default-branch push provenance', () => {
@@ -338,10 +338,10 @@ describe('Railway coordinated DAG writer rollout policy', () => {
     );
 
     const deployStepNames = [
-      'Verify Railway deploy access',
-      'Deploy to Railway',
-      'Wait for deployment success',
-      'Post-deploy watchdog/budget regression check',
+      'Verify paired Railway targets',
+      'Deploy and verify Railway worker',
+      'Deploy and verify Railway web pair',
+      'Post-deploy web watchdog/budget regression check',
     ];
     for (const stepName of deployStepNames) {
       expect(namedStep('deploy-production', stepName)).toBeDefined();

--- a/tests/railway-readiness-deployment-contract.test.js
+++ b/tests/railway-readiness-deployment-contract.test.js
@@ -31,32 +31,71 @@ function namedStep(name) {
 }
 
 describe('Railway role-aware deployment evidence', () => {
-  it('binds Railway SUCCESS to the exact deployment created by this upload', () => {
+  it('requires distinct explicit web and worker targets and never green-skips missing configuration', () => {
+    const deployJob = workflow.jobs?.['deploy-production'] ?? {};
+    const validation = namedStep('Validate deploy configuration').run ?? '';
+
+    expect(deployJob.env).toMatchObject({
+      RAILWAY_PROJECT_ID: '${{ vars.RAILWAY_PROJECT_ID }}',
+      RAILWAY_WEB_SERVICE_ID: '${{ vars.RAILWAY_WEB_SERVICE_ID }}',
+      RAILWAY_WORKER_SERVICE_ID: '${{ vars.RAILWAY_WORKER_SERVICE_ID }}',
+      RAILWAY_ENVIRONMENT_NAME: '${{ vars.RAILWAY_ENVIRONMENT_NAME }}',
+    });
+    expect(deployJob.env?.RAILWAY_SERVICE_ID).toBeUndefined();
+    expect(validation).toContain('RAILWAY_WEB_SERVICE_ID');
+    expect(validation).toContain('RAILWAY_WORKER_SERVICE_ID');
+    expect(validation).toContain('RAILWAY_ENVIRONMENT_NAME');
+    expect(validation).toContain('RAILWAY_PAIRED_SERVICE_IDS_NOT_DISTINCT');
+    expect(validation).not.toContain('defaulting to production');
+    expect(validation).not.toContain('should_deploy=false');
+    expect(deploymentSteps().map(step => step.name)).not.toContain(
+      'Skip auto deploy when Railway credentials are missing',
+    );
+  });
+
+  it('promotes and observes the exact worker deployment before the exact web deployment', () => {
     const steps = deploymentSteps();
     const names = steps.map(step => step.name);
 
-    expect(names.indexOf('Deploy to Railway')).toBeLessThan(
-      names.indexOf('Wait for deployment success'),
+    expect(names.indexOf('Validate Railway compatibility')).toBeLessThan(
+      names.indexOf('Verify paired Railway targets'),
     );
-    expect(names).not.toContain('Capture current deployment identity');
-    expect(names).not.toContain('Verify role-aware readiness activation');
+    expect(names.indexOf('Verify paired Railway targets')).toBeLessThan(
+      names.indexOf('Deploy and verify Railway worker'),
+    );
+    expect(names.indexOf('Deploy and verify Railway worker')).toBeLessThan(
+      names.indexOf('Deploy and verify Railway web pair'),
+    );
 
-    const deploy = namedStep('Deploy to Railway').run;
-    expect(deploy).toContain(
+    const worker = namedStep('Deploy and verify Railway worker').run;
+    expect(worker).toContain(
       'node scripts/railway-auto-deploy-observer.mjs enqueue',
     );
-    expect(deploy).toContain('DEPLOYMENT_ID');
-    expect(deploy).toContain('--deploy-ref "${DEPLOY_REF}"');
-
-    const wait = namedStep('Wait for deployment success').run;
-    expect(wait).toContain(
+    expect(worker).toContain('WORKER_DEPLOYMENT_ID');
+    expect(worker).toContain('--service "${RAILWAY_WORKER_SERVICE_ID}"');
+    expect(worker).toContain('--deploy-ref "${DEPLOY_REF}"');
+    expect(worker).toContain(
       'node scripts/railway-auto-deploy-observer.mjs wait',
     );
-    expect(wait).toContain('--deployment-id "${DEPLOYMENT_ID}"');
-    expect(wait).not.toContain('railway deployment list');
-    expect(wait).not.toContain('seq ');
-    expect(wait).not.toContain("readFileSync(0, 'utf8')");
-    expect(wait).not.toMatch(/echo "DEPLOYMENT_ID=.*GITHUB_ENV/u);
+    expect(worker).toContain('--deployment-id "${worker_deployment_id}"');
+
+    const web = namedStep('Deploy and verify Railway web pair').run;
+    expect(web).toContain(
+      'node scripts/railway-auto-deploy-observer.mjs enqueue',
+    );
+    expect(web).toContain('WEB_DEPLOYMENT_ID');
+    expect(web).toContain('--service "${RAILWAY_WEB_SERVICE_ID}"');
+    expect(web).toContain('--deploy-ref "${DEPLOY_REF}"');
+    expect(web).toContain(
+      'node scripts/railway-auto-deploy-observer.mjs wait',
+    );
+    expect(web).toContain('--deployment-id "${web_deployment_id}"');
+
+    for (const script of [worker, web]) {
+      expect(script).not.toContain('railway deployment list');
+      expect(script).not.toContain('seq ');
+      expect(script).not.toContain("readFileSync(0, 'utf8')");
+    }
 
     expect(deploymentObserverSource).toContain("'--detach'");
     expect(deploymentObserverSource).toContain(
@@ -71,54 +110,67 @@ describe('Railway role-aware deployment evidence', () => {
     expect(deploymentObserverSource).not.toContain('shell: true');
   });
 
-  it('binds post-deploy evidence to an exact-target readiness request and drain contract', () => {
+  it('preflights and re-verifies both exact roles and active deployments', () => {
     const steps = deploymentSteps();
     const names = steps.map(step => step.name);
-    const evidenceName = 'Wait for deployment success';
+    const preflight = namedStep('Verify paired Railway targets').run;
+    const worker = namedStep('Deploy and verify Railway worker').run;
+    const web = namedStep('Deploy and verify Railway web pair').run;
 
-    expect(names.indexOf(evidenceName)).toBeLessThan(
-      names.indexOf('Post-deploy watchdog/budget regression check'),
+    expect(names.indexOf('Deploy and verify Railway web pair')).toBeLessThan(
+      names.indexOf('Post-deploy web watchdog/budget regression check'),
     );
 
-    const evidence = namedStep(evidenceName).run;
-    expect(evidence).toContain(
-      'env -u RAILWAY_TOKEN node scripts/validate-railway-compatibility.js',
+    expect(preflight.match(
+      /railway-auto-deploy-observer\.mjs active-id/gu,
+    )).toHaveLength(2);
+    expect(preflight).toContain('BASELINE_WORKER_DEPLOYMENT_ID');
+    expect(preflight).toContain('BASELINE_WEB_DEPLOYMENT_ID');
+    expect(preflight).toContain('role=worker readiness=ready');
+    expect(preflight).toContain('role=web readiness=ready evidence=direct');
+
+    for (const evidence of [worker, web]) {
+      expect(evidence).toContain(
+        'node scripts/railway-auto-deploy-observer.mjs verify-active',
+      );
+      expect(evidence).toContain(
+        'node scripts/railway-auto-deploy-observer.mjs variables',
+      );
+      expect(evidence).toContain('verify-railway-readiness-activation.mjs');
+      expect(evidence).not.toContain('variables_json=');
+    }
+    expect(worker).toContain('role=worker readiness=ready');
+    expect(web).toContain('role=web readiness=ready evidence=direct');
+    expect(web).toContain('--deployment-id "${WORKER_DEPLOYMENT_ID}"');
+    expect(web).toContain('--deployment-id "${web_deployment_id}"');
+    expect(web).toContain('pair_status=SUCCESS');
+    expect(web).toContain('tracked_healthcheck=/readyz');
+    expect(web).toContain('tracked_drainingSeconds=60');
+    expect(web).toContain('effective_settings_readback=required');
+
+    expect(preflight).toMatch(
+      /railway-auto-deploy-observer\.mjs variables.+env -u RAILWAY_TOKEN RAILWAY_SERVICE_ID="\$\{RAILWAY_WORKER_SERVICE_ID\}".+verify-railway-readiness-activation\.mjs/su,
     );
-    expect(evidence).toContain(
-      'node scripts/railway-auto-deploy-observer.mjs verify-active',
+    expect(preflight).toMatch(
+      /railway-auto-deploy-observer\.mjs variables.+env -u RAILWAY_TOKEN RAILWAY_SERVICE_ID="\$\{RAILWAY_WEB_SERVICE_ID\}".+verify-railway-readiness-activation\.mjs/su,
     );
-    expect(evidence).toContain(
-      'node scripts/railway-auto-deploy-observer.mjs variables',
-    );
-    expect(evidence).toContain('DEPLOYMENT_ID');
-    expect(evidence).toContain('verify-railway-readiness-activation.mjs');
-    expect(evidence).toMatch(
-      /railway-auto-deploy-observer\.mjs variables.+env -u RAILWAY_TOKEN node scripts\/verify-railway-readiness-activation\.mjs/su,
-    );
-    expect(evidence).not.toContain('variables_json=');
-    expect(evidence).toMatch(
-      /railway-auto-deploy-observer\.mjs wait.+railway-auto-deploy-observer\.mjs verify-active.+railway-auto-deploy-observer\.mjs variables.+verify-railway-readiness-activation\.mjs.+railway-auto-deploy-observer\.mjs verify-active/su,
-    );
-    expect(evidence).toContain('tracked_healthcheck=/readyz');
-    expect(evidence).toContain('tracked_drainingSeconds=60');
-    expect(evidence).toContain('effective_settings_readback=required');
   });
 
   it('serializes production observers and bounds every remote read', () => {
     const deployJob = workflow.jobs?.['deploy-production'] ?? {};
-    const access = namedStep('Verify Railway deploy access').run ?? '';
-    const deploy = namedStep('Deploy to Railway').run ?? '';
-    const wait = namedStep('Wait for deployment success').run ?? '';
+    const access = namedStep('Verify paired Railway targets').run ?? '';
+    const worker = namedStep('Deploy and verify Railway worker').run ?? '';
+    const web = namedStep('Deploy and verify Railway web pair').run ?? '';
 
     expect(deployJob.concurrency).toEqual({
       group: 'railway-auto-deploy-production',
       'cancel-in-progress': false,
     });
-    expect(deployJob['timeout-minutes']).toBe(60);
+    expect(deployJob['timeout-minutes']).toBe(130);
     expect(access).toContain(
       'node scripts/railway-auto-deploy-observer.mjs variables',
     );
-    expect(`${access}\n${deploy}\n${wait}`).not.toMatch(
+    expect(`${access}\n${worker}\n${web}`).not.toMatch(
       /^\s*railway\s+/mu,
     );
     expect(deploymentObserverSource).toContain('timeout: limits.timeoutMs');


### PR DESCRIPTION
## Summary
- restore the inactive rollout sentinel and make missing promotion configuration fail closed
- promote the exact main SHA as one worker-first web/worker pair with baseline capture, exact role/readiness checks, and final pair re-verification
- keep Railway-native triggers disabled and document non-atomic failure/reconciliation behavior

## Root cause
Automatic promotion had four independent blockers: an active repository hold, a web-only service selector, no dedicated production project-token secret, and no Railway-native deployment triggers. This PR restores the canonical GitHub-owned pair rather than enabling duplicate native triggers.

## Validation
- `npm run build` (Node 20.19.0)
- `npm run lint` (0 errors; 76 existing warnings)
- focused Railway Jest suites: 4 suites, 80 tests
- `npm run validate:railway`
- `npm run docs:check` (327/327)
- independent code/security review: no blocking findings

## Operational contract
This promotion is coordinated, not provider-atomic. Worker activates before web. If web then fails, the workflow fails with exact baseline/attempt IDs and requires an approved forward-complete or exact-baseline reconciliation; it does not guess or auto-rollback across potentially incompatible schema.