### PR TITLE
Add reliable Railway PR preview lifecycle

### DIFF
--- a/.github/workflows/railway-pr-preview-lifecycle.yml
+++ b/.github/workflows/railway-pr-preview-lifecycle.yml
@@ -1,0 +1,106 @@
+name: Railway PR Preview Lifecycle
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+      - labeled
+      - unlabeled
+      - converted_to_draft
+      - edited
+      - closed
+  repository_dispatch:
+    types:
+      - railway_pr_preview_reconcile
+  schedule:
+    - cron: '23 */6 * * *'
+
+permissions: {}
+
+concurrency:
+  group: railway-pr-preview-lifecycle-${{ github.event.pull_request.number || github.event.client_payload.pr_number || 'scheduled-scan' }}
+  cancel-in-progress: false
+
+jobs:
+  run-event-preview-lifecycle:
+    name: Converge event preview lifecycle
+    if: >-
+      github.repository == 'pbjustin/Arcanos'
+      && (
+        github.event_name == 'repository_dispatch'
+        || (
+          github.event_name == 'pull_request_target'
+          && github.event.pull_request.base.repo.full_name == github.repository
+          && github.event.pull_request.head.repo.full_name == github.repository
+        )
+      )
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    uses: ./.github/workflows/railway-pr-preview-run.yml
+    with:
+      pr_number: ${{ github.event.pull_request.number || github.event.client_payload.pr_number }}
+      event_action: ${{ github.event_name == 'repository_dispatch' && 'manual' || github.event.action }}
+      event_label_name: ${{ github.event.label.name || '' }}
+      event_head_sha: ${{ github.event.pull_request.head.sha || '' }}
+
+  discover-scheduled-previews:
+    name: Discover scheduled preview reconciliation set
+    if: github.event_name == 'schedule' && github.repository == 'pbjustin/Arcanos'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: railway-pr-preview-lifecycle
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      pr_numbers: ${{ steps.discover.outputs.pr_numbers }}
+
+    steps:
+      - name: Check out trusted lifecycle controller
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Set up pinned Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20.19.0'
+
+      - name: Discover exact opt-in and controller-owned PR numbers
+        id: discover
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_PR_PREVIEW_LIFECYCLE_API_TOKEN }}
+        run: node scripts/railway-pr-preview-lifecycle.mjs discover
+
+  reconcile-scheduled-previews:
+    name: Converge scheduled preview ${{ matrix.pr_number }}
+    needs: discover-scheduled-previews
+    if: >-
+      needs.discover-scheduled-previews.result == 'success'
+      && needs.discover-scheduled-previews.outputs.pr_numbers != '[]'
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        pr_number: ${{ fromJSON(needs.discover-scheduled-previews.outputs.pr_numbers) }}
+    concurrency:
+      group: railway-pr-preview-lifecycle-${{ matrix.pr_number }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    uses: ./.github/workflows/railway-pr-preview-run.yml
+    with:
+      pr_number: ${{ matrix.pr_number }}
+      event_action: manual
+      event_label_name: ''
+      event_head_sha: ''

--- a/.github/workflows/railway-pr-preview-run.yml
+++ b/.github/workflows/railway-pr-preview-run.yml
@@ -1,0 +1,159 @@
+name: Railway PR Preview Run
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        required: true
+        type: number
+      event_action:
+        required: true
+        type: string
+      event_label_name:
+        required: true
+        type: string
+      event_head_sha:
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  lifecycle:
+    name: Reconcile exact Railway preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 110
+    environment: railway-pr-preview-lifecycle
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    env:
+      EXPECTED_OPT_IN_LABEL: railway-preview
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      PR_NUMBER: ${{ inputs.pr_number }}
+      EVENT_ACTION: ${{ inputs.event_action }}
+      EVENT_LABEL_NAME: ${{ inputs.event_label_name }}
+      EVENT_HEAD_SHA: ${{ inputs.event_head_sha }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    outputs:
+      action: ${{ steps.manage.outputs.action }}
+      preview_ready: ${{ steps.manage.outputs.preview_ready }}
+      pr_number: ${{ steps.manage.outputs.pr_number }}
+      head_sha: ${{ steps.manage.outputs.head_sha }}
+      environment_id: ${{ steps.manage.outputs.environment_id }}
+      worker_deployment_id: ${{ steps.manage.outputs.worker_deployment_id }}
+      web_deployment_id: ${{ steps.manage.outputs.web_deployment_id }}
+      worker_base_url: ${{ steps.manage.outputs.worker_base_url }}
+      web_base_url: ${{ steps.manage.outputs.web_base_url }}
+
+    steps:
+      # The local reusable workflow comes from the caller's exact trusted
+      # commit. The lifecycle credential never shares a runner with PR data.
+      - name: Check out trusted lifecycle controller
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Set up pinned Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20.19.0'
+
+      - name: Manage exact Railway PR preview
+        id: manage
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_PR_PREVIEW_LIFECYCLE_API_TOKEN }}
+        run: node scripts/railway-pr-preview-lifecycle.mjs event
+
+  preview-e2e:
+    name: Run sealed Railway preview E2E
+    needs: lifecycle
+    if: needs.lifecycle.outputs.preview_ready == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      PR_NUMBER: ${{ needs.lifecycle.outputs.pr_number }}
+      HEAD_SHA: ${{ needs.lifecycle.outputs.head_sha }}
+      WEB_BASE_URL: ${{ needs.lifecycle.outputs.web_base_url }}
+      WORKER_BASE_URL: ${{ needs.lifecycle.outputs.worker_base_url }}
+
+    steps:
+      - name: Check out trusted verifier
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: trusted
+          persist-credentials: false
+
+      - name: Check out exact opted-in PR head as evidence only
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: ${{ needs.lifecycle.outputs.head_sha }}
+          path: head-evidence
+          persist-credentials: false
+
+      - name: Set up pinned Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20.19.0'
+
+      - name: Run exact-head sealed application E2E
+        env:
+          GITHUB_TOKEN: ''
+        run: >-
+          node "$GITHUB_WORKSPACE/trusted/scripts/native-pr-preview-e2e.mjs"
+          --git-evidence-root "$GITHUB_WORKSPACE/head-evidence"
+          --pr-number "${PR_NUMBER}"
+          --commit-sha "${HEAD_SHA}"
+          --web-base-url "${WEB_BASE_URL}"
+          --worker-base-url "${WORKER_BASE_URL}"
+          --execute
+          --allow-network
+
+  report-preview-status:
+    name: Publish exact-head preview status
+    needs:
+      - lifecycle
+      - preview-e2e
+    if: always() && needs.lifecycle.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    env:
+      EXPECTED_OPT_IN_LABEL: railway-preview
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      PR_NUMBER: ${{ inputs.pr_number }}
+      EVENT_ACTION: ${{ inputs.event_action }}
+      EVENT_LABEL_NAME: ${{ inputs.event_label_name }}
+      EVENT_HEAD_SHA: ${{ inputs.event_head_sha }}
+      LIFECYCLE_HEAD_SHA: ${{ needs.lifecycle.outputs.head_sha }}
+      LIFECYCLE_RESULT: ${{ needs.lifecycle.result }}
+      PREVIEW_READY: ${{ needs.lifecycle.outputs.preview_ready }}
+      E2E_RESULT: ${{ needs.preview-e2e.result }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    steps:
+      - name: Check out trusted status reporter
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Set up pinned Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20.19.0'
+
+      - name: Publish bounded commit status
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/railway-pr-preview-lifecycle.mjs report-status

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -322,6 +322,71 @@ must not receive inherited production secrets or copied production data.
 Provider-level secret isolation or a trusted-source deployment policy is a
 prerequisite for those previews.
 
+The repository-owned
+[`Railway PR Preview Lifecycle`](../.github/workflows/railway-pr-preview-lifecycle.yml)
+workflow replaces reliance on Railway's GitHub PR lifecycle for explicitly
+opted-in previews. Only same-repository, `main`-targeted PRs carrying the exact
+`railway-preview` label are eligible; drafts wait for `ready_for_review`, and
+label removal, conversion to draft, retargeting away from `main`, or close
+requests teardown. This opt-in is
+also the scope boundary that keeps unrelated Gaming and GPT-OSS work out of the
+controller. A fixed `repository_dispatch` recovery event always executes the
+default-branch controller, and a six-hour scheduled sweep discovers only open
+opt-in PRs plus environments carrying the controller-reserved name prefix. Every
+wakeup converges current GitHub state, so replaced or stale event runs do not
+replay obsolete lifecycle intent.
+
+For an on-demand recovery, send the fixed event type with a JSON-number payload,
+for example `gh api --method POST repos/pbjustin/Arcanos/dispatches -f
+event_type=railway_pr_preview_reconcile -F client_payload[pr_number]=1435`.
+Quoted or non-canonical PR numbers fail input validation and cannot create a
+second concurrency identity.
+
+The `pull_request_target` lifecycle job checks out `github.workflow_sha`, uses
+immutable checkout/setup actions, and receives the dedicated
+`RAILWAY_PR_PREVIEW_LIFECYCLE_API_TOKEN` only in the controller step. It rejects
+account-wide tokens, requires the pinned workspace and project to be visible,
+and constrains every operation to fixed project resources. The credential is
+workspace-scoped at Railway, so it must still be treated as workspace authority.
+PR-head code is neither installed nor executed with that credential. Store the
+token as a secret on the `railway-pr-preview-lifecycle` GitHub Environment, and
+restrict that environment to the protected `main` branch; both the event and
+scheduled paths call the same trusted reusable three-job workflow.
+The controller verifies the credential-empty two-role base and complete project
+visibility, creates an exact ephemeral `pr-676861-<N>` child with initial
+deploys and staged/background apply disabled, removes cloned triggers to a
+twice-observed zero state, and deploys the exact head SHA worker-first. It polls
+only returned deployment IDs and finally requires the exact worker/web pair to
+be the sole active non-stopped successes with the reviewed PR manifest,
+Railway domains, and role/readiness identities. Cleanup validates the exact
+custom ownership predicate before deleting by UUID and verifies both ID and
+name disappear; absence is success only after complete inventory proves base
+and production visibility.
+
+The sealed 112-request E2E runs in a separate job that has no Railway secret. It
+executes the trusted default-branch verifier and uses the exact opted-in head
+checkout only as clean Git provenance evidence; PR code cannot weaken its own
+verdict. A final trusted, no-Railway-authority job revalidates that head and
+publishes `Railway PR Preview E2E` as an informational commit
+status, because an ordinary `pull_request_target` job result belongs to the
+trusted workflow SHA rather than the PR head. The workflow writes `pending`
+before reconciliation and a terminal result afterward. Do not make this
+label-opt-in status globally required: unrelated unlabeled PRs are intentionally
+not preview-gated. Creating the `railway-preview` label and provisioning the
+protected GitHub Environment and its dedicated workspace secret are
+repository/settings operations outside source control.
+
+The controller refuses preview creation while Railway-native PR environments
+remain enabled. During cutover, provision the label and protected environment
+secret first, disable
+the provider-native PR lifecycle, separately inventory and explicitly dispose
+of any legacy `Arcanos-pr-*` environments after exact ownership review, and then
+exercise a disposable labeled PR
+through creation, synchronize, exact-head E2E, and close cleanup. Production
+GitHub triggers remain disabled and paired promotion remains the only normal
+production writer. The introducing PR cannot test its own trusted lifecycle;
+the workflow must first exist on the default branch.
+
 The Railway worker-diagnostics cleanup workflow is a trusted
 `pull_request_target: closed` boundary. It never checks out pull-request code.
 It resolves only the exact

--- a/docs/RAILWAY_DEPLOYMENT.md
+++ b/docs/RAILWAY_DEPLOYMENT.md
@@ -85,6 +85,64 @@ Launcher behavior:
 - The native PR worker role remains the passive health-only server. The historical `--pr-preview-safe` flag remains available as an explicit passive fallback for both roles.
 - Native application readiness reports `trustScope: trusted-pr-accidental-effects`, `protectsMaliciousPr: false`, and `requiresPlatformSecretIsolationForUntrustedCode: true`. Repository code cannot prevent a malicious PR from reading an inherited parent environment or removing its own guard. Do not enable native application previews for forks or untrusted contributors unless Railway prevents production/provider/database/Redis credentials and data from reaching the PR container before code starts.
 - `npm run railway:probe:native-pr -- --pr-number <N> --commit-sha <SHA> --web-base-url https://<confirmed-web-pr-host> --worker-base-url https://<confirmed-worker-pr-host>` performs a no-network dry run. It fails unless the canonical Arcanos `origin`, local HEAD, and an entirely clean tracked/untracked worktree match the supplied commit evidence. Add both `--execute --allow-network` only after independently confirming those two hosts. The live runner makes 112 bounded, sequential, credential-free, no-redirect requests: the original 68-request matrix plus seven public Gaming requests, 28 Gaming-source requests (eight true unauthenticated checks, including auth-first `OPTIONS` and encoded-status cases, and 20 explicitly labeled `simulatedAuth` fixtures), two worker-role Gaming denials, six sealed self-heal approval cases, and one worker-role approval-contract denial. The unauthenticated set includes malformed and 16,385-byte bodies to prove auth-before-parser behavior. After the selector, the source fixtures mirror the production 16 KiB limit, closed 413/415 parser errors, and one-decode status-path containment. The runner verifies correlation, security, `no-store`, source `no-cache`, bounded-body, and synthetic-provenance headers. It reports served-public-identity and effect-free self-heal approval component evidence; it does not assert Railway control-plane ownership or real bearer-auth, provider, storage, queue, normal self-heal loop, actuator, or worker execution.
+- The trusted
+  [Railway PR preview lifecycle workflow](../.github/workflows/railway-pr-preview-lifecycle.yml)
+  owns preview creation and teardown for PRs carrying the exact
+  `railway-preview` label. The opt-in prevents repository-wide preview creation
+  for unrelated Gaming, GPT-OSS, or other work. It accepts only a
+  same-repository PR targeting `main`, skips drafts until `ready_for_review`,
+  and treats every admitted PR event as a wakeup to converge current state.
+  Retargeting an owned preview away from `main` is an explicit teardown wakeup.
+  A fixed `repository_dispatch` event provides an on-demand default-branch
+  recovery path, while a six-hour sweep covers missed creation and teardown
+  events using only open opt-in PRs and controller-owned environment names.
+  Dispatch recovery with a numeric payload, for example `gh api --method POST
+  repos/pbjustin/Arcanos/dispatches -f
+  event_type=railway_pr_preview_reconcile -F
+  client_payload[pr_number]=1435`; quoted or non-canonical PR numbers are
+  rejected.
+- The lifecycle controller checks out only trusted default-branch workflow
+  code while its dedicated workspace token is present. It never installs or
+  executes PR-head code in that job. The token is Railway workspace-scoped; the
+  controller additionally pins every operation to the exact project, base, and
+  service IDs. Store the token only as a secret on the
+  `railway-pr-preview-lifecycle` GitHub Environment and restrict that
+  environment to protected branch `main`; event and scheduled calls use the
+  same trusted reusable workflow. It attests the exact credential-empty base, creates only the
+  reserved `pr-676861-<N>` namespace with `ephemeral=true`, skipped initial deploys,
+  and disabled staged/background apply, removes and twice verifies cloned
+  GitHub triggers, then deploys the exact PR SHA worker-first through Railway's
+  API. Each returned deployment ID must become the sole active non-stopped
+  `SUCCESS` for its exact role and pass repository, commit, manifest, domain,
+  and readiness checks. A newer failed latest record does not mask the sole
+  active success. Ambiguity, pagination truncation, trigger recreation,
+  deployment races, or provider-schema drift fails closed.
+- Only the separate credential-free job checks out the opted-in PR head, and it
+  uses that checkout solely as clean exact-SHA Git evidence. The executed
+  112-request harness and contract come from the trusted default-branch checkout.
+  A final trusted job writes the
+  `Railway PR Preview E2E` commit status against the revalidated exact head; it
+  has no Railway authority and never checks out the head. Configure
+  `RAILWAY_PR_PREVIEW_LIFECYCLE_API_TOKEN` with a token scoped only to the
+  pinned Railway workspace. Account-wide and project-environment tokens are
+  rejected. Configure the protected GitHub Environment and the
+  `railway-preview` label before rehearsal. The commit
+  status is informational for this opt-in policy; do not configure it as a
+  global required check because unrelated unlabeled PRs are intentionally out
+  of preview scope.
+- Cutover is deliberately fail closed. Railway-native PR environment creation
+  must be disabled before the controller will create a custom preview, because
+  both mechanisms can create competing environments and deployments for the
+  same PR even though their reserved names differ. Keep production
+  GitHub triggers disabled; this workflow does not change production promotion.
+  Install the dedicated secret and label before disabling the native lifecycle,
+  then separately inventory and explicitly dispose of legacy `Arcanos-pr-*`
+  children only after exact ownership review; the controller deliberately never
+  adopts or deletes that older namespace. Finally, prove one disposable labeled
+  PR through open/ready, synchronize, and close. The PR that introduces the
+  workflow cannot exercise its own trusted
+  lifecycle because unmerged `pull_request_target` code is not present on the
+  default branch.
 - A production-shaped worker-diagnostics E2E must not activate or reuse that
   native environment. Use an empty custom
   `worker-diagnostics-pr-<PR_NUMBER>-e2e` environment with environment-scoped

--- a/scripts/native-pr-preview-e2e.mjs
+++ b/scripts/native-pr-preview-e2e.mjs
@@ -35,6 +35,7 @@ const WEB_RESPONSE_HEADER_CONTRACT = Object.freeze({
 const REPOSITORY_ROOT = fileURLToPath(new URL('../', import.meta.url));
 const VALUE_ARGUMENTS = new Set([
   '--commit-sha',
+  '--git-evidence-root',
   '--max-response-bytes',
   '--pr-number',
   '--request-timeout-ms',
@@ -176,12 +177,12 @@ function repositoryPathsMatch(actualPath, expectedPath) {
     : actual === expected;
 }
 
-export function readLocalGitState(cwd = REPOSITORY_ROOT) {
+export function readLocalGitState(cwd = REPOSITORY_ROOT, expectedRoot = cwd) {
   const repositoryRoot = runLocalGit(
     ['rev-parse', '--show-toplevel'],
     cwd
   );
-  if (!repositoryPathsMatch(repositoryRoot, REPOSITORY_ROOT)) {
+  if (!repositoryPathsMatch(repositoryRoot, expectedRoot)) {
     fail('NATIVE_PR_PREVIEW_LOCAL_REPOSITORY_ROOT_MISMATCH');
   }
   const head = runLocalGit(['rev-parse', 'HEAD'], cwd).toLowerCase();
@@ -207,7 +208,7 @@ export function readLocalGitState(cwd = REPOSITORY_ROOT) {
 
 export function parseNativePrPreviewE2eArguments(
   args,
-  { localGitState = readLocalGitState() } = {}
+  { localGitState = undefined } = {}
 ) {
   const values = new Map();
   const booleans = new Set();
@@ -245,6 +246,12 @@ export function parseNativePrPreviewE2eArguments(
     }
   }
 
+  const gitEvidenceRoot = values.has('--git-evidence-root')
+    ? path.resolve(values.get('--git-evidence-root'))
+    : REPOSITORY_ROOT;
+  const observedLocalGitState = localGitState
+    ?? readLocalGitState(gitEvidenceRoot, gitEvidenceRoot);
+
   const execute = booleans.has('--execute');
   const allowNetwork = booleans.has('--allow-network');
   if (execute !== allowNetwork) {
@@ -260,13 +267,13 @@ export function parseNativePrPreviewE2eArguments(
   if (!COMMIT_PATTERN.test(commitSha ?? '')) {
     fail('NATIVE_PR_PREVIEW_COMMIT_INVALID');
   }
-  if (!localGitState.clean) {
+  if (!observedLocalGitState.clean) {
     fail('NATIVE_PR_PREVIEW_LOCAL_WORKTREE_DIRTY');
   }
-  if (localGitState.repository !== CANONICAL_REPOSITORY) {
+  if (observedLocalGitState.repository !== CANONICAL_REPOSITORY) {
     fail('NATIVE_PR_PREVIEW_LOCAL_REPOSITORY_MISMATCH');
   }
-  if (commitSha !== localGitState.head) {
+  if (commitSha !== observedLocalGitState.head) {
     fail('NATIVE_PR_PREVIEW_LOCAL_HEAD_MISMATCH');
   }
 
@@ -295,7 +302,7 @@ export function parseNativePrPreviewE2eArguments(
       'NATIVE_PR_PREVIEW_MAX_RESPONSE_BYTES_INVALID'
     ),
     prNumber,
-    repository: localGitState.repository,
+    repository: observedLocalGitState.repository,
     requestTimeoutMs: readInteger(
       values.get('--request-timeout-ms') ?? String(DEFAULT_REQUEST_TIMEOUT_MS),
       1_000,

--- a/scripts/native-pr-preview-e2e.test.mjs
+++ b/scripts/native-pr-preview-e2e.test.mjs
@@ -1,4 +1,8 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { test } from 'node:test';
 import { setTimeout as delay } from 'node:timers/promises';
 
@@ -9,6 +13,7 @@ import {
   expectedNativePrPreviewResponseBody,
   nativePrPreviewCaseCorrelation,
   parseNativePrPreviewE2eArguments,
+  readLocalGitState,
   runNativePrPreviewE2e,
 } from './native-pr-preview-e2e.mjs';
 import {
@@ -314,6 +319,52 @@ test('rejects dirty worktrees and non-canonical repositories', () => {
       error instanceof NativePrPreviewE2eError
       && error.code === 'NATIVE_PR_PREVIEW_LOCAL_REPOSITORY_MISMATCH'
   );
+});
+
+test('reads exact candidate Git evidence without executing candidate files', () => {
+  const repositoryRoot = mkdtempSync(path.join(tmpdir(), 'arcanos-preview-evidence-'));
+  const runGit = (...args) => {
+    const result = spawnSync('git', args, {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    assert.equal(result.status, 0, result.stderr);
+    return result.stdout.trim();
+  };
+  try {
+    runGit('init');
+    runGit('config', 'user.email', 'preview-evidence@example.invalid');
+    runGit('config', 'user.name', 'Preview Evidence');
+    writeFileSync(path.join(repositoryRoot, 'candidate.txt'), 'candidate evidence\n');
+    runGit('add', 'candidate.txt');
+    runGit('commit', '-m', 'candidate evidence');
+    runGit('remote', 'add', 'origin', 'https://github.com/pbjustin/Arcanos.git');
+    const head = runGit('rev-parse', 'HEAD').toLowerCase();
+
+    assert.deepEqual(readLocalGitState(repositoryRoot, repositoryRoot), {
+      clean: true,
+      head,
+      repository: 'pbjustin/Arcanos',
+    });
+    const evidenceArguments = validArguments('--git-evidence-root', repositoryRoot);
+    evidenceArguments[evidenceArguments.indexOf('--commit-sha') + 1] = head;
+    const parsed = parseNativePrPreviewE2eArguments(evidenceArguments);
+    assert.equal(parsed.commitSha, head);
+    assert.throws(
+      () => readLocalGitState(repositoryRoot, path.dirname(repositoryRoot)),
+      (error) => error instanceof NativePrPreviewE2eError
+        && error.code === 'NATIVE_PR_PREVIEW_LOCAL_REPOSITORY_ROOT_MISMATCH'
+    );
+    writeFileSync(path.join(repositoryRoot, 'candidate.txt'), 'dirty evidence\n');
+    assert.throws(
+      () => readLocalGitState(repositoryRoot, repositoryRoot),
+      (error) => error instanceof NativePrPreviewE2eError
+        && error.code === 'NATIVE_PR_PREVIEW_LOCAL_WORKTREE_DIRTY'
+    );
+  } finally {
+    rmSync(repositoryRoot, { recursive: true, force: true });
+  }
 });
 
 test('executes the bounded credential-free matrix and detects identity stability', async () => {

--- a/scripts/railway-pr-preview-lifecycle.mjs
+++ b/scripts/railway-pr-preview-lifecycle.mjs
@@ -84,6 +84,10 @@ const FAILED_DEPLOYMENT_STATUSES = new Set([
   'SLEEPING',
 ]);
 const EXPECTED_PROPERTY_MAPPINGS = Object.freeze({
+  'build.buildCommand': '$.build.buildCommand',
+  'build.builder': '$.build.builder',
+  'build.cache': '$.build.cache',
+  'build.env': '$.build.env',
   'deploy.startCommand': '$.environments.pr.deploy.startCommand',
   'deploy.healthcheckPath': '$.environments.pr.deploy.healthcheckPath',
   'deploy.healthcheckTimeout': '$.environments.pr.deploy.healthcheckTimeout',
@@ -92,6 +96,7 @@ const EXPECTED_PROPERTY_MAPPINGS = Object.freeze({
   'deploy.preDeployCommand': '$.environments.pr.deploy.preDeployCommand',
   'deploy.cronSchedule': '$.environments.pr.deploy.cronSchedule',
   'deploy.drainingSeconds': '$.deploy.drainingSeconds',
+  'deploy.env': '$.deploy.env',
 });
 
 const TOKEN_TYPE_QUERY = `
@@ -566,9 +571,8 @@ function validateEnvironmentConfig(config, {
         && hasExactKeys(serviceConfig.variables, ['ARCANOS_PROCESS_KIND'])
         && hasExactKeys(
           serviceConfig.variables.ARCANOS_PROCESS_KIND,
-          ['generator', 'value']
+          ['value']
         )
-        && serviceConfig.variables.ARCANOS_PROCESS_KIND.generator === null
         && serviceConfig.variables.ARCANOS_PROCESS_KIND.value === role,
       errorCode
     );

--- a/scripts/railway-pr-preview-lifecycle.mjs
+++ b/scripts/railway-pr-preview-lifecycle.mjs
@@ -1,13 +1,17 @@
 #!/usr/bin/env node
 
+import { Buffer } from 'node:buffer';
 import { appendFileSync } from 'node:fs';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
 const COMMIT_PATTERN = /^[0-9a-f]{40}$/u;
+const GITHUB_OBJECT_ID_PATTERN = /^[0-9a-f]{40}$/iu;
 const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]*$/u;
-const HEAD_REF_PATTERN = /^(?![./])(?!.*(?:\.\.|\/\.|\.\/|\/\/))[A-Za-z0-9._/-]{1,255}$/u;
+const GITHUB_HEAD_REF_PREFIX = 'refs/heads/';
+const GITHUB_REF_LIMIT_BYTES = 255;
+const GIT_REF_FORBIDDEN_CHARACTERS = new Set(['~', '^', ':', '?', '*', '[', '\\']);
 const RAILWAY_API_URL = 'https://backboard.railway.com/graphql/v2';
 const GITHUB_API_URL = 'https://api.github.com';
 const API_TIMEOUT_MS = 10_000;
@@ -23,6 +27,7 @@ const READINESS_POLL_ATTEMPTS = 15;
 const DELETE_POLL_INTERVAL_MS = 5_000;
 const DELETE_POLL_ATTEMPTS = 12;
 const TRIGGER_QUIESCENCE_INTERVAL_MS = 2_000;
+const PREVIEW_REGION = 'us-east4-eqdc4a';
 
 const services = Object.freeze({
   worker: Object.freeze({
@@ -365,6 +370,42 @@ function hasExactKeys(value, expectedKeys) {
     && actual.every((key, index) => key === expected[index]);
 }
 
+function hasExactPreviewRegionConfig(value) {
+  return hasExactKeys(value, [PREVIEW_REGION])
+    && hasExactKeys(value[PREVIEW_REGION], ['numReplicas'])
+    && value[PREVIEW_REGION].numReplicas === 1;
+}
+
+function isValidGitHubHeadRef(value) {
+  if (typeof value !== 'string' || value.length === 0) {
+    return false;
+  }
+  if (
+    Buffer.byteLength(`${GITHUB_HEAD_REF_PREFIX}${value}`, 'utf8') > GITHUB_REF_LIMIT_BYTES
+    || value.startsWith('refs/')
+    || GITHUB_OBJECT_ID_PATTERN.test(value)
+    || value.includes('..')
+    || value.includes('@{')
+    || value.endsWith('.')
+  ) {
+    return false;
+  }
+  for (const character of value) {
+    const codePoint = character.codePointAt(0);
+    if (
+      codePoint <= 0x20
+      || codePoint === 0x7f
+      || GIT_REF_FORBIDDEN_CHARACTERS.has(character)
+    ) {
+      return false;
+    }
+  }
+  return value.split('/').every(component =>
+    component.length > 0
+    && !component.startsWith('.')
+    && !component.endsWith('.lock'));
+}
+
 function escapeRegex(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
 }
@@ -422,11 +463,11 @@ export function validateLifecyclePullRequest(rawPullRequest, expectedPrNumber) {
       && (rawPullRequest.state === 'open' || rawPullRequest.state === 'closed')
       && typeof rawPullRequest.draft === 'boolean'
       && typeof rawPullRequest.base?.ref === 'string'
-      && HEAD_REF_PATTERN.test(rawPullRequest.base.ref)
+      && isValidGitHubHeadRef(rawPullRequest.base.ref)
       && rawPullRequest.base?.repo?.full_name === CONTRACT.repository
       && rawPullRequest.head?.repo?.full_name === CONTRACT.repository
       && typeof rawPullRequest.head?.ref === 'string'
-      && HEAD_REF_PATTERN.test(rawPullRequest.head.ref)
+      && isValidGitHubHeadRef(rawPullRequest.head.ref)
       && typeof rawPullRequest.head?.sha === 'string'
       && COMMIT_PATTERN.test(rawPullRequest.head.sha.toLowerCase()),
     'RAILWAY_PR_PREVIEW_GITHUB_PR_INVALID'
@@ -558,12 +599,13 @@ function validateEnvironmentConfig(config, {
       ])
         && isRecord(serviceConfig.build)
         && isRecord(serviceConfig.deploy)
+        && hasExactPreviewRegionConfig(serviceConfig.deploy.multiRegionConfig)
         && serviceConfig.groupId === CONTRACT.serviceGroupId
         && isRecord(serviceConfig.networking)
         && sourceHasExpectedKeys
         && typeof serviceConfig.source.branch === 'string'
         && (allowAnyBranch
-          ? HEAD_REF_PATTERN.test(serviceConfig.source.branch)
+          ? isValidGitHubHeadRef(serviceConfig.source.branch)
           : expectedBranches.includes(serviceConfig.source.branch))
         && serviceConfig.source.repo === CONTRACT.repository
         && (serviceConfig.source.checkSuites === undefined
@@ -717,7 +759,7 @@ export function validateOwnedPreviewEnvironment(environment, {
         && trigger.repository === CONTRACT.repository
         && typeof trigger.branch === 'string'
         && (allowAnyHeadRef
-          ? HEAD_REF_PATTERN.test(trigger.branch)
+          ? isValidGitHubHeadRef(trigger.branch)
           : trigger.branch === CONTRACT.baseBranch
           || (headRef !== undefined && trigger.branch === headRef))
         && trigger.provider === 'github'
@@ -879,6 +921,7 @@ export function validatePreviewDeployment(deployment, {
       && deploy.cronSchedule === null
       && deploy.runtime === 'V2'
       && deploy.numReplicas === 1
+      && hasExactPreviewRegionConfig(deploy.multiRegionConfig)
       && deploy.requiredMountPath === null,
     'RAILWAY_PR_PREVIEW_DEPLOYMENT_MISMATCH'
   );

--- a/scripts/railway-pr-preview-lifecycle.mjs
+++ b/scripts/railway-pr-preview-lifecycle.mjs
@@ -61,6 +61,7 @@ export const RAILWAY_PR_PREVIEW_CONTRACT = Object.freeze({
 });
 
 const CONTRACT = RAILWAY_PR_PREVIEW_CONTRACT;
+const ENVIRONMENT_PREFIX_PATTERN = escapeRegex(CONTRACT.environmentPrefix);
 const PROTECTED_ENVIRONMENT_IDS = new Set([
   CONTRACT.baseEnvironmentId,
   CONTRACT.productionEnvironmentId,
@@ -359,6 +360,10 @@ function hasExactKeys(value, expectedKeys) {
     && actual.every((key, index) => key === expected[index]);
 }
 
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
 function isUuid(value) {
   return typeof value === 'string' && UUID_PATTERN.test(value);
 }
@@ -577,7 +582,10 @@ function validatePreviewDomain(domain, {
   prNumber,
 }) {
   const hostname = domain?.domain;
-  const marker = new RegExp(`(?:^|[.-])pr-676861-${prNumber}(?:[.-]|$)`, 'iu');
+  const marker = new RegExp(
+    `(?:^|[.-])${ENVIRONMENT_PREFIX_PATTERN}${prNumber}(?:[.-]|$)`,
+    'iu'
+  );
   requireCondition(
     isRecord(domain)
       && isUuid(domain.id)
@@ -845,7 +853,7 @@ export function validatePreviewDeployment(deployment, {
       && meta.rootDirectory === null
       && Array.isArray(meta.volumeMounts)
       && meta.volumeMounts.length === 0
-      && isRecord(mappings)
+      && hasExactKeys(mappings, Object.keys(EXPECTED_PROPERTY_MAPPINGS))
       && Object.entries(EXPECTED_PROPERTY_MAPPINGS).every(
         ([key, value]) => mappings[key] === value
       )
@@ -1503,7 +1511,7 @@ export async function discoverRailwayPrPreviewNumbers({ github, railway }) {
   await railway.validateAuthority({ requireNativeDisabled: false });
   const numbers = new Set();
   const prefixPattern = new RegExp(
-    `^${CONTRACT.environmentPrefix}([1-9][0-9]*)$`,
+    `^${ENVIRONMENT_PREFIX_PATTERN}([1-9][0-9]*)$`,
     'u'
   );
   for (const environment of await railway.listEnvironments()) {
@@ -1708,7 +1716,7 @@ export class RailwayGraphqlApi {
 
   async createEnvironment(input) {
     const expectedNamePattern = new RegExp(
-      `^${CONTRACT.environmentPrefix}[1-9][0-9]*$`,
+      `^${ENVIRONMENT_PREFIX_PATTERN}[1-9][0-9]*$`,
       'u'
     );
     requireCondition(
@@ -1903,7 +1911,7 @@ export class RailwayGraphqlApi {
 
   async deleteAndVerifyEnvironment(environment) {
     const ownedNamePattern = new RegExp(
-      `^${CONTRACT.environmentPrefix}[1-9][0-9]*$`,
+      `^${ENVIRONMENT_PREFIX_PATTERN}[1-9][0-9]*$`,
       'u'
     );
     requireCondition(

--- a/scripts/railway-pr-preview-lifecycle.mjs
+++ b/scripts/railway-pr-preview-lifecycle.mjs
@@ -1,0 +1,2271 @@
+#!/usr/bin/env node
+
+import { appendFileSync } from 'node:fs';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+const COMMIT_PATTERN = /^[0-9a-f]{40}$/u;
+const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]*$/u;
+const HEAD_REF_PATTERN = /^(?![./])(?!.*(?:\.\.|\/\.|\.\/|\/\/))[A-Za-z0-9._/-]{1,255}$/u;
+const RAILWAY_API_URL = 'https://backboard.railway.com/graphql/v2';
+const GITHUB_API_URL = 'https://api.github.com';
+const API_TIMEOUT_MS = 10_000;
+const API_RESPONSE_LIMIT_BYTES = 2 * 1024 * 1024;
+const GITHUB_RESPONSE_LIMIT_BYTES = 512 * 1024;
+const READINESS_RESPONSE_LIMIT_BYTES = 64 * 1024;
+const DEPLOYMENT_POLL_INTERVAL_MS = 10_000;
+const DEPLOYMENT_POLL_ATTEMPTS = 270;
+const PROJECTION_POLL_INTERVAL_MS = 5_000;
+const PROJECTION_POLL_ATTEMPTS = 24;
+const READINESS_POLL_INTERVAL_MS = 2_000;
+const READINESS_POLL_ATTEMPTS = 15;
+const DELETE_POLL_INTERVAL_MS = 5_000;
+const DELETE_POLL_ATTEMPTS = 12;
+const TRIGGER_QUIESCENCE_INTERVAL_MS = 2_000;
+
+const services = Object.freeze({
+  worker: Object.freeze({
+    baseInstanceId: '40b099b2-e883-4fd1-969b-17a5bf5706e5',
+    id: '1765befb-b805-4051-9af9-28634e986886',
+    name: 'ARCANOS Worker',
+    role: 'worker',
+  }),
+  web: Object.freeze({
+    baseInstanceId: '83a7bff0-b5a7-45b0-bdec-277da4d0a2c2',
+    id: 'c4ade025-3f13-4fca-9309-5d0dd81396fe',
+    name: 'ARCANOS V2',
+    role: 'web',
+  }),
+});
+
+export const RAILWAY_PR_PREVIEW_CONTRACT = Object.freeze({
+  repository: 'pbjustin/Arcanos',
+  baseBranch: 'main',
+  optInLabel: 'railway-preview',
+  statusContext: 'Railway PR Preview E2E',
+  workspaceId: '1c9265a3-986f-4304-ad3e-5a874caab039',
+  projectId: '7faf44e5-519c-4e73-8d7a-da9f389e6187',
+  baseEnvironmentId: '8d5594c5-075e-4ad5-8fad-9e6e0866032d',
+  baseEnvironmentName: 'pr-preview-base-20260812',
+  baseSourceEnvironmentId: '4800907a-2c12-4739-b384-4f3ac06a9620',
+  productionEnvironmentId: 'fb583147-6c39-4343-9267-500f357d25ab',
+  environmentPrefix: 'pr-676861-',
+  serviceGroupId: '6f8cef49-8ec0-4e31-8205-c93c266ba439',
+  baseStartCommand:
+    'node scripts/start-railway-service-with-integrity.mjs --pr-preview-safe',
+  previewStartCommand:
+    'node scripts/start-railway-service-with-integrity.mjs --pr-preview-app-safe-v1',
+  buildCommand: 'npm ci --include=dev --no-audit --no-fund && npm run build',
+  services,
+});
+
+const CONTRACT = RAILWAY_PR_PREVIEW_CONTRACT;
+const PROTECTED_ENVIRONMENT_IDS = new Set([
+  CONTRACT.baseEnvironmentId,
+  CONTRACT.productionEnvironmentId,
+]);
+const SERVICE_IDS = new Set(Object.values(CONTRACT.services).map(({ id }) => id));
+const PENDING_DEPLOYMENT_STATUSES = new Set([
+  'INITIALIZING',
+  'QUEUED',
+  'BUILDING',
+  'DEPLOYING',
+  'WAITING',
+  'NEEDS_APPROVAL',
+]);
+const FAILED_DEPLOYMENT_STATUSES = new Set([
+  'FAILED',
+  'CRASHED',
+  'REMOVED',
+  'REMOVING',
+  'SKIPPED',
+  'SLEEPING',
+]);
+const EXPECTED_PROPERTY_MAPPINGS = Object.freeze({
+  'deploy.startCommand': '$.environments.pr.deploy.startCommand',
+  'deploy.healthcheckPath': '$.environments.pr.deploy.healthcheckPath',
+  'deploy.healthcheckTimeout': '$.environments.pr.deploy.healthcheckTimeout',
+  'deploy.restartPolicyType': '$.environments.pr.deploy.restartPolicyType',
+  'deploy.restartPolicyMaxRetries': '$.environments.pr.deploy.restartPolicyMaxRetries',
+  'deploy.preDeployCommand': '$.environments.pr.deploy.preDeployCommand',
+  'deploy.cronSchedule': '$.environments.pr.deploy.cronSchedule',
+  'deploy.drainingSeconds': '$.deploy.drainingSeconds',
+});
+
+const TOKEN_TYPE_QUERY = `
+  query PreviewLifecycleTokenType {
+    me {
+      id
+    }
+  }
+`;
+
+const AUTHORITY_QUERY = `
+  query PreviewLifecycleAuthority($projectId: String!) {
+    apiToken {
+      workspaces {
+        id
+      }
+    }
+    project(id: $projectId) {
+      id
+      workspaceId
+      baseEnvironmentId
+      primaryEnvironmentId
+      prDeploys
+      botPrEnvironments
+      focusedPrEnvironments
+    }
+  }
+`;
+
+const ENVIRONMENTS_QUERY = `
+  query PreviewLifecycleEnvironments($projectId: String!, $after: String) {
+    environments(projectId: $projectId, first: 100, after: $after) {
+      edges {
+        cursor
+        node {
+          id
+          name
+          projectId
+          isEphemeral
+          deletedAt
+          sourceEnvironment {
+            id
+          }
+          meta {
+            prNumber
+            prRepo
+            branch
+            baseBranch
+          }
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;
+
+const ENVIRONMENT_QUERY = `
+  query PreviewLifecycleEnvironment($projectId: String!, $environmentId: String!) {
+    environment(id: $environmentId, projectId: $projectId) {
+      id
+      name
+      projectId
+      isEphemeral
+      deletedAt
+      sourceEnvironment {
+        id
+      }
+      meta {
+        prNumber
+        prRepo
+        branch
+        baseBranch
+      }
+      config(decryptVariables: true)
+      deploymentTriggers(first: 100) {
+        edges {
+          node {
+            id
+            projectId
+            environmentId
+            serviceId
+            repository
+            branch
+            provider
+            checkSuites
+          }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+      serviceInstances(first: 100) {
+        edges {
+          node {
+            id
+            serviceId
+            serviceName
+            environmentId
+            deletedAt
+            source {
+              repo
+              image
+            }
+            railwayConfigFile
+            rootDirectory
+            dockerfilePath
+            startCommand
+            healthcheckPath
+            healthcheckTimeout
+            drainingSeconds
+            restartPolicyType
+            restartPolicyMaxRetries
+            latestDeployment {
+              id
+              projectId
+              environmentId
+              serviceId
+              status
+              deploymentStopped
+              meta
+            }
+            activeDeployments {
+              id
+              projectId
+              environmentId
+              serviceId
+              status
+              deploymentStopped
+              meta
+            }
+            domains {
+              serviceDomains {
+                id
+                domain
+                environmentId
+                serviceId
+                deletedAt
+                syncStatus
+              }
+              customDomains {
+                id
+                domain
+                environmentId
+                serviceId
+                deletedAt
+                isRailwayDomain
+              }
+            }
+          }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+      volumeInstances(first: 100) {
+        edges {
+          node {
+            id
+            environmentId
+            serviceId
+            volumeId
+            mountPath
+            deletedAt
+            state
+          }
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+    }
+  }
+`;
+
+const CREATE_ENVIRONMENT_MUTATION = `
+  mutation CreatePreviewLifecycleEnvironment($input: EnvironmentCreateInput!) {
+    environmentCreate(input: $input) {
+      id
+      name
+      projectId
+      isEphemeral
+      sourceEnvironment {
+        id
+      }
+    }
+  }
+`;
+
+const DELETE_TRIGGER_MUTATION = `
+  mutation DeletePreviewLifecycleTrigger($id: String!) {
+    deploymentTriggerDelete(id: $id)
+  }
+`;
+
+const DEPLOY_SERVICE_MUTATION = `
+  mutation DeployPreviewLifecycleService(
+    $environmentId: String!
+    $serviceId: String!
+    $commitSha: String!
+  ) {
+    serviceInstanceDeployV2(
+      environmentId: $environmentId
+      serviceId: $serviceId
+      commitSha: $commitSha
+    )
+  }
+`;
+
+const DEPLOYMENT_QUERY = `
+  query PreviewLifecycleDeployment($id: String!) {
+    deployment(id: $id) {
+      id
+      projectId
+      environmentId
+      serviceId
+      status
+      deploymentStopped
+      createdAt
+      statusUpdatedAt
+      meta
+    }
+  }
+`;
+
+const DELETE_ENVIRONMENT_MUTATION = `
+  mutation DeletePreviewLifecycleEnvironment($id: String!) {
+    environmentDelete(id: $id)
+  }
+`;
+
+export class RailwayPrPreviewLifecycleError extends Error {
+  constructor(code) {
+    super(code);
+    this.name = 'RailwayPrPreviewLifecycleError';
+    this.code = code;
+  }
+}
+
+function fail(code) {
+  throw new RailwayPrPreviewLifecycleError(code);
+}
+
+function requireCondition(condition, code) {
+  if (!condition) {
+    fail(code);
+  }
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasExactKeys(value, expectedKeys) {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const actual = Object.keys(value).sort();
+  const expected = [...expectedKeys].sort();
+  return actual.length === expected.length
+    && actual.every((key, index) => key === expected[index]);
+}
+
+function isUuid(value) {
+  return typeof value === 'string' && UUID_PATTERN.test(value);
+}
+
+function requireUuid(value, code) {
+  requireCondition(isUuid(value), code);
+  return value;
+}
+
+function requireCommit(value, code) {
+  requireCondition(typeof value === 'string' && COMMIT_PATTERN.test(value), code);
+  return value;
+}
+
+function readConnection(connection, code) {
+  requireCondition(
+    isRecord(connection)
+      && Array.isArray(connection.edges)
+      && isRecord(connection.pageInfo)
+      && connection.pageInfo.hasNextPage === false,
+    code
+  );
+  const nodes = connection.edges.map((edge) => edge?.node);
+  requireCondition(nodes.every(isRecord), code);
+  return nodes;
+}
+
+function readLabels(rawLabels) {
+  requireCondition(Array.isArray(rawLabels), 'RAILWAY_PR_PREVIEW_GITHUB_PR_INVALID');
+  const labels = rawLabels.map((label) =>
+    typeof label === 'string' ? label : label?.name);
+  requireCondition(
+    labels.every((label) =>
+      typeof label === 'string'
+      && label.length > 0
+      && label.length <= 100
+      && label.trim() === label),
+    'RAILWAY_PR_PREVIEW_GITHUB_PR_INVALID'
+  );
+  return [...new Set(labels)];
+}
+
+export function validateLifecyclePullRequest(rawPullRequest, expectedPrNumber) {
+  requireCondition(
+    Number.isSafeInteger(expectedPrNumber) && expectedPrNumber > 0,
+    'RAILWAY_PR_PREVIEW_PR_NUMBER_INVALID'
+  );
+  requireCondition(
+    isRecord(rawPullRequest)
+      && rawPullRequest.number === expectedPrNumber
+      && (rawPullRequest.state === 'open' || rawPullRequest.state === 'closed')
+      && typeof rawPullRequest.draft === 'boolean'
+      && typeof rawPullRequest.base?.ref === 'string'
+      && HEAD_REF_PATTERN.test(rawPullRequest.base.ref)
+      && rawPullRequest.base?.repo?.full_name === CONTRACT.repository
+      && rawPullRequest.head?.repo?.full_name === CONTRACT.repository
+      && typeof rawPullRequest.head?.ref === 'string'
+      && HEAD_REF_PATTERN.test(rawPullRequest.head.ref)
+      && typeof rawPullRequest.head?.sha === 'string'
+      && COMMIT_PATTERN.test(rawPullRequest.head.sha.toLowerCase()),
+    'RAILWAY_PR_PREVIEW_GITHUB_PR_INVALID'
+  );
+  return Object.freeze({
+    number: expectedPrNumber,
+    state: rawPullRequest.state,
+    draft: rawPullRequest.draft,
+    baseRef: rawPullRequest.base.ref,
+    headRef: rawPullRequest.head.ref,
+    headSha: rawPullRequest.head.sha.toLowerCase(),
+    repository: rawPullRequest.head.repo.full_name,
+    labels: Object.freeze(readLabels(rawPullRequest.labels)),
+  });
+}
+
+export function decideLifecycleAction({
+  eventAction,
+  eventLabelName = '',
+  pullRequest,
+}) {
+  requireCondition(isRecord(pullRequest), 'RAILWAY_PR_PREVIEW_GITHUB_PR_INVALID');
+  const optedIn = pullRequest.labels.includes(CONTRACT.optInLabel);
+  const eligible = pullRequest.state === 'open'
+    && !pullRequest.draft
+    && pullRequest.baseRef === CONTRACT.baseBranch
+    && optedIn;
+
+  requireCondition([
+    'manual',
+    'closed',
+    'converted_to_draft',
+    'edited',
+    'unlabeled',
+    'labeled',
+    'opened',
+    'reopened',
+    'ready_for_review',
+    'synchronize',
+  ].includes(eventAction), 'RAILWAY_PR_PREVIEW_EVENT_ACTION_INVALID');
+  if (eligible) {
+    return 'reconcile';
+  }
+  const canOwnAControllerPreview = eventAction === 'closed'
+    || eventAction === 'converted_to_draft'
+    || eventAction === 'manual'
+    || (eventAction === 'edited' && pullRequest.baseRef !== CONTRACT.baseBranch)
+    || (eventAction === 'unlabeled' && eventLabelName === CONTRACT.optInLabel);
+  return canOwnAControllerPreview ? 'cleanup' : 'noop';
+}
+
+export function validateLifecycleAuthority(authority, {
+  requireNativeDisabled = false,
+} = {}) {
+  const workspaces = authority?.apiToken?.workspaces;
+  const project = authority?.project;
+  requireCondition(
+    Array.isArray(workspaces)
+      && workspaces.length === 1
+      && workspaces[0]?.id === CONTRACT.workspaceId,
+    'RAILWAY_PR_PREVIEW_AUTHORITY_MISMATCH'
+  );
+  requireCondition(
+    isRecord(project)
+      && project.id === CONTRACT.projectId
+      && project.workspaceId === CONTRACT.workspaceId
+      && project.baseEnvironmentId === CONTRACT.baseEnvironmentId
+      && project.primaryEnvironmentId === CONTRACT.productionEnvironmentId,
+    'RAILWAY_PR_PREVIEW_AUTHORITY_MISMATCH'
+  );
+  if (requireNativeDisabled) {
+    requireCondition(
+      project.prDeploys === false,
+      'RAILWAY_PR_PREVIEW_NATIVE_LIFECYCLE_ENABLED'
+    );
+  }
+  return project;
+}
+
+function validateEnvironmentConfig(config, {
+  allowAnyBranch = false,
+  expectedBranches,
+  allowCheckSuites,
+  errorCode = 'RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH',
+} = {}) {
+  const expectedGroup = {
+    color: 'blue',
+    icon: null,
+    isCollapsed: false,
+    name: 'arcanos',
+  };
+  requireCondition(
+    hasExactKeys(config, [
+      'groups',
+      'privateNetworkDisabled',
+      'services',
+      'sharedVariables',
+    ])
+      && isRecord(config.groups)
+      && hasExactKeys(config.groups, [CONTRACT.serviceGroupId])
+      && hasExactKeys(config.groups[CONTRACT.serviceGroupId], Object.keys(expectedGroup))
+      && Object.entries(expectedGroup).every(
+        ([key, value]) => config.groups[CONTRACT.serviceGroupId][key] === value
+      )
+      && config.privateNetworkDisabled === false
+      && isRecord(config.services)
+      && isRecord(config.sharedVariables)
+      && Object.keys(config.sharedVariables).length === 0
+      && hasExactKeys(config.services, [...SERVICE_IDS]),
+    errorCode
+  );
+  for (const [role, service] of Object.entries(CONTRACT.services)) {
+    const serviceConfig = config.services[service.id];
+    const sourceHasExpectedKeys = hasExactKeys(
+      serviceConfig?.source,
+      ['branch', 'repo']
+    ) || (allowCheckSuites && hasExactKeys(
+      serviceConfig?.source,
+      ['branch', 'checkSuites', 'repo']
+    ));
+    requireCondition(
+      hasExactKeys(serviceConfig, [
+        'build',
+        'deploy',
+        'groupId',
+        'networking',
+        'source',
+        'variables',
+      ])
+        && isRecord(serviceConfig.build)
+        && isRecord(serviceConfig.deploy)
+        && serviceConfig.groupId === CONTRACT.serviceGroupId
+        && isRecord(serviceConfig.networking)
+        && sourceHasExpectedKeys
+        && typeof serviceConfig.source.branch === 'string'
+        && (allowAnyBranch
+          ? HEAD_REF_PATTERN.test(serviceConfig.source.branch)
+          : expectedBranches.includes(serviceConfig.source.branch))
+        && serviceConfig.source.repo === CONTRACT.repository
+        && (serviceConfig.source.checkSuites === undefined
+          || serviceConfig.source.checkSuites === false)
+        && hasExactKeys(serviceConfig.variables, ['ARCANOS_PROCESS_KIND'])
+        && hasExactKeys(
+          serviceConfig.variables.ARCANOS_PROCESS_KIND,
+          ['generator', 'value']
+        )
+        && serviceConfig.variables.ARCANOS_PROCESS_KIND.generator === null
+        && serviceConfig.variables.ARCANOS_PROCESS_KIND.value === role,
+      errorCode
+    );
+  }
+}
+
+function validatePreviewDomain(domain, {
+  environmentId,
+  requireActive,
+  serviceId,
+  prNumber,
+}) {
+  const hostname = domain?.domain;
+  const marker = new RegExp(`(?:^|[.-])pr-676861-${prNumber}(?:[.-]|$)`, 'iu');
+  requireCondition(
+    isRecord(domain)
+      && isUuid(domain.id)
+      && domain.environmentId === environmentId
+      && domain.serviceId === serviceId
+      && domain.deletedAt === null
+      && (requireActive
+        ? domain.syncStatus === 'ACTIVE'
+        : ['CREATING', 'UPDATING', 'ACTIVE'].includes(domain.syncStatus))
+      && typeof hostname === 'string'
+      && hostname === hostname.toLowerCase()
+      && hostname.endsWith('.up.railway.app')
+      && marker.test(hostname)
+      && !/(?:^|[.-])production(?:[.-]|$)/iu.test(hostname),
+    'RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH'
+  );
+  return hostname;
+}
+
+function validateServiceNode(node, {
+  environmentId,
+  prNumber,
+  requireActiveDomains,
+  role,
+}) {
+  const service = CONTRACT.services[role];
+  requireCondition(
+    isRecord(node)
+      && isUuid(node.id)
+      && node.serviceId === service.id
+      && node.serviceName === service.name
+      && node.environmentId === environmentId
+      && node.deletedAt === null
+      && node.source?.repo === CONTRACT.repository
+      && node.source?.image === null
+      && node.rootDirectory === null
+      && node.startCommand === CONTRACT.baseStartCommand
+      && node.healthcheckPath === '/readyz'
+      && node.healthcheckTimeout === 300
+      && node.drainingSeconds === null
+      && node.restartPolicyType === 'NEVER'
+      && node.restartPolicyMaxRetries === 10
+      && (node.latestDeployment === null || isRecord(node.latestDeployment))
+      && Array.isArray(node.activeDeployments)
+      && node.activeDeployments.length <= 1
+      && node.activeDeployments.every(isRecord)
+      && isRecord(node.domains)
+      && Array.isArray(node.domains.serviceDomains)
+      && Array.isArray(node.domains.customDomains)
+      && node.domains.customDomains.length === 0,
+    'RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH'
+  );
+  const domains = node.domains.serviceDomains;
+  requireCondition(
+    requireActiveDomains ? domains.length === 1 : domains.length <= 1,
+    'RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH'
+  );
+  const hostname = domains.length === 1
+    ? validatePreviewDomain(domains[0], {
+        environmentId,
+        requireActive: requireActiveDomains,
+        serviceId: service.id,
+        prNumber,
+      })
+    : null;
+  return { hostname, node };
+}
+
+export function validateOwnedPreviewEnvironment(environment, {
+  allowAnyHeadRef = false,
+  headRef = undefined,
+  prNumber,
+  requireActiveDomains = false,
+} = {}) {
+  requireCondition(
+    Number.isSafeInteger(prNumber) && prNumber > 0,
+    'RAILWAY_PR_PREVIEW_PR_NUMBER_INVALID'
+  );
+  const expectedName = `${CONTRACT.environmentPrefix}${prNumber}`;
+  requireCondition(
+    isRecord(environment)
+      && isUuid(environment.id)
+      && !PROTECTED_ENVIRONMENT_IDS.has(environment.id)
+      && environment.name === expectedName
+      && environment.projectId === CONTRACT.projectId
+      && environment.isEphemeral === true
+      && environment.deletedAt === null
+      && environment.sourceEnvironment?.id === CONTRACT.baseEnvironmentId
+      && environment.meta === null,
+    'RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH'
+  );
+  validateEnvironmentConfig(environment.config, {
+    allowAnyBranch: allowAnyHeadRef,
+    allowCheckSuites: true,
+    expectedBranches: [CONTRACT.baseBranch, headRef],
+  });
+  const serviceNodes = readConnection(
+    environment.serviceInstances,
+    'RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH'
+  );
+  const volumeNodes = readConnection(
+    environment.volumeInstances,
+    'RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH'
+  );
+  const triggerNodes = readConnection(
+    environment.deploymentTriggers,
+    'RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH'
+  );
+  requireCondition(
+    volumeNodes.length === 0
+      && serviceNodes.length === 2
+      && new Set(serviceNodes.map((node) => node.id)).size === 2
+      && new Set(serviceNodes.map((node) => node.serviceId)).size === 2
+      && serviceNodes.every((node) => SERVICE_IDS.has(node.serviceId)),
+    'RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH'
+  );
+  const triggerIds = new Set();
+  for (const trigger of triggerNodes) {
+    requireCondition(
+      isUuid(trigger.id)
+        && !triggerIds.has(trigger.id)
+        && trigger.projectId === CONTRACT.projectId
+        && trigger.environmentId === environment.id
+        && SERVICE_IDS.has(trigger.serviceId)
+        && trigger.repository === CONTRACT.repository
+        && typeof trigger.branch === 'string'
+        && (allowAnyHeadRef
+          ? HEAD_REF_PATTERN.test(trigger.branch)
+          : trigger.branch === CONTRACT.baseBranch
+          || (headRef !== undefined && trigger.branch === headRef))
+        && trigger.provider === 'github'
+        && trigger.checkSuites === false,
+      'RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH'
+    );
+    triggerIds.add(trigger.id);
+  }
+  const byServiceId = new Map(serviceNodes.map((node) => [node.serviceId, node]));
+  const worker = validateServiceNode(byServiceId.get(CONTRACT.services.worker.id), {
+    environmentId: environment.id,
+    prNumber,
+    requireActiveDomains,
+    role: 'worker',
+  });
+  const web = validateServiceNode(byServiceId.get(CONTRACT.services.web.id), {
+    environmentId: environment.id,
+    prNumber,
+    requireActiveDomains,
+    role: 'web',
+  });
+  return Object.freeze({
+    environmentId: environment.id,
+    worker,
+    web,
+  });
+}
+
+export function validateBasePreviewEnvironment(environment) {
+  requireCondition(
+    isRecord(environment)
+      && environment.id === CONTRACT.baseEnvironmentId
+      && environment.name === CONTRACT.baseEnvironmentName
+      && environment.projectId === CONTRACT.projectId
+      && environment.isEphemeral === false
+      && environment.deletedAt === null
+      && environment.sourceEnvironment?.id === CONTRACT.baseSourceEnvironmentId
+      && environment.meta === null,
+    'RAILWAY_PR_PREVIEW_BASE_MISMATCH'
+  );
+  validateEnvironmentConfig(environment.config, {
+    allowCheckSuites: false,
+    errorCode: 'RAILWAY_PR_PREVIEW_BASE_MISMATCH',
+    expectedBranches: [CONTRACT.baseBranch],
+  });
+  const triggers = readConnection(
+    environment.deploymentTriggers,
+    'RAILWAY_PR_PREVIEW_BASE_MISMATCH'
+  );
+  const servicesForBase = readConnection(
+    environment.serviceInstances,
+    'RAILWAY_PR_PREVIEW_BASE_MISMATCH'
+  );
+  const volumes = readConnection(
+    environment.volumeInstances,
+    'RAILWAY_PR_PREVIEW_BASE_MISMATCH'
+  );
+  requireCondition(
+    triggers.length === 0
+      && volumes.length === 0
+      && servicesForBase.length === 2
+      && new Set(servicesForBase.map((node) => node.serviceId)).size === 2,
+    'RAILWAY_PR_PREVIEW_BASE_MISMATCH'
+  );
+  for (const [role, service] of Object.entries(CONTRACT.services)) {
+    const nodes = servicesForBase.filter((node) => node.serviceId === service.id);
+    requireCondition(nodes.length === 1, 'RAILWAY_PR_PREVIEW_BASE_MISMATCH');
+    const node = nodes[0];
+    const expectedDomain = role === 'worker'
+      ? 'arcanos-worker-pr-preview-base-20260812.up.railway.app'
+      : 'arcanos-v2-pr-preview-base-20260812.up.railway.app';
+    requireCondition(
+      node.id === service.baseInstanceId
+        && node.environmentId === CONTRACT.baseEnvironmentId
+        && node.serviceName === service.name
+        && node.deletedAt === null
+        && node.source?.repo === CONTRACT.repository
+        && node.source?.image === null
+        && node.railwayConfigFile === null
+        && node.rootDirectory === null
+        && node.dockerfilePath === null
+        && node.startCommand === CONTRACT.baseStartCommand
+        && node.healthcheckPath === '/readyz'
+        && node.healthcheckTimeout === 300
+        && node.restartPolicyType === 'NEVER'
+        && node.restartPolicyMaxRetries === 10
+        && node.drainingSeconds === null
+        && node.latestDeployment === null
+        && Array.isArray(node.activeDeployments)
+        && node.activeDeployments.length === 0
+        && Array.isArray(node.domains?.serviceDomains)
+        && node.domains.serviceDomains.length === 1
+        && isUuid(node.domains.serviceDomains[0]?.id)
+        && node.domains.serviceDomains[0]?.domain === expectedDomain
+        && node.domains.serviceDomains[0]?.environmentId === CONTRACT.baseEnvironmentId
+        && node.domains.serviceDomains[0]?.serviceId === service.id
+        && node.domains.serviceDomains[0]?.deletedAt === null
+        && node.domains.serviceDomains[0]?.syncStatus === 'ACTIVE'
+        && Array.isArray(node.domains?.customDomains)
+        && node.domains.customDomains.length === 0
+        && role === service.role,
+      'RAILWAY_PR_PREVIEW_BASE_MISMATCH'
+    );
+  }
+  return environment;
+}
+
+export function validatePreviewDeployment(deployment, {
+  deploymentId,
+  environmentId,
+  serviceId,
+  commitSha,
+}) {
+  requireUuid(deploymentId, 'RAILWAY_PR_PREVIEW_DEPLOYMENT_MISMATCH');
+  requireUuid(environmentId, 'RAILWAY_PR_PREVIEW_DEPLOYMENT_MISMATCH');
+  requireCondition(SERVICE_IDS.has(serviceId), 'RAILWAY_PR_PREVIEW_DEPLOYMENT_MISMATCH');
+  requireCommit(commitSha, 'RAILWAY_PR_PREVIEW_DEPLOYMENT_MISMATCH');
+  const meta = deployment?.meta;
+  const manifest = meta?.serviceManifest;
+  const build = manifest?.build;
+  const deploy = manifest?.deploy;
+  const mappings = meta?.propertyFileMapping;
+  requireCondition(
+    isRecord(deployment)
+      && deployment.id === deploymentId
+      && deployment.projectId === CONTRACT.projectId
+      && deployment.environmentId === environmentId
+      && deployment.serviceId === serviceId
+      && deployment.status === 'SUCCESS'
+      && deployment.deploymentStopped === false
+      && isRecord(meta)
+      && meta.repo === CONTRACT.repository
+      && meta.commitHash?.toLowerCase() === commitSha
+      && meta.configFile === '/railway.json'
+      && meta.buildOnly === false
+      && meta.reason === 'deploy'
+      && meta.rootDirectory === null
+      && Array.isArray(meta.volumeMounts)
+      && meta.volumeMounts.length === 0
+      && isRecord(mappings)
+      && Object.entries(EXPECTED_PROPERTY_MAPPINGS).every(
+        ([key, value]) => mappings[key] === value
+      )
+      && isRecord(build)
+      && build.builder === 'DOCKERFILE'
+      && build.dockerfilePath === '/Dockerfile'
+      && build.buildCommand === CONTRACT.buildCommand
+      && build.buildEnvironment === 'V3'
+      && Array.isArray(build.watchPatterns)
+      && build.watchPatterns.length === 0
+      && isRecord(deploy)
+      && deploy.startCommand === CONTRACT.previewStartCommand
+      && deploy.healthcheckPath === '/readyz'
+      && deploy.healthcheckTimeout === 300
+      && deploy.drainingSeconds === 60
+      && deploy.restartPolicyType === 'NEVER'
+      && deploy.restartPolicyMaxRetries === null
+      && deploy.preDeployCommand === null
+      && deploy.cronSchedule === null
+      && deploy.runtime === 'V2'
+      && deploy.numReplicas === 1
+      && deploy.requiredMountPath === null,
+    'RAILWAY_PR_PREVIEW_DEPLOYMENT_MISMATCH'
+  );
+  return deployment;
+}
+
+function readRoleNode(environment, role) {
+  const serviceId = CONTRACT.services[role].id;
+  const servicesInEnvironment = readConnection(
+    environment.serviceInstances,
+    'RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH'
+  );
+  const matches = servicesInEnvironment.filter((node) => node.serviceId === serviceId);
+  requireCondition(matches.length === 1, 'RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH');
+  return matches[0];
+}
+
+function validateObservedDeploymentIdentity(deployment, {
+  environmentId,
+  serviceId,
+  code = 'RAILWAY_PR_PREVIEW_ACTIVE_DEPLOYMENT_AMBIGUOUS',
+}) {
+  requireCondition(
+    isRecord(deployment)
+      && isUuid(deployment.id)
+      && deployment.projectId === CONTRACT.projectId
+      && deployment.environmentId === environmentId
+      && deployment.serviceId === serviceId
+      && deployment.meta?.repo === CONTRACT.repository
+      && typeof deployment.meta?.commitHash === 'string'
+      && COMMIT_PATTERN.test(deployment.meta.commitHash.toLowerCase()),
+    code
+  );
+  return deployment;
+}
+
+function validatePriorActiveDeployment(deployment, options) {
+  validateObservedDeploymentIdentity(deployment, options);
+  requireCondition(
+    deployment.status === 'SUCCESS' && deployment.deploymentStopped === false,
+    'RAILWAY_PR_PREVIEW_ACTIVE_DEPLOYMENT_AMBIGUOUS'
+  );
+}
+
+function selectRoleDeployment(environment, role, commitSha) {
+  const node = readRoleNode(environment, role);
+  const active = node.activeDeployments;
+  requireCondition(
+    Array.isArray(active) && active.length <= 1,
+    'RAILWAY_PR_PREVIEW_ACTIVE_DEPLOYMENT_AMBIGUOUS'
+  );
+  const serviceId = CONTRACT.services[role].id;
+  const activeDeployment = active[0] ?? null;
+  if (activeDeployment) {
+    validatePriorActiveDeployment(activeDeployment, {
+      environmentId: environment.id,
+      serviceId,
+    });
+  }
+  const latest = node.latestDeployment;
+  if (latest !== null) {
+    validateObservedDeploymentIdentity(latest, {
+      environmentId: environment.id,
+      serviceId,
+      code: 'RAILWAY_PR_PREVIEW_DEPLOYMENT_CONFLICT',
+    });
+    const latestCommit = latest.meta.commitHash.toLowerCase();
+    if (latest.id !== activeDeployment?.id) {
+      if (PENDING_DEPLOYMENT_STATUSES.has(latest.status)) {
+        requireCondition(
+          latestCommit === commitSha,
+          'RAILWAY_PR_PREVIEW_DEPLOYMENT_CONFLICT'
+        );
+        return { deployment: latest, state: 'pending' };
+      }
+      if (latest.status === 'SUCCESS') {
+        requireCondition(
+          latestCommit === commitSha && latest.deploymentStopped === false,
+          'RAILWAY_PR_PREVIEW_DEPLOYMENT_CONFLICT'
+        );
+        return { deployment: latest, state: 'pending' };
+      }
+      requireCondition(
+        FAILED_DEPLOYMENT_STATUSES.has(latest.status),
+        'RAILWAY_PR_PREVIEW_DEPLOYMENT_STATUS_UNKNOWN'
+      );
+    }
+  }
+  if (activeDeployment?.meta.commitHash.toLowerCase() !== commitSha) {
+    return null;
+  }
+  validatePreviewDeployment(activeDeployment, {
+    deploymentId: activeDeployment.id,
+    environmentId: environment.id,
+    serviceId,
+    commitSha,
+  });
+  return { deployment: activeDeployment, state: 'active' };
+}
+
+function assertWorkerFirstState(environment, commitSha) {
+  const worker = selectRoleDeployment(environment, 'worker', commitSha);
+  const web = selectRoleDeployment(environment, 'web', commitSha);
+  if (web !== null) {
+    requireCondition(
+      worker?.state === 'active',
+      'RAILWAY_PR_PREVIEW_WORKER_FIRST_CONFLICT'
+    );
+  }
+}
+
+function validateReadiness(readiness, {
+  role,
+  prNumber,
+  commitSha,
+}) {
+  const shared = isRecord(readiness)
+    && readiness.ready === true
+    && readiness.processKind === role
+    && readiness.prNumber === prNumber
+    && readiness.sourceCommit === commitSha;
+  if (role === 'worker') {
+    requireCondition(
+      shared && readiness.mode === 'passive-pr-preview',
+      'RAILWAY_PR_PREVIEW_READINESS_MISMATCH'
+    );
+    return;
+  }
+  requireCondition(
+    shared
+      && readiness.mode === 'native-pr-application-e2e-v1'
+      && readiness.applicationImported === true
+      && readiness.fixturesSealed === true
+      && readiness.protectedEffectsEnabled === false
+      && readiness.protectsMaliciousPr === false
+      && readiness.requiresPlatformSecretIsolationForUntrustedCode === true,
+    'RAILWAY_PR_PREVIEW_READINESS_MISMATCH'
+  );
+}
+
+async function requireCurrentPullRequest({
+  expected,
+  verifyCurrentPullRequest,
+}) {
+  requireCondition(
+    typeof verifyCurrentPullRequest === 'function',
+    'RAILWAY_PR_PREVIEW_GITHUB_REVALIDATION_REQUIRED'
+  );
+  const current = await verifyCurrentPullRequest();
+  requireCondition(
+    current.number === expected.number
+      && current.state === 'open'
+      && current.draft === false
+      && expected.baseRef === CONTRACT.baseBranch
+      && current.baseRef === CONTRACT.baseBranch
+      && current.repository === CONTRACT.repository
+      && current.headRef === expected.headRef
+      && current.headSha === expected.headSha
+      && current.labels.includes(CONTRACT.optInLabel),
+    'RAILWAY_PR_PREVIEW_GITHUB_STATE_CHANGED'
+  );
+  return current;
+}
+
+function previewMatches(environments, expectedName) {
+  requireCondition(Array.isArray(environments), 'RAILWAY_PR_PREVIEW_INVENTORY_INVALID');
+  return environments.filter((environment) => environment?.name === expectedName);
+}
+
+function assertNoInitialDeploymentRace(environment) {
+  for (const role of ['worker', 'web']) {
+    const node = readRoleNode(environment, role);
+    requireCondition(
+      node.latestDeployment === null
+        && Array.isArray(node.activeDeployments)
+        && node.activeDeployments.length === 0,
+      'RAILWAY_PR_PREVIEW_TRIGGER_RACE'
+    );
+  }
+}
+
+function readObservedDeploymentIds(environment) {
+  const ids = new Set();
+  for (const role of ['worker', 'web']) {
+    const node = readRoleNode(environment, role);
+    const observed = [
+      node.latestDeployment,
+      ...(Array.isArray(node.activeDeployments) ? node.activeDeployments : []),
+    ].filter((deployment) => deployment !== null);
+    for (const deployment of observed) {
+      requireCondition(
+        isRecord(deployment) && isUuid(deployment.id),
+        'RAILWAY_PR_PREVIEW_DEPLOYMENT_MISMATCH'
+      );
+      ids.add(deployment.id);
+    }
+  }
+  return ids;
+}
+
+async function sleepProjection(railway, milliseconds) {
+  if (typeof railway.sleep === 'function') {
+    await railway.sleep(milliseconds);
+  }
+}
+
+async function waitForOwnedEnvironment({
+  environmentId,
+  headRef,
+  prNumber,
+  railway,
+  requireActiveDomains = false,
+  expectedDeployments = undefined,
+  commitSha = undefined,
+}) {
+  let lastProjectionError;
+  for (let attempt = 0; attempt < PROJECTION_POLL_ATTEMPTS; attempt += 1) {
+    try {
+      const environment = await railway.readEnvironment(environmentId);
+      const ownership = validateOwnedPreviewEnvironment(environment, {
+        headRef,
+        prNumber,
+        requireActiveDomains,
+      });
+      if (expectedDeployments) {
+        for (const [role, deploymentId] of Object.entries(expectedDeployments)) {
+          assertExactActiveRole(environment, {
+            role,
+            deploymentId,
+            commitSha,
+          });
+        }
+      }
+      return { environment, ownership };
+    } catch (error) {
+      if (!(error instanceof RailwayPrPreviewLifecycleError)) {
+        throw error;
+      }
+      lastProjectionError = error;
+    }
+    await sleepProjection(railway, PROJECTION_POLL_INTERVAL_MS);
+  }
+  throw lastProjectionError
+    ?? new RailwayPrPreviewLifecycleError('RAILWAY_PR_PREVIEW_PROJECTION_TIMEOUT');
+}
+
+async function waitForEnvironmentInventory({
+  environmentId,
+  expectedName,
+  railway,
+}) {
+  let lastReadError;
+  for (let attempt = 0; attempt < PROJECTION_POLL_ATTEMPTS; attempt += 1) {
+    try {
+      const matches = previewMatches(await railway.listEnvironments(), expectedName);
+      requireCondition(matches.length <= 1, 'RAILWAY_PR_PREVIEW_ENVIRONMENT_AMBIGUOUS');
+      if (matches.length === 1) {
+        requireCondition(
+          matches[0].id === environmentId,
+          'RAILWAY_PR_PREVIEW_CREATE_MISMATCH'
+        );
+        return matches[0];
+      }
+    } catch (error) {
+      if (!(error instanceof RailwayPrPreviewLifecycleError)) {
+        throw error;
+      }
+      lastReadError = error;
+    }
+    await sleepProjection(railway, PROJECTION_POLL_INTERVAL_MS);
+  }
+  throw lastReadError
+    ?? new RailwayPrPreviewLifecycleError(
+      'RAILWAY_PR_PREVIEW_CREATE_VISIBILITY_TIMEOUT'
+    );
+}
+
+async function quiesceTriggers({ environment, pullRequest, railway }) {
+  const before = readObservedDeploymentIds(environment);
+  await railway.removeAndVerifyTriggers(environment, pullRequest);
+  const { environment: latest } = await waitForOwnedEnvironment({
+    environmentId: environment.id,
+    headRef: pullRequest.headRef,
+    prNumber: pullRequest.number,
+    railway,
+  });
+  const triggers = readConnection(
+    latest.deploymentTriggers,
+    'RAILWAY_PR_PREVIEW_TRIGGER_MISMATCH'
+  );
+  requireCondition(triggers.length === 0, 'RAILWAY_PR_PREVIEW_TRIGGER_REAPPEARED');
+  const after = readObservedDeploymentIds(latest);
+  requireCondition(
+    [...after].every((deploymentId) => before.has(deploymentId)),
+    'RAILWAY_PR_PREVIEW_TRIGGER_RACE'
+  );
+  return latest;
+}
+
+async function waitForReadiness({
+  baseUrl,
+  commitSha,
+  prNumber,
+  railway,
+  role,
+}) {
+  let lastError;
+  for (let attempt = 0; attempt < READINESS_POLL_ATTEMPTS; attempt += 1) {
+    try {
+      const readiness = await railway.readReadiness({
+        baseUrl,
+        commitSha,
+        prNumber,
+        role,
+      });
+      validateReadiness(readiness, { role, prNumber, commitSha });
+      return readiness;
+    } catch (error) {
+      if (!(error instanceof RailwayPrPreviewLifecycleError)) {
+        throw error;
+      }
+      lastError = error;
+    }
+    await sleepProjection(railway, READINESS_POLL_INTERVAL_MS);
+  }
+  throw lastError
+    ?? new RailwayPrPreviewLifecycleError('RAILWAY_PR_PREVIEW_READINESS_TIMEOUT');
+}
+
+async function ensureRoleDeployment({
+  environment,
+  role,
+  pullRequest,
+  railway,
+  verifyCurrentPullRequest,
+}) {
+  const existing = selectRoleDeployment(
+    environment,
+    role,
+    pullRequest.headSha
+  );
+  const serviceId = CONTRACT.services[role].id;
+  if (existing?.state === 'active') {
+    return existing.deployment.id;
+  }
+  if (existing?.state === 'pending') {
+    const observed = await railway.waitForDeployment({
+      commitSha: pullRequest.headSha,
+      deploymentId: existing.deployment.id,
+      environmentId: environment.id,
+      serviceId,
+    });
+    validatePreviewDeployment(observed, {
+      deploymentId: existing.deployment.id,
+      environmentId: environment.id,
+      serviceId,
+      commitSha: pullRequest.headSha,
+    });
+    return existing.deployment.id;
+  }
+  await requireCurrentPullRequest({ expected: pullRequest, verifyCurrentPullRequest });
+  const deploymentId = await railway.deployExact({
+    commitSha: pullRequest.headSha,
+    environmentId: environment.id,
+    serviceId,
+  });
+  requireUuid(deploymentId, 'RAILWAY_PR_PREVIEW_DEPLOYMENT_ID_INVALID');
+  const observed = await railway.waitForDeployment({
+    commitSha: pullRequest.headSha,
+    deploymentId,
+    environmentId: environment.id,
+    serviceId,
+  });
+  validatePreviewDeployment(observed, {
+    deploymentId,
+    environmentId: environment.id,
+    serviceId,
+    commitSha: pullRequest.headSha,
+  });
+  return deploymentId;
+}
+
+function assertExactActiveRole(environment, {
+  role,
+  deploymentId,
+  commitSha,
+}) {
+  const node = readRoleNode(environment, role);
+  requireCondition(
+    Array.isArray(node.activeDeployments)
+      && node.activeDeployments.length === 1
+      && node.activeDeployments[0]?.id === deploymentId,
+    'RAILWAY_PR_PREVIEW_ACTIVE_DEPLOYMENT_AMBIGUOUS'
+  );
+  validatePreviewDeployment(node.activeDeployments[0], {
+    deploymentId,
+    environmentId: environment.id,
+    serviceId: CONTRACT.services[role].id,
+    commitSha,
+  });
+  if (node.latestDeployment !== null && node.latestDeployment.id !== deploymentId) {
+    validateObservedDeploymentIdentity(node.latestDeployment, {
+      environmentId: environment.id,
+      serviceId: CONTRACT.services[role].id,
+      code: 'RAILWAY_PR_PREVIEW_DEPLOYMENT_CONFLICT',
+    });
+    requireCondition(
+      FAILED_DEPLOYMENT_STATUSES.has(node.latestDeployment.status),
+      'RAILWAY_PR_PREVIEW_DEPLOYMENT_CONFLICT'
+    );
+  }
+}
+
+export async function reconcileRailwayPrPreview({
+  pullRequest,
+  railway,
+  verifyCurrentPullRequest,
+}) {
+  requireCondition(isRecord(railway), 'RAILWAY_PR_PREVIEW_ADAPTER_INVALID');
+  await railway.validateAuthority({ requireNativeDisabled: true });
+  const base = await railway.readBaseEnvironment();
+  if (typeof railway.validateBaseEnvironment === 'function') {
+    railway.validateBaseEnvironment(base);
+  } else {
+    validateBasePreviewEnvironment(base);
+  }
+
+  const expectedName = `${CONTRACT.environmentPrefix}${pullRequest.number}`;
+  let matches = previewMatches(await railway.listEnvironments(), expectedName);
+  requireCondition(matches.length <= 1, 'RAILWAY_PR_PREVIEW_ENVIRONMENT_AMBIGUOUS');
+  let target;
+  if (matches.length === 0) {
+    await requireCurrentPullRequest({ expected: pullRequest, verifyCurrentPullRequest });
+    const created = await railway.createEnvironment({
+      projectId: CONTRACT.projectId,
+      name: expectedName,
+      sourceEnvironmentId: CONTRACT.baseEnvironmentId,
+      ephemeral: true,
+      skipInitialDeploys: true,
+      stageInitialChanges: false,
+      applyChangesInBackground: false,
+    });
+    requireCondition(
+      isRecord(created)
+        && isUuid(created.id)
+        && created.name === expectedName
+        && created.projectId === CONTRACT.projectId
+        && created.isEphemeral === true
+        && created.sourceEnvironment?.id === CONTRACT.baseEnvironmentId,
+      'RAILWAY_PR_PREVIEW_CREATE_MISMATCH'
+    );
+    try {
+      await waitForEnvironmentInventory({
+        environmentId: created.id,
+        expectedName,
+        railway,
+      });
+      ({ environment: target } = await waitForOwnedEnvironment({
+        environmentId: created.id,
+        headRef: pullRequest.headRef,
+        prNumber: pullRequest.number,
+        railway,
+      }));
+      assertNoInitialDeploymentRace(target);
+      target = await quiesceTriggers({ environment: target, pullRequest, railway });
+      assertNoInitialDeploymentRace(target);
+    } catch (error) {
+      if (typeof railway.deleteAndVerifyEnvironment === 'function') {
+        await railway.deleteAndVerifyEnvironment(created);
+      }
+      throw error;
+    }
+  } else {
+    ({ environment: target } = await waitForOwnedEnvironment({
+      environmentId: matches[0].id,
+      headRef: pullRequest.headRef,
+      prNumber: pullRequest.number,
+      railway,
+    }));
+    target = await quiesceTriggers({ environment: target, pullRequest, railway });
+  }
+
+  assertWorkerFirstState(target, pullRequest.headSha);
+
+  const workerDeploymentId = await ensureRoleDeployment({
+    environment: target,
+    role: 'worker',
+    pullRequest,
+    railway,
+    verifyCurrentPullRequest,
+  });
+  ({ environment: target } = await waitForOwnedEnvironment({
+    commitSha: pullRequest.headSha,
+    environmentId: target.id,
+    expectedDeployments: { worker: workerDeploymentId },
+    headRef: pullRequest.headRef,
+    prNumber: pullRequest.number,
+    railway,
+  }));
+  target = await quiesceTriggers({ environment: target, pullRequest, railway });
+  assertExactActiveRole(target, {
+    commitSha: pullRequest.headSha,
+    deploymentId: workerDeploymentId,
+    role: 'worker',
+  });
+
+  await requireCurrentPullRequest({ expected: pullRequest, verifyCurrentPullRequest });
+  const webDeploymentId = await ensureRoleDeployment({
+    environment: target,
+    role: 'web',
+    pullRequest,
+    railway,
+    verifyCurrentPullRequest,
+  });
+  await requireCurrentPullRequest({ expected: pullRequest, verifyCurrentPullRequest });
+  let readyProjection = await waitForOwnedEnvironment({
+    commitSha: pullRequest.headSha,
+    environmentId: target.id,
+    expectedDeployments: {
+      web: webDeploymentId,
+      worker: workerDeploymentId,
+    },
+    headRef: pullRequest.headRef,
+    prNumber: pullRequest.number,
+    railway,
+    requireActiveDomains: true,
+  });
+  target = await quiesceTriggers({
+    environment: readyProjection.environment,
+    pullRequest,
+    railway,
+  });
+  await requireCurrentPullRequest({ expected: pullRequest, verifyCurrentPullRequest });
+  readyProjection = await waitForOwnedEnvironment({
+    commitSha: pullRequest.headSha,
+    environmentId: target.id,
+    expectedDeployments: {
+      web: webDeploymentId,
+      worker: workerDeploymentId,
+    },
+    headRef: pullRequest.headRef,
+    prNumber: pullRequest.number,
+    railway,
+    requireActiveDomains: true,
+  });
+  const ownership = readyProjection.ownership;
+  requireCondition(
+    readConnection(
+      readyProjection.environment.deploymentTriggers,
+      'RAILWAY_PR_PREVIEW_TRIGGER_MISMATCH'
+    ).length === 0,
+    'RAILWAY_PR_PREVIEW_TRIGGER_REAPPEARED'
+  );
+
+  await waitForReadiness({
+    baseUrl: `https://${ownership.worker.hostname}`,
+    commitSha: pullRequest.headSha,
+    prNumber: pullRequest.number,
+    railway,
+    role: 'worker',
+  });
+  await waitForReadiness({
+    baseUrl: `https://${ownership.web.hostname}`,
+    commitSha: pullRequest.headSha,
+    prNumber: pullRequest.number,
+    railway,
+    role: 'web',
+  });
+
+  return Object.freeze({
+    action: 'reconcile',
+    environmentId: target.id,
+    headSha: pullRequest.headSha,
+    prNumber: pullRequest.number,
+    webBaseUrl: `https://${ownership.web.hostname}`,
+    webDeploymentId,
+    workerBaseUrl: `https://${ownership.worker.hostname}`,
+    workerDeploymentId,
+  });
+}
+
+export async function cleanupRailwayPrPreview({
+  pullRequest,
+  railway,
+  verifyCurrentPullRequest = undefined,
+}) {
+  await railway.validateAuthority({ requireNativeDisabled: false });
+  const expectedName = `${CONTRACT.environmentPrefix}${pullRequest.number}`;
+  const matches = previewMatches(await railway.listEnvironments(), expectedName);
+  requireCondition(matches.length <= 1, 'RAILWAY_PR_PREVIEW_ENVIRONMENT_AMBIGUOUS');
+  if (matches.length === 0) {
+    return Object.freeze({
+      action: 'cleanup',
+      deleted: false,
+      prNumber: pullRequest.number,
+    });
+  }
+  requireCondition(
+    typeof verifyCurrentPullRequest === 'function',
+    'RAILWAY_PR_PREVIEW_GITHUB_REVALIDATION_REQUIRED'
+  );
+  const target = await railway.readEnvironment(matches[0].id);
+  validateOwnedPreviewEnvironment(target, {
+    allowAnyHeadRef: true,
+    headRef: pullRequest.headRef,
+    prNumber: pullRequest.number,
+  });
+  const current = await verifyCurrentPullRequest();
+  requireCondition(
+    current.number === pullRequest.number
+      && current.repository === CONTRACT.repository
+      && current.headRef === pullRequest.headRef
+      && current.headSha === pullRequest.headSha
+      && decideLifecycleAction({
+        eventAction: 'manual',
+        pullRequest: current,
+      }) !== 'reconcile',
+    'RAILWAY_PR_PREVIEW_GITHUB_STATE_CHANGED'
+  );
+  await railway.deleteAndVerifyEnvironment(target);
+  return Object.freeze({
+    action: 'cleanup',
+    deleted: true,
+    environmentId: target.id,
+    prNumber: pullRequest.number,
+  });
+}
+
+export async function discoverRailwayPrPreviewNumbers({ github, railway }) {
+  requireCondition(
+    isRecord(github) && isRecord(railway),
+    'RAILWAY_PR_PREVIEW_ADAPTER_INVALID'
+  );
+  await railway.validateAuthority({ requireNativeDisabled: false });
+  const numbers = new Set();
+  const prefixPattern = new RegExp(
+    `^${CONTRACT.environmentPrefix}([1-9][0-9]*)$`,
+    'u'
+  );
+  for (const environment of await railway.listEnvironments()) {
+    const match = prefixPattern.exec(environment.name);
+    if (!match) {
+      continue;
+    }
+    const prNumber = Number.parseInt(match[1], 10);
+    requireCondition(
+      Number.isSafeInteger(prNumber) && prNumber > 0,
+      'RAILWAY_PR_PREVIEW_PR_NUMBER_INVALID'
+    );
+    numbers.add(prNumber);
+  }
+  for (const rawPullRequest of await github.listOpenPullRequests()) {
+    const inScope = rawPullRequest?.base?.ref === CONTRACT.baseBranch
+      && rawPullRequest.base?.repo?.full_name === CONTRACT.repository
+      && rawPullRequest.head?.repo?.full_name === CONTRACT.repository
+      && Array.isArray(rawPullRequest.labels)
+      && rawPullRequest.labels.some((label) => label?.name === CONTRACT.optInLabel);
+    if (!inScope) {
+      continue;
+    }
+    const pullRequest = validateLifecyclePullRequest(
+      rawPullRequest,
+      rawPullRequest.number
+    );
+    numbers.add(pullRequest.number);
+  }
+  requireCondition(numbers.size <= 100, 'RAILWAY_PR_PREVIEW_SWEEP_LIMIT_EXCEEDED');
+  return Object.freeze([...numbers].sort((left, right) => left - right));
+}
+
+async function readBoundedJson(response, maxBytes, code) {
+  requireCondition(response?.body && typeof response.body.getReader === 'function', code);
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    total += value.byteLength;
+    requireCondition(total <= maxBytes, code);
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes));
+  } catch {
+    fail(code);
+  }
+}
+
+export class RailwayGraphqlApi {
+  constructor({ token, fetchImpl = globalThis.fetch, sleepImpl = undefined }) {
+    requireCondition(
+      typeof token === 'string'
+        && token.length >= 20
+        && token.trim() === token,
+      'RAILWAY_PR_PREVIEW_TOKEN_INVALID'
+    );
+    requireCondition(typeof fetchImpl === 'function', 'RAILWAY_PR_PREVIEW_FETCH_UNAVAILABLE');
+    this.token = token;
+    this.fetchImpl = fetchImpl;
+    this.sleepImpl = sleepImpl ?? ((milliseconds) =>
+      new Promise((resolve) => setTimeout(resolve, milliseconds)));
+  }
+
+  async requestRaw(query, variables = {}) {
+    let response;
+    try {
+      response = await this.fetchImpl(RAILWAY_API_URL, {
+        method: 'POST',
+        redirect: 'error',
+        signal: AbortSignal.timeout(API_TIMEOUT_MS),
+        headers: {
+          authorization: `Bearer ${this.token}`,
+          'content-type': 'application/json',
+          'user-agent': 'arcanos-railway-pr-preview-lifecycle/1',
+        },
+        body: JSON.stringify({ query, variables }),
+      });
+    } catch {
+      fail('RAILWAY_PR_PREVIEW_API_FAILED');
+    }
+    const body = await readBoundedJson(
+      response,
+      API_RESPONSE_LIMIT_BYTES,
+      'RAILWAY_PR_PREVIEW_API_FAILED'
+    );
+    requireCondition(response.ok && isRecord(body), 'RAILWAY_PR_PREVIEW_API_FAILED');
+    return body;
+  }
+
+  async graphql(query, variables = {}) {
+    const body = await this.requestRaw(query, variables);
+    requireCondition(
+      Array.isArray(body.errors) ? body.errors.length === 0 : body.errors === undefined,
+      'RAILWAY_PR_PREVIEW_API_FAILED'
+    );
+    requireCondition(isRecord(body.data), 'RAILWAY_PR_PREVIEW_API_FAILED');
+    return body.data;
+  }
+
+  async validateTokenType() {
+    const body = await this.requestRaw(TOKEN_TYPE_QUERY);
+    requireCondition(
+      body.data?.me == null
+        && Array.isArray(body.errors)
+        && body.errors.length > 0,
+      body.data?.me?.id
+        ? 'RAILWAY_PR_PREVIEW_ACCOUNT_TOKEN_FORBIDDEN'
+        : 'RAILWAY_PR_PREVIEW_WORKSPACE_TOKEN_UNPROVEN'
+    );
+  }
+
+  async validateAuthority({ requireNativeDisabled }) {
+    await this.validateTokenType();
+    const data = await this.graphql(AUTHORITY_QUERY, {
+      projectId: CONTRACT.projectId,
+    });
+    return validateLifecycleAuthority(data, { requireNativeDisabled });
+  }
+
+  async readBaseEnvironment() {
+    return this.readEnvironment(CONTRACT.baseEnvironmentId);
+  }
+
+  validateBaseEnvironment(environment) {
+    return validateBasePreviewEnvironment(environment);
+  }
+
+  async sleep(milliseconds) {
+    await this.sleepImpl(milliseconds);
+  }
+
+  async listEnvironments() {
+    const environments = [];
+    const ids = new Set();
+    let after = null;
+    for (let page = 0; page < 20; page += 1) {
+      const data = await this.graphql(ENVIRONMENTS_QUERY, {
+        projectId: CONTRACT.projectId,
+        after,
+      });
+      const connection = data.environments;
+      requireCondition(
+        isRecord(connection)
+          && Array.isArray(connection.edges)
+          && isRecord(connection.pageInfo),
+        'RAILWAY_PR_PREVIEW_INVENTORY_INVALID'
+      );
+      for (const edge of connection.edges) {
+        const node = edge?.node;
+        requireCondition(
+          isRecord(node)
+            && isUuid(node.id)
+            && typeof node.name === 'string'
+            && node.name.length > 0
+            && node.projectId === CONTRACT.projectId
+            && !ids.has(node.id),
+          'RAILWAY_PR_PREVIEW_INVENTORY_INVALID'
+        );
+        ids.add(node.id);
+        environments.push(node);
+      }
+      if (connection.pageInfo.hasNextPage === false) {
+        requireCondition(
+          ids.has(CONTRACT.baseEnvironmentId)
+            && ids.has(CONTRACT.productionEnvironmentId),
+          'RAILWAY_PR_PREVIEW_INVENTORY_VISIBILITY_INSUFFICIENT'
+        );
+        return environments;
+      }
+      requireCondition(
+        connection.pageInfo.hasNextPage === true
+          && typeof connection.pageInfo.endCursor === 'string'
+          && connection.pageInfo.endCursor.length > 0,
+        'RAILWAY_PR_PREVIEW_INVENTORY_INVALID'
+      );
+      after = connection.pageInfo.endCursor;
+    }
+    fail('RAILWAY_PR_PREVIEW_INVENTORY_LIMIT_EXCEEDED');
+  }
+
+  async readEnvironment(environmentId) {
+    requireUuid(environmentId, 'RAILWAY_PR_PREVIEW_ENVIRONMENT_ID_INVALID');
+    const data = await this.graphql(ENVIRONMENT_QUERY, {
+      projectId: CONTRACT.projectId,
+      environmentId,
+    });
+    requireCondition(isRecord(data.environment), 'RAILWAY_PR_PREVIEW_ENVIRONMENT_INVALID');
+    return data.environment;
+  }
+
+  async createEnvironment(input) {
+    const expectedNamePattern = new RegExp(
+      `^${CONTRACT.environmentPrefix}[1-9][0-9]*$`,
+      'u'
+    );
+    requireCondition(
+      isRecord(input)
+        && hasExactKeys(input, [
+          'applyChangesInBackground',
+          'ephemeral',
+          'name',
+          'projectId',
+          'skipInitialDeploys',
+          'sourceEnvironmentId',
+          'stageInitialChanges',
+        ])
+        && input.projectId === CONTRACT.projectId
+        && input.sourceEnvironmentId === CONTRACT.baseEnvironmentId
+        && input.ephemeral === true
+        && input.skipInitialDeploys === true
+        && input.stageInitialChanges === false
+        && input.applyChangesInBackground === false
+        && typeof input.name === 'string'
+        && expectedNamePattern.test(input.name),
+      'RAILWAY_PR_PREVIEW_CREATE_INPUT_INVALID'
+    );
+    const data = await this.graphql(CREATE_ENVIRONMENT_MUTATION, { input });
+    return data.environmentCreate;
+  }
+
+  async removeAndVerifyTriggers(environment, pullRequest) {
+    const triggerNodes = readConnection(
+      environment.deploymentTriggers,
+      'RAILWAY_PR_PREVIEW_TRIGGER_MISMATCH'
+    );
+    const triggerIds = new Set();
+    for (const trigger of triggerNodes) {
+      requireCondition(
+        isUuid(trigger.id)
+          && !triggerIds.has(trigger.id)
+          && trigger.projectId === CONTRACT.projectId
+          && trigger.environmentId === environment.id
+          && SERVICE_IDS.has(trigger.serviceId)
+          && trigger.repository === CONTRACT.repository
+          && (trigger.branch === CONTRACT.baseBranch
+            || trigger.branch === pullRequest.headRef)
+          && trigger.provider === 'github'
+          && trigger.checkSuites === false,
+        'RAILWAY_PR_PREVIEW_TRIGGER_MISMATCH'
+      );
+      triggerIds.add(trigger.id);
+      const data = await this.graphql(DELETE_TRIGGER_MUTATION, { id: trigger.id });
+      requireCondition(
+        data.deploymentTriggerDelete === true,
+        'RAILWAY_PR_PREVIEW_TRIGGER_DELETE_FAILED'
+      );
+    }
+
+    let latest = environment;
+    for (let observation = 0; observation < 2; observation += 1) {
+      latest = await this.readEnvironment(environment.id);
+      validateOwnedPreviewEnvironment(latest, {
+        headRef: pullRequest.headRef,
+        prNumber: pullRequest.number,
+      });
+      requireCondition(
+        readConnection(
+          latest.deploymentTriggers,
+          'RAILWAY_PR_PREVIEW_TRIGGER_MISMATCH'
+        ).length === 0,
+        'RAILWAY_PR_PREVIEW_TRIGGER_REAPPEARED'
+      );
+      if (observation === 0) {
+        await this.sleepImpl(TRIGGER_QUIESCENCE_INTERVAL_MS);
+      }
+    }
+    return latest;
+  }
+
+  async deployExact({ commitSha, environmentId, serviceId }) {
+    requireCommit(commitSha, 'RAILWAY_PR_PREVIEW_COMMIT_INVALID');
+    requireUuid(environmentId, 'RAILWAY_PR_PREVIEW_ENVIRONMENT_ID_INVALID');
+    requireCondition(
+      !PROTECTED_ENVIRONMENT_IDS.has(environmentId),
+      'RAILWAY_PR_PREVIEW_DEPLOY_TARGET_INVALID'
+    );
+    requireCondition(SERVICE_IDS.has(serviceId), 'RAILWAY_PR_PREVIEW_SERVICE_ID_INVALID');
+    const data = await this.graphql(DEPLOY_SERVICE_MUTATION, {
+      environmentId,
+      serviceId,
+      commitSha,
+    });
+    requireUuid(
+      data.serviceInstanceDeployV2,
+      'RAILWAY_PR_PREVIEW_DEPLOYMENT_ID_INVALID'
+    );
+    return data.serviceInstanceDeployV2;
+  }
+
+  async waitForDeployment({ deploymentId, environmentId, serviceId, commitSha }) {
+    let transientReadFailures = 0;
+    for (let attempt = 0; attempt < DEPLOYMENT_POLL_ATTEMPTS; attempt += 1) {
+      let data;
+      try {
+        data = await this.graphql(DEPLOYMENT_QUERY, { id: deploymentId });
+      } catch (error) {
+        if (!(error instanceof RailwayPrPreviewLifecycleError)
+          || error.code !== 'RAILWAY_PR_PREVIEW_API_FAILED') {
+          throw error;
+        }
+        transientReadFailures += 1;
+        requireCondition(
+          transientReadFailures <= 5,
+          'RAILWAY_PR_PREVIEW_DEPLOYMENT_OBSERVATION_FAILED'
+        );
+        await this.sleepImpl(DEPLOYMENT_POLL_INTERVAL_MS);
+        continue;
+      }
+      transientReadFailures = 0;
+      const observed = data.deployment;
+      requireCondition(
+        isRecord(observed)
+          && observed.id === deploymentId
+          && observed.projectId === CONTRACT.projectId
+          && observed.environmentId === environmentId
+          && observed.serviceId === serviceId,
+        'RAILWAY_PR_PREVIEW_DEPLOYMENT_MISMATCH'
+      );
+      if (observed.status === 'SUCCESS') {
+        return validatePreviewDeployment(observed, {
+          deploymentId,
+          environmentId,
+          serviceId,
+          commitSha,
+        });
+      }
+      if (FAILED_DEPLOYMENT_STATUSES.has(observed.status)) {
+        fail('RAILWAY_PR_PREVIEW_DEPLOYMENT_FAILED');
+      }
+      requireCondition(
+        PENDING_DEPLOYMENT_STATUSES.has(observed.status),
+        'RAILWAY_PR_PREVIEW_DEPLOYMENT_STATUS_UNKNOWN'
+      );
+      await this.sleepImpl(DEPLOYMENT_POLL_INTERVAL_MS);
+    }
+    fail('RAILWAY_PR_PREVIEW_DEPLOYMENT_TIMEOUT');
+  }
+
+  async readReadiness({ baseUrl }) {
+    let parsed;
+    try {
+      parsed = new URL(baseUrl);
+    } catch {
+      fail('RAILWAY_PR_PREVIEW_READINESS_TARGET_INVALID');
+    }
+    requireCondition(
+      parsed.protocol === 'https:'
+        && !parsed.username
+        && !parsed.password
+        && !parsed.port
+        && (parsed.pathname === '' || parsed.pathname === '/')
+        && !parsed.search
+        && !parsed.hash
+        && parsed.hostname.endsWith('.up.railway.app')
+        && !/(?:^|[.-])production(?:[.-]|$)/iu.test(parsed.hostname),
+      'RAILWAY_PR_PREVIEW_READINESS_TARGET_INVALID'
+    );
+    let response;
+    try {
+      response = await this.fetchImpl(`${parsed.origin}/readyz`, {
+        method: 'GET',
+        redirect: 'error',
+        signal: AbortSignal.timeout(API_TIMEOUT_MS),
+        headers: {
+          accept: 'application/json',
+          'user-agent': 'arcanos-railway-pr-preview-lifecycle/1',
+        },
+      });
+    } catch {
+      fail('RAILWAY_PR_PREVIEW_READINESS_FAILED');
+    }
+    requireCondition(
+      response.ok
+        && response.status === 200
+        && response.headers.get('cache-control') === 'no-store'
+        && response.headers.get('content-type')?.toLowerCase().startsWith('application/json'),
+      'RAILWAY_PR_PREVIEW_READINESS_FAILED'
+    );
+    return readBoundedJson(
+      response,
+      READINESS_RESPONSE_LIMIT_BYTES,
+      'RAILWAY_PR_PREVIEW_READINESS_FAILED'
+    );
+  }
+
+  async deleteAndVerifyEnvironment(environment) {
+    const ownedNamePattern = new RegExp(
+      `^${CONTRACT.environmentPrefix}[1-9][0-9]*$`,
+      'u'
+    );
+    requireCondition(
+      isRecord(environment)
+        && isUuid(environment.id)
+        && !PROTECTED_ENVIRONMENT_IDS.has(environment.id)
+        && typeof environment.name === 'string'
+        && ownedNamePattern.test(environment.name)
+        && environment.projectId === CONTRACT.projectId
+        && environment.isEphemeral === true
+        && environment.sourceEnvironment?.id === CONTRACT.baseEnvironmentId
+        && (environment.deletedAt === undefined || environment.deletedAt === null),
+      'RAILWAY_PR_PREVIEW_DELETE_TARGET_INVALID'
+    );
+    const data = await this.graphql(DELETE_ENVIRONMENT_MUTATION, {
+      id: environment.id,
+    });
+    requireCondition(
+      data.environmentDelete === true,
+      'RAILWAY_PR_PREVIEW_DELETE_FAILED'
+    );
+    for (let attempt = 0; attempt < DELETE_POLL_ATTEMPTS; attempt += 1) {
+      const environments = await this.listEnvironments();
+      const sameId = environments.some((item) => item.id === environment.id);
+      const sameName = environments.filter((item) => item.name === environment.name);
+      if (!sameId && sameName.length === 0) {
+        return;
+      }
+      requireCondition(
+        sameName.every((item) => item.id === environment.id),
+        'RAILWAY_PR_PREVIEW_DELETE_IDENTITY_CHANGED'
+      );
+      await this.sleepImpl(DELETE_POLL_INTERVAL_MS);
+    }
+    fail('RAILWAY_PR_PREVIEW_DELETE_TIMEOUT');
+  }
+}
+
+export class GitHubApi {
+  constructor({ token, fetchImpl = globalThis.fetch }) {
+    requireCondition(
+      typeof token === 'string'
+        && token.length >= 20
+        && token.trim() === token,
+      'RAILWAY_PR_PREVIEW_GITHUB_TOKEN_INVALID'
+    );
+    requireCondition(typeof fetchImpl === 'function', 'RAILWAY_PR_PREVIEW_FETCH_UNAVAILABLE');
+    this.token = token;
+    this.fetchImpl = fetchImpl;
+  }
+
+  async request(pathname, { method = 'GET', body = undefined } = {}) {
+    requireCondition(
+      typeof pathname === 'string' && pathname.startsWith('/repos/pbjustin/Arcanos/'),
+      'RAILWAY_PR_PREVIEW_GITHUB_REQUEST_INVALID'
+    );
+    let response;
+    try {
+      response = await this.fetchImpl(`${GITHUB_API_URL}${pathname}`, {
+        method,
+        redirect: 'error',
+        signal: AbortSignal.timeout(API_TIMEOUT_MS),
+        headers: {
+          accept: 'application/vnd.github+json',
+          authorization: `Bearer ${this.token}`,
+          'content-type': 'application/json',
+          'user-agent': 'arcanos-railway-pr-preview-lifecycle/1',
+          'x-github-api-version': '2022-11-28',
+        },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      });
+    } catch {
+      fail('RAILWAY_PR_PREVIEW_GITHUB_API_FAILED');
+    }
+    const parsed = await readBoundedJson(
+      response,
+      GITHUB_RESPONSE_LIMIT_BYTES,
+      'RAILWAY_PR_PREVIEW_GITHUB_API_FAILED'
+    );
+    requireCondition(
+      response.ok && (isRecord(parsed) || Array.isArray(parsed)),
+      'RAILWAY_PR_PREVIEW_GITHUB_API_FAILED'
+    );
+    return parsed;
+  }
+
+  async readPullRequest(prNumber) {
+    return this.request(`/repos/${CONTRACT.repository}/pulls/${prNumber}`);
+  }
+
+  async listOpenPullRequests() {
+    const pullRequests = [];
+    for (let page = 1; page <= 20; page += 1) {
+      const observed = await this.request(
+        `/repos/${CONTRACT.repository}/pulls?state=open&per_page=100&page=${page}`
+      );
+      requireCondition(
+        Array.isArray(observed) && observed.every(isRecord),
+        'RAILWAY_PR_PREVIEW_GITHUB_API_FAILED'
+      );
+      pullRequests.push(...observed);
+      if (observed.length < 100) {
+        return pullRequests;
+      }
+    }
+    fail('RAILWAY_PR_PREVIEW_GITHUB_PAGINATION_LIMIT_EXCEEDED');
+  }
+
+  async writeCommitStatus({ sha, state, description, targetUrl }) {
+    requireCommit(sha, 'RAILWAY_PR_PREVIEW_COMMIT_INVALID');
+    requireCondition(
+      ['pending', 'success', 'failure'].includes(state)
+        && typeof description === 'string'
+        && description.length > 0
+        && description.length <= 140
+        && typeof targetUrl === 'string'
+        && /^https:\/\/github\.com\/pbjustin\/Arcanos\/actions\/runs\/[1-9][0-9]*$/u
+          .test(targetUrl),
+      'RAILWAY_PR_PREVIEW_STATUS_INVALID'
+    );
+    const result = await this.request(
+      `/repos/${CONTRACT.repository}/statuses/${sha}`,
+      {
+        method: 'POST',
+        body: {
+          state,
+          context: CONTRACT.statusContext,
+          description,
+          target_url: targetUrl,
+        },
+      }
+    );
+    requireCondition(
+      result.sha?.toLowerCase() === sha && result.context === CONTRACT.statusContext,
+      'RAILWAY_PR_PREVIEW_STATUS_WRITE_FAILED'
+    );
+  }
+}
+
+function readPrNumber(raw) {
+  requireCondition(
+    typeof raw === 'string' && POSITIVE_INTEGER_PATTERN.test(raw),
+    'RAILWAY_PR_PREVIEW_PR_NUMBER_INVALID'
+  );
+  const number = Number.parseInt(raw, 10);
+  requireCondition(Number.isSafeInteger(number), 'RAILWAY_PR_PREVIEW_PR_NUMBER_INVALID');
+  return number;
+}
+
+function readEventInput(env) {
+  requireCondition(
+    env.GITHUB_REPOSITORY === CONTRACT.repository
+      && env.EXPECTED_OPT_IN_LABEL === CONTRACT.optInLabel,
+    'RAILWAY_PR_PREVIEW_REPOSITORY_MISMATCH'
+  );
+  const eventAction = env.EVENT_ACTION ?? '';
+  const eventLabelName = env.EVENT_LABEL_NAME ?? '';
+  const eventHeadSha = (env.EVENT_HEAD_SHA ?? '').toLowerCase();
+  requireCondition(
+    eventHeadSha === '' || COMMIT_PATTERN.test(eventHeadSha),
+    'RAILWAY_PR_PREVIEW_COMMIT_INVALID'
+  );
+  requireCondition(
+    eventLabelName.length <= 100 && eventLabelName.trim() === eventLabelName,
+    'RAILWAY_PR_PREVIEW_EVENT_LABEL_INVALID'
+  );
+  return {
+    eventAction,
+    eventHeadSha,
+    eventLabelName,
+    prNumber: readPrNumber(env.PR_NUMBER),
+  };
+}
+
+function writeGithubOutputs(values, outputPath = process.env.GITHUB_OUTPUT) {
+  if (!outputPath) {
+    return;
+  }
+  const lines = [];
+  for (const [name, rawValue] of Object.entries(values)) {
+    const value = String(rawValue ?? '');
+    requireCondition(
+      /^[a-z_][a-z0-9_]*$/u.test(name)
+        && !value.includes('\n')
+        && !value.includes('\r'),
+      'RAILWAY_PR_PREVIEW_OUTPUT_INVALID'
+    );
+    lines.push(`${name}=${value}`);
+  }
+  appendFileSync(outputPath, `${lines.join('\n')}\n`, { encoding: 'utf8' });
+}
+
+function lifecycleOutputs(result, pullRequest) {
+  return {
+    action: result.action,
+    preview_ready: result.action === 'reconcile' ? 'true' : 'false',
+    pr_number: pullRequest.number,
+    head_sha: pullRequest.headSha,
+    environment_id: result.environmentId ?? '',
+    worker_deployment_id: result.workerDeploymentId ?? '',
+    web_deployment_id: result.webDeploymentId ?? '',
+    worker_base_url: result.workerBaseUrl ?? '',
+    web_base_url: result.webBaseUrl ?? '',
+  };
+}
+
+async function runEventCli(env = process.env) {
+  const input = readEventInput(env);
+  const github = new GitHubApi({ token: env.GITHUB_TOKEN });
+  const readCurrent = async () => validateLifecyclePullRequest(
+    await github.readPullRequest(input.prNumber),
+    input.prNumber
+  );
+  const pullRequest = await readCurrent();
+  const action = decideLifecycleAction({
+    eventAction: input.eventAction,
+    eventLabelName: input.eventLabelName,
+    pullRequest,
+  });
+  if (action === 'noop') {
+    const result = { action: 'noop', reason: 'not-opted-in' };
+    writeGithubOutputs(lifecycleOutputs(result, pullRequest), env.GITHUB_OUTPUT);
+    return result;
+  }
+  if (action === 'reconcile') {
+    await github.writeCommitStatus({
+      sha: pullRequest.headSha,
+      state: 'pending',
+      description: 'Reconciling exact-SHA Railway preview and sealed E2E.',
+      targetUrl: env.RUN_URL,
+    });
+  }
+  let result;
+  try {
+    const railway = new RailwayGraphqlApi({ token: env.RAILWAY_API_TOKEN });
+    result = action === 'reconcile'
+      ? await reconcileRailwayPrPreview({
+          pullRequest,
+          railway,
+          verifyCurrentPullRequest: readCurrent,
+        })
+      : await cleanupRailwayPrPreview({
+          pullRequest,
+          railway,
+          verifyCurrentPullRequest: readCurrent,
+        });
+  } catch (error) {
+    if (action === 'reconcile') {
+      const current = await readCurrent().catch(() => null);
+      if (current?.headSha === pullRequest.headSha) {
+        await github.writeCommitStatus({
+          sha: pullRequest.headSha,
+          state: 'failure',
+          description: 'Railway preview lifecycle failed before sealed E2E.',
+          targetUrl: env.RUN_URL,
+        }).catch(() => undefined);
+      }
+    }
+    throw error;
+  }
+  writeGithubOutputs(lifecycleOutputs(result, pullRequest), env.GITHUB_OUTPUT);
+  return result;
+}
+
+async function runReportStatusCli(env = process.env) {
+  const input = readEventInput(env);
+  const github = new GitHubApi({ token: env.GITHUB_TOKEN });
+  const pullRequest = validateLifecyclePullRequest(
+    await github.readPullRequest(input.prNumber),
+    input.prNumber
+  );
+  const lifecycleHeadSha = (env.LIFECYCLE_HEAD_SHA ?? '').toLowerCase();
+  requireCondition(
+    lifecycleHeadSha === '' || COMMIT_PATTERN.test(lifecycleHeadSha),
+    'RAILWAY_PR_PREVIEW_COMMIT_INVALID'
+  );
+  const expectedHeadSha = lifecycleHeadSha || input.eventHeadSha;
+  if (!expectedHeadSha || expectedHeadSha !== pullRequest.headSha) {
+    return { action: 'status-skipped', reason: 'stale-event' };
+  }
+  const desired = decideLifecycleAction({
+    eventAction: input.eventAction,
+    eventLabelName: input.eventLabelName,
+    pullRequest,
+  });
+  if (desired !== 'reconcile') {
+    return { action: 'status-skipped', reason: 'not-reconcile' };
+  }
+  const succeeded = desired === 'reconcile'
+    && env.LIFECYCLE_RESULT === 'success'
+    && env.PREVIEW_READY === 'true'
+    && env.E2E_RESULT === 'success';
+  await github.writeCommitStatus({
+    sha: pullRequest.headSha,
+    state: succeeded ? 'success' : 'failure',
+    description: succeeded
+      ? 'Exact-SHA Railway preview and sealed E2E passed.'
+      : 'Railway preview lifecycle or sealed E2E failed.',
+    targetUrl: env.RUN_URL,
+  });
+  return {
+    action: 'status-written',
+    headSha: pullRequest.headSha,
+    state: succeeded ? 'success' : 'failure',
+  };
+}
+
+async function runDiscoverCli(env = process.env) {
+  requireCondition(
+    env.GITHUB_REPOSITORY === CONTRACT.repository,
+    'RAILWAY_PR_PREVIEW_REPOSITORY_MISMATCH'
+  );
+  const github = new GitHubApi({ token: env.GITHUB_TOKEN });
+  const railway = new RailwayGraphqlApi({ token: env.RAILWAY_API_TOKEN });
+  const prNumbers = await discoverRailwayPrPreviewNumbers({ github, railway });
+  writeGithubOutputs({ pr_numbers: JSON.stringify(prNumbers) }, env.GITHUB_OUTPUT);
+  return {
+    action: 'discover',
+    prNumberCount: prNumbers.length,
+  };
+}
+
+async function runCli() {
+  try {
+    const command = process.argv[2] ?? 'event';
+    const result = command === 'event'
+      ? await runEventCli()
+      : command === 'report-status'
+        ? await runReportStatusCli()
+        : command === 'discover'
+          ? await runDiscoverCli()
+          : fail('RAILWAY_PR_PREVIEW_COMMAND_INVALID');
+    process.stdout.write(`${JSON.stringify({
+      schemaVersion: 1,
+      kind: 'railway_pr_preview_lifecycle',
+      summary: {
+        status: 'PASS',
+        action: result.action,
+        ...(result.reason ? { reason: result.reason } : {}),
+        ...(result.prNumber ? { prNumber: result.prNumber } : {}),
+        ...(result.headSha ? { headSha: result.headSha } : {}),
+      },
+    })}\n`);
+  } catch (error) {
+    const failure = error instanceof RailwayPrPreviewLifecycleError
+      ? error
+      : new RailwayPrPreviewLifecycleError('RAILWAY_PR_PREVIEW_UNEXPECTED_FAILURE');
+    process.stderr.write(`${JSON.stringify({
+      schemaVersion: 1,
+      kind: 'railway_pr_preview_lifecycle',
+      summary: {
+        status: 'FAIL',
+        code: failure.code,
+      },
+    })}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (
+  process.argv[1]
+  && import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await runCli();
+}

--- a/tests/railway-pr-preview-lifecycle.test.js
+++ b/tests/railway-pr-preview-lifecycle.test.js
@@ -1,0 +1,1177 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+
+import {
+  RAILWAY_PR_PREVIEW_CONTRACT,
+  RailwayGraphqlApi,
+  RailwayPrPreviewLifecycleError,
+  cleanupRailwayPrPreview,
+  decideLifecycleAction,
+  discoverRailwayPrPreviewNumbers,
+  reconcileRailwayPrPreview,
+  validateBasePreviewEnvironment,
+  validateLifecycleAuthority,
+  validateLifecyclePullRequest,
+  validateOwnedPreviewEnvironment,
+  validatePreviewDeployment,
+} from '../scripts/railway-pr-preview-lifecycle.mjs';
+
+const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..'
+);
+const workflowPath = path.join(
+  repositoryRoot,
+  '.github',
+  'workflows',
+  'railway-pr-preview-lifecycle.yml'
+);
+const reusableWorkflowPath = path.join(
+  repositoryRoot,
+  '.github',
+  'workflows',
+  'railway-pr-preview-run.yml'
+);
+
+const CONTRACT = RAILWAY_PR_PREVIEW_CONTRACT;
+const PR_NUMBER = 1435;
+const HEAD_SHA = 'a'.repeat(40);
+const HEAD_REF = 'codex/railway-preview-lifecycle-fixture';
+const WORKER_DEPLOYMENT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1';
+const WEB_DEPLOYMENT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2';
+const PREVIEW_ENVIRONMENT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3';
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function pullRequest(overrides = {}) {
+  return {
+    number: PR_NUMBER,
+    state: 'open',
+    draft: false,
+    base: {
+      ref: 'main',
+      repo: { full_name: CONTRACT.repository },
+    },
+    head: {
+      ref: HEAD_REF,
+      sha: HEAD_SHA,
+      repo: { full_name: CONTRACT.repository },
+    },
+    labels: [{ name: CONTRACT.optInLabel }],
+    ...overrides,
+  };
+}
+
+function deployment({
+  id,
+  serviceId,
+  commitSha = HEAD_SHA,
+  status = 'SUCCESS',
+  stopped = false,
+} = {}) {
+  return {
+    id,
+    projectId: CONTRACT.projectId,
+    environmentId: PREVIEW_ENVIRONMENT_ID,
+    serviceId,
+    status,
+    deploymentStopped: stopped,
+    meta: {
+      repo: CONTRACT.repository,
+      commitHash: commitSha,
+      configFile: '/railway.json',
+      buildOnly: false,
+      reason: 'deploy',
+      rootDirectory: null,
+      volumeMounts: [],
+      propertyFileMapping: {
+        'deploy.startCommand': '$.environments.pr.deploy.startCommand',
+        'deploy.healthcheckPath': '$.environments.pr.deploy.healthcheckPath',
+        'deploy.healthcheckTimeout': '$.environments.pr.deploy.healthcheckTimeout',
+        'deploy.restartPolicyType': '$.environments.pr.deploy.restartPolicyType',
+        'deploy.restartPolicyMaxRetries': '$.environments.pr.deploy.restartPolicyMaxRetries',
+        'deploy.preDeployCommand': '$.environments.pr.deploy.preDeployCommand',
+        'deploy.cronSchedule': '$.environments.pr.deploy.cronSchedule',
+        'deploy.drainingSeconds': '$.deploy.drainingSeconds',
+      },
+      serviceManifest: {
+        build: {
+          builder: 'DOCKERFILE',
+          dockerfilePath: '/Dockerfile',
+          buildCommand: CONTRACT.buildCommand,
+          buildEnvironment: 'V3',
+          watchPatterns: [],
+        },
+        deploy: {
+          startCommand: CONTRACT.previewStartCommand,
+          healthcheckPath: '/readyz',
+          healthcheckTimeout: 300,
+          drainingSeconds: 60,
+          restartPolicyType: 'NEVER',
+          restartPolicyMaxRetries: null,
+          preDeployCommand: null,
+          cronSchedule: null,
+          runtime: 'V2',
+          numReplicas: 1,
+          requiredMountPath: null,
+        },
+      },
+    },
+  };
+}
+
+function serviceNode({ role, activeDeployments = [], latestDeployment = null } = {}) {
+  const service = CONTRACT.services[role];
+  return {
+    id: role === 'worker'
+      ? 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1'
+      : 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2',
+    serviceId: service.id,
+    serviceName: service.name,
+    environmentId: PREVIEW_ENVIRONMENT_ID,
+    deletedAt: null,
+    source: { repo: CONTRACT.repository, image: null },
+    railwayConfigFile: '/railway.json',
+    rootDirectory: null,
+    dockerfilePath: null,
+    startCommand: CONTRACT.baseStartCommand,
+    healthcheckPath: '/readyz',
+    healthcheckTimeout: 300,
+    drainingSeconds: null,
+    restartPolicyType: 'NEVER',
+    restartPolicyMaxRetries: 10,
+    latestDeployment,
+    activeDeployments,
+    domains: {
+      serviceDomains: [{
+        id: role === 'worker'
+          ? 'cccccccc-cccc-4ccc-8ccc-ccccccccccc1'
+          : 'cccccccc-cccc-4ccc-8ccc-ccccccccccc2',
+        domain: role === 'worker'
+          ? `arcanos-worker-pr-676861-${PR_NUMBER}.up.railway.app`
+          : `arcanos-v2-pr-676861-${PR_NUMBER}.up.railway.app`,
+        environmentId: PREVIEW_ENVIRONMENT_ID,
+        serviceId: service.id,
+        deletedAt: null,
+        syncStatus: 'ACTIVE',
+      }],
+      customDomains: [],
+    },
+  };
+}
+
+function environment({
+  triggers = [],
+  workerActive = [],
+  webActive = [],
+  workerLatest = null,
+  webLatest = null,
+  overrides = {},
+} = {}) {
+  return {
+    id: PREVIEW_ENVIRONMENT_ID,
+    name: `${CONTRACT.environmentPrefix}${PR_NUMBER}`,
+    projectId: CONTRACT.projectId,
+    isEphemeral: true,
+    deletedAt: null,
+    sourceEnvironment: { id: CONTRACT.baseEnvironmentId },
+    meta: null,
+    config: {
+      groups: {
+        [CONTRACT.serviceGroupId]: {
+          color: 'blue',
+          icon: null,
+          isCollapsed: false,
+          name: 'arcanos',
+        },
+      },
+      privateNetworkDisabled: false,
+      services: {
+        [CONTRACT.services.worker.id]: {
+          build: {},
+          deploy: {},
+          groupId: CONTRACT.serviceGroupId,
+          networking: {},
+          source: {
+            branch: HEAD_REF,
+            checkSuites: false,
+            repo: CONTRACT.repository,
+          },
+          variables: {
+            ARCANOS_PROCESS_KIND: { generator: null, value: 'worker' },
+          },
+        },
+        [CONTRACT.services.web.id]: {
+          build: {},
+          deploy: {},
+          groupId: CONTRACT.serviceGroupId,
+          networking: {},
+          source: {
+            branch: HEAD_REF,
+            checkSuites: false,
+            repo: CONTRACT.repository,
+          },
+          variables: {
+            ARCANOS_PROCESS_KIND: { generator: null, value: 'web' },
+          },
+        },
+      },
+      sharedVariables: {},
+    },
+    deploymentTriggers: {
+      edges: triggers.map(node => ({ node })),
+      pageInfo: { hasNextPage: false, endCursor: null },
+    },
+    serviceInstances: {
+      edges: [
+        { node: serviceNode({ role: 'worker', activeDeployments: workerActive, latestDeployment: workerLatest }) },
+        { node: serviceNode({ role: 'web', activeDeployments: webActive, latestDeployment: webLatest }) },
+      ],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    },
+    volumeInstances: {
+      edges: [],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    },
+    ...overrides,
+  };
+}
+
+function baseEnvironment() {
+  const base = environment();
+  base.id = CONTRACT.baseEnvironmentId;
+  base.name = CONTRACT.baseEnvironmentName;
+  base.isEphemeral = false;
+  base.sourceEnvironment = { id: CONTRACT.baseSourceEnvironmentId };
+  for (const [role, service] of Object.entries(CONTRACT.services)) {
+    const serviceConfig = base.config.services[service.id];
+    serviceConfig.source = { branch: 'main', repo: CONTRACT.repository };
+    const node = base.serviceInstances.edges.find(
+      edge => edge.node.serviceId === service.id
+    ).node;
+    node.id = service.baseInstanceId;
+    node.environmentId = CONTRACT.baseEnvironmentId;
+    node.railwayConfigFile = null;
+    node.domains.serviceDomains[0].environmentId = CONTRACT.baseEnvironmentId;
+    node.domains.serviceDomains[0].domain = role === 'worker'
+      ? 'arcanos-worker-pr-preview-base-20260812.up.railway.app'
+      : 'arcanos-v2-pr-preview-base-20260812.up.railway.app';
+  }
+  return base;
+}
+
+describe('Railway PR preview lifecycle workflow', () => {
+  const workflow = fs.readFileSync(workflowPath, 'utf8').replaceAll('\r\n', '\n');
+  const parsed = yaml.load(workflow);
+  const reusableWorkflow = fs
+    .readFileSync(reusableWorkflowPath, 'utf8')
+    .replaceAll('\r\n', '\n');
+  const reusable = yaml.load(reusableWorkflow);
+
+  it('uses a trusted event workflow with an exact opt-in and per-PR non-cancelling lock', () => {
+    expect(workflow).toContain('pull_request_target:');
+    for (const event of [
+      'opened',
+      'reopened',
+      'ready_for_review',
+      'synchronize',
+      'labeled',
+      'unlabeled',
+      'converted_to_draft',
+      'edited',
+      'closed',
+    ]) {
+      expect(workflow).toContain(`- ${event}`);
+    }
+    expect(workflow).toContain('repository_dispatch:');
+    expect(workflow).not.toContain('workflow_dispatch:');
+    expect(workflow).toContain('railway_pr_preview_reconcile');
+    expect(workflow).toContain("cron: '23 */6 * * *'");
+    expect(reusableWorkflow).toContain('railway-preview');
+    expect(parsed.concurrency['cancel-in-progress']).toBe(false);
+    expect(parsed.concurrency.group).toContain('railway-pr-preview-lifecycle-');
+    expect(parsed.jobs['run-event-preview-lifecycle'].uses).toBe(
+      './.github/workflows/railway-pr-preview-run.yml'
+    );
+    const scheduled = parsed.jobs['reconcile-scheduled-previews'];
+    expect(scheduled.strategy['fail-fast']).toBe(false);
+    expect(scheduled.strategy['max-parallel']).toBe(2);
+    expect(scheduled.concurrency.group).toContain('matrix.pr_number');
+    expect(scheduled.uses).toBe('./.github/workflows/railway-pr-preview-run.yml');
+    expect(JSON.stringify(scheduled)).not.toContain('RAILWAY_API_TOKEN');
+  });
+
+  it('keeps PR code away from the dedicated Railway credential', () => {
+    const lifecycle = reusable.jobs.lifecycle;
+    const tokenSteps = lifecycle.steps.filter(
+      step => step.env?.RAILWAY_API_TOKEN !== undefined
+    );
+    expect(tokenSteps).toHaveLength(1);
+    expect(tokenSteps[0].env.RAILWAY_API_TOKEN).toBe(
+      '${{ secrets.RAILWAY_PR_PREVIEW_LIFECYCLE_API_TOKEN }}'
+    );
+    expect(lifecycle.environment).toBe('railway-pr-preview-lifecycle');
+    expect(lifecycle.env?.RAILWAY_API_TOKEN).toBeUndefined();
+    const lifecycleSource = reusableWorkflow.slice(
+      reusableWorkflow.indexOf('  lifecycle:\n'),
+      reusableWorkflow.indexOf('\n  preview-e2e:', reusableWorkflow.indexOf('  lifecycle:\n'))
+    );
+    expect(lifecycleSource).toContain('ref: ${{ github.workflow_sha }}');
+    expect(lifecycleSource).toContain('persist-credentials: false');
+    expect(lifecycleSource).not.toContain('head-evidence');
+    expect(lifecycleSource).not.toContain('npm install');
+    expect(lifecycleSource).not.toContain('npm ci');
+    expect(lifecycleSource).not.toContain('railway up');
+    const discovery = parsed.jobs['discover-scheduled-previews'];
+    expect(discovery.environment).toBe('railway-pr-preview-lifecycle');
+    expect(discovery.steps.filter(
+      step => step.env?.RAILWAY_API_TOKEN !== undefined
+    )).toHaveLength(1);
+    for (const job of Object.values(reusable.jobs)) {
+      const serialized = JSON.stringify(job);
+      expect(!(serialized.includes('RAILWAY_API_TOKEN')
+        && serialized.includes('head-evidence'))).toBe(true);
+    }
+  });
+
+  it('runs the trusted 112-request harness against a Railway-secret-free head checkout', () => {
+    const e2e = reusable.jobs['preview-e2e'];
+    expect(e2e.permissions).toEqual({ contents: 'read' });
+    expect(e2e.steps.some(step =>
+      step.with?.ref === '${{ needs.lifecycle.outputs.head_sha }}'
+      && step.with?.path === 'head-evidence'
+      && step.with?.['persist-credentials'] === false)).toBe(true);
+    expect(e2e.steps.some(step =>
+      step.with?.ref === '${{ github.workflow_sha }}'
+      && step.with?.path === 'trusted'
+      && step.with?.['persist-credentials'] === false)).toBe(true);
+    expect(e2e.steps.some(step =>
+      String(step.run ?? '').includes('trusted/scripts/native-pr-preview-e2e.mjs')
+      && String(step.run).includes('--git-evidence-root')
+      && String(step.run).includes('head-evidence')
+      && String(step.run).includes('--execute')
+      && String(step.run).includes('--allow-network'))).toBe(true);
+    expect(JSON.stringify(e2e)).not.toContain('RAILWAY_API_TOKEN');
+    expect(JSON.stringify(e2e)).not.toContain('RAILWAY_PR_PREVIEW_LIFECYCLE_API_TOKEN');
+  });
+
+  it('publishes a narrowly scoped head status without Railway authority or PR checkout', () => {
+    const reporter = reusable.jobs['report-preview-status'];
+    expect(reporter.permissions.statuses).toBe('write');
+    expect(reporter.permissions['pull-requests']).toBe('read');
+    expect(JSON.stringify(reporter)).not.toContain('RAILWAY_API_TOKEN');
+    expect(reporter.steps.some(step => step.uses?.startsWith('actions/checkout@'))).toBe(true);
+    expect(reporter.steps.find(step => step.uses?.startsWith('actions/checkout@'))?.with?.ref).toBe(
+      '${{ github.workflow_sha }}'
+    );
+    expect(reporter.steps.some(step =>
+      String(step.run ?? '').includes('report-status'))).toBe(true);
+  });
+});
+
+describe('Railway PR preview lifecycle policy', () => {
+  it('reconciles only an open, ready, same-repository main PR with the opt-in label', () => {
+    const pr = validateLifecyclePullRequest(pullRequest(), PR_NUMBER);
+    expect(decideLifecycleAction({ eventAction: 'synchronize', pullRequest: pr })).toBe('reconcile');
+
+    expect(decideLifecycleAction({
+      eventAction: 'opened',
+      pullRequest: validateLifecyclePullRequest(pullRequest({ draft: true }), PR_NUMBER),
+    })).toBe('noop');
+    expect(decideLifecycleAction({
+      eventAction: 'labeled',
+      eventLabelName: 'documentation',
+      pullRequest: pr,
+    })).toBe('reconcile');
+  });
+
+  it('cleans up only the exact opt-in lifecycle transitions', () => {
+    const closed = validateLifecyclePullRequest(pullRequest({ state: 'closed' }), PR_NUMBER);
+    const draft = validateLifecyclePullRequest(pullRequest({ draft: true }), PR_NUMBER);
+    const unlabeled = validateLifecyclePullRequest(pullRequest({ labels: [] }), PR_NUMBER);
+    const retargeted = validateLifecyclePullRequest(pullRequest({
+      base: { ref: 'develop', repo: { full_name: CONTRACT.repository } },
+    }), PR_NUMBER);
+    expect(decideLifecycleAction({ eventAction: 'closed', pullRequest: closed })).toBe('cleanup');
+    expect(decideLifecycleAction({ eventAction: 'converted_to_draft', pullRequest: draft })).toBe('cleanup');
+    expect(decideLifecycleAction({
+      eventAction: 'unlabeled',
+      eventLabelName: CONTRACT.optInLabel,
+      pullRequest: unlabeled,
+    })).toBe('cleanup');
+    expect(decideLifecycleAction({
+      eventAction: 'unlabeled',
+      eventLabelName: 'documentation',
+      pullRequest: unlabeled,
+    })).toBe('noop');
+    expect(decideLifecycleAction({
+      eventAction: 'edited',
+      pullRequest: retargeted,
+    })).toBe('cleanup');
+    expect(decideLifecycleAction({
+      eventAction: 'manual',
+      pullRequest: retargeted,
+    })).toBe('cleanup');
+  });
+
+  it('converges stale destructive events against current PR state', () => {
+    const reopened = validateLifecyclePullRequest(pullRequest(), PR_NUMBER);
+    expect(decideLifecycleAction({
+      eventAction: 'closed',
+      pullRequest: reopened,
+    })).toBe('reconcile');
+    expect(decideLifecycleAction({
+      eventAction: 'converted_to_draft',
+      pullRequest: reopened,
+    })).toBe('reconcile');
+    expect(decideLifecycleAction({
+      eventAction: 'unlabeled',
+      eventLabelName: CONTRACT.optInLabel,
+      pullRequest: reopened,
+    })).toBe('reconcile');
+  });
+
+  it.each([
+    ['fork', { head: { ref: 'branch', sha: HEAD_SHA, repo: { full_name: 'attacker/fork' } } }],
+    ['wrong number', { number: PR_NUMBER + 1 }],
+  ])('rejects a %s before provider access', (_name, overrides) => {
+    expect(() => validateLifecyclePullRequest(pullRequest(overrides), PR_NUMBER)).toThrow(
+      RailwayPrPreviewLifecycleError
+    );
+  });
+
+  it('requires exact workspace/project/base authority and native lifecycle cutover', () => {
+    const authority = {
+      apiToken: { workspaces: [{ id: CONTRACT.workspaceId }] },
+      project: {
+        id: CONTRACT.projectId,
+        workspaceId: CONTRACT.workspaceId,
+        baseEnvironmentId: CONTRACT.baseEnvironmentId,
+        primaryEnvironmentId: CONTRACT.productionEnvironmentId,
+        prDeploys: false,
+      },
+    };
+    expect(() => validateLifecycleAuthority(authority, { requireNativeDisabled: true })).not.toThrow();
+    expect(() => validateLifecycleAuthority({
+      ...authority,
+      project: { ...authority.project, prDeploys: true },
+    }, { requireNativeDisabled: true })).toThrow('RAILWAY_PR_PREVIEW_NATIVE_LIFECYCLE_ENABLED');
+  });
+
+  it('attests the exact credential-empty base topology from live provider shape', () => {
+    expect(() => validateBasePreviewEnvironment(baseEnvironment())).not.toThrow();
+    const wrongAncestor = baseEnvironment();
+    wrongAncestor.sourceEnvironment.id = CONTRACT.productionEnvironmentId;
+    expect(() => validateBasePreviewEnvironment(wrongAncestor)).toThrow(
+      'RAILWAY_PR_PREVIEW_BASE_MISMATCH'
+    );
+    const wrongRetries = baseEnvironment();
+    wrongRetries.serviceInstances.edges[0].node.restartPolicyMaxRetries = 0;
+    expect(() => validateBasePreviewEnvironment(wrongRetries)).toThrow(
+      'RAILWAY_PR_PREVIEW_BASE_MISMATCH'
+    );
+  });
+
+  it('accepts only an exact controller-owned, credential-empty two-role environment', () => {
+    expect(() => validateOwnedPreviewEnvironment(environment(), {
+      headRef: HEAD_REF,
+      prNumber: PR_NUMBER,
+      requireActiveDomains: true,
+    })).not.toThrow();
+
+    const withVolume = environment();
+    withVolume.volumeInstances.edges.push({ node: {
+      id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+      environmentId: PREVIEW_ENVIRONMENT_ID,
+      serviceId: CONTRACT.services.web.id,
+      volumeId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+      mountPath: '/data',
+      deletedAt: null,
+      state: 'READY',
+    } });
+    expect(() => validateOwnedPreviewEnvironment(withVolume, {
+      headRef: HEAD_REF,
+      prNumber: PR_NUMBER,
+    })).toThrow('RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH');
+
+    const withSecret = environment();
+    withSecret.config.services[CONTRACT.services.web.id].variables.OPENAI_API_KEY = {
+      generator: null,
+      value: 'sensitive-test-sentinel',
+    };
+    expect(() => validateOwnedPreviewEnvironment(withSecret, {
+      headRef: HEAD_REF,
+      prNumber: PR_NUMBER,
+    })).toThrow('RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH');
+
+    const withForeignTrigger = environment({ triggers: [{
+      id: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+      projectId: CONTRACT.projectId,
+      environmentId: PREVIEW_ENVIRONMENT_ID,
+      serviceId: CONTRACT.services.web.id,
+      repository: 'attacker/fork',
+      branch: 'main',
+      provider: 'github',
+      checkSuites: false,
+    }] });
+    expect(() => validateOwnedPreviewEnvironment(withForeignTrigger, {
+      headRef: pullRequest().head.ref,
+      prNumber: PR_NUMBER,
+    })).toThrow('RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH');
+  });
+
+  it('attests exact deployment identity and PR-safe manifest', () => {
+    expect(() => validatePreviewDeployment(deployment({
+      id: WORKER_DEPLOYMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+    }), {
+      deploymentId: WORKER_DEPLOYMENT_ID,
+      environmentId: PREVIEW_ENVIRONMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+      commitSha: HEAD_SHA,
+    })).not.toThrow();
+
+    const unsafe = deployment({
+      id: WORKER_DEPLOYMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+    });
+    unsafe.meta.serviceManifest.deploy.startCommand = 'npm start';
+    expect(() => validatePreviewDeployment(unsafe, {
+      deploymentId: WORKER_DEPLOYMENT_ID,
+      environmentId: PREVIEW_ENVIRONMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+      commitSha: HEAD_SHA,
+    })).toThrow('RAILWAY_PR_PREVIEW_DEPLOYMENT_MISMATCH');
+  });
+
+  it('ignores a newer failed latest record when the sole active deployment is exact', async () => {
+    const worker = deployment({
+      id: WORKER_DEPLOYMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+    });
+    const web = deployment({
+      id: WEB_DEPLOYMENT_ID,
+      serviceId: CONTRACT.services.web.id,
+    });
+    const failedLatest = deployment({
+      id: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+      serviceId: CONTRACT.services.worker.id,
+      status: 'FAILED',
+      stopped: true,
+    });
+    const active = environment({
+      workerActive: [worker],
+      webActive: [web],
+      workerLatest: failedLatest,
+      webLatest: web,
+    });
+    const calls = [];
+    const railway = {
+      async validateAuthority() { calls.push('authority'); },
+      async readBaseEnvironment() { calls.push('base'); return { valid: true }; },
+      validateBaseEnvironment(base) { expect(base).toEqual({ valid: true }); },
+      async listEnvironments() { calls.push('list'); return [active]; },
+      async readEnvironment() { calls.push('environment'); return active; },
+      async removeAndVerifyTriggers() { calls.push('triggers'); },
+      async deployExact() { throw new Error('Exact active pair must not redeploy.'); },
+      async readReadiness({ role }) {
+        calls.push(`readiness:${role}`);
+        return role === 'worker'
+          ? {
+              ready: true,
+              mode: 'passive-pr-preview',
+              processKind: 'worker',
+              prNumber: PR_NUMBER,
+              sourceCommit: HEAD_SHA,
+            }
+          : {
+              ready: true,
+              mode: 'native-pr-application-e2e-v1',
+              processKind: 'web',
+              prNumber: PR_NUMBER,
+              sourceCommit: HEAD_SHA,
+              applicationImported: true,
+              fixturesSealed: true,
+              protectedEffectsEnabled: false,
+              protectsMaliciousPr: false,
+              requiresPlatformSecretIsolationForUntrustedCode: true,
+            };
+      },
+    };
+
+    const result = await reconcileRailwayPrPreview({
+      pullRequest: validateLifecyclePullRequest(pullRequest(), PR_NUMBER),
+      railway,
+      verifyCurrentPullRequest: async () => {
+        calls.push('github');
+        return validateLifecyclePullRequest(pullRequest(), PR_NUMBER);
+      },
+    });
+
+    expect(result).toMatchObject({
+      action: 'reconcile',
+      headSha: HEAD_SHA,
+      workerDeploymentId: WORKER_DEPLOYMENT_ID,
+      webDeploymentId: WEB_DEPLOYMENT_ID,
+    });
+    expect(calls).not.toContain('deploy');
+    expect(calls).toEqual(expect.arrayContaining([
+      'authority',
+      'base',
+      'triggers',
+      'readiness:worker',
+      'readiness:web',
+    ]));
+  });
+
+  it('resumes an exact pending worker deployment without enqueueing a duplicate', async () => {
+    const pendingWorker = deployment({
+      id: WORKER_DEPLOYMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+      status: 'BUILDING',
+      stopped: true,
+    });
+    const activeWorker = deployment({
+      id: WORKER_DEPLOYMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+    });
+    const activeWeb = deployment({
+      id: WEB_DEPLOYMENT_ID,
+      serviceId: CONTRACT.services.web.id,
+    });
+    let current = environment({
+      workerLatest: pendingWorker,
+    });
+    const calls = [];
+    const railway = {
+      async validateAuthority() {},
+      async readBaseEnvironment() { return { valid: true }; },
+      validateBaseEnvironment() {},
+      async listEnvironments() { return [current]; },
+      async readEnvironment() { return current; },
+      async removeAndVerifyTriggers() {},
+      async deployExact() { throw new Error('must not enqueue a duplicate'); },
+      async waitForDeployment({ deploymentId }) {
+        calls.push(`wait:${deploymentId}`);
+        current = environment({
+          workerActive: [activeWorker],
+          workerLatest: activeWorker,
+          webActive: [activeWeb],
+          webLatest: activeWeb,
+        });
+        return activeWorker;
+      },
+      async readReadiness({ role }) {
+        return role === 'worker'
+          ? {
+              ready: true,
+              mode: 'passive-pr-preview',
+              processKind: 'worker',
+              prNumber: PR_NUMBER,
+              sourceCommit: HEAD_SHA,
+            }
+          : {
+              ready: true,
+              mode: 'native-pr-application-e2e-v1',
+              processKind: 'web',
+              prNumber: PR_NUMBER,
+              sourceCommit: HEAD_SHA,
+              applicationImported: true,
+              fixturesSealed: true,
+              protectedEffectsEnabled: false,
+              protectsMaliciousPr: false,
+              requiresPlatformSecretIsolationForUntrustedCode: true,
+            };
+      },
+    };
+
+    await expect(reconcileRailwayPrPreview({
+      pullRequest: validateLifecyclePullRequest(pullRequest(), PR_NUMBER),
+      railway,
+      verifyCurrentPullRequest: async () =>
+        validateLifecyclePullRequest(pullRequest(), PR_NUMBER),
+    })).resolves.toMatchObject({
+      workerDeploymentId: WORKER_DEPLOYMENT_ID,
+      webDeploymentId: WEB_DEPLOYMENT_ID,
+    });
+    expect(calls).toEqual([`wait:${WORKER_DEPLOYMENT_ID}`]);
+  });
+
+  it('fails closed on a pending deployment for a different head', async () => {
+    const foreignPending = deployment({
+      id: WORKER_DEPLOYMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+      commitSha: 'b'.repeat(40),
+      status: 'DEPLOYING',
+      stopped: true,
+    });
+    const current = environment({ workerLatest: foreignPending });
+    let deployed = false;
+    const railway = {
+      async validateAuthority() {},
+      async readBaseEnvironment() { return { valid: true }; },
+      validateBaseEnvironment() {},
+      async listEnvironments() { return [current]; },
+      async readEnvironment() { return current; },
+      async removeAndVerifyTriggers() {},
+      async deployExact() { deployed = true; return WORKER_DEPLOYMENT_ID; },
+    };
+
+    await expect(reconcileRailwayPrPreview({
+      pullRequest: validateLifecyclePullRequest(pullRequest(), PR_NUMBER),
+      railway,
+      verifyCurrentPullRequest: async () =>
+        validateLifecyclePullRequest(pullRequest(), PR_NUMBER),
+    })).rejects.toThrow('RAILWAY_PR_PREVIEW_DEPLOYMENT_CONFLICT');
+    expect(deployed).toBe(false);
+  });
+
+  it('rejects an exact web deployment before the worker is active', async () => {
+    const pendingWeb = deployment({
+      id: WEB_DEPLOYMENT_ID,
+      serviceId: CONTRACT.services.web.id,
+      status: 'BUILDING',
+      stopped: true,
+    });
+    const current = environment({ webLatest: pendingWeb });
+    let deployed = false;
+    const railway = {
+      async validateAuthority() {},
+      async readBaseEnvironment() { return { valid: true }; },
+      validateBaseEnvironment() {},
+      async listEnvironments() { return [current]; },
+      async readEnvironment() { return current; },
+      async removeAndVerifyTriggers() {},
+      async deployExact() { deployed = true; return WORKER_DEPLOYMENT_ID; },
+    };
+
+    await expect(reconcileRailwayPrPreview({
+      pullRequest: validateLifecyclePullRequest(pullRequest(), PR_NUMBER),
+      railway,
+      verifyCurrentPullRequest: async () =>
+        validateLifecyclePullRequest(pullRequest(), PR_NUMBER),
+    })).rejects.toThrow('RAILWAY_PR_PREVIEW_WORKER_FIRST_CONFLICT');
+    expect(deployed).toBe(false);
+  });
+
+  it('fails closed when a cloned trigger survives the quiescence readback', async () => {
+    const trigger = {
+      id: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+      projectId: CONTRACT.projectId,
+      environmentId: PREVIEW_ENVIRONMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+      repository: CONTRACT.repository,
+      branch: HEAD_REF,
+      provider: 'github',
+      checkSuites: false,
+    };
+    const current = environment({ triggers: [trigger] });
+    let deployed = false;
+    const railway = {
+      async validateAuthority() {},
+      async readBaseEnvironment() { return { valid: true }; },
+      validateBaseEnvironment() {},
+      async listEnvironments() { return [current]; },
+      async readEnvironment() { return current; },
+      async removeAndVerifyTriggers() {},
+      async deployExact() { deployed = true; return WORKER_DEPLOYMENT_ID; },
+    };
+
+    await expect(reconcileRailwayPrPreview({
+      pullRequest: validateLifecyclePullRequest(pullRequest(), PR_NUMBER),
+      railway,
+      verifyCurrentPullRequest: async () =>
+        validateLifecyclePullRequest(pullRequest(), PR_NUMBER),
+    })).rejects.toThrow('RAILWAY_PR_PREVIEW_TRIGGER_REAPPEARED');
+    expect(deployed).toBe(false);
+  });
+
+  it('deletes a newly created environment when trigger quiescence fails', async () => {
+    const created = environment();
+    let inventoryReads = 0;
+    let deletedId;
+    let createInput;
+    const railway = {
+      async validateAuthority() {},
+      async readBaseEnvironment() { return { valid: true }; },
+      validateBaseEnvironment() {},
+      async listEnvironments() {
+        inventoryReads += 1;
+        return inventoryReads === 1 ? [] : [created];
+      },
+      async createEnvironment(input) {
+        createInput = input;
+        return {
+          id: created.id,
+          name: created.name,
+          projectId: CONTRACT.projectId,
+          isEphemeral: true,
+          sourceEnvironment: { id: CONTRACT.baseEnvironmentId },
+        };
+      },
+      async readEnvironment() { return created; },
+      async removeAndVerifyTriggers() {
+        throw new RailwayPrPreviewLifecycleError(
+          'RAILWAY_PR_PREVIEW_TRIGGER_DELETE_FAILED'
+        );
+      },
+      async deleteAndVerifyEnvironment(target) { deletedId = target.id; },
+    };
+
+    await expect(reconcileRailwayPrPreview({
+      pullRequest: validateLifecyclePullRequest(pullRequest(), PR_NUMBER),
+      railway,
+      verifyCurrentPullRequest: async () =>
+        validateLifecyclePullRequest(pullRequest(), PR_NUMBER),
+    })).rejects.toThrow('RAILWAY_PR_PREVIEW_TRIGGER_DELETE_FAILED');
+    expect(createInput).toEqual({
+      applyChangesInBackground: false,
+      ephemeral: true,
+      name: `${CONTRACT.environmentPrefix}${PR_NUMBER}`,
+      projectId: CONTRACT.projectId,
+      skipInitialDeploys: true,
+      sourceEnvironmentId: CONTRACT.baseEnvironmentId,
+      stageInitialChanges: false,
+    });
+    expect(deletedId).toBe(PREVIEW_ENVIRONMENT_ID);
+  });
+
+  it('does not create a preview after the PR is retargeted away from main', async () => {
+    let created = false;
+    const retargeted = validateLifecyclePullRequest(pullRequest({
+      base: { ref: 'develop', repo: { full_name: CONTRACT.repository } },
+    }), PR_NUMBER);
+    await expect(reconcileRailwayPrPreview({
+      pullRequest: validateLifecyclePullRequest(pullRequest(), PR_NUMBER),
+      railway: {
+        async validateAuthority() {},
+        async readBaseEnvironment() { return { valid: true }; },
+        validateBaseEnvironment() {},
+        async listEnvironments() { return []; },
+        async createEnvironment() { created = true; },
+      },
+      verifyCurrentPullRequest: async () => retargeted,
+    })).rejects.toThrow('RAILWAY_PR_PREVIEW_GITHUB_STATE_CHANGED');
+    expect(created).toBe(false);
+  });
+
+  it('deploys worker first and never enqueues web after worker failure', async () => {
+    const empty = environment();
+    const calls = [];
+    const railway = {
+      async validateAuthority() { calls.push('authority'); },
+      async readBaseEnvironment() { return { valid: true }; },
+      validateBaseEnvironment() {},
+      async listEnvironments() { return [empty]; },
+      async readEnvironment() { return empty; },
+      async removeAndVerifyTriggers() { calls.push('triggers'); },
+      async deployExact({ serviceId }) {
+        calls.push(`deploy:${serviceId}`);
+        if (serviceId === CONTRACT.services.worker.id) {
+          throw new RailwayPrPreviewLifecycleError('RAILWAY_PR_PREVIEW_DEPLOYMENT_FAILED');
+        }
+        return WEB_DEPLOYMENT_ID;
+      },
+    };
+
+    await expect(reconcileRailwayPrPreview({
+      pullRequest: validateLifecyclePullRequest(pullRequest(), PR_NUMBER),
+      railway,
+      verifyCurrentPullRequest: async () =>
+        validateLifecyclePullRequest(pullRequest(), PR_NUMBER),
+    })).rejects.toThrow('RAILWAY_PR_PREVIEW_DEPLOYMENT_FAILED');
+
+    expect(calls).toContain(`deploy:${CONTRACT.services.worker.id}`);
+    expect(calls).not.toContain(`deploy:${CONTRACT.services.web.id}`);
+  });
+
+  it('discovers only exact opt-in PRs and controller-owned environments', async () => {
+    const numbers = await discoverRailwayPrPreviewNumbers({
+      github: {
+        async listOpenPullRequests() {
+          return [
+            pullRequest(),
+            pullRequest({
+              number: PR_NUMBER + 1,
+              labels: [{ name: 'documentation' }],
+            }),
+            pullRequest({
+              number: PR_NUMBER + 2,
+              head: {
+                ref: 'fork',
+                sha: 'b'.repeat(40),
+                repo: { full_name: 'attacker/fork' },
+              },
+            }),
+          ];
+        },
+      },
+      railway: {
+        async validateAuthority(options) {
+          expect(options).toEqual({ requireNativeDisabled: false });
+        },
+        async listEnvironments() {
+          return [
+            {
+              id: PREVIEW_ENVIRONMENT_ID,
+              name: `${CONTRACT.environmentPrefix}${PR_NUMBER + 3}`,
+              projectId: CONTRACT.projectId,
+            },
+            {
+              id: CONTRACT.baseEnvironmentId,
+              name: CONTRACT.baseEnvironmentName,
+              projectId: CONTRACT.projectId,
+            },
+            {
+              id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+              name: `Arcanos-pr-${PR_NUMBER + 4}`,
+              projectId: CONTRACT.projectId,
+            },
+          ];
+        },
+      },
+    });
+
+    expect(numbers).toEqual([PR_NUMBER, PR_NUMBER + 3]);
+  });
+
+  it('does not delete after an ineligible PR becomes eligible again', async () => {
+    const target = environment();
+    let deleted = false;
+    const closed = validateLifecyclePullRequest(
+      pullRequest({ state: 'closed' }),
+      PR_NUMBER
+    );
+    await expect(cleanupRailwayPrPreview({
+      pullRequest: closed,
+      railway: {
+        async validateAuthority() {},
+        async listEnvironments() { return [target]; },
+        async readEnvironment() { return target; },
+        async deleteAndVerifyEnvironment() { deleted = true; },
+      },
+      verifyCurrentPullRequest: async () =>
+        validateLifecyclePullRequest(pullRequest(), PR_NUMBER),
+    })).rejects.toThrow('RAILWAY_PR_PREVIEW_GITHUB_STATE_CHANGED');
+    expect(deleted).toBe(false);
+  });
+
+  it('cleans an exact owned preview after the PR is retargeted away from main', async () => {
+    const target = environment();
+    const retargeted = validateLifecyclePullRequest(pullRequest({
+      base: { ref: 'develop', repo: { full_name: CONTRACT.repository } },
+    }), PR_NUMBER);
+    let deletedId;
+    await expect(cleanupRailwayPrPreview({
+      pullRequest: retargeted,
+      railway: {
+        async validateAuthority() {},
+        async listEnvironments() { return [target]; },
+        async readEnvironment() { return target; },
+        async deleteAndVerifyEnvironment(item) { deletedId = item.id; },
+      },
+      verifyCurrentPullRequest: async () => retargeted,
+    })).resolves.toMatchObject({ action: 'cleanup', deleted: true });
+    expect(deletedId).toBe(PREVIEW_ENVIRONMENT_ID);
+  });
+
+  it('can clean a controller-owned environment after the PR branch is renamed', async () => {
+    const target = environment();
+    target.config.services[CONTRACT.services.worker.id].source.branch = 'renamed/branch';
+    target.config.services[CONTRACT.services.web.id].source.branch = 'renamed/branch';
+    let deletedId;
+    const closed = validateLifecyclePullRequest(
+      pullRequest({ state: 'closed', head: {
+        ref: 'new/branch-name',
+        sha: HEAD_SHA,
+        repo: { full_name: CONTRACT.repository },
+      } }),
+      PR_NUMBER
+    );
+    await expect(cleanupRailwayPrPreview({
+      pullRequest: closed,
+      railway: {
+        async validateAuthority() {},
+        async listEnvironments() { return [target]; },
+        async readEnvironment() { return target; },
+        async deleteAndVerifyEnvironment(item) { deletedId = item.id; },
+      },
+      verifyCurrentPullRequest: async () => closed,
+    })).resolves.toMatchObject({ deleted: true });
+    expect(deletedId).toBe(PREVIEW_ENVIRONMENT_ID);
+  });
+
+  it('rejects malformed branch identity during cleanup', async () => {
+    const target = environment();
+    target.config.services[CONTRACT.services.worker.id].source.branch = 123;
+    let deleted = false;
+    const closed = validateLifecyclePullRequest(
+      pullRequest({ state: 'closed' }),
+      PR_NUMBER
+    );
+    await expect(cleanupRailwayPrPreview({
+      pullRequest: closed,
+      railway: {
+        async validateAuthority() {},
+        async listEnvironments() { return [target]; },
+        async readEnvironment() { return target; },
+        async deleteAndVerifyEnvironment() { deleted = true; },
+      },
+      verifyCurrentPullRequest: async () => closed,
+    })).rejects.toThrow('RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH');
+    expect(deleted).toBe(false);
+  });
+});
+
+describe('Railway PR preview lifecycle provider client', () => {
+  const safeCreateInput = () => ({
+    projectId: CONTRACT.projectId,
+    name: `${CONTRACT.environmentPrefix}${PR_NUMBER}`,
+    sourceEnvironmentId: CONTRACT.baseEnvironmentId,
+    ephemeral: true,
+    skipInitialDeploys: true,
+    stageInitialChanges: false,
+    applyChangesInBackground: false,
+  });
+
+  it('uses the exact safe clone flags and exact-SHA deployment mutation', async () => {
+    const requests = [];
+    const api = new RailwayGraphqlApi({
+      token: 'workspace-token-for-test-only-000000000000',
+      fetchImpl: async (_url, options) => {
+        const request = JSON.parse(options.body);
+        requests.push({ request, options });
+        if (request.query.includes('CreatePreviewLifecycleEnvironment')) {
+          return jsonResponse({ data: { environmentCreate: {
+            id: PREVIEW_ENVIRONMENT_ID,
+            name: `${CONTRACT.environmentPrefix}${PR_NUMBER}`,
+            projectId: CONTRACT.projectId,
+            isEphemeral: true,
+            sourceEnvironment: { id: CONTRACT.baseEnvironmentId },
+          } } });
+        }
+        if (request.query.includes('DeployPreviewLifecycleService')) {
+          return jsonResponse({ data: {
+            serviceInstanceDeployV2: WORKER_DEPLOYMENT_ID,
+          } });
+        }
+        throw new Error('Unexpected operation.');
+      },
+    });
+
+    const input = safeCreateInput();
+    await expect(api.createEnvironment(input)).resolves.toMatchObject({
+      id: PREVIEW_ENVIRONMENT_ID,
+    });
+    await expect(api.deployExact({
+      commitSha: HEAD_SHA,
+      environmentId: PREVIEW_ENVIRONMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+    })).resolves.toBe(WORKER_DEPLOYMENT_ID);
+
+    expect(requests[0].request.variables).toEqual({ input });
+    expect(requests[1].request.variables).toEqual({
+      commitSha: HEAD_SHA,
+      environmentId: PREVIEW_ENVIRONMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+    });
+    for (const { options } of requests) {
+      expect(options.redirect).toBe('error');
+      expect(options.headers.authorization).toBe(
+        'Bearer workspace-token-for-test-only-000000000000'
+      );
+      expect(options.signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+
+  it('rejects an account-wide token before any project operation', async () => {
+    const operations = [];
+    const api = new RailwayGraphqlApi({
+      token: 'account-token-for-test-only-0000000000000',
+      fetchImpl: async (_url, options) => {
+        const request = JSON.parse(options.body);
+        operations.push(request.query);
+        return jsonResponse({ data: { me: { id: 'account-user' } } });
+      },
+    });
+
+    await expect(api.validateAuthority({
+      requireNativeDisabled: true,
+    })).rejects.toThrow('RAILWAY_PR_PREVIEW_ACCOUNT_TOKEN_FORBIDDEN');
+    expect(operations).toHaveLength(1);
+    expect(operations[0]).toContain('PreviewLifecycleTokenType');
+  });
+
+  it('caps provider responses without exposing the provider body', async () => {
+    const oversized = JSON.stringify({
+      data: { padding: 'x'.repeat(2 * 1024 * 1024) },
+    });
+    const api = new RailwayGraphqlApi({
+      token: 'workspace-token-for-test-only-000000000000',
+      fetchImpl: async () => new Response(oversized, {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    });
+
+    await expect(api.createEnvironment(safeCreateInput())).rejects.toThrow(
+      'RAILWAY_PR_PREVIEW_API_FAILED'
+    );
+  });
+
+  it('rejects unsafe create, deploy, and delete targets before provider access', async () => {
+    let requests = 0;
+    const api = new RailwayGraphqlApi({
+      token: 'workspace-token-for-test-only-000000000000',
+      fetchImpl: async () => {
+        requests += 1;
+        throw new Error('Provider access should not occur.');
+      },
+    });
+
+    await expect(api.createEnvironment({
+      ...safeCreateInput(),
+      skipInitialDeploys: false,
+    })).rejects.toThrow('RAILWAY_PR_PREVIEW_CREATE_INPUT_INVALID');
+    for (const environmentId of [
+      CONTRACT.baseEnvironmentId,
+      CONTRACT.productionEnvironmentId,
+    ]) {
+      await expect(api.deployExact({
+        commitSha: HEAD_SHA,
+        environmentId,
+        serviceId: CONTRACT.services.worker.id,
+      })).rejects.toThrow('RAILWAY_PR_PREVIEW_DEPLOY_TARGET_INVALID');
+    }
+    await expect(api.deleteAndVerifyEnvironment({
+      ...environment(),
+      name: `Arcanos-pr-${PR_NUMBER}`,
+    })).rejects.toThrow('RAILWAY_PR_PREVIEW_DELETE_TARGET_INVALID');
+    expect(requests).toBe(0);
+  });
+
+  it('fails closed when cleanup identity is ambiguous', async () => {
+    const target = environment();
+    const railway = {
+      async validateAuthority() {},
+      async listEnvironments() { return [target, { ...target, id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd' }]; },
+      async readEnvironment() { throw new Error('Ambiguity reached target read.'); },
+      async deleteAndVerifyEnvironment() { throw new Error('Ambiguity reached deletion.'); },
+    };
+
+    const { cleanupRailwayPrPreview } = await import(
+      '../scripts/railway-pr-preview-lifecycle.mjs'
+    );
+    await expect(cleanupRailwayPrPreview({
+      pullRequest: validateLifecyclePullRequest(pullRequest({ state: 'closed' }), PR_NUMBER),
+      railway,
+    })).rejects.toThrow('RAILWAY_PR_PREVIEW_ENVIRONMENT_AMBIGUOUS');
+  });
+});

--- a/tests/railway-pr-preview-lifecycle.test.js
+++ b/tests/railway-pr-preview-lifecycle.test.js
@@ -155,8 +155,8 @@ function serviceNode({ role, activeDeployments = [], latestDeployment = null } =
           ? 'cccccccc-cccc-4ccc-8ccc-ccccccccccc1'
           : 'cccccccc-cccc-4ccc-8ccc-ccccccccccc2',
         domain: role === 'worker'
-          ? `arcanos-worker-pr-676861-${PR_NUMBER}.up.railway.app`
-          : `arcanos-v2-pr-676861-${PR_NUMBER}.up.railway.app`,
+          ? `arcanos-worker-${CONTRACT.environmentPrefix}${PR_NUMBER}.up.railway.app`
+          : `arcanos-v2-${CONTRACT.environmentPrefix}${PR_NUMBER}.up.railway.app`,
         environmentId: PREVIEW_ENVIRONMENT_ID,
         serviceId: service.id,
         deletedAt: null,
@@ -525,6 +525,14 @@ describe('Railway PR preview lifecycle policy', () => {
       headRef: pullRequest().head.ref,
       prNumber: PR_NUMBER,
     })).toThrow('RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH');
+
+    const withNearMissDomain = environment();
+    withNearMissDomain.serviceInstances.edges[0].node.domains.serviceDomains[0].domain =
+      `arcanos-worker-pr-676862-${PR_NUMBER}.up.railway.app`;
+    expect(() => validateOwnedPreviewEnvironment(withNearMissDomain, {
+      headRef: HEAD_REF,
+      prNumber: PR_NUMBER,
+    })).toThrow('RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH');
   });
 
   it('attests exact deployment identity and PR-safe manifest', () => {
@@ -544,6 +552,22 @@ describe('Railway PR preview lifecycle policy', () => {
     });
     unsafe.meta.serviceManifest.deploy.startCommand = 'npm start';
     expect(() => validatePreviewDeployment(unsafe, {
+      deploymentId: WORKER_DEPLOYMENT_ID,
+      environmentId: PREVIEW_ENVIRONMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+      commitSha: HEAD_SHA,
+    })).toThrow('RAILWAY_PR_PREVIEW_DEPLOYMENT_MISMATCH');
+  });
+
+  it('rejects unexpected deployment property mapping keys', () => {
+    const unexpectedMapping = deployment({
+      id: WORKER_DEPLOYMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+    });
+    unexpectedMapping.meta.propertyFileMapping['deploy.numReplicas'] =
+      '$.environments.pr.deploy.numReplicas';
+
+    expect(() => validatePreviewDeployment(unexpectedMapping, {
       deploymentId: WORKER_DEPLOYMENT_ID,
       environmentId: PREVIEW_ENVIRONMENT_ID,
       serviceId: CONTRACT.services.worker.id,

--- a/tests/railway-pr-preview-lifecycle.test.js
+++ b/tests/railway-pr-preview-lifecycle.test.js
@@ -39,6 +39,7 @@ const CONTRACT = RAILWAY_PR_PREVIEW_CONTRACT;
 const PR_NUMBER = 1435;
 const HEAD_SHA = 'a'.repeat(40);
 const HEAD_REF = 'codex/railway-preview-lifecycle-fixture';
+const PREVIEW_REGION = 'us-east4-eqdc4a';
 const WORKER_DEPLOYMENT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1';
 const WEB_DEPLOYMENT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2';
 const PREVIEW_ENVIRONMENT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3';
@@ -125,6 +126,9 @@ function deployment({
           cronSchedule: null,
           runtime: 'V2',
           numReplicas: 1,
+          multiRegionConfig: {
+            [PREVIEW_REGION]: { numReplicas: 1 },
+          },
           requiredMountPath: null,
         },
       },
@@ -201,7 +205,11 @@ function environment({
       services: {
         [CONTRACT.services.worker.id]: {
           build: {},
-          deploy: {},
+          deploy: {
+            multiRegionConfig: {
+              [PREVIEW_REGION]: { numReplicas: 1 },
+            },
+          },
           groupId: CONTRACT.serviceGroupId,
           networking: {},
           source: {
@@ -215,7 +223,11 @@ function environment({
         },
         [CONTRACT.services.web.id]: {
           build: {},
-          deploy: {},
+          deploy: {
+            multiRegionConfig: {
+              [PREVIEW_REGION]: { numReplicas: 1 },
+            },
+          },
           groupId: CONTRACT.serviceGroupId,
           networking: {},
           source: {
@@ -452,6 +464,60 @@ describe('Railway PR preview lifecycle policy', () => {
     );
   });
 
+  it.each([
+    'feature+preview',
+    'feature@preview',
+    'fix#1435',
+    'feature=preview',
+    'feature,preview',
+    'hello-$USER',
+    'feature;preview',
+    'feature/雪',
+    '-feature',
+    '@',
+    'feature/foo./bar',
+    'a'.repeat(244),
+  ])('accepts the Git-valid branch ref %s', (headRef) => {
+    const validated = validateLifecyclePullRequest(pullRequest({
+      head: {
+        ref: headRef,
+        sha: HEAD_SHA,
+        repo: { full_name: CONTRACT.repository },
+      },
+    }), PR_NUMBER);
+
+    expect(validated.headRef).toBe(headRef);
+  });
+
+  it.each([
+    'feature preview',
+    'feature..preview',
+    'feature@{preview',
+    'feature.lock',
+    'feature.lock/preview',
+    'feature/.hidden',
+    'feature//preview',
+    'feature~preview',
+    'feature^preview',
+    'feature:preview',
+    'feature?preview',
+    'feature*preview',
+    'feature[preview',
+    'feature\\preview',
+    'feature/preview.',
+    'refs/heads/feature',
+    'a'.repeat(40),
+    'a'.repeat(245),
+  ])('rejects the Git-invalid branch ref %s', (headRef) => {
+    expect(() => validateLifecyclePullRequest(pullRequest({
+      head: {
+        ref: headRef,
+        sha: HEAD_SHA,
+        repo: { full_name: CONTRACT.repository },
+      },
+    }), PR_NUMBER)).toThrow('RAILWAY_PR_PREVIEW_GITHUB_PR_INVALID');
+  });
+
   it('requires exact workspace/project/base authority and native lifecycle cutover', () => {
     const authority = {
       apiToken: { workspaces: [{ id: CONTRACT.workspaceId }] },
@@ -480,6 +546,22 @@ describe('Railway PR preview lifecycle policy', () => {
     const wrongRetries = baseEnvironment();
     wrongRetries.serviceInstances.edges[0].node.restartPolicyMaxRetries = 0;
     expect(() => validateBasePreviewEnvironment(wrongRetries)).toThrow(
+      'RAILWAY_PR_PREVIEW_BASE_MISMATCH'
+    );
+  });
+
+  it('rejects base region or replica topology drift', () => {
+    const extraRegion = baseEnvironment();
+    extraRegion.config.services[CONTRACT.services.worker.id]
+      .deploy.multiRegionConfig['us-west2'] = { numReplicas: 1 };
+    expect(() => validateBasePreviewEnvironment(extraRegion)).toThrow(
+      'RAILWAY_PR_PREVIEW_BASE_MISMATCH'
+    );
+
+    const extraReplica = baseEnvironment();
+    extraReplica.config.services[CONTRACT.services.web.id]
+      .deploy.multiRegionConfig[PREVIEW_REGION].numReplicas = 2;
+    expect(() => validateBasePreviewEnvironment(extraReplica)).toThrow(
       'RAILWAY_PR_PREVIEW_BASE_MISMATCH'
     );
   });
@@ -581,6 +663,35 @@ describe('Railway PR preview lifecycle policy', () => {
       '$.environments.pr.deploy.numReplicas';
 
     expect(() => validatePreviewDeployment(unexpectedMapping, {
+      deploymentId: WORKER_DEPLOYMENT_ID,
+      environmentId: PREVIEW_ENVIRONMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+      commitSha: HEAD_SHA,
+    })).toThrow('RAILWAY_PR_PREVIEW_DEPLOYMENT_MISMATCH');
+  });
+
+  it('rejects realized deployment region or replica topology drift', () => {
+    const extraRegion = deployment({
+      id: WORKER_DEPLOYMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+    });
+    extraRegion.meta.serviceManifest.deploy.multiRegionConfig['us-west2'] = {
+      numReplicas: 1,
+    };
+    expect(() => validatePreviewDeployment(extraRegion, {
+      deploymentId: WORKER_DEPLOYMENT_ID,
+      environmentId: PREVIEW_ENVIRONMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+      commitSha: HEAD_SHA,
+    })).toThrow('RAILWAY_PR_PREVIEW_DEPLOYMENT_MISMATCH');
+
+    const extraReplica = deployment({
+      id: WORKER_DEPLOYMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+    });
+    extraReplica.meta.serviceManifest.deploy
+      .multiRegionConfig[PREVIEW_REGION].numReplicas = 2;
+    expect(() => validatePreviewDeployment(extraReplica, {
       deploymentId: WORKER_DEPLOYMENT_ID,
       environmentId: PREVIEW_ENVIRONMENT_ID,
       serviceId: CONTRACT.services.worker.id,
@@ -1020,13 +1131,22 @@ describe('Railway PR preview lifecycle policy', () => {
   });
 
   it('can clean a controller-owned environment after the PR branch is renamed', async () => {
-    const target = environment();
-    target.config.services[CONTRACT.services.worker.id].source.branch = 'renamed/branch';
-    target.config.services[CONTRACT.services.web.id].source.branch = 'renamed/branch';
+    const target = environment({ triggers: [{
+      id: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+      projectId: CONTRACT.projectId,
+      environmentId: PREVIEW_ENVIRONMENT_ID,
+      serviceId: CONTRACT.services.worker.id,
+      repository: CONTRACT.repository,
+      branch: 'renamed#branch',
+      provider: 'github',
+      checkSuites: false,
+    }] });
+    target.config.services[CONTRACT.services.worker.id].source.branch = 'renamed+branch';
+    target.config.services[CONTRACT.services.web.id].source.branch = 'renamed+branch';
     let deletedId;
     const closed = validateLifecyclePullRequest(
       pullRequest({ state: 'closed', head: {
-        ref: 'new/branch-name',
+        ref: 'new@branch-name',
         sha: HEAD_SHA,
         repo: { full_name: CONTRACT.repository },
       } }),

--- a/tests/railway-pr-preview-lifecycle.test.js
+++ b/tests/railway-pr-preview-lifecycle.test.js
@@ -92,6 +92,10 @@ function deployment({
       rootDirectory: null,
       volumeMounts: [],
       propertyFileMapping: {
+        'build.buildCommand': '$.build.buildCommand',
+        'build.builder': '$.build.builder',
+        'build.cache': '$.build.cache',
+        'build.env': '$.build.env',
         'deploy.startCommand': '$.environments.pr.deploy.startCommand',
         'deploy.healthcheckPath': '$.environments.pr.deploy.healthcheckPath',
         'deploy.healthcheckTimeout': '$.environments.pr.deploy.healthcheckTimeout',
@@ -100,6 +104,7 @@ function deployment({
         'deploy.preDeployCommand': '$.environments.pr.deploy.preDeployCommand',
         'deploy.cronSchedule': '$.environments.pr.deploy.cronSchedule',
         'deploy.drainingSeconds': '$.deploy.drainingSeconds',
+        'deploy.env': '$.deploy.env',
       },
       serviceManifest: {
         build: {
@@ -205,7 +210,7 @@ function environment({
             repo: CONTRACT.repository,
           },
           variables: {
-            ARCANOS_PROCESS_KIND: { generator: null, value: 'worker' },
+            ARCANOS_PROCESS_KIND: { value: 'worker' },
           },
         },
         [CONTRACT.services.web.id]: {
@@ -219,7 +224,7 @@ function environment({
             repo: CONTRACT.repository,
           },
           variables: {
-            ARCANOS_PROCESS_KIND: { generator: null, value: 'web' },
+            ARCANOS_PROCESS_KIND: { value: 'web' },
           },
         },
       },
@@ -507,6 +512,14 @@ describe('Railway PR preview lifecycle policy', () => {
       value: 'sensitive-test-sentinel',
     };
     expect(() => validateOwnedPreviewEnvironment(withSecret, {
+      headRef: HEAD_REF,
+      prNumber: PR_NUMBER,
+    })).toThrow('RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH');
+
+    const withUnexpectedVariableMetadata = environment();
+    withUnexpectedVariableMetadata.config.services[CONTRACT.services.web.id]
+      .variables.ARCANOS_PROCESS_KIND.generator = null;
+    expect(() => validateOwnedPreviewEnvironment(withUnexpectedVariableMetadata, {
       headRef: HEAD_REF,
       prNumber: PR_NUMBER,
     })).toThrow('RAILWAY_PR_PREVIEW_OWNERSHIP_MISMATCH');


### PR DESCRIPTION
## Summary

- add an opt-in, repository-owned Railway PR preview lifecycle for same-repository PRs targeting `main`
- reconcile missed create/update/cleanup events through trusted event, repository-dispatch, and scheduled paths
- deploy the exact PR SHA worker-first with strict project/environment/service/deployment attestation
- keep the Railway credential on a protected, trusted runner and run the sealed 112-request E2E on a separate credential-free runner
- clean up only controller-owned previews after close, draft conversion, label removal, or base-branch retargeting
- document the guarded cutover and legacy-environment disposal procedure

## Root cause

Railway's native GitHub PR lifecycle saw PR #1434 but did not create its preview environment. The surviving #1432/#1433 environments were manual fallback clones with `meta: null`, so Railway did not own them as native previews and did not remove them when those PRs closed.

This change stops treating provider webhooks as the only lifecycle authority. Every admitted event is a wakeup to converge freshly read GitHub and Railway state, while a six-hour sweep repairs missed events.

## Safety and impact

The controller is opt-in through the exact `railway-preview` label, so unrelated Gaming and GPT-OSS work remains outside its scope. It uses the reserved `pr-676861-<N>` namespace and never adopts or automatically deletes legacy `Arcanos-pr-*` environments.

Create, deploy, trigger deletion, and environment deletion operations are pinned and fail closed on ambiguity, provider-schema drift, stale PR state, deployment races, or protected targets. PR-head files are used only as clean Git evidence; the verifier itself executes from trusted default-branch code.

The workflow intentionally refuses preview creation while Railway-native `prDeploys` remains enabled. GitHub Environment/secret/label provisioning, native-lifecycle cutover, legacy cleanup, and the disposable-PR rehearsal remain separately authorized operational steps after merge.

## Validation

Using Node 20.19.0 and npm 10.8.2:

- lifecycle Jest suite: 31/31 passed
- sealed native-preview `node:test` suite: 11/11 passed
- `npm run docs:check`: 329/329 passed
- `npm run type-check`: passed
- `npm run lint`: passed with 76 existing warnings and no errors
- `npm run validate:railway`: passed
- `npm run build`: passed
- `git diff --check`: passed

The broad root suite completed with 612 suites / 8,159 tests passing and one unchanged GPT-OSS migration-guard test failing because it assumes LF markers on this Windows CRLF checkout. Its complete test/input/guard surface is identical to `origin/main`, and GPT-OSS is explicitly outside this slice.