### PR TITLE
fix(ci): accept Railway preview cutover state

### DIFF
--- a/scripts/railway-pr-preview-lifecycle.mjs
+++ b/scripts/railway-pr-preview-lifecycle.mjs
@@ -534,13 +534,20 @@ export function validateLifecycleAuthority(authority, {
     isRecord(project)
       && project.id === CONTRACT.projectId
       && project.workspaceId === CONTRACT.workspaceId
-      && project.baseEnvironmentId === CONTRACT.baseEnvironmentId
       && project.primaryEnvironmentId === CONTRACT.productionEnvironmentId,
+    'RAILWAY_PR_PREVIEW_AUTHORITY_MISMATCH'
+  );
+  const nativeLifecycleEnabled = project.prDeploys === true
+    && project.baseEnvironmentId === CONTRACT.baseEnvironmentId;
+  const nativeLifecycleDisabled = project.prDeploys === false
+    && project.baseEnvironmentId === null;
+  requireCondition(
+    nativeLifecycleEnabled || nativeLifecycleDisabled,
     'RAILWAY_PR_PREVIEW_AUTHORITY_MISMATCH'
   );
   if (requireNativeDisabled) {
     requireCondition(
-      project.prDeploys === false,
+      nativeLifecycleDisabled,
       'RAILWAY_PR_PREVIEW_NATIVE_LIFECYCLE_ENABLED'
     );
   }

--- a/tests/railway-pr-preview-lifecycle.test.js
+++ b/tests/railway-pr-preview-lifecycle.test.js
@@ -592,22 +592,47 @@ describe('Railway PR preview lifecycle policy', () => {
     }), PR_NUMBER)).toThrow('RAILWAY_PR_PREVIEW_GITHUB_PR_INVALID');
   });
 
-  it('requires exact workspace/project/base authority and native lifecycle cutover', () => {
+  it('requires coherent exact authority before and after native lifecycle cutover', () => {
     const authority = {
       apiToken: { workspaces: [{ id: CONTRACT.workspaceId }] },
       project: {
         id: CONTRACT.projectId,
         workspaceId: CONTRACT.workspaceId,
-        baseEnvironmentId: CONTRACT.baseEnvironmentId,
+        baseEnvironmentId: null,
         primaryEnvironmentId: CONTRACT.productionEnvironmentId,
         prDeploys: false,
       },
     };
     expect(() => validateLifecycleAuthority(authority, { requireNativeDisabled: true })).not.toThrow();
+    expect(() => validateLifecycleAuthority(authority, { requireNativeDisabled: false })).not.toThrow();
+    const nativeAuthority = {
+      ...authority,
+      project: {
+        ...authority.project,
+        baseEnvironmentId: CONTRACT.baseEnvironmentId,
+        prDeploys: true,
+      },
+    };
+    expect(() => validateLifecycleAuthority(nativeAuthority, {
+      requireNativeDisabled: false,
+    })).not.toThrow();
+    expect(() => validateLifecycleAuthority(nativeAuthority, {
+      requireNativeDisabled: true,
+    })).toThrow('RAILWAY_PR_PREVIEW_NATIVE_LIFECYCLE_ENABLED');
     expect(() => validateLifecycleAuthority({
       ...authority,
-      project: { ...authority.project, prDeploys: true },
-    }, { requireNativeDisabled: true })).toThrow('RAILWAY_PR_PREVIEW_NATIVE_LIFECYCLE_ENABLED');
+      project: {
+        ...authority.project,
+        baseEnvironmentId: CONTRACT.baseEnvironmentId,
+      },
+    }, { requireNativeDisabled: false })).toThrow('RAILWAY_PR_PREVIEW_AUTHORITY_MISMATCH');
+    expect(() => validateLifecycleAuthority({
+      ...nativeAuthority,
+      project: {
+        ...nativeAuthority.project,
+        baseEnvironmentId: null,
+      },
+    }, { requireNativeDisabled: false })).toThrow('RAILWAY_PR_PREVIEW_AUTHORITY_MISMATCH');
   });
 
   it('attests the exact credential-empty base topology from live provider shape', () => {

--- a/tests/railway-pr-preview-lifecycle.test.js
+++ b/tests/railway-pr-preview-lifecycle.test.js
@@ -821,7 +821,10 @@ describe('Railway PR preview lifecycle policy', () => {
     });
     const calls = [];
     const railway = {
-      async validateAuthority() { calls.push('authority'); },
+      async validateAuthority(options) {
+        expect(options).toEqual({ requireNativeDisabled: true });
+        calls.push('authority');
+      },
       async readBaseEnvironment() { calls.push('base'); return { valid: true }; },
       validateBaseEnvironment(base) { expect(base).toEqual({ valid: true }); },
       async listEnvironments() { calls.push('list'); return [active]; },
@@ -1098,7 +1101,9 @@ describe('Railway PR preview lifecycle policy', () => {
     await expect(reconcileRailwayPrPreview({
       pullRequest: validateLifecyclePullRequest(pullRequest(), PR_NUMBER),
       railway: {
-        async validateAuthority() {},
+        async validateAuthority(options) {
+          expect(options).toEqual({ requireNativeDisabled: true });
+        },
         async readBaseEnvironment() { return { valid: true }; },
         validateBaseEnvironment() {},
         async listEnvironments() { return []; },
@@ -1219,7 +1224,9 @@ describe('Railway PR preview lifecycle policy', () => {
     await expect(cleanupRailwayPrPreview({
       pullRequest: retargeted,
       railway: {
-        async validateAuthority() {},
+        async validateAuthority(options) {
+          expect(options).toEqual({ requireNativeDisabled: false });
+        },
         async listEnvironments() { return [target]; },
         async readEnvironment() { return target; },
         async deleteAndVerifyEnvironment(item) { deletedId = item.id; },


### PR DESCRIPTION
## Overview
Railway clears `project.baseEnvironmentId` when native PR deployments are disabled. The trusted preview controller incorrectly required the pre-cutover base pointer and therefore stopped with `RAILWAY_PR_PREVIEW_AUTHORITY_MISMATCH` before creating PR #1436's custom environment.

This hotfix accepts only the two coherent provider states: native enabled with the exact pinned base pointer, or native disabled with a null pointer. Reconciliation still requires the disabled state, and the pinned base environment remains independently read and fully attested by exact ID before any mutation.

## Prerequisites
- [x] Issue reproduced and severity confirmed
- [x] Scope limited to minimal fix

## Setup
Required verification before merge:
- [ ] `npm run build` (controller-only JavaScript change; focused and Railway checks used)
- [x] Targeted tests executed: 66/66 lifecycle tests under Node 20.19.0
- [x] Basic compatibility checks verified: `npm run validate:railway` and `npm run check:native-pr-preview-imports`

## Configuration
- [x] No secret/config changes in this PR
- [x] Required variable changes documented: none
- [x] Security implications reviewed; crossed authority states remain fail-closed

## Run locally
- [x] Reproduction no longer occurs in the authority-state matrix
- [x] No obvious regression in reconcile, cleanup, or scheduled discovery caller modes

## Deploy (Railway)
- [x] Deploy order and rollback plan documented: merge controller hotfix, dispatch exact PR #1436 reconciliation; revert this hotfix if authority validation regresses
- [ ] On-call/owners notified
- [x] Post-deploy checks listed: controller lifecycle, worker-first/web-second deployments, sealed 112-request E2E

## Troubleshooting
If hotfix fails in production, rollback trigger:
- [x] New authority-validation regression
- [x] Unexpected Railway environment creation
- [x] Sealed E2E failure

## References
- Failed post-cutover run: https://github.com/pbjustin/Arcanos/actions/runs/31827381651
- Related PR: https://github.com/pbjustin/Arcanos/pull/1436
- Preceding controller hotfix: https://github.com/pbjustin/Arcanos/pull/1437
