### PR TITLE
Fix Backstage canon UUID default binding

### DIFF
--- a/docs/DATABASE_MIGRATIONS.md
+++ b/docs/DATABASE_MIGRATIONS.md
@@ -233,6 +233,11 @@ their transaction-local `search_path` to `public, pg_catalog`; the preceding
 non-transactional concurrent-index phase schema-qualifies its shared table.
 Every owned object therefore resolves in the intended application schema rather
 than a caller-controlled session schema.
+The two canon UUID defaults bind PostgreSQL's built-in
+`pg_catalog.gen_random_uuid()` explicitly. Re-running the forward migration
+also normalizes pre-promotion Phase 2 installs that bound those defaults to
+pgcrypto's legacy `public.gen_random_uuid()` wrapper, before the exact catalog
+verifier runs.
 
 The migration adds:
 

--- a/migrations/20260814_backstage_canon_storyline_v1.sql
+++ b/migrations/20260814_backstage_canon_storyline_v1.sql
@@ -127,7 +127,7 @@ CREATE TABLE IF NOT EXISTS backstage_canon_revisions (
 );
 
 CREATE TABLE IF NOT EXISTS backstage_storyline_threads (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  id UUID PRIMARY KEY DEFAULT pg_catalog.gen_random_uuid(),
   universe_id TEXT NOT NULL,
   story_key TEXT NOT NULL,
   title TEXT NOT NULL,
@@ -214,7 +214,7 @@ CREATE TABLE IF NOT EXISTS backstage_storyline_participants (
 );
 
 CREATE TABLE IF NOT EXISTS backstage_storyline_canon_beats (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  id UUID PRIMARY KEY DEFAULT pg_catalog.gen_random_uuid(),
   universe_id TEXT NOT NULL,
   storyline_id UUID NOT NULL,
   sequence INTEGER NOT NULL,
@@ -274,6 +274,14 @@ CREATE TABLE IF NOT EXISTS backstage_storyline_canon_beats (
   CONSTRAINT ck_backstage_storyline_canon_beats_revision
     CHECK (universe_revision > 0)
 );
+
+-- Normalize installs created by the original Phase 2 migration, where a
+-- public-first search_path could bind these defaults to pgcrypto's legacy
+-- wrapper instead of PostgreSQL's built-in function.
+ALTER TABLE backstage_storyline_threads
+  ALTER COLUMN id SET DEFAULT pg_catalog.gen_random_uuid();
+ALTER TABLE backstage_storyline_canon_beats
+  ALTER COLUMN id SET DEFAULT pg_catalog.gen_random_uuid();
 
 CREATE INDEX IF NOT EXISTS idx_backstage_storyline_threads_universe_status_updated
   ON backstage_storyline_threads(universe_id, status, updated_at DESC, id);
@@ -371,7 +379,7 @@ BEGIN
   ) ON COMMIT DROP;
 
   CREATE TEMP TABLE p2_expected_backstage_storyline_threads (
-    id UUID DEFAULT gen_random_uuid(),
+    id UUID DEFAULT pg_catalog.gen_random_uuid(),
     universe_id TEXT NOT NULL,
     story_key TEXT NOT NULL,
     title TEXT NOT NULL,
@@ -460,7 +468,7 @@ BEGIN
   ) ON COMMIT DROP;
 
   CREATE TEMP TABLE p2_expected_backstage_storyline_canon_beats (
-    id UUID DEFAULT gen_random_uuid(),
+    id UUID DEFAULT pg_catalog.gen_random_uuid(),
     universe_id TEXT NOT NULL,
     storyline_id UUID NOT NULL,
     sequence INTEGER NOT NULL,

--- a/src/core/db/schema.ts
+++ b/src/core/db/schema.ts
@@ -894,7 +894,7 @@ export const TABLE_DEFINITIONS = [
   )`,
 
   `CREATE TABLE IF NOT EXISTS backstage_storyline_threads (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    id UUID PRIMARY KEY DEFAULT pg_catalog.gen_random_uuid(),
     universe_id TEXT NOT NULL,
     story_key TEXT NOT NULL,
     title TEXT NOT NULL,
@@ -981,7 +981,7 @@ export const TABLE_DEFINITIONS = [
   )`,
 
   `CREATE TABLE IF NOT EXISTS backstage_storyline_canon_beats (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    id UUID PRIMARY KEY DEFAULT pg_catalog.gen_random_uuid(),
     universe_id TEXT NOT NULL,
     storyline_id UUID NOT NULL,
     sequence INTEGER NOT NULL,
@@ -1138,7 +1138,7 @@ BEGIN
   ) ON COMMIT DROP;
 
   CREATE TEMP TABLE p2_expected_backstage_storyline_threads (
-    id UUID DEFAULT gen_random_uuid(),
+    id UUID DEFAULT pg_catalog.gen_random_uuid(),
     universe_id TEXT NOT NULL,
     story_key TEXT NOT NULL,
     title TEXT NOT NULL,
@@ -1227,7 +1227,7 @@ BEGIN
   ) ON COMMIT DROP;
 
   CREATE TEMP TABLE p2_expected_backstage_storyline_canon_beats (
-    id UUID DEFAULT gen_random_uuid(),
+    id UUID DEFAULT pg_catalog.gen_random_uuid(),
     universe_id TEXT NOT NULL,
     storyline_id UUID NOT NULL,
     sequence INTEGER NOT NULL,

--- a/tests/backstage-booker-schema-parity.test.ts
+++ b/tests/backstage-booker-schema-parity.test.ts
@@ -415,6 +415,31 @@ describe('Backstage Booker canon/storyline schema', () => {
   it.each([
     ['runtime bootstrap', runtimeSchemaSql],
     ['forward migration', canonForwardMigration]
+  ])('%s binds canon UUID defaults to the built-in function', (_label, sql) => {
+    expect(
+      sql.match(
+        /id UUID(?: PRIMARY KEY)? DEFAULT pg_catalog\.gen_random_uuid\(\)/gu
+      )
+    ).toHaveLength(4);
+  });
+
+  it('repairs UUID defaults installed by the original public-first migration', () => {
+    expect(canonForwardMigration).toContain(
+      `ALTER TABLE backstage_storyline_threads
+  ALTER COLUMN id SET DEFAULT pg_catalog.gen_random_uuid();`
+    );
+    expect(canonForwardMigration).toContain(
+      `ALTER TABLE backstage_storyline_canon_beats
+  ALTER COLUMN id SET DEFAULT pg_catalog.gen_random_uuid();`
+    );
+    expect(runtimeSchemaSql).not.toContain(
+      'ALTER COLUMN id SET DEFAULT pg_catalog.gen_random_uuid()'
+    );
+  });
+
+  it.each([
+    ['runtime bootstrap', runtimeSchemaSql],
+    ['forward migration', canonForwardMigration]
   ])('%s rejects drifted Phase-2 tables, constraints, and indexes', (_label, sql) => {
     expect(sql).toContain('p2_expected_backstage_canon_heads');
     expect(sql).toContain('actual_columns IS DISTINCT FROM expected_columns');

--- a/tests/integration/backstage-canon-storyline.pg18.integration.test.ts
+++ b/tests/integration/backstage-canon-storyline.pg18.integration.test.ts
@@ -10,6 +10,7 @@ import {
   type BackstageCanonBeatAppendInput,
   type BackstageCanonStorylineUpsertInput
 } from '../../src/core/db/repositories/backstageBookerRepository.js';
+import { TABLE_DEFINITIONS } from '../../src/core/db/schema.js';
 import {
   assertDisposablePostgresTestDatabaseUrl,
   POSTGRES_TEST_DATABASE_NAME,
@@ -51,6 +52,14 @@ const canonConcurrentIndexPhase = canonForwardMigration
 const canonTransactionalPhase = canonForwardMigration
   .slice(canonTransactionalPhaseStart)
   .trim();
+const runtimeCanonVerifier = TABLE_DEFINITIONS.find(sql =>
+  sql.includes(
+    '-- CREATE ... IF NOT EXISTS is intentionally paired with an exact catalog'
+  )
+);
+if (!runtimeCanonVerifier) {
+  throw new Error('Runtime Backstage canon catalog verifier is missing.');
+}
 
 async function applyCanonForwardMigration(client: Client): Promise<void> {
   await client.query(canonConcurrentIndexPhase);
@@ -195,6 +204,14 @@ describeWithDatabase('Backstage canon/storyline persistence on PostgreSQL 18', (
     expect(target.rows[0]?.current_database).toBe(POSTGRES_TEST_DATABASE_NAME);
     expect(Number(target.rows[0]?.server_version_num)).toBeGreaterThanOrEqual(180_000);
 
+    await observer.query(
+      'CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public'
+    );
+    const publicUuidFunction = await observer.query<{ installed: boolean }>(
+      `SELECT to_regprocedure('public.gen_random_uuid()') IS NOT NULL AS installed`
+    );
+    expect(publicUuidFunction.rows[0]?.installed).toBe(true);
+
     const preexisting = await observer.query<{ table_name: string }>(
       `SELECT table_name
        FROM information_schema.tables
@@ -318,6 +335,68 @@ describeWithDatabase('Backstage canon/storyline persistence on PostgreSQL 18', (
       'fk_backstage_storyline_participants_wrestler',
       'uq_backstage_events_universe_id'
     ]);
+  }, 60_000);
+
+  test('normalizes UUID defaults independently of the runtime search path', async () => {
+    await observer.query(
+      `ALTER TABLE public.backstage_storyline_threads
+         ALTER COLUMN id SET DEFAULT public.gen_random_uuid();
+       ALTER TABLE public.backstage_storyline_canon_beats
+         ALTER COLUMN id SET DEFAULT public.gen_random_uuid();`
+    );
+    await observer.query('SET search_path TO "$user", public');
+
+    try {
+      await applyCanonForwardMigration(observer);
+      await observer.query(runtimeCanonVerifier);
+
+      const dependencies = await observer.query<{
+        table_name: string;
+        function_schema: string;
+        function_name: string;
+      }>(
+        `SELECT
+           table_class.relname AS table_name,
+           function_namespace.nspname AS function_schema,
+           function_proc.proname AS function_name
+         FROM pg_attrdef AS attribute_default
+         INNER JOIN pg_class AS table_class
+           ON table_class.oid = attribute_default.adrelid
+         INNER JOIN pg_attribute AS attribute
+           ON attribute.attrelid = attribute_default.adrelid
+          AND attribute.attnum = attribute_default.adnum
+         INNER JOIN pg_depend AS dependency
+           ON dependency.classid = 'pg_attrdef'::REGCLASS
+          AND dependency.objid = attribute_default.oid
+          AND dependency.refclassid = 'pg_proc'::REGCLASS
+         INNER JOIN pg_proc AS function_proc
+           ON function_proc.oid = dependency.refobjid
+         INNER JOIN pg_namespace AS function_namespace
+           ON function_namespace.oid = function_proc.pronamespace
+         WHERE table_class.relnamespace = 'public'::REGNAMESPACE
+           AND table_class.relname = ANY($1::TEXT[])
+           AND attribute.attname = 'id'
+         ORDER BY table_class.relname`,
+        [[
+          'backstage_storyline_canon_beats',
+          'backstage_storyline_threads'
+        ]]
+      );
+      expect(dependencies.rows).toEqual([
+        {
+          table_name: 'backstage_storyline_canon_beats',
+          function_schema: 'pg_catalog',
+          function_name: 'gen_random_uuid'
+        },
+        {
+          table_name: 'backstage_storyline_threads',
+          function_schema: 'pg_catalog',
+          function_name: 'gen_random_uuid'
+        }
+      ]);
+    } finally {
+      await observer.query('SET search_path TO public, pg_catalog');
+    }
   }, 60_000);
 
   test('serializes concurrent update CAS attempts without a revision gap', async () => {

--- a/tests/integration/backstage-canon-storyline.pg18.integration.test.ts
+++ b/tests/integration/backstage-canon-storyline.pg18.integration.test.ts
@@ -349,30 +349,25 @@ describeWithDatabase('Backstage canon/storyline persistence on PostgreSQL 18', (
     try {
       await applyCanonForwardMigration(observer);
       await observer.query(runtimeCanonVerifier);
+      await observer.query('SET search_path TO public, pg_catalog');
 
-      const dependencies = await observer.query<{
+      const defaults = await observer.query<{
         table_name: string;
-        function_schema: string;
-        function_name: string;
+        default_expression: string;
       }>(
         `SELECT
            table_class.relname AS table_name,
-           function_namespace.nspname AS function_schema,
-           function_proc.proname AS function_name
+           pg_get_expr(
+             attribute_default.adbin,
+             attribute_default.adrelid,
+             false
+           ) AS default_expression
          FROM pg_attrdef AS attribute_default
          INNER JOIN pg_class AS table_class
            ON table_class.oid = attribute_default.adrelid
          INNER JOIN pg_attribute AS attribute
            ON attribute.attrelid = attribute_default.adrelid
           AND attribute.attnum = attribute_default.adnum
-         INNER JOIN pg_depend AS dependency
-           ON dependency.classid = 'pg_attrdef'::REGCLASS
-          AND dependency.objid = attribute_default.oid
-          AND dependency.refclassid = 'pg_proc'::REGCLASS
-         INNER JOIN pg_proc AS function_proc
-           ON function_proc.oid = dependency.refobjid
-         INNER JOIN pg_namespace AS function_namespace
-           ON function_namespace.oid = function_proc.pronamespace
          WHERE table_class.relnamespace = 'public'::REGNAMESPACE
            AND table_class.relname = ANY($1::TEXT[])
            AND attribute.attname = 'id'
@@ -382,16 +377,14 @@ describeWithDatabase('Backstage canon/storyline persistence on PostgreSQL 18', (
           'backstage_storyline_threads'
         ]]
       );
-      expect(dependencies.rows).toEqual([
+      expect(defaults.rows).toEqual([
         {
           table_name: 'backstage_storyline_canon_beats',
-          function_schema: 'pg_catalog',
-          function_name: 'gen_random_uuid'
+          default_expression: 'pg_catalog.gen_random_uuid()'
         },
         {
           table_name: 'backstage_storyline_threads',
-          function_schema: 'pg_catalog',
-          function_name: 'gen_random_uuid'
+          default_expression: 'pg_catalog.gen_random_uuid()'
         }
       ]);
     } finally {


### PR DESCRIPTION
## What changed

- Bind the Phase 2A storyline and canon-beat UUID defaults to `pg_catalog.gen_random_uuid()` in runtime and verifier definitions.
- Make the rerunnable Phase 2 migration normalize pre-promotion installs that bound the defaults to pgcrypto's legacy public wrapper.
- Add static parity coverage and a PostgreSQL 18 regression for the conflicting search paths.
- Document the repair behavior.

## Root cause

The production migration ran with `search_path = public, pg_catalog`, so two defaults bound to `public.gen_random_uuid()`. Worker startup used the default path where `pg_catalog` is searched first, and its exact catalog verifier rejected the otherwise-equivalent default expression.

## Impact

The migration repair changes only future UUID default generation for the two new Phase 2 tables. It does not rewrite existing rows. The current production rollout remains on the previous worker/web pair.

## Validation

- Focused schema parity: 25/25 passed
- Targeted ESLint: passed
- `npm run type-check`: passed
- `npm run build`: passed
- `npm run validate:railway`: passed
- `git diff --check`: passed
- PostgreSQL integration guard tests: 6/6 passed locally; database cases will run in CI

## Coordinated rollout

After this exact PR head is green, apply and verify migration SHA-256 `b4801e3fdb8ce3a5cfa541c8eaa7164d39344b950338f6ad93de2efe8e2d5f1e` against production before merging, because a successful main CI run automatically starts the worker-first/web-second Railway deployment.